### PR TITLE
docs(specs): remove cross-references between pattern and structure specs

### DIFF
--- a/specs/pattern-remediation/DISCOVERY_PROMPT.md
+++ b/specs/pattern-remediation/DISCOVERY_PROMPT.md
@@ -160,35 +160,20 @@ Found 45 packages in topological order:
 @beep/web
 ```
 
-### Pattern Remediation vs Structure Refactoring
-
-**Pattern remediation is more flexible than structure refactoring:**
-
-- **Pattern fixes** (`.map()` → `A.map()`) are internal code changes
-- They don't change exports, file names, or import paths
-- Each package can be fixed and validated independently
-- Order matters less - any order works
-
-**Structure refactoring** (renaming files/directories) requires reverse topological order because renamed exports break consumers.
-
 ### Recommended Order for Pattern Remediation
-
-For consistency with structure-standardization and to establish patterns early:
 
 **Process from BOTTOM to TOP of topo-sort (reverse order):**
 
 1. **Consumer packages first** (e.g., `@beep/web`)
-   - Can reference correct patterns in provider packages
    - Validation passes immediately after fixes
-   - No risk since internal changes don't affect exports
+   - Internal changes don't affect exports
 
 2. **Provider packages later** (e.g., `@beep/types`)
-   - By the time you reach them, you've established muscle memory
-   - Consistent approach across both specs
+   - By the time you reach them, you've established consistent patterns
 
 ### Integrating with PLAN.md
 
-When generating PLAN.md, **use reverse topo-sort order** (same as structure-standardization):
+When generating PLAN.md, **use reverse topo-sort order**:
 
 ```markdown
 ## Execution Order (Reverse Topological)
@@ -202,7 +187,7 @@ Process packages in this order (consumers first):
 N. @beep/types (0 deps) - 3 violations
 ```
 
-This maintains consistency with structure-standardization and allows each package to pass validation immediately after fixes.
+This allows each package to pass validation immediately after fixes.
 
 ---
 

--- a/specs/pattern-remediation/ORCHESTRATION_TEMPLATE.md
+++ b/specs/pattern-remediation/ORCHESTRATION_TEMPLATE.md
@@ -36,18 +36,11 @@ This outputs packages with **fewest dependencies first**. **REVERSE this list** 
 
 For **pattern remediation**, order is flexible since internal code changes don't break consumers. However, we use reverse order for:
 
-1. **Consistency** with structure-standardization spec
-2. **Validation flow** - consumer packages can be validated immediately
-3. **Reference patterns** - by the time you reach provider packages, you've established consistent patterns
+1. **Validation flow** - consumer packages can be validated immediately
+2. **Reference patterns** - by the time you reach provider packages, you've established consistent patterns
+3. **Predictability** - consistent ordering across the monorepo
 
-### Note: Pattern vs Structure
-
-Unlike structure refactoring, pattern fixes don't change exports:
-- Fixing `.map()` → `A.map()` doesn't break consumers
-- Each package is independently validatable
-- Less critical than structure refactoring order
-
-**Process from BOTTOM to TOP of topo-sort output for consistency.**
+**Process from BOTTOM to TOP of topo-sort output.**
 
 ## Execution Strategy
 


### PR DESCRIPTION
- Remove "Note: Pattern vs Structure" section from pattern-remediation
- Remove "Pattern Remediation vs Structure Refactoring" comparison
- Keep specs independent and focused on their own scope

pattern-remediation: Effect pattern compliance (code changes only)
structure-standardization: imports, exports, folder structure, naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated pattern remediation specification documents with simplified and clarified language.
* Reorganized execution order rationale to emphasize validation flow, reference patterns, and predictability.
* Streamlined guidance and removed redundant explanatory sections for improved readability.
* Refined supporting examples and commentary to align with updated specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->