### PR TITLE
fix(iam-server): replace hardcoded SIWE nonce with cryptographically …

### DIFF
--- a/packages/iam/server/src/adapters/better-auth/Options.ts
+++ b/packages/iam/server/src/adapters/better-auth/Options.ts
@@ -463,9 +463,14 @@ export const makeAuth = ({
       siwe({
         domain: serverEnv.app.domain,
         getNonce: async () => {
-          return "beep";
+          // Generate cryptographically secure random nonce to prevent replay attacks
+          const randomBytes = crypto.getRandomValues(new Uint8Array(32));
+          return Array.from(randomBytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
         },
         verifyMessage: async () => {
+          // TODO: Implement proper SIWE message verification
+          // This currently disables SIWE authentication - implement with viem or ethers.js
+          // to verify the signature before enabling in production
           return false;
         },
       }),


### PR DESCRIPTION
…secure random value

The SIWE plugin was using a static nonce "beep" which could enable replay attacks if signature verification were enabled. Now generates a 64-character hex string using crypto.getRandomValues() for each authentication attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security of nonce generation for Ethereum authentication with cryptographically secure random values.

* **Chores**
  * Temporarily disabled message verification for Ethereum sign-in pending implementation update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->