### PR TITLE
[codex] Add dual Set utilities

### DIFF
--- a/.changeset/bright-sets-arrive.md
+++ b/.changeset/bright-sets-arrive.md
@@ -1,0 +1,5 @@
+---
+"@beep/utils": patch
+---
+
+Add dual `Set` utilities with coverage, bound helpers, and public namespace export.

--- a/packages/common/utils/src/Set.ts
+++ b/packages/common/utils/src/Set.ts
@@ -1,0 +1,1148 @@
+/**
+ * Readonly Set utilities with custom equivalence support.
+ *
+ * @module
+ * @since 0.0.0
+ */
+
+import * as A from "effect/Array";
+import type * as Equivalence from "effect/Equivalence";
+import { dual, identity } from "effect/Function";
+import * as O from "effect/Option";
+import type * as Order from "effect/Order";
+import type * as P from "effect/Predicate";
+import * as Result from "effect/Result";
+
+/**
+ * Mutable Set alias used when a helper intentionally returns a writable copy.
+ *
+ * @example
+ * ```ts
+ * import { Set } from "@beep/utils"
+ *
+ * const values: Set.MutableSet<number> = new globalThis.Set([1, 2])
+ * values.add(3)
+ *
+ * void values
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type MutableSet<A> = globalThis.Set<A>;
+
+/**
+ * Readonly Set alias used by the Set utility module.
+ *
+ * @example
+ * ```ts
+ * import { Set } from "@beep/utils"
+ *
+ * const values: Set.Set<string> = new globalThis.Set(["beep"])
+ *
+ * void values
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type Set<A> = ReadonlySet<A>;
+
+/**
+ * Shared empty readonly Set value.
+ *
+ * @example
+ * ```ts
+ * import { Set } from "@beep/utils"
+ *
+ * const size = Set.empty.size
+ *
+ * void size
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const empty: Set<never> = new globalThis.Set<never>();
+
+/**
+ * Clone a mutable Set into a readonly Set.
+ *
+ * @example
+ * ```ts
+ * import { Set } from "@beep/utils"
+ *
+ * const mutable = new globalThis.Set([1, 2])
+ * const readonly = Set.fromMutable(mutable)
+ *
+ * void readonly
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export function fromMutable<A>(self: MutableSet<A>): Set<A> {
+  return new globalThis.Set(self);
+}
+
+/**
+ * Clone a readonly Set into a mutable Set.
+ *
+ * @example
+ * ```ts
+ * import { Set } from "@beep/utils"
+ *
+ * const readonly: Set.Set<number> = new globalThis.Set([1, 2])
+ * const mutable = Set.toMutable(readonly)
+ * mutable.add(3)
+ *
+ * void mutable
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export function toMutable<A>(self: Set<A>): MutableSet<A> {
+  return new globalThis.Set(self);
+}
+
+/**
+ * Create a Set containing a single value.
+ *
+ * @example
+ * ```ts
+ * import { Set } from "@beep/utils"
+ *
+ * const value = Set.singleton("beep")
+ *
+ * void value
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export function singleton<A>(value: A): Set<A> {
+  return new globalThis.Set([value]);
+}
+
+/**
+ * Create a Set from an array, deduplicating values with an equivalence.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const dataFirst = Set.fromArray([1, 1, 2], Equivalence.strictEqual<number>())
+ * const dataLast = pipe([1, 2, 2], Set.fromArray(Equivalence.strictEqual<number>()))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const fromArray: {
+  <A>(equivalence: Equivalence.Equivalence<A>): (self: ReadonlyArray<A>) => Set<A>;
+  <A>(self: ReadonlyArray<A>, equivalence: Equivalence.Equivalence<A>): Set<A>;
+} = dual(2, fromArray_);
+
+/**
+ * Convert a Set to a sorted readonly array.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Order from "effect/Order"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([3, 1, 2])
+ * const dataFirst = Set.toArray(values, Order.Number)
+ * const dataLast = pipe(values, Set.toArray(Order.Number))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category getters
+ * @since 0.0.0
+ */
+export const toArray: {
+  <A>(order: Order.Order<A>): (self: Set<A>) => ReadonlyArray<A>;
+  <A>(self: Set<A>, order: Order.Order<A>): ReadonlyArray<A>;
+} = dual(2, toArray_);
+
+/**
+ * Find the first Set value that matches a predicate or refinement.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2, 3])
+ * const dataFirst = Set.findFirst(values, (value) => value > 1)
+ * const dataLast = pipe(values, Set.findFirst((value) => value > 2))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category elements
+ * @since 0.0.0
+ */
+export const findFirst: {
+  <A, B extends A>(refinement: P.Refinement<A, B>): (self: Set<A>) => O.Option<B>;
+  <A>(predicate: P.Predicate<A>): (self: Set<A>) => O.Option<A>;
+  <A, B extends A>(self: Set<A>, refinement: P.Refinement<A, B>): O.Option<B>;
+  <A>(self: Set<A>, predicate: P.Predicate<A>): O.Option<A>;
+} = dual(2, findFirst_);
+
+/**
+ * Find and map the first Set value that returns `Option.some`.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as O from "effect/Option"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set(["a", "bb", "ccc"])
+ * const dataFirst = Set.findFirstMap(values, (value) => value.length > 1 ? O.some(value.length) : O.none())
+ * const dataLast = pipe(values, Set.findFirstMap((value) => value.length > 2 ? O.some(value) : O.none()))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category elements
+ * @since 0.0.0
+ */
+export const findFirstMap: {
+  <A, B>(f: (value: A) => O.Option<B>): (self: Set<A>) => O.Option<B>;
+  <A, B>(self: Set<A>, f: (value: A) => O.Option<B>): O.Option<B>;
+} = dual(2, findFirstMap_);
+
+/**
+ * Test whether at least one Set value satisfies a predicate.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2, 3])
+ * const dataFirst = Set.some(values, (value) => value > 2)
+ * const dataLast = pipe(values, Set.some((value) => value > 3))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category predicates
+ * @since 0.0.0
+ */
+export const some: {
+  <A>(predicate: P.Predicate<A>): (self: Set<A>) => boolean;
+  <A>(self: Set<A>, predicate: P.Predicate<A>): boolean;
+} = dual(2, <A>(self: Set<A>, predicate: P.Predicate<A>): boolean => A.some(A.fromIterable(self), predicate));
+
+/**
+ * Test whether every Set value satisfies a predicate.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2, 3])
+ * const dataFirst = Set.every(values, (value) => value > 0)
+ * const dataLast = pipe(values, Set.every((value) => value < 4))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category predicates
+ * @since 0.0.0
+ */
+export const every: {
+  <A>(predicate: P.Predicate<A>): (self: Set<A>) => boolean;
+  <A>(self: Set<A>, predicate: P.Predicate<A>): boolean;
+} = dual(2, <A>(self: Set<A>, predicate: P.Predicate<A>): boolean => A.every(A.fromIterable(self), predicate));
+
+/**
+ * Test whether a value is equivalent to an element in the Set.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set(["a", "b"])
+ * const eq = Equivalence.strictEqual<string>()
+ * const dataFirst = Set.elem(values, "a", eq)
+ * const dataLast = pipe(values, Set.elem("c", eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category predicates
+ * @since 0.0.0
+ */
+export const elem: {
+  <A>(value: NoInfer<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => boolean;
+  <A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): boolean;
+} = dual(3, elem_);
+
+/**
+ * Test whether every value in one Set is present in another Set.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const left = new globalThis.Set([1, 2])
+ * const right = new globalThis.Set([1, 2, 3])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.isSubset(left, right, eq)
+ * const dataLast = pipe(left, Set.isSubset(right, eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category predicates
+ * @since 0.0.0
+ */
+export const isSubset: {
+  <A>(that: Set<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => boolean;
+  <A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): boolean;
+} = dual(3, isSubset_);
+
+/**
+ * Keep values that satisfy a predicate or refinement.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2, 3])
+ * const dataFirst = Set.filter(values, (value) => value > 1)
+ * const dataLast = pipe(values, Set.filter((value) => value < 3))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const filter: {
+  <A, B extends A>(refinement: P.Refinement<A, B>): (self: Set<A>) => Set<B>;
+  <A>(predicate: P.Predicate<A>): (self: Set<A>) => Set<A>;
+  <A, B extends A>(self: Set<A>, refinement: P.Refinement<A, B>): Set<B>;
+  <A>(self: Set<A>, predicate: P.Predicate<A>): Set<A>;
+} = dual(2, filter_);
+
+/**
+ * Split values by a predicate or refinement into excluded and included Sets.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2, 3, 4])
+ * const dataFirst = Set.partition(values, (value) => value % 2 === 0)
+ * const dataLast = pipe(values, Set.partition((value) => value > 2))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const partition: {
+  <A, B extends A>(refinement: P.Refinement<A, B>): (self: Set<A>) => readonly [Set<A>, Set<B>];
+  <A>(predicate: P.Predicate<A>): (self: Set<A>) => readonly [Set<A>, Set<A>];
+  <A, B extends A>(self: Set<A>, refinement: P.Refinement<A, B>): readonly [Set<A>, Set<B>];
+  <A>(self: Set<A>, predicate: P.Predicate<A>): readonly [Set<A>, Set<A>];
+} = dual(2, partition_);
+
+/**
+ * Map Set values while deduplicating mapped values with an equivalence.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set(["a", "bb", "cc"])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.map(values, (value) => value.length, eq)
+ * const dataLast = pipe(values, Set.map((value) => value.length + 1, eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category mapping
+ * @since 0.0.0
+ */
+export const map: {
+  <A, B>(f: (value: A) => B, equivalence: Equivalence.Equivalence<B>): (self: Set<A>) => Set<B>;
+  <A, B>(self: Set<A>, f: (value: A) => B, equivalence: Equivalence.Equivalence<B>): Set<B>;
+} = dual(3, map_);
+
+/**
+ * Flat-map Set values while deduplicating flattened values with an equivalence.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.chain(values, (value) => new globalThis.Set([value, value + 1]), eq)
+ * const dataLast = pipe(values, Set.chain((value) => new globalThis.Set([value * 2]), eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category mapping
+ * @since 0.0.0
+ */
+export const chain: {
+  <A, B>(f: (value: A) => Set<B>, equivalence: Equivalence.Equivalence<B>): (self: Set<A>) => Set<B>;
+  <A, B>(self: Set<A>, f: (value: A) => Set<B>, equivalence: Equivalence.Equivalence<B>): Set<B>;
+} = dual(3, chain_);
+
+/**
+ * Map Set values to `Option` and keep the present mapped values.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import * as O from "effect/Option"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2, 3])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.filterMap(values, (value) => value > 1 ? O.some(value * 2) : O.none(), eq)
+ * const dataLast = pipe(values, Set.filterMap((value) => value > 2 ? O.some(value) : O.none(), eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const filterMap: {
+  <A, B>(f: (value: A) => O.Option<B>, equivalence: Equivalence.Equivalence<B>): (self: Set<A>) => Set<B>;
+  <A, B>(self: Set<A>, f: (value: A) => O.Option<B>, equivalence: Equivalence.Equivalence<B>): Set<B>;
+} = dual(3, filterMap_);
+
+/**
+ * Remove `Option.none` values and unwrap present values.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import * as O from "effect/Option"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([O.some(1), O.none(), O.some(1)])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.compact(values, eq)
+ * const dataLast = pipe(values, Set.compact(eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const compact: {
+  <A>(equivalence: Equivalence.Equivalence<A>): (self: Set<O.Option<A>>) => Set<A>;
+  <A>(self: Set<O.Option<A>>, equivalence: Equivalence.Equivalence<A>): Set<A>;
+} = dual(2, compact_);
+
+/**
+ * Split `Result` values into failures and successes.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import * as Result from "effect/Result"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([Result.fail("missing"), Result.succeed(1)])
+ * const dataFirst = Set.separate(values, Equivalence.strictEqual<string>(), Equivalence.strictEqual<number>())
+ * const dataLast = pipe(values, Set.separate(Equivalence.strictEqual<string>(), Equivalence.strictEqual<number>()))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const separate: {
+  <E, A>(
+    failureEquivalence: Equivalence.Equivalence<E>,
+    successEquivalence: Equivalence.Equivalence<A>
+  ): (self: Set<Result.Result<A, E>>) => readonly [Set<E>, Set<A>];
+  <E, A>(
+    self: Set<Result.Result<A, E>>,
+    failureEquivalence: Equivalence.Equivalence<E>,
+    successEquivalence: Equivalence.Equivalence<A>
+  ): readonly [Set<E>, Set<A>];
+} = dual(3, separate_);
+
+/**
+ * Partition values with a function returning `Result`.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import * as Result from "effect/Result"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2, 3])
+ * const split = (value: number) => value % 2 === 0 ? Result.succeed(value) : Result.fail(`${value}`)
+ * const dataFirst = Set.partitionMap(values, split, Equivalence.strictEqual<string>(), Equivalence.strictEqual<number>())
+ * const dataLast = pipe(values, Set.partitionMap(split, Equivalence.strictEqual<string>(), Equivalence.strictEqual<number>()))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const partitionMap: {
+  <A, E, B>(
+    f: (value: A) => Result.Result<B, E>,
+    failureEquivalence: Equivalence.Equivalence<E>,
+    successEquivalence: Equivalence.Equivalence<B>
+  ): (self: Set<A>) => readonly [Set<E>, Set<B>];
+  <A, E, B>(
+    self: Set<A>,
+    f: (value: A) => Result.Result<B, E>,
+    failureEquivalence: Equivalence.Equivalence<E>,
+    successEquivalence: Equivalence.Equivalence<B>
+  ): readonly [Set<E>, Set<B>];
+} = dual(4, partitionMap_);
+
+/**
+ * Keep values that are present in both Sets.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const left = new globalThis.Set([1, 2])
+ * const right = new globalThis.Set([2, 3])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.intersection(left, right, eq)
+ * const dataLast = pipe(left, Set.intersection(right, eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const intersection: {
+  <A>(that: Set<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A>;
+} = dual(3, intersection_);
+
+/**
+ * Keep values from the first Set that are absent from the second Set.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const left = new globalThis.Set([1, 2, 3])
+ * const right = new globalThis.Set([2])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.difference(left, right, eq)
+ * const dataLast = pipe(left, Set.difference(right, eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const difference: {
+  <A>(that: Set<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A>;
+} = dual(3, difference_);
+
+/**
+ * Combine two Sets while deduplicating with an equivalence.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const left = new globalThis.Set([1, 2])
+ * const right = new globalThis.Set([2, 3])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.union(left, right, eq)
+ * const dataLast = pipe(left, Set.union(right, eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category combinators
+ * @since 0.0.0
+ */
+export const union: {
+  <A>(that: Set<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A>;
+} = dual(3, union_);
+
+/**
+ * Insert a value when an equivalent value is not already present.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.insert(values, 3, eq)
+ * const dataLast = pipe(values, Set.insert(4, eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category combinators
+ * @since 0.0.0
+ */
+export const insert: {
+  <A>(value: NoInfer<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A>;
+} = dual(3, insert_);
+
+/**
+ * Remove values equivalent to the provided value.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2, 3])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.remove(values, 2, eq)
+ * const dataLast = pipe(values, Set.remove(3, eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category filtering
+ * @since 0.0.0
+ */
+export const remove: {
+  <A>(value: NoInfer<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A>;
+} = dual(3, remove_);
+
+/**
+ * Remove a present value or insert an absent value.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([1, 2])
+ * const eq = Equivalence.strictEqual<number>()
+ * const dataFirst = Set.toggle(values, 2, eq)
+ * const dataLast = pipe(values, Set.toggle(3, eq))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category combinators
+ * @since 0.0.0
+ */
+export const toggle: {
+  <A>(value: NoInfer<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A>;
+} = dual(3, toggle_);
+
+/**
+ * Reduce Set values in sorted order.
+ *
+ * Supports both data-first and data-last calling conventions.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from "effect"
+ * import * as Order from "effect/Order"
+ * import { Set } from "@beep/utils"
+ *
+ * const values = new globalThis.Set([3, 1, 2])
+ * const dataFirst = Set.reduce(values, "", (out, value) => `${out}${value}`, Order.Number)
+ * const dataLast = pipe(values, Set.reduce("", (out, value) => `${out}${value}`, Order.Number))
+ *
+ * void dataFirst
+ * void dataLast
+ * ```
+ *
+ * @category folding
+ * @since 0.0.0
+ */
+export const reduce: {
+  <A, B>(initial: B, f: (accumulator: B, value: A) => B, order: Order.Order<A>): (self: Set<A>) => B;
+  <A, B>(self: Set<A>, initial: B, f: (accumulator: B, value: A) => B, order: Order.Order<A>): B;
+} = dual(4, reduce_);
+
+/**
+ * Bound Set helpers for one ordered/equivalent value domain.
+ *
+ * @example
+ * ```ts
+ * import * as Order from "effect/Order"
+ * import { Set } from "@beep/utils"
+ *
+ * const numbers = Set.make(Order.Number)
+ * const values = numbers.fromArray([2, 1, 2])
+ * const withThree = numbers.insert(values, 3)
+ *
+ * void withThree
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export interface SetSchemaExtensions<A> {
+  readonly concat: {
+    (values: Iterable<A>): (self: Set<A>) => Set<A>;
+    (self: Set<A>, values: Iterable<A>): Set<A>;
+  };
+  readonly difference: {
+    (that: Set<A>): (self: Set<A>) => Set<A>;
+    (self: Set<A>, that: Set<A>): Set<A>;
+  };
+  readonly elem: {
+    (value: A): (self: Set<A>) => boolean;
+    (self: Set<A>, value: A): boolean;
+  };
+  readonly empty: () => Set<A>;
+  readonly filter: {
+    <B extends A>(refinement: P.Refinement<A, B>): (self: Set<A>) => Set<B>;
+    (predicate: P.Predicate<A>): (self: Set<A>) => Set<A>;
+    <B extends A>(self: Set<A>, refinement: P.Refinement<A, B>): Set<B>;
+    (self: Set<A>, predicate: P.Predicate<A>): Set<A>;
+  };
+  readonly filterMap: {
+    (f: (value: A) => O.Option<A>): (self: Set<A>) => Set<A>;
+    (self: Set<A>, f: (value: A) => O.Option<A>): Set<A>;
+  };
+  readonly from: (values: Iterable<A>) => Set<A>;
+  readonly fromArray: (values: ReadonlyArray<A>) => Set<A>;
+  readonly insert: {
+    (value: A): (self: Set<A>) => Set<A>;
+    (self: Set<A>, value: A): Set<A>;
+  };
+  readonly intersection: {
+    (that: Set<A>): (self: Set<A>) => Set<A>;
+    (self: Set<A>, that: Set<A>): Set<A>;
+  };
+  readonly isSubset: {
+    (that: Set<A>): (self: Set<A>) => boolean;
+    (self: Set<A>, that: Set<A>): boolean;
+  };
+  readonly map: {
+    (f: (value: A) => A): (self: Set<A>) => Set<A>;
+    (self: Set<A>, f: (value: A) => A): Set<A>;
+  };
+  readonly reduce: {
+    <B>(initial: B, f: (accumulator: B, value: A) => B): (self: Set<A>) => B;
+    <B>(self: Set<A>, initial: B, f: (accumulator: B, value: A) => B): B;
+  };
+  readonly remove: {
+    (value: A): (self: Set<A>) => Set<A>;
+    (self: Set<A>, value: A): Set<A>;
+  };
+  readonly replace: {
+    (value: A): (self: Set<A>) => Set<A>;
+    (self: Set<A>, value: A): Set<A>;
+  };
+  readonly toArray: (self: Set<A>) => ReadonlyArray<A>;
+  readonly toggle: {
+    (value: A): (self: Set<A>) => Set<A>;
+    (self: Set<A>, value: A): Set<A>;
+  };
+  readonly union: {
+    (that: Set<A>): (self: Set<A>) => Set<A>;
+    (self: Set<A>, that: Set<A>): Set<A>;
+  };
+}
+
+/**
+ * Create bound Set helpers from an order and optional equivalence.
+ *
+ * When an equivalence is omitted, equality is derived from the order by
+ * considering values equivalent when comparison returns `0`.
+ *
+ * @example
+ * ```ts
+ * import * as Order from "effect/Order"
+ * import { Set } from "@beep/utils"
+ *
+ * const numbers = Set.make(Order.Number)
+ * const values = numbers.from([3, 1, 2])
+ * const sorted = numbers.toArray(values)
+ *
+ * void sorted
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const make: <A>(order: Order.Order<A>, equivalence?: Equivalence.Equivalence<A>) => SetSchemaExtensions<A> =
+  make_;
+
+/** @internal */
+function fromArray_<A>(self: ReadonlyArray<A>, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  const out = new globalThis.Set<A>();
+
+  for (const value of self) {
+    if (!elem_(out, value, equivalence)) {
+      out.add(value);
+    }
+  }
+
+  return out;
+}
+
+/** @internal */
+function toArray_<A>(self: Set<A>, order: Order.Order<A>): ReadonlyArray<A> {
+  return A.sort(A.fromIterable(self), order);
+}
+
+/** @internal */
+function findFirst_<A, B extends A>(self: Set<A>, refinement: P.Refinement<A, B>): O.Option<B>;
+function findFirst_<A>(self: Set<A>, predicate: P.Predicate<A>): O.Option<A>;
+function findFirst_<A>(self: Set<A>, predicate: P.Predicate<A>): O.Option<A> {
+  return A.findFirst(self, predicate);
+}
+
+/** @internal */
+function findFirstMap_<A, B>(self: Set<A>, f: (value: A) => O.Option<B>): O.Option<B> {
+  return A.findFirst(self, f);
+}
+
+/** @internal */
+function elem_<A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): boolean {
+  for (const item of self) {
+    if (equivalence(value, item)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** @internal */
+function isSubset_<A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): boolean {
+  return every(self, (value) => elem_(that, value, equivalence));
+}
+
+/** @internal */
+function filter_<A, B extends A>(self: Set<A>, refinement: P.Refinement<A, B>): Set<B>;
+function filter_<A>(self: Set<A>, predicate: P.Predicate<A>): Set<A>;
+function filter_<A>(self: Set<A>, predicate: P.Predicate<A>): Set<A> {
+  const out = new globalThis.Set<A>();
+
+  for (const value of self) {
+    if (predicate(value)) {
+      out.add(value);
+    }
+  }
+
+  return out;
+}
+
+/** @internal */
+function partition_<A, B extends A>(self: Set<A>, refinement: P.Refinement<A, B>): readonly [Set<A>, Set<B>];
+function partition_<A>(self: Set<A>, predicate: P.Predicate<A>): readonly [Set<A>, Set<A>];
+function partition_<A>(self: Set<A>, predicate: P.Predicate<A>): readonly [Set<A>, Set<A>] {
+  const excluded = new globalThis.Set<A>();
+  const included = new globalThis.Set<A>();
+
+  for (const value of self) {
+    if (predicate(value)) {
+      included.add(value);
+    } else {
+      excluded.add(value);
+    }
+  }
+
+  return [excluded, included];
+}
+
+/** @internal */
+function map_<A, B>(self: Set<A>, f: (value: A) => B, equivalence: Equivalence.Equivalence<B>): Set<B> {
+  const out = new globalThis.Set<B>();
+
+  for (const value of self) {
+    const mapped = f(value);
+
+    if (!elem_(out, mapped, equivalence)) {
+      out.add(mapped);
+    }
+  }
+
+  return out;
+}
+
+/** @internal */
+function chain_<A, B>(self: Set<A>, f: (value: A) => Set<B>, equivalence: Equivalence.Equivalence<B>): Set<B> {
+  const out = new globalThis.Set<B>();
+
+  for (const value of self) {
+    for (const mapped of f(value)) {
+      if (!elem_(out, mapped, equivalence)) {
+        out.add(mapped);
+      }
+    }
+  }
+
+  return out;
+}
+
+/** @internal */
+function filterMap_<A, B>(self: Set<A>, f: (value: A) => O.Option<B>, equivalence: Equivalence.Equivalence<B>): Set<B> {
+  const out = new globalThis.Set<B>();
+
+  for (const value of self) {
+    O.match(f(value), {
+      onNone: () => undefined,
+      onSome: (mapped) => {
+        if (!elem_(out, mapped, equivalence)) {
+          out.add(mapped);
+        }
+      },
+    });
+  }
+
+  return out;
+}
+
+/** @internal */
+function compact_<A>(self: Set<O.Option<A>>, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  return filterMap_(self, identity, equivalence);
+}
+
+/** @internal */
+function partitionMap_<A, E, B>(
+  self: Set<A>,
+  f: (value: A) => Result.Result<B, E>,
+  failureEquivalence: Equivalence.Equivalence<E>,
+  successEquivalence: Equivalence.Equivalence<B>
+): readonly [Set<E>, Set<B>] {
+  const failures = new globalThis.Set<E>();
+  const successes = new globalThis.Set<B>();
+
+  for (const value of self) {
+    Result.match(f(value), {
+      onFailure: (failure) => {
+        if (!elem_(failures, failure, failureEquivalence)) {
+          failures.add(failure);
+        }
+      },
+      onSuccess: (success) => {
+        if (!elem_(successes, success, successEquivalence)) {
+          successes.add(success);
+        }
+      },
+    });
+  }
+
+  return [failures, successes];
+}
+
+/** @internal */
+function separate_<E, A>(
+  self: Set<Result.Result<A, E>>,
+  failureEquivalence: Equivalence.Equivalence<E>,
+  successEquivalence: Equivalence.Equivalence<A>
+): readonly [Set<E>, Set<A>] {
+  return partitionMap_(self, identity, failureEquivalence, successEquivalence);
+}
+
+/** @internal */
+function intersection_<A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  return filter_(self, (value) => elem_(that, value, equivalence));
+}
+
+/** @internal */
+function difference_<A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  return filter_(self, (value) => !elem_(that, value, equivalence));
+}
+
+/** @internal */
+function union_<A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  const out = new globalThis.Set(self);
+
+  for (const value of that) {
+    if (!elem_(out, value, equivalence)) {
+      out.add(value);
+    }
+  }
+
+  return out;
+}
+
+/** @internal */
+function insert_<A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  if (elem_(self, value, equivalence)) {
+    return self;
+  }
+
+  const out = new globalThis.Set(self);
+  out.add(value);
+  return out;
+}
+
+/** @internal */
+function remove_<A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  return filter_(self, (item) => !equivalence(value, item));
+}
+
+/** @internal */
+function toggle_<A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  return elem_(self, value, equivalence) ? remove_(self, value, equivalence) : insert_(self, value, equivalence);
+}
+
+/** @internal */
+function reduce_<A, B>(self: Set<A>, initial: B, f: (accumulator: B, value: A) => B, order: Order.Order<A>): B {
+  return A.reduce(toArray_(self, order), initial, f);
+}
+
+/** @internal */
+function concat_<A>(self: Set<A>, values: Iterable<A>, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  return union_(self, fromArray_(A.fromIterable(values), equivalence), equivalence);
+}
+
+/** @internal */
+function replace_<A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A> {
+  return insert_(remove_(self, value, equivalence), value, equivalence);
+}
+
+/** @internal */
+function make_<A>(order: Order.Order<A>, equivalence?: Equivalence.Equivalence<A>): SetSchemaExtensions<A> {
+  const eq: Equivalence.Equivalence<A> = equivalence ?? ((self, that) => order(self, that) === 0);
+
+  return {
+    empty: () => new globalThis.Set<A>(),
+    from: (values) => fromArray_(A.fromIterable(values), eq),
+    fromArray: (values) => fromArray_(values, eq),
+    toArray: (self) => toArray_(self, order),
+    elem: dual(2, (self: Set<A>, value: A): boolean => elem_(self, value, eq)),
+    isSubset: dual(2, (self: Set<A>, that: Set<A>): boolean => isSubset_(self, that, eq)),
+    insert: dual(2, (self: Set<A>, value: A): Set<A> => insert_(self, value, eq)),
+    remove: dual(2, (self: Set<A>, value: A): Set<A> => remove_(self, value, eq)),
+    toggle: dual(2, (self: Set<A>, value: A): Set<A> => toggle_(self, value, eq)),
+    replace: dual(2, (self: Set<A>, value: A): Set<A> => replace_(self, value, eq)),
+    concat: dual(2, (self: Set<A>, values: Iterable<A>): Set<A> => concat_(self, values, eq)),
+    union: dual(2, (self: Set<A>, that: Set<A>): Set<A> => union_(self, that, eq)),
+    intersection: dual(2, (self: Set<A>, that: Set<A>): Set<A> => intersection_(self, that, eq)),
+    difference: dual(2, (self: Set<A>, that: Set<A>): Set<A> => difference_(self, that, eq)),
+    map: dual(2, (self: Set<A>, f: (value: A) => A): Set<A> => map_(self, f, eq)),
+    filter: dual(2, filter_),
+    filterMap: dual(2, (self: Set<A>, f: (value: A) => O.Option<A>): Set<A> => filterMap_(self, f, eq)),
+    reduce: dual(
+      3,
+      <B>(self: Set<A>, initial: B, f: (accumulator: B, value: A) => B): B => reduce_(self, initial, f, order)
+    ),
+  };
+}

--- a/packages/common/utils/src/Set.ts
+++ b/packages/common/utils/src/Set.ts
@@ -5,13 +5,13 @@
  * @since 0.0.0
  */
 
+import { Result } from "effect";
 import * as A from "effect/Array";
 import type * as Equivalence from "effect/Equivalence";
 import { dual, identity } from "effect/Function";
 import * as O from "effect/Option";
 import type * as Order from "effect/Order";
 import type * as P from "effect/Predicate";
-import * as Result from "effect/Result";
 
 /**
  * Mutable Set alias used when a helper intentionally returns a writable copy.
@@ -49,13 +49,83 @@ export type MutableSet<A> = globalThis.Set<A>;
 export type Set<A> = ReadonlySet<A>;
 
 /**
- * Shared empty readonly Set value.
+ * Equivalence options used by Set helpers that need custom equality.
+ *
+ * @example
+ * ```ts
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const options: Set.EquivalenceOptions<number> = {
+ *   equivalence: Equivalence.strictEqual<number>(),
+ * }
+ *
+ * void options
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export interface EquivalenceOptions<A> {
+  readonly equivalence: Equivalence.Equivalence<A>;
+}
+
+/**
+ * Equivalence options used when splitting `Result` values.
+ *
+ * @example
+ * ```ts
+ * import * as Equivalence from "effect/Equivalence"
+ * import { Set } from "@beep/utils"
+ *
+ * const options: Set.ResultEquivalenceOptions<string, number> = {
+ *   failureEquivalence: Equivalence.strictEqual<string>(),
+ *   successEquivalence: Equivalence.strictEqual<number>(),
+ * }
+ *
+ * void options
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export interface ResultEquivalenceOptions<E, A> {
+  readonly failureEquivalence: Equivalence.Equivalence<E>;
+  readonly successEquivalence: Equivalence.Equivalence<A>;
+}
+
+/**
+ * Options for reducing Set values in deterministic order.
+ *
+ * @example
+ * ```ts
+ * import * as Order from "effect/Order"
+ * import { Set } from "@beep/utils"
+ *
+ * const options: Set.ReduceOptions<number, string> = {
+ *   f: (out, value) => `${out}${value}`,
+ *   order: Order.Number,
+ * }
+ *
+ * void options
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export interface ReduceOptions<A, B> {
+  readonly f: (accumulator: B, value: A) => B;
+  readonly order: Order.Order<A>;
+}
+
+/**
+ * Create a fresh empty readonly Set.
  *
  * @example
  * ```ts
  * import { Set } from "@beep/utils"
  *
- * const size = Set.empty.size
+ * const size = Set.empty().size
  *
  * void size
  * ```
@@ -63,7 +133,9 @@ export type Set<A> = ReadonlySet<A>;
  * @category constructors
  * @since 0.0.0
  */
-export const empty: Set<never> = new globalThis.Set<never>();
+export function empty(): Set<never> {
+  return new globalThis.Set<never>();
+}
 
 /**
  * Clone a mutable Set into a readonly Set.
@@ -136,8 +208,9 @@ export function singleton<A>(value: A): Set<A> {
  * import * as Equivalence from "effect/Equivalence"
  * import { Set } from "@beep/utils"
  *
- * const dataFirst = Set.fromArray([1, 1, 2], Equivalence.strictEqual<number>())
- * const dataLast = pipe([1, 2, 2], Set.fromArray(Equivalence.strictEqual<number>()))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.fromArray([1, 1, 2], options)
+ * const dataLast = pipe([1, 2, 2], Set.fromArray(options))
  *
  * void dataFirst
  * void dataLast
@@ -147,9 +220,12 @@ export function singleton<A>(value: A): Set<A> {
  * @since 0.0.0
  */
 export const fromArray: {
-  <A>(equivalence: Equivalence.Equivalence<A>): (self: ReadonlyArray<A>) => Set<A>;
-  <A>(self: ReadonlyArray<A>, equivalence: Equivalence.Equivalence<A>): Set<A>;
-} = dual(2, fromArray_);
+  <A>(options: EquivalenceOptions<A>): (self: ReadonlyArray<A>) => Set<A>;
+  <A>(self: ReadonlyArray<A>, options: EquivalenceOptions<A>): Set<A>;
+} = dual(
+  2,
+  <A>(self: ReadonlyArray<A>, options: EquivalenceOptions<A>): Set<A> => fromArray_(self, options.equivalence)
+);
 
 /**
  * Convert a Set to a sorted readonly array.
@@ -257,7 +333,15 @@ export const findFirstMap: {
 export const some: {
   <A>(predicate: P.Predicate<A>): (self: Set<A>) => boolean;
   <A>(self: Set<A>, predicate: P.Predicate<A>): boolean;
-} = dual(2, <A>(self: Set<A>, predicate: P.Predicate<A>): boolean => A.some(A.fromIterable(self), predicate));
+} = dual(2, <A>(self: Set<A>, predicate: P.Predicate<A>): boolean => {
+  for (const value of self) {
+    if (predicate(value)) {
+      return true;
+    }
+  }
+
+  return false;
+});
 
 /**
  * Test whether every Set value satisfies a predicate.
@@ -283,7 +367,15 @@ export const some: {
 export const every: {
   <A>(predicate: P.Predicate<A>): (self: Set<A>) => boolean;
   <A>(self: Set<A>, predicate: P.Predicate<A>): boolean;
-} = dual(2, <A>(self: Set<A>, predicate: P.Predicate<A>): boolean => A.every(A.fromIterable(self), predicate));
+} = dual(2, <A>(self: Set<A>, predicate: P.Predicate<A>): boolean => {
+  for (const value of self) {
+    if (!predicate(value)) {
+      return false;
+    }
+  }
+
+  return true;
+});
 
 /**
  * Test whether a value is equivalent to an element in the Set.
@@ -297,9 +389,9 @@ export const every: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set(["a", "b"])
- * const eq = Equivalence.strictEqual<string>()
- * const dataFirst = Set.elem(values, "a", eq)
- * const dataLast = pipe(values, Set.elem("c", eq))
+ * const options = { equivalence: Equivalence.strictEqual<string>() }
+ * const dataFirst = Set.elem(values, "a", options)
+ * const dataLast = pipe(values, Set.elem("c", options))
  *
  * void dataFirst
  * void dataLast
@@ -309,9 +401,11 @@ export const every: {
  * @since 0.0.0
  */
 export const elem: {
-  <A>(value: NoInfer<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => boolean;
-  <A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): boolean;
-} = dual(3, elem_);
+  <A>(value: NoInfer<A>, options: EquivalenceOptions<A>): (self: Set<A>) => boolean;
+  <A>(self: Set<A>, value: A, options: EquivalenceOptions<A>): boolean;
+} = dual(3, <A>(self: Set<A>, value: A, options: EquivalenceOptions<A>): boolean =>
+  elem_(self, value, options.equivalence)
+);
 
 /**
  * Test whether every value in one Set is present in another Set.
@@ -326,9 +420,9 @@ export const elem: {
  *
  * const left = new globalThis.Set([1, 2])
  * const right = new globalThis.Set([1, 2, 3])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.isSubset(left, right, eq)
- * const dataLast = pipe(left, Set.isSubset(right, eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.isSubset(left, right, options)
+ * const dataLast = pipe(left, Set.isSubset(right, options))
  *
  * void dataFirst
  * void dataLast
@@ -338,9 +432,11 @@ export const elem: {
  * @since 0.0.0
  */
 export const isSubset: {
-  <A>(that: Set<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => boolean;
-  <A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): boolean;
-} = dual(3, isSubset_);
+  <A>(that: Set<A>, options: EquivalenceOptions<A>): (self: Set<A>) => boolean;
+  <A>(self: Set<A>, that: Set<A>, options: EquivalenceOptions<A>): boolean;
+} = dual(3, <A>(self: Set<A>, that: Set<A>, options: EquivalenceOptions<A>): boolean =>
+  isSubset_(self, that, options.equivalence)
+);
 
 /**
  * Keep values that satisfy a predicate or refinement.
@@ -410,9 +506,9 @@ export const partition: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set(["a", "bb", "cc"])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.map(values, (value) => value.length, eq)
- * const dataLast = pipe(values, Set.map((value) => value.length + 1, eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.map(values, (value) => value.length, options)
+ * const dataLast = pipe(values, Set.map((value) => value.length + 1, options))
  *
  * void dataFirst
  * void dataLast
@@ -422,9 +518,12 @@ export const partition: {
  * @since 0.0.0
  */
 export const map: {
-  <A, B>(f: (value: A) => B, equivalence: Equivalence.Equivalence<B>): (self: Set<A>) => Set<B>;
-  <A, B>(self: Set<A>, f: (value: A) => B, equivalence: Equivalence.Equivalence<B>): Set<B>;
-} = dual(3, map_);
+  <A, B>(f: (value: A) => B, options: EquivalenceOptions<B>): (self: Set<A>) => Set<B>;
+  <A, B>(self: Set<A>, f: (value: A) => B, options: EquivalenceOptions<B>): Set<B>;
+} = dual(
+  3,
+  <A, B>(self: Set<A>, f: (value: A) => B, options: EquivalenceOptions<B>): Set<B> => map_(self, f, options.equivalence)
+);
 
 /**
  * Flat-map Set values while deduplicating flattened values with an equivalence.
@@ -438,9 +537,9 @@ export const map: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set([1, 2])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.chain(values, (value) => new globalThis.Set([value, value + 1]), eq)
- * const dataLast = pipe(values, Set.chain((value) => new globalThis.Set([value * 2]), eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.chain(values, (value) => new globalThis.Set([value, value + 1]), options)
+ * const dataLast = pipe(values, Set.chain((value) => new globalThis.Set([value * 2]), options))
  *
  * void dataFirst
  * void dataLast
@@ -450,9 +549,13 @@ export const map: {
  * @since 0.0.0
  */
 export const chain: {
-  <A, B>(f: (value: A) => Set<B>, equivalence: Equivalence.Equivalence<B>): (self: Set<A>) => Set<B>;
-  <A, B>(self: Set<A>, f: (value: A) => Set<B>, equivalence: Equivalence.Equivalence<B>): Set<B>;
-} = dual(3, chain_);
+  <A, B>(f: (value: A) => Set<B>, options: EquivalenceOptions<B>): (self: Set<A>) => Set<B>;
+  <A, B>(self: Set<A>, f: (value: A) => Set<B>, options: EquivalenceOptions<B>): Set<B>;
+} = dual(
+  3,
+  <A, B>(self: Set<A>, f: (value: A) => Set<B>, options: EquivalenceOptions<B>): Set<B> =>
+    chain_(self, f, options.equivalence)
+);
 
 /**
  * Map Set values to `Option` and keep the present mapped values.
@@ -467,9 +570,9 @@ export const chain: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set([1, 2, 3])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.filterMap(values, (value) => value > 1 ? O.some(value * 2) : O.none(), eq)
- * const dataLast = pipe(values, Set.filterMap((value) => value > 2 ? O.some(value) : O.none(), eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.filterMap(values, (value) => value > 1 ? O.some(value * 2) : O.none(), options)
+ * const dataLast = pipe(values, Set.filterMap((value) => value > 2 ? O.some(value) : O.none(), options))
  *
  * void dataFirst
  * void dataLast
@@ -479,9 +582,13 @@ export const chain: {
  * @since 0.0.0
  */
 export const filterMap: {
-  <A, B>(f: (value: A) => O.Option<B>, equivalence: Equivalence.Equivalence<B>): (self: Set<A>) => Set<B>;
-  <A, B>(self: Set<A>, f: (value: A) => O.Option<B>, equivalence: Equivalence.Equivalence<B>): Set<B>;
-} = dual(3, filterMap_);
+  <A, B>(f: (value: A) => O.Option<B>, options: EquivalenceOptions<B>): (self: Set<A>) => Set<B>;
+  <A, B>(self: Set<A>, f: (value: A) => O.Option<B>, options: EquivalenceOptions<B>): Set<B>;
+} = dual(
+  3,
+  <A, B>(self: Set<A>, f: (value: A) => O.Option<B>, options: EquivalenceOptions<B>): Set<B> =>
+    filterMap_(self, f, options.equivalence)
+);
 
 /**
  * Remove `Option.none` values and unwrap present values.
@@ -496,9 +603,9 @@ export const filterMap: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set([O.some(1), O.none(), O.some(1)])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.compact(values, eq)
- * const dataLast = pipe(values, Set.compact(eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.compact(values, options)
+ * const dataLast = pipe(values, Set.compact(options))
  *
  * void dataFirst
  * void dataLast
@@ -508,9 +615,9 @@ export const filterMap: {
  * @since 0.0.0
  */
 export const compact: {
-  <A>(equivalence: Equivalence.Equivalence<A>): (self: Set<O.Option<A>>) => Set<A>;
-  <A>(self: Set<O.Option<A>>, equivalence: Equivalence.Equivalence<A>): Set<A>;
-} = dual(2, compact_);
+  <A>(options: EquivalenceOptions<A>): (self: Set<O.Option<A>>) => Set<A>;
+  <A>(self: Set<O.Option<A>>, options: EquivalenceOptions<A>): Set<A>;
+} = dual(2, <A>(self: Set<O.Option<A>>, options: EquivalenceOptions<A>): Set<A> => compact_(self, options.equivalence));
 
 /**
  * Split `Result` values into failures and successes.
@@ -525,8 +632,12 @@ export const compact: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set([Result.fail("missing"), Result.succeed(1)])
- * const dataFirst = Set.separate(values, Equivalence.strictEqual<string>(), Equivalence.strictEqual<number>())
- * const dataLast = pipe(values, Set.separate(Equivalence.strictEqual<string>(), Equivalence.strictEqual<number>()))
+ * const options = {
+ *   failureEquivalence: Equivalence.strictEqual<string>(),
+ *   successEquivalence: Equivalence.strictEqual<number>(),
+ * }
+ * const dataFirst = Set.separate(values, options)
+ * const dataLast = pipe(values, Set.separate(options))
  *
  * void dataFirst
  * void dataLast
@@ -536,16 +647,13 @@ export const compact: {
  * @since 0.0.0
  */
 export const separate: {
-  <E, A>(
-    failureEquivalence: Equivalence.Equivalence<E>,
-    successEquivalence: Equivalence.Equivalence<A>
-  ): (self: Set<Result.Result<A, E>>) => readonly [Set<E>, Set<A>];
-  <E, A>(
-    self: Set<Result.Result<A, E>>,
-    failureEquivalence: Equivalence.Equivalence<E>,
-    successEquivalence: Equivalence.Equivalence<A>
-  ): readonly [Set<E>, Set<A>];
-} = dual(3, separate_);
+  <E, A>(options: ResultEquivalenceOptions<E, A>): (self: Set<Result.Result<A, E>>) => readonly [Set<E>, Set<A>];
+  <E, A>(self: Set<Result.Result<A, E>>, options: ResultEquivalenceOptions<E, A>): readonly [Set<E>, Set<A>];
+} = dual(
+  2,
+  <E, A>(self: Set<Result.Result<A, E>>, options: ResultEquivalenceOptions<E, A>): readonly [Set<E>, Set<A>] =>
+    separate_(self, options.failureEquivalence, options.successEquivalence)
+);
 
 /**
  * Partition values with a function returning `Result`.
@@ -561,8 +669,12 @@ export const separate: {
  *
  * const values = new globalThis.Set([1, 2, 3])
  * const split = (value: number) => value % 2 === 0 ? Result.succeed(value) : Result.fail(`${value}`)
- * const dataFirst = Set.partitionMap(values, split, Equivalence.strictEqual<string>(), Equivalence.strictEqual<number>())
- * const dataLast = pipe(values, Set.partitionMap(split, Equivalence.strictEqual<string>(), Equivalence.strictEqual<number>()))
+ * const options = {
+ *   failureEquivalence: Equivalence.strictEqual<string>(),
+ *   successEquivalence: Equivalence.strictEqual<number>(),
+ * }
+ * const dataFirst = Set.partitionMap(values, split, options)
+ * const dataLast = pipe(values, Set.partitionMap(split, options))
  *
  * void dataFirst
  * void dataLast
@@ -574,16 +686,21 @@ export const separate: {
 export const partitionMap: {
   <A, E, B>(
     f: (value: A) => Result.Result<B, E>,
-    failureEquivalence: Equivalence.Equivalence<E>,
-    successEquivalence: Equivalence.Equivalence<B>
+    options: ResultEquivalenceOptions<E, B>
   ): (self: Set<A>) => readonly [Set<E>, Set<B>];
   <A, E, B>(
     self: Set<A>,
     f: (value: A) => Result.Result<B, E>,
-    failureEquivalence: Equivalence.Equivalence<E>,
-    successEquivalence: Equivalence.Equivalence<B>
+    options: ResultEquivalenceOptions<E, B>
   ): readonly [Set<E>, Set<B>];
-} = dual(4, partitionMap_);
+} = dual(
+  3,
+  <A, E, B>(
+    self: Set<A>,
+    f: (value: A) => Result.Result<B, E>,
+    options: ResultEquivalenceOptions<E, B>
+  ): readonly [Set<E>, Set<B>] => partitionMap_(self, f, options.failureEquivalence, options.successEquivalence)
+);
 
 /**
  * Keep values that are present in both Sets.
@@ -598,9 +715,9 @@ export const partitionMap: {
  *
  * const left = new globalThis.Set([1, 2])
  * const right = new globalThis.Set([2, 3])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.intersection(left, right, eq)
- * const dataLast = pipe(left, Set.intersection(right, eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.intersection(left, right, options)
+ * const dataLast = pipe(left, Set.intersection(right, options))
  *
  * void dataFirst
  * void dataLast
@@ -610,9 +727,13 @@ export const partitionMap: {
  * @since 0.0.0
  */
 export const intersection: {
-  <A>(that: Set<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
-  <A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A>;
-} = dual(3, intersection_);
+  <A>(that: Set<A>, options: EquivalenceOptions<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, that: Set<A>, options: EquivalenceOptions<A>): Set<A>;
+} = dual(
+  3,
+  <A>(self: Set<A>, that: Set<A>, options: EquivalenceOptions<A>): Set<A> =>
+    intersection_(self, that, options.equivalence)
+);
 
 /**
  * Keep values from the first Set that are absent from the second Set.
@@ -627,9 +748,9 @@ export const intersection: {
  *
  * const left = new globalThis.Set([1, 2, 3])
  * const right = new globalThis.Set([2])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.difference(left, right, eq)
- * const dataLast = pipe(left, Set.difference(right, eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.difference(left, right, options)
+ * const dataLast = pipe(left, Set.difference(right, options))
  *
  * void dataFirst
  * void dataLast
@@ -639,9 +760,13 @@ export const intersection: {
  * @since 0.0.0
  */
 export const difference: {
-  <A>(that: Set<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
-  <A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A>;
-} = dual(3, difference_);
+  <A>(that: Set<A>, options: EquivalenceOptions<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, that: Set<A>, options: EquivalenceOptions<A>): Set<A>;
+} = dual(
+  3,
+  <A>(self: Set<A>, that: Set<A>, options: EquivalenceOptions<A>): Set<A> =>
+    difference_(self, that, options.equivalence)
+);
 
 /**
  * Combine two Sets while deduplicating with an equivalence.
@@ -656,9 +781,9 @@ export const difference: {
  *
  * const left = new globalThis.Set([1, 2])
  * const right = new globalThis.Set([2, 3])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.union(left, right, eq)
- * const dataLast = pipe(left, Set.union(right, eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.union(left, right, options)
+ * const dataLast = pipe(left, Set.union(right, options))
  *
  * void dataFirst
  * void dataLast
@@ -668,9 +793,12 @@ export const difference: {
  * @since 0.0.0
  */
 export const union: {
-  <A>(that: Set<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
-  <A>(self: Set<A>, that: Set<A>, equivalence: Equivalence.Equivalence<A>): Set<A>;
-} = dual(3, union_);
+  <A>(that: Set<A>, options: EquivalenceOptions<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, that: Set<A>, options: EquivalenceOptions<A>): Set<A>;
+} = dual(
+  3,
+  <A>(self: Set<A>, that: Set<A>, options: EquivalenceOptions<A>): Set<A> => union_(self, that, options.equivalence)
+);
 
 /**
  * Insert a value when an equivalent value is not already present.
@@ -684,9 +812,9 @@ export const union: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set([1, 2])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.insert(values, 3, eq)
- * const dataLast = pipe(values, Set.insert(4, eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.insert(values, 3, options)
+ * const dataLast = pipe(values, Set.insert(4, options))
  *
  * void dataFirst
  * void dataLast
@@ -696,9 +824,12 @@ export const union: {
  * @since 0.0.0
  */
 export const insert: {
-  <A>(value: NoInfer<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
-  <A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A>;
-} = dual(3, insert_);
+  <A>(value: NoInfer<A>, options: EquivalenceOptions<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, value: A, options: EquivalenceOptions<A>): Set<A>;
+} = dual(
+  3,
+  <A>(self: Set<A>, value: A, options: EquivalenceOptions<A>): Set<A> => insert_(self, value, options.equivalence)
+);
 
 /**
  * Remove values equivalent to the provided value.
@@ -712,9 +843,9 @@ export const insert: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set([1, 2, 3])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.remove(values, 2, eq)
- * const dataLast = pipe(values, Set.remove(3, eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.remove(values, 2, options)
+ * const dataLast = pipe(values, Set.remove(3, options))
  *
  * void dataFirst
  * void dataLast
@@ -724,9 +855,12 @@ export const insert: {
  * @since 0.0.0
  */
 export const remove: {
-  <A>(value: NoInfer<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
-  <A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A>;
-} = dual(3, remove_);
+  <A>(value: NoInfer<A>, options: EquivalenceOptions<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, value: A, options: EquivalenceOptions<A>): Set<A>;
+} = dual(
+  3,
+  <A>(self: Set<A>, value: A, options: EquivalenceOptions<A>): Set<A> => remove_(self, value, options.equivalence)
+);
 
 /**
  * Remove a present value or insert an absent value.
@@ -740,9 +874,9 @@ export const remove: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set([1, 2])
- * const eq = Equivalence.strictEqual<number>()
- * const dataFirst = Set.toggle(values, 2, eq)
- * const dataLast = pipe(values, Set.toggle(3, eq))
+ * const options = { equivalence: Equivalence.strictEqual<number>() }
+ * const dataFirst = Set.toggle(values, 2, options)
+ * const dataLast = pipe(values, Set.toggle(3, options))
  *
  * void dataFirst
  * void dataLast
@@ -752,9 +886,12 @@ export const remove: {
  * @since 0.0.0
  */
 export const toggle: {
-  <A>(value: NoInfer<A>, equivalence: Equivalence.Equivalence<A>): (self: Set<A>) => Set<A>;
-  <A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalence<A>): Set<A>;
-} = dual(3, toggle_);
+  <A>(value: NoInfer<A>, options: EquivalenceOptions<A>): (self: Set<A>) => Set<A>;
+  <A>(self: Set<A>, value: A, options: EquivalenceOptions<A>): Set<A>;
+} = dual(
+  3,
+  <A>(self: Set<A>, value: A, options: EquivalenceOptions<A>): Set<A> => toggle_(self, value, options.equivalence)
+);
 
 /**
  * Reduce Set values in sorted order.
@@ -768,8 +905,9 @@ export const toggle: {
  * import { Set } from "@beep/utils"
  *
  * const values = new globalThis.Set([3, 1, 2])
- * const dataFirst = Set.reduce(values, "", (out, value) => `${out}${value}`, Order.Number)
- * const dataLast = pipe(values, Set.reduce("", (out, value) => `${out}${value}`, Order.Number))
+ * const options = { f: (out: string, value: number) => `${out}${value}`, order: Order.Number }
+ * const dataFirst = Set.reduce(values, "", options)
+ * const dataLast = pipe(values, Set.reduce("", options))
  *
  * void dataFirst
  * void dataLast
@@ -779,9 +917,12 @@ export const toggle: {
  * @since 0.0.0
  */
 export const reduce: {
-  <A, B>(initial: B, f: (accumulator: B, value: A) => B, order: Order.Order<A>): (self: Set<A>) => B;
-  <A, B>(self: Set<A>, initial: B, f: (accumulator: B, value: A) => B, order: Order.Order<A>): B;
-} = dual(4, reduce_);
+  <A, B>(initial: B, options: ReduceOptions<A, B>): (self: Set<A>) => B;
+  <A, B>(self: Set<A>, initial: B, options: ReduceOptions<A, B>): B;
+} = dual(
+  3,
+  <A, B>(self: Set<A>, initial: B, options: ReduceOptions<A, B>): B => reduce_(self, initial, options.f, options.order)
+);
 
 /**
  * Bound Set helpers for one ordered/equivalent value domain.
@@ -801,7 +942,11 @@ export const reduce: {
  * @category models
  * @since 0.0.0
  */
-export interface SetSchemaExtensions<A> {
+export interface BoundSetHelpers<A> {
+  readonly chain: {
+    (f: (value: A) => Set<A>): (self: Set<A>) => Set<A>;
+    (self: Set<A>, f: (value: A) => Set<A>): Set<A>;
+  };
   readonly concat: {
     (values: Iterable<A>): (self: Set<A>) => Set<A>;
     (self: Set<A>, values: Iterable<A>): Set<A>;
@@ -887,20 +1032,11 @@ export interface SetSchemaExtensions<A> {
  * @category constructors
  * @since 0.0.0
  */
-export const make: <A>(order: Order.Order<A>, equivalence?: Equivalence.Equivalence<A>) => SetSchemaExtensions<A> =
-  make_;
+export const make: <A>(order: Order.Order<A>, equivalence?: Equivalence.Equivalence<A>) => BoundSetHelpers<A> = make_;
 
 /** @internal */
 function fromArray_<A>(self: ReadonlyArray<A>, equivalence: Equivalence.Equivalence<A>): Set<A> {
-  const out = new globalThis.Set<A>();
-
-  for (const value of self) {
-    if (!elem_(out, value, equivalence)) {
-      out.add(value);
-    }
-  }
-
-  return out;
+  return new globalThis.Set(A.dedupeWith(self, equivalence));
 }
 
 /** @internal */
@@ -917,7 +1053,15 @@ function findFirst_<A>(self: Set<A>, predicate: P.Predicate<A>): O.Option<A> {
 
 /** @internal */
 function findFirstMap_<A, B>(self: Set<A>, f: (value: A) => O.Option<B>): O.Option<B> {
-  return A.findFirst(self, f);
+  for (const value of self) {
+    const mapped = f(value);
+
+    if (O.isSome(mapped)) {
+      return mapped;
+    }
+  }
+
+  return O.none();
 }
 
 /** @internal */
@@ -1004,14 +1148,11 @@ function filterMap_<A, B>(self: Set<A>, f: (value: A) => O.Option<B>, equivalenc
   const out = new globalThis.Set<B>();
 
   for (const value of self) {
-    O.match(f(value), {
-      onNone: () => undefined,
-      onSome: (mapped) => {
-        if (!elem_(out, mapped, equivalence)) {
-          out.add(mapped);
-        }
-      },
-    });
+    const mapped = f(value);
+
+    if (O.isSome(mapped) && !elem_(out, mapped.value, equivalence)) {
+      out.add(mapped.value);
+    }
   }
 
   return out;
@@ -1119,7 +1260,7 @@ function replace_<A>(self: Set<A>, value: A, equivalence: Equivalence.Equivalenc
 }
 
 /** @internal */
-function make_<A>(order: Order.Order<A>, equivalence?: Equivalence.Equivalence<A>): SetSchemaExtensions<A> {
+function make_<A>(order: Order.Order<A>, equivalence?: Equivalence.Equivalence<A>): BoundSetHelpers<A> {
   const eq: Equivalence.Equivalence<A> = equivalence ?? ((self, that) => order(self, that) === 0);
 
   return {
@@ -1137,6 +1278,7 @@ function make_<A>(order: Order.Order<A>, equivalence?: Equivalence.Equivalence<A
     union: dual(2, (self: Set<A>, that: Set<A>): Set<A> => union_(self, that, eq)),
     intersection: dual(2, (self: Set<A>, that: Set<A>): Set<A> => intersection_(self, that, eq)),
     difference: dual(2, (self: Set<A>, that: Set<A>): Set<A> => difference_(self, that, eq)),
+    chain: dual(2, (self: Set<A>, f: (value: A) => Set<A>): Set<A> => chain_(self, f, eq)),
     map: dual(2, (self: Set<A>, f: (value: A) => A): Set<A> => map_(self, f, eq)),
     filter: dual(2, filter_),
     filterMap: dual(2, (self: Set<A>, f: (value: A) => O.Option<A>): Set<A> => filterMap_(self, f, eq)),

--- a/packages/common/utils/src/index.ts
+++ b/packages/common/utils/src/index.ts
@@ -81,6 +81,13 @@ export * as P from "./Predicate.ts";
  */
 export * from "./Random.ts";
 /**
+ * Readonly Set utilities with custom equivalence support.
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export * as Set from "./Set.ts";
+/**
  * String utilities extending `effect/String` with typed case conversions.
  *
  * @category utilities

--- a/packages/common/utils/test/Set.test.ts
+++ b/packages/common/utils/test/Set.test.ts
@@ -1,0 +1,273 @@
+import { Set } from "@beep/utils";
+import * as Equivalence from "effect/Equivalence";
+import { pipe } from "effect/Function";
+import * as O from "effect/Option";
+import * as Order from "effect/Order";
+import * as Result from "effect/Result";
+import { describe, expect, it } from "vitest";
+
+const numberEq = Equivalence.strictEqual<number>();
+const stringEq = Equivalence.strictEqual<string>();
+
+const fromNumbers = (values: ReadonlyArray<number>): Set.Set<number> => Set.fromArray(values, numberEq);
+const toNumbers = (values: Set.Set<number>): ReadonlyArray<number> => Set.toArray(values, Order.Number);
+
+describe("@beep/utils Set constructors and boundaries", () => {
+  it("exposes empty and clones mutable boundaries", () => {
+    expect(Set.empty.size).toBe(0);
+
+    const mutable = new globalThis.Set([1, 2]);
+    const readonly = Set.fromMutable(mutable);
+    mutable.add(3);
+
+    expect(toNumbers(readonly)).toEqual([1, 2]);
+
+    const mutableCopy = Set.toMutable(readonly);
+    mutableCopy.add(4);
+
+    expect(toNumbers(readonly)).toEqual([1, 2]);
+    expect(Set.toArray(mutableCopy, Order.Number)).toEqual([1, 2, 4]);
+    expect(toNumbers(Set.singleton(9))).toEqual([9]);
+  });
+
+  it("deduplicates from arrays and sorts in both invocation styles", () => {
+    const dataFirst = Set.fromArray([3, 1, 3, 2], numberEq);
+    const dataLast = pipe([2, 2, 1], Set.fromArray(numberEq));
+
+    expect(Set.toArray(dataFirst, Order.Number)).toEqual([1, 2, 3]);
+    expect(pipe(dataFirst, Set.toArray(Order.Number))).toEqual([1, 2, 3]);
+    expect(Set.toArray(dataLast, Order.Number)).toEqual([1, 2]);
+  });
+});
+
+describe("@beep/utils Set find helpers", () => {
+  it("finds values and maps first present values", () => {
+    const values = fromNumbers([1, 2, 3]);
+
+    expect(Set.findFirst(values, (value) => value > 1)).toEqual(O.some(2));
+    expect(
+      pipe(
+        values,
+        Set.findFirst((value) => value > 4)
+      )
+    ).toEqual(O.none());
+    expect(Set.findFirstMap(values, (value) => (value > 2 ? O.some(`${value}`) : O.none()))).toEqual(O.some("3"));
+    expect(
+      pipe(
+        values,
+        Set.findFirstMap((value) => (value > 4 ? O.some(value) : O.none()))
+      )
+    ).toEqual(O.none());
+  });
+
+  it("supports refinement overloads", () => {
+    type Tagged =
+      | { readonly _tag: "number"; readonly value: number }
+      | { readonly _tag: "string"; readonly value: string };
+
+    const isNumberTagged = (value: Tagged): value is Extract<Tagged, { readonly _tag: "number" }> =>
+      value._tag === "number";
+    const values: Set.Set<Tagged> = new globalThis.Set([
+      { _tag: "string", value: "one" },
+      { _tag: "number", value: 1 },
+    ]);
+
+    expect(Set.findFirst(values, isNumberTagged)).toEqual(O.some({ _tag: "number", value: 1 }));
+  });
+});
+
+describe("@beep/utils Set predicates", () => {
+  it("checks predicates, element membership, and subset relationships", () => {
+    const values = fromNumbers([1, 2, 3]);
+
+    expect(Set.some(values, (value) => value === 2)).toBe(true);
+    expect(
+      pipe(
+        values,
+        Set.some((value) => value > 3)
+      )
+    ).toBe(false);
+    expect(Set.every(values, (value) => value > 0)).toBe(true);
+    expect(
+      pipe(
+        values,
+        Set.every((value) => value < 3)
+      )
+    ).toBe(false);
+    expect(Set.elem(values, 2, numberEq)).toBe(true);
+    expect(pipe(values, Set.elem(4, numberEq))).toBe(false);
+    expect(Set.isSubset(fromNumbers([1, 2]), values, numberEq)).toBe(true);
+    expect(pipe(fromNumbers([1, 4]), Set.isSubset(values, numberEq))).toBe(false);
+  });
+});
+
+describe("@beep/utils Set filtering", () => {
+  it("filters and partitions values", () => {
+    const values = fromNumbers([1, 2, 3, 4]);
+
+    expect(toNumbers(Set.filter(values, (value) => value > 1))).toEqual([2, 3, 4]);
+    expect(
+      toNumbers(
+        pipe(
+          values,
+          Set.filter((value) => value < 3)
+        )
+      )
+    ).toEqual([1, 2]);
+
+    const [odds, evens] = Set.partition(values, (value) => value % 2 === 0);
+    const [small, large] = pipe(
+      values,
+      Set.partition((value) => value > 2)
+    );
+
+    expect(toNumbers(odds)).toEqual([1, 3]);
+    expect(toNumbers(evens)).toEqual([2, 4]);
+    expect(toNumbers(small)).toEqual([1, 2]);
+    expect(toNumbers(large)).toEqual([3, 4]);
+  });
+
+  it("filterMaps and compacts optional values with deduplication", () => {
+    const values = fromNumbers([2, 3, 4]);
+    const optionalValues = new globalThis.Set([O.some(1), O.none<number>(), O.some(1)]);
+
+    expect(toNumbers(Set.filterMap(values, (value) => (value % 2 === 0 ? O.some(1) : O.none()), numberEq))).toEqual([
+      1,
+    ]);
+    expect(
+      toNumbers(
+        pipe(
+          values,
+          Set.filterMap((value) => (value > 3 ? O.some(value) : O.none()), numberEq)
+        )
+      )
+    ).toEqual([4]);
+    expect(toNumbers(Set.compact(optionalValues, numberEq))).toEqual([1]);
+    expect(toNumbers(pipe(optionalValues, Set.compact(numberEq)))).toEqual([1]);
+  });
+
+  it("partitions and separates Result values", () => {
+    const values = fromNumbers([1, 2, 3, 4]);
+    const split = (value: number): Result.Result<number, string> =>
+      value % 2 === 0 ? Result.succeed(value / 2) : Result.fail("odd");
+
+    const [failures, successes] = Set.partitionMap(values, split, stringEq, numberEq);
+    const [noFailures, duplicateSuccesses] = pipe(
+      fromNumbers([2, 4]),
+      Set.partitionMap(() => Result.succeed(1), stringEq, numberEq)
+    );
+    const resultValues: Set.Set<Result.Result<number, string>> = new globalThis.Set([
+      Result.fail("left"),
+      Result.fail("left"),
+      Result.succeed(1),
+      Result.succeed(1),
+    ]);
+    const [left, right] = Set.separate(resultValues, stringEq, numberEq);
+    const [leftDataLast, rightDataLast] = pipe(resultValues, Set.separate(stringEq, numberEq));
+
+    expect(Set.toArray(failures, Order.String)).toEqual(["odd"]);
+    expect(toNumbers(successes)).toEqual([1, 2]);
+    expect(Set.toArray(noFailures, Order.String)).toEqual([]);
+    expect(toNumbers(duplicateSuccesses)).toEqual([1]);
+    expect(Set.toArray(left, Order.String)).toEqual(["left"]);
+    expect(toNumbers(right)).toEqual([1]);
+    expect(Set.toArray(leftDataLast, Order.String)).toEqual(["left"]);
+    expect(toNumbers(rightDataLast)).toEqual([1]);
+  });
+});
+
+describe("@beep/utils Set algebra", () => {
+  it("maps and chains with output equivalence", () => {
+    const words = new globalThis.Set(["a", "bb", "cc"]);
+    const values = fromNumbers([1, 2]);
+
+    expect(toNumbers(Set.map(words, (value) => value.length, numberEq))).toEqual([1, 2]);
+    expect(
+      toNumbers(
+        pipe(
+          words,
+          Set.map((value) => value.length + 10, numberEq)
+        )
+      )
+    ).toEqual([11, 12]);
+    expect(toNumbers(Set.chain(values, (value) => fromNumbers([value, value + 1]), numberEq))).toEqual([1, 2, 3]);
+    expect(
+      toNumbers(
+        pipe(
+          values,
+          Set.chain((value) => fromNumbers([value * 2]), numberEq)
+        )
+      )
+    ).toEqual([2, 4]);
+  });
+
+  it("combines, intersects, and subtracts sets", () => {
+    const left = fromNumbers([1, 2, 3]);
+    const right = fromNumbers([2, 4]);
+
+    expect(toNumbers(Set.intersection(left, right, numberEq))).toEqual([2]);
+    expect(toNumbers(pipe(left, Set.intersection(right, numberEq)))).toEqual([2]);
+    expect(toNumbers(Set.difference(left, right, numberEq))).toEqual([1, 3]);
+    expect(toNumbers(pipe(left, Set.difference(right, numberEq)))).toEqual([1, 3]);
+    expect(toNumbers(Set.union(left, right, numberEq))).toEqual([1, 2, 3, 4]);
+    expect(toNumbers(pipe(left, Set.union(right, numberEq)))).toEqual([1, 2, 3, 4]);
+  });
+
+  it("inserts, removes, toggles, and reduces values", () => {
+    const values = fromNumbers([1, 2]);
+    const unchanged = Set.insert(values, 2, numberEq);
+    const ordered = fromNumbers([3, 1, 2]);
+
+    expect(unchanged).toBe(values);
+    expect(toNumbers(pipe(values, Set.insert(3, numberEq)))).toEqual([1, 2, 3]);
+    expect(toNumbers(Set.remove(values, 1, numberEq))).toEqual([2]);
+    expect(toNumbers(pipe(values, Set.remove(2, numberEq)))).toEqual([1]);
+    expect(toNumbers(Set.toggle(values, 1, numberEq))).toEqual([2]);
+    expect(toNumbers(pipe(values, Set.toggle(3, numberEq)))).toEqual([1, 2, 3]);
+    expect(Set.reduce(ordered, "", (out, value) => `${out}${value}`, Order.Number)).toBe("123");
+    expect(
+      pipe(
+        ordered,
+        Set.reduce(0, (out, value) => out + value, Order.Number)
+      )
+    ).toBe(6);
+  });
+});
+
+describe("@beep/utils Set.make", () => {
+  it("binds helpers to an ordered value domain", () => {
+    const numbers = Set.make(Order.Number);
+    const base = numbers.from([3, 1, 2, 2]);
+
+    expect(numbers.empty().size).toBe(0);
+    expect(numbers.toArray(base)).toEqual([1, 2, 3]);
+    expect(numbers.toArray(numbers.fromArray([2, 2, 1]))).toEqual([1, 2]);
+    expect(numbers.elem(base, 2)).toBe(true);
+    expect(pipe(base, numbers.elem(4))).toBe(false);
+    expect(numbers.isSubset(numbers.from([1, 2]), base)).toBe(true);
+    expect(pipe(numbers.from([1, 4]), numbers.isSubset(base))).toBe(false);
+    expect(numbers.toArray(numbers.insert(base, 4))).toEqual([1, 2, 3, 4]);
+    expect(numbers.toArray(pipe(base, numbers.remove(2)))).toEqual([1, 3]);
+    expect(numbers.toArray(numbers.toggle(base, 2))).toEqual([1, 3]);
+    expect(numbers.toArray(pipe(base, numbers.toggle(4)))).toEqual([1, 2, 3, 4]);
+    expect(numbers.toArray(numbers.concat(base, [3, 4, 4]))).toEqual([1, 2, 3, 4]);
+    expect(numbers.toArray(numbers.union(base, numbers.from([3, 5])))).toEqual([1, 2, 3, 5]);
+    expect(numbers.toArray(numbers.intersection(base, numbers.from([2, 4])))).toEqual([2]);
+    expect(numbers.toArray(numbers.difference(base, numbers.from([2])))).toEqual([1, 3]);
+    expect(numbers.toArray(numbers.map(base, (value) => value % 2))).toEqual([0, 1]);
+    expect(numbers.toArray(numbers.filter(base, (value) => value > 1))).toEqual([2, 3]);
+    expect(numbers.toArray(numbers.filterMap(base, (value) => (value > 1 ? O.some(value - 1) : O.none())))).toEqual([
+      1, 2,
+    ]);
+    expect(numbers.reduce(base, "", (out, value) => `${out}${value}`)).toBe("123");
+  });
+
+  it("accepts a custom equivalence", () => {
+    const caseInsensitiveEq = Equivalence.make<string>((self, that) => self.toLowerCase() === that.toLowerCase());
+    const strings = Set.make(Order.String, caseInsensitiveEq);
+    const values = strings.from(["a", "A", "b"]);
+
+    expect(strings.toArray(values)).toEqual(["a", "b"]);
+    expect(strings.toArray(strings.replace(values, "A"))).toEqual(["A", "b"]);
+  });
+});

--- a/packages/common/utils/test/Set.test.ts
+++ b/packages/common/utils/test/Set.test.ts
@@ -8,13 +8,15 @@ import { describe, expect, it } from "vitest";
 
 const numberEq = Equivalence.strictEqual<number>();
 const stringEq = Equivalence.strictEqual<string>();
+const numberEqOptions: Set.EquivalenceOptions<number> = { equivalence: numberEq };
 
-const fromNumbers = (values: ReadonlyArray<number>): Set.Set<number> => Set.fromArray(values, numberEq);
+const fromNumbers = (values: ReadonlyArray<number>): Set.Set<number> => Set.fromArray(values, numberEqOptions);
 const toNumbers = (values: Set.Set<number>): ReadonlyArray<number> => Set.toArray(values, Order.Number);
 
 describe("@beep/utils Set constructors and boundaries", () => {
   it("exposes empty and clones mutable boundaries", () => {
-    expect(Set.empty.size).toBe(0);
+    expect(Set.empty().size).toBe(0);
+    expect(Set.empty()).not.toBe(Set.empty());
 
     const mutable = new globalThis.Set([1, 2]);
     const readonly = Set.fromMutable(mutable);
@@ -31,8 +33,8 @@ describe("@beep/utils Set constructors and boundaries", () => {
   });
 
   it("deduplicates from arrays and sorts in both invocation styles", () => {
-    const dataFirst = Set.fromArray([3, 1, 3, 2], numberEq);
-    const dataLast = pipe([2, 2, 1], Set.fromArray(numberEq));
+    const dataFirst = Set.fromArray([3, 1, 3, 2], numberEqOptions);
+    const dataLast = pipe([2, 2, 1], Set.fromArray(numberEqOptions));
 
     expect(Set.toArray(dataFirst, Order.Number)).toEqual([1, 2, 3]);
     expect(pipe(dataFirst, Set.toArray(Order.Number))).toEqual([1, 2, 3]);
@@ -94,10 +96,10 @@ describe("@beep/utils Set predicates", () => {
         Set.every((value) => value < 3)
       )
     ).toBe(false);
-    expect(Set.elem(values, 2, numberEq)).toBe(true);
-    expect(pipe(values, Set.elem(4, numberEq))).toBe(false);
-    expect(Set.isSubset(fromNumbers([1, 2]), values, numberEq)).toBe(true);
-    expect(pipe(fromNumbers([1, 4]), Set.isSubset(values, numberEq))).toBe(false);
+    expect(Set.elem(values, 2, numberEqOptions)).toBe(true);
+    expect(pipe(values, Set.elem(4, numberEqOptions))).toBe(false);
+    expect(Set.isSubset(fromNumbers([1, 2]), values, numberEqOptions)).toBe(true);
+    expect(pipe(fromNumbers([1, 4]), Set.isSubset(values, numberEqOptions))).toBe(false);
   });
 });
 
@@ -131,30 +133,34 @@ describe("@beep/utils Set filtering", () => {
     const values = fromNumbers([2, 3, 4]);
     const optionalValues = new globalThis.Set([O.some(1), O.none<number>(), O.some(1)]);
 
-    expect(toNumbers(Set.filterMap(values, (value) => (value % 2 === 0 ? O.some(1) : O.none()), numberEq))).toEqual([
-      1,
-    ]);
+    expect(
+      toNumbers(Set.filterMap(values, (value) => (value % 2 === 0 ? O.some(1) : O.none()), numberEqOptions))
+    ).toEqual([1]);
     expect(
       toNumbers(
         pipe(
           values,
-          Set.filterMap((value) => (value > 3 ? O.some(value) : O.none()), numberEq)
+          Set.filterMap((value) => (value > 3 ? O.some(value) : O.none()), numberEqOptions)
         )
       )
     ).toEqual([4]);
-    expect(toNumbers(Set.compact(optionalValues, numberEq))).toEqual([1]);
-    expect(toNumbers(pipe(optionalValues, Set.compact(numberEq)))).toEqual([1]);
+    expect(toNumbers(Set.compact(optionalValues, numberEqOptions))).toEqual([1]);
+    expect(toNumbers(pipe(optionalValues, Set.compact(numberEqOptions)))).toEqual([1]);
   });
 
   it("partitions and separates Result values", () => {
     const values = fromNumbers([1, 2, 3, 4]);
     const split = (value: number): Result.Result<number, string> =>
       value % 2 === 0 ? Result.succeed(value / 2) : Result.fail("odd");
+    const resultOptions: Set.ResultEquivalenceOptions<string, number> = {
+      failureEquivalence: stringEq,
+      successEquivalence: numberEq,
+    };
 
-    const [failures, successes] = Set.partitionMap(values, split, stringEq, numberEq);
+    const [failures, successes] = Set.partitionMap(values, split, resultOptions);
     const [noFailures, duplicateSuccesses] = pipe(
       fromNumbers([2, 4]),
-      Set.partitionMap(() => Result.succeed(1), stringEq, numberEq)
+      Set.partitionMap(() => Result.succeed(1), resultOptions)
     );
     const resultValues: Set.Set<Result.Result<number, string>> = new globalThis.Set([
       Result.fail("left"),
@@ -162,8 +168,8 @@ describe("@beep/utils Set filtering", () => {
       Result.succeed(1),
       Result.succeed(1),
     ]);
-    const [left, right] = Set.separate(resultValues, stringEq, numberEq);
-    const [leftDataLast, rightDataLast] = pipe(resultValues, Set.separate(stringEq, numberEq));
+    const [left, right] = Set.separate(resultValues, resultOptions);
+    const [leftDataLast, rightDataLast] = pipe(resultValues, Set.separate(resultOptions));
 
     expect(Set.toArray(failures, Order.String)).toEqual(["odd"]);
     expect(toNumbers(successes)).toEqual([1, 2]);
@@ -181,21 +187,23 @@ describe("@beep/utils Set algebra", () => {
     const words = new globalThis.Set(["a", "bb", "cc"]);
     const values = fromNumbers([1, 2]);
 
-    expect(toNumbers(Set.map(words, (value) => value.length, numberEq))).toEqual([1, 2]);
+    expect(toNumbers(Set.map(words, (value) => value.length, numberEqOptions))).toEqual([1, 2]);
     expect(
       toNumbers(
         pipe(
           words,
-          Set.map((value) => value.length + 10, numberEq)
+          Set.map((value) => value.length + 10, numberEqOptions)
         )
       )
     ).toEqual([11, 12]);
-    expect(toNumbers(Set.chain(values, (value) => fromNumbers([value, value + 1]), numberEq))).toEqual([1, 2, 3]);
+    expect(toNumbers(Set.chain(values, (value) => fromNumbers([value, value + 1]), numberEqOptions))).toEqual([
+      1, 2, 3,
+    ]);
     expect(
       toNumbers(
         pipe(
           values,
-          Set.chain((value) => fromNumbers([value * 2]), numberEq)
+          Set.chain((value) => fromNumbers([value * 2]), numberEqOptions)
         )
       )
     ).toEqual([2, 4]);
@@ -205,32 +213,27 @@ describe("@beep/utils Set algebra", () => {
     const left = fromNumbers([1, 2, 3]);
     const right = fromNumbers([2, 4]);
 
-    expect(toNumbers(Set.intersection(left, right, numberEq))).toEqual([2]);
-    expect(toNumbers(pipe(left, Set.intersection(right, numberEq)))).toEqual([2]);
-    expect(toNumbers(Set.difference(left, right, numberEq))).toEqual([1, 3]);
-    expect(toNumbers(pipe(left, Set.difference(right, numberEq)))).toEqual([1, 3]);
-    expect(toNumbers(Set.union(left, right, numberEq))).toEqual([1, 2, 3, 4]);
-    expect(toNumbers(pipe(left, Set.union(right, numberEq)))).toEqual([1, 2, 3, 4]);
+    expect(toNumbers(Set.intersection(left, right, numberEqOptions))).toEqual([2]);
+    expect(toNumbers(pipe(left, Set.intersection(right, numberEqOptions)))).toEqual([2]);
+    expect(toNumbers(Set.difference(left, right, numberEqOptions))).toEqual([1, 3]);
+    expect(toNumbers(pipe(left, Set.difference(right, numberEqOptions)))).toEqual([1, 3]);
+    expect(toNumbers(Set.union(left, right, numberEqOptions))).toEqual([1, 2, 3, 4]);
+    expect(toNumbers(pipe(left, Set.union(right, numberEqOptions)))).toEqual([1, 2, 3, 4]);
   });
 
   it("inserts, removes, toggles, and reduces values", () => {
     const values = fromNumbers([1, 2]);
-    const unchanged = Set.insert(values, 2, numberEq);
+    const unchanged = Set.insert(values, 2, numberEqOptions);
     const ordered = fromNumbers([3, 1, 2]);
 
     expect(unchanged).toBe(values);
-    expect(toNumbers(pipe(values, Set.insert(3, numberEq)))).toEqual([1, 2, 3]);
-    expect(toNumbers(Set.remove(values, 1, numberEq))).toEqual([2]);
-    expect(toNumbers(pipe(values, Set.remove(2, numberEq)))).toEqual([1]);
-    expect(toNumbers(Set.toggle(values, 1, numberEq))).toEqual([2]);
-    expect(toNumbers(pipe(values, Set.toggle(3, numberEq)))).toEqual([1, 2, 3]);
-    expect(Set.reduce(ordered, "", (out, value) => `${out}${value}`, Order.Number)).toBe("123");
-    expect(
-      pipe(
-        ordered,
-        Set.reduce(0, (out, value) => out + value, Order.Number)
-      )
-    ).toBe(6);
+    expect(toNumbers(pipe(values, Set.insert(3, numberEqOptions)))).toEqual([1, 2, 3]);
+    expect(toNumbers(Set.remove(values, 1, numberEqOptions))).toEqual([2]);
+    expect(toNumbers(pipe(values, Set.remove(2, numberEqOptions)))).toEqual([1]);
+    expect(toNumbers(Set.toggle(values, 1, numberEqOptions))).toEqual([2]);
+    expect(toNumbers(pipe(values, Set.toggle(3, numberEqOptions)))).toEqual([1, 2, 3]);
+    expect(Set.reduce(ordered, "", { f: (out, value) => `${out}${value}`, order: Order.Number })).toBe("123");
+    expect(pipe(ordered, Set.reduce(0, { f: (out, value) => out + value, order: Order.Number }))).toBe(6);
   });
 });
 
@@ -238,6 +241,7 @@ describe("@beep/utils Set.make", () => {
   it("binds helpers to an ordered value domain", () => {
     const numbers = Set.make(Order.Number);
     const base = numbers.from([3, 1, 2, 2]);
+    const isSmallNumber = (value: number): value is 1 | 2 => value < 3;
 
     expect(numbers.empty().size).toBe(0);
     expect(numbers.toArray(base)).toEqual([1, 2, 3]);
@@ -254,8 +258,11 @@ describe("@beep/utils Set.make", () => {
     expect(numbers.toArray(numbers.union(base, numbers.from([3, 5])))).toEqual([1, 2, 3, 5]);
     expect(numbers.toArray(numbers.intersection(base, numbers.from([2, 4])))).toEqual([2]);
     expect(numbers.toArray(numbers.difference(base, numbers.from([2])))).toEqual([1, 3]);
+    expect(numbers.toArray(numbers.chain(base, (value) => numbers.from([value, value + 1])))).toEqual([1, 2, 3, 4]);
     expect(numbers.toArray(numbers.map(base, (value) => value % 2))).toEqual([0, 1]);
     expect(numbers.toArray(numbers.filter(base, (value) => value > 1))).toEqual([2, 3]);
+    const narrowed: Set.Set<1 | 2> = numbers.filter(base, isSmallNumber);
+    expect(numbers.toArray(narrowed)).toEqual([1, 2]);
     expect(numbers.toArray(numbers.filterMap(base, (value) => (value > 1 ? O.some(value - 1) : O.none())))).toEqual([
       1, 2,
     ]);


### PR DESCRIPTION
## Summary
- add the `@beep/utils` Set namespace export
- implement dual data-first/data-last Set helpers with private `@internal` underscore helpers
- add focused unit tests covering the Set module and `Set.make` bound helpers

## Validation
- `bun run --cwd packages/common/utils audit`
- `bunx --bun vitest run test/Set.test.ts --coverage --coverage.include=src/Set.ts --coverage.thresholds.lines=100 --coverage.thresholds.functions=100 --coverage.thresholds.branches=100 --coverage.thresholds.statements=100`
- `bun run --cwd packages/common/utils docgen` exits successfully

Note: docgen currently reports non-blocking example typecheck warnings in existing `NodeUrl.ts` examples on `origin/main`; the new Set examples are not the source of those warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `Set` utility module providing comprehensive immutable set operations with support for custom equality semantics and flexible ordering.

* **Tests**
  * Added extensive test coverage for all Set operations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->