### PR TITLE
chore(acp): hoist schema compiler helpers

### DIFF
--- a/.changeset/quiet-acp-hoists.md
+++ b/.changeset/quiet-acp-hoists.md
@@ -1,0 +1,4 @@
+---
+---
+
+Record the ACP schema helper hoist and upstream parity cleanup without forcing a package release from this internal driver maintenance branch.

--- a/packages/drivers/acp/scripts/generate.ts
+++ b/packages/drivers/acp/scripts/generate.ts
@@ -74,6 +74,12 @@ class UpstreamJsonSchema extends S.Class<UpstreamJsonSchema>($I`UpstreamJsonSche
   })
 ) {}
 
+const decodeUpstreamSchema = S.decodeEffect(S.fromJsonString(UpstreamJsonSchema));
+const decodeMetaJson = S.decodeEffect(S.fromJsonString(MetaJson));
+const encodeAgentMethods = S.encodeEffect(S.fromJsonString(MetaJson.fields.agentMethods));
+const encodeClientMethods = S.encodeEffect(S.fromJsonString(MetaJson.fields.clientMethods));
+const encodeVersion = S.encodeEffect(S.fromJsonString(MetaJson.fields.version));
+
 const getGeneratedPaths = Effect.fn("getGeneratedPaths")(function* () {
   const path = yield* Path.Path;
   const generatedDir = path.join(import.meta.dirname, "..", "src", "_generated");
@@ -120,12 +126,9 @@ const downloadSchemas = Effect.fn("downloadSchemas")(function* (tag: string) {
   );
 });
 
-const readJsonFile = Effect.fn("readJsonFile")(function* <
-  SchemaValue extends S.Top & { readonly DecodingServices: never },
->(schema: SchemaValue, filePath: string) {
+const readFileString = Effect.fn("readFileString")(function* (filePath: string) {
   const fs = yield* FileSystem.FileSystem;
-  const raw = yield* fs.readFileString(filePath);
-  return yield* S.decodeEffect(S.fromJsonString(schema))(raw);
+  return yield* fs.readFileString(filePath);
 });
 
 const writeGeneratedFiles = Effect.fn("writeGeneratedFiles")(function* (schemaOutput: string, metaOutput: string) {
@@ -280,8 +283,8 @@ const generateSchemas = Effect.fn("generateSchemas")(function* (skipDownload: bo
     yield* downloadSchemas(CURRENT_SCHEMA_RELEASE);
   }
 
-  const upstreamSchema = yield* readJsonFile(UpstreamJsonSchema, upstreamSchemaPath);
-  const upstreamMeta = yield* readJsonFile(MetaJson, upstreamMetaPath);
+  const upstreamSchema = yield* readFileString(upstreamSchemaPath).pipe(Effect.flatMap(decodeUpstreamSchema));
+  const upstreamMeta = yield* readFileString(upstreamMetaPath).pipe(Effect.flatMap(decodeMetaJson));
   const normalizedDefinitions = R.map(upstreamSchema.$defs, normalizeNullableTypes);
 
   const sortedEntries = pipe(
@@ -341,21 +344,17 @@ const generateSchemas = Effect.fn("generateSchemas")(function* (skipDownload: bo
     "",
     renderMetaConst(
       "AGENT_METHODS",
-      yield* S.encodeEffect(S.fromJsonString(MetaJson.fields.agentMethods))(upstreamMeta.agentMethods),
+      yield* encodeAgentMethods(upstreamMeta.agentMethods),
       "Generated ACP agent method lookup table."
     ),
     "",
     renderMetaConst(
       "CLIENT_METHODS",
-      yield* S.encodeEffect(S.fromJsonString(MetaJson.fields.clientMethods))(upstreamMeta.clientMethods),
+      yield* encodeClientMethods(upstreamMeta.clientMethods),
       "Generated ACP client method lookup table."
     ),
     "",
-    renderMetaConst(
-      "PROTOCOL_VERSION",
-      yield* S.encodeEffect(S.fromJsonString(MetaJson.fields.version))(upstreamMeta.version),
-      "Generated ACP protocol version."
-    ),
+    renderMetaConst("PROTOCOL_VERSION", yield* encodeVersion(upstreamMeta.version), "Generated ACP protocol version."),
     "",
   ].join("\n");
 

--- a/packages/drivers/acp/src/internal/shared.ts
+++ b/packages/drivers/acp/src/internal/shared.ts
@@ -4,6 +4,8 @@ import type { RpcClientError } from "effect/unstable/rpc";
 import * as AcpSchema from "../_generated/schema.gen.ts";
 import * as AcpError from "../errors.ts";
 
+const isAcpProtocolError = S.is(AcpSchema.Error);
+const isAcpRequestError = S.is(AcpError.AcpRequestError);
 const formatSchemaIssue = SchemaIssue.makeFormatterDefault();
 
 export const callRpc = <A>(
@@ -18,7 +20,7 @@ export const callRpc = <A>(
         })
       )
     ),
-    Effect.catchIf(S.is(AcpSchema.Error), (error) => Effect.fail(AcpError.AcpRequestError.fromProtocolError(error)))
+    Effect.catchIf(isAcpProtocolError, (error) => Effect.fail(AcpError.AcpRequestError.fromProtocolError(error)))
   );
 
 interface RunHandlerOptions<A, B> {
@@ -45,7 +47,7 @@ export const runHandler = Effect.fnUntraced(function* <A, B>({ handler, method, 
   }
   return yield* handler(payload).pipe(
     Effect.mapError((error) =>
-      S.is(AcpError.AcpRequestError)(error)
+      isAcpRequestError(error)
         ? error.toProtocolError()
         : AcpError.AcpRequestError.internalError(error.message).toProtocolError()
     )

--- a/packages/drivers/acp/src/protocol.ts
+++ b/packages/drivers/acp/src/protocol.ts
@@ -23,6 +23,8 @@ import * as AcpSchema from "./_generated/schema.gen.ts";
 import * as AcpError from "./errors.ts";
 
 const $I = $AcpId.create("protocol");
+const isAcpError = S.is(AcpError.AcpError);
+const isAcpRequestError = S.is(AcpError.AcpRequestError);
 
 /**
  * Structured log event emitted by the ACP protocol adapter.
@@ -527,7 +529,7 @@ export const makeAcpPatchedProtocol = Effect.fn($I`makeAcpPatchedProtocol`)(func
     ),
     Effect.matchEffect({
       onFailure: (error) => {
-        const normalized: AcpError.AcpError = S.is(AcpError.AcpError)(error)
+        const normalized: AcpError.AcpError = isAcpError(error)
           ? error
           : new AcpError.AcpTransportError({
               cause: error,
@@ -626,7 +628,7 @@ function isProtocolError(value: unknown): value is { code: number; message: stri
 }
 
 function normalizeToRequestError(error: AcpError.AcpError): AcpError.AcpRequestError {
-  return S.is(AcpError.AcpRequestError)(error) ? error : AcpError.AcpRequestError.internalError(error.message);
+  return isAcpRequestError(error) ? error : AcpError.AcpRequestError.internalError(error.message);
 }
 
 function toRpcClientError(error: AcpError.AcpError): RpcClientError.RpcClientError {

--- a/packages/drivers/acp/test/agent.test.ts
+++ b/packages/drivers/acp/test/agent.test.ts
@@ -22,6 +22,7 @@ const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String
 const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
 const decodeRequestPermissionRequest = Schema.decodeEffect(Schema.fromJsonString(RequestPermissionRequest));
 const decodeInitializeResponse = Schema.decodeEffect(Schema.fromJsonString(InitializeResponse));
+const decodeExtRequest = Schema.decodeEffect(Schema.fromJsonString(ExtRequest));
 
 it.effect("effect-acp agent handles core agent requests and outbound client requests", () =>
   Effect.gen(function* () {
@@ -184,9 +185,7 @@ it.effect("effect-acp agent uses distinct ids for RPC calls and extension reques
       const firstOutbound = yield* Queue.take(output);
       const secondOutbound = yield* Queue.take(output);
 
-      const decodedPermission = Schema.decodeEffect(Schema.fromJsonString(RequestPermissionRequest));
-      const decodedExt = Schema.decodeEffect(Schema.fromJsonString(ExtRequest));
-      const firstIsPermission = yield* decodedPermission(firstOutbound).pipe(
+      const firstIsPermission = yield* decodeRequestPermissionRequest(firstOutbound).pipe(
         Effect.match({
           onFailure: () => false,
           onSuccess: () => true,
@@ -194,9 +193,11 @@ it.effect("effect-acp agent uses distinct ids for RPC calls and extension reques
       );
 
       const permissionRequest = firstIsPermission
-        ? yield* decodedPermission(firstOutbound)
-        : yield* decodedPermission(secondOutbound);
-      const extRequest = firstIsPermission ? yield* decodedExt(secondOutbound) : yield* decodedExt(firstOutbound);
+        ? yield* decodeRequestPermissionRequest(firstOutbound)
+        : yield* decodeRequestPermissionRequest(secondOutbound);
+      const extRequest = firstIsPermission
+        ? yield* decodeExtRequest(secondOutbound)
+        : yield* decodeExtRequest(firstOutbound);
 
       assert.notEqual(permissionRequest.id, extRequest.id);
 

--- a/packages/drivers/acp/test/agent.test.ts
+++ b/packages/drivers/acp/test/agent.test.ts
@@ -20,6 +20,8 @@ const SessionCancelNotification = jsonRpcNotification("session/cancel", AcpSchem
 const ExtPingNotification = jsonRpcNotification("x/ping", Schema.Struct({ count: Schema.Number }));
 const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String }));
 const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
+const decodeRequestPermissionRequest = Schema.decodeEffect(Schema.fromJsonString(RequestPermissionRequest));
+const decodeInitializeResponse = Schema.decodeEffect(Schema.fromJsonString(InitializeResponse));
 
 it.effect("effect-acp agent handles core agent requests and outbound client requests", () =>
   Effect.gen(function* () {
@@ -66,9 +68,7 @@ it.effect("effect-acp agent handles core agent requests and outbound client requ
         })
         .pipe(Effect.forkScoped);
 
-      const permissionRequest = yield* Schema.decodeEffect(Schema.fromJsonString(RequestPermissionRequest))(
-        yield* Queue.take(output)
-      );
+      const permissionRequest = yield* decodeRequestPermissionRequest(yield* Queue.take(output));
       assert.equal(permissionRequest.jsonrpc, "2.0");
       assert.equal(permissionRequest.method, "session/request_permission");
       assert.deepEqual(permissionRequest.params, {
@@ -119,9 +119,7 @@ it.effect("effect-acp agent handles core agent requests and outbound client requ
         })
       );
 
-      const initResponse = yield* Schema.decodeEffect(Schema.fromJsonString(InitializeResponse))(
-        yield* Queue.take(output)
-      );
+      const initResponse = yield* decodeInitializeResponse(yield* Queue.take(output));
       assert.deepEqual(initResponse, {
         jsonrpc: "2.0",
         id: 2,

--- a/packages/drivers/acp/test/integration/client.integration.test.ts
+++ b/packages/drivers/acp/test/integration/client.integration.test.ts
@@ -19,8 +19,14 @@ import { encodeJsonl, jsonRpcRequest, jsonRpcResponse, makeInMemoryStdio } from 
 
 const InitializeRequest = jsonRpcRequest("initialize", AcpSchema.InitializeRequest);
 const InitializeResponse = jsonRpcResponse(AcpSchema.InitializeResponse);
-const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String }));
-const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
+const ExtRequestPayload = Schema.Struct({ hello: Schema.String });
+const ExtResponsePayload = Schema.Struct({ ok: Schema.Boolean });
+const TypedRequestPayload = Schema.Struct({ message: Schema.String });
+const TypedNotificationPayload = Schema.Struct({ count: Schema.Number });
+const ExtRequest = jsonRpcRequest("x/test", ExtRequestPayload);
+const ExtResponse = jsonRpcResponse(ExtResponsePayload);
+const decodeInitializeRequest = Schema.decodeEffect(Schema.fromJsonString(InitializeRequest));
+const decodeExtRequest = Schema.decodeEffect(Schema.fromJsonString(ExtRequest));
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../fixtures/acp-mock-peer.ts")
 );
@@ -73,7 +79,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
         yield* acp.handleElicitationComplete((notification) =>
           Ref.update(elicitationCompletions, (current) => [...current, notification])
         );
-        yield* acp.handleExtRequest("x/typed_request", Schema.Struct({ message: Schema.String }), (payload) =>
+        yield* acp.handleExtRequest("x/typed_request", TypedRequestPayload, (payload) =>
           Ref.update(typedRequests, (current) => [...current, payload]).pipe(
             Effect.as({
               ok: true,
@@ -81,7 +87,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
             })
           )
         );
-        yield* acp.handleExtNotification("x/typed_notification", Schema.Struct({ count: Schema.Number }), (payload) =>
+        yield* acp.handleExtNotification("x/typed_notification", TypedNotificationPayload, (payload) =>
           Ref.update(typedNotifications, (current) => [...current, payload])
         );
 
@@ -163,9 +169,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
             },
           })
         );
-        yield* acp.handleExtRequest("x/typed_request", Schema.Struct({ message: Schema.String }), () =>
-          Effect.succeed({ ok: true })
-        );
+        yield* acp.handleExtRequest("x/typed_request", TypedRequestPayload, () => Effect.succeed({ ok: true }));
 
         yield* acp.agent.initialize({
           protocolVersion: 1,
@@ -235,7 +239,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
             },
           })
         );
-        yield* acp.handleExtRequest("x/typed_request", Schema.Struct({ message: Schema.String }), (payload) =>
+        yield* acp.handleExtRequest("x/typed_request", TypedRequestPayload, (payload) =>
           Ref.update(typedRequests, (current) => [...current, payload]).pipe(
             Effect.as({
               ok: true,
@@ -243,7 +247,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
             })
           )
         );
-        yield* acp.handleExtNotification("x/typed_notification", Schema.Struct({ count: Schema.Number }), (payload) =>
+        yield* acp.handleExtNotification("x/typed_notification", TypedNotificationPayload, (payload) =>
           Ref.update(typedNotifications, (current) => [...current, payload])
         );
 
@@ -311,14 +315,8 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
             },
           })
         );
-        yield* acp.handleExtRequest("x/typed_request", Schema.Struct({ message: Schema.String }), () =>
-          Effect.succeed({ ok: true })
-        );
-        yield* acp.handleExtNotification(
-          "x/typed_notification",
-          Schema.Struct({ count: Schema.Number }),
-          () => Effect.void
-        );
+        yield* acp.handleExtRequest("x/typed_request", TypedRequestPayload, () => Effect.succeed({ ok: true }));
+        yield* acp.handleExtNotification("x/typed_notification", TypedNotificationPayload, () => Effect.void);
         yield* acp.handleSessionUpdate(() =>
           Effect.fail(AcpError.AcpRequestError.internalError("session update handler failed"))
         );
@@ -375,9 +373,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
       const firstOutbound = yield* Queue.take(output);
       const secondOutbound = yield* Queue.take(output);
 
-      const decodedInitialize = Schema.decodeEffect(Schema.fromJsonString(InitializeRequest));
-      const decodedExt = Schema.decodeEffect(Schema.fromJsonString(ExtRequest));
-      const firstIsInitialize = yield* decodedInitialize(firstOutbound).pipe(
+      const firstIsInitialize = yield* decodeInitializeRequest(firstOutbound).pipe(
         Effect.match({
           onFailure: () => false,
           onSuccess: () => true,
@@ -385,9 +381,11 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
       );
 
       const initializeRequest = firstIsInitialize
-        ? yield* decodedInitialize(firstOutbound)
-        : yield* decodedInitialize(secondOutbound);
-      const extRequest = firstIsInitialize ? yield* decodedExt(secondOutbound) : yield* decodedExt(firstOutbound);
+        ? yield* decodeInitializeRequest(firstOutbound)
+        : yield* decodeInitializeRequest(secondOutbound);
+      const extRequest = firstIsInitialize
+        ? yield* decodeExtRequest(secondOutbound)
+        : yield* decodeExtRequest(firstOutbound);
 
       assert.notEqual(initializeRequest.id, extRequest.id);
 

--- a/packages/drivers/acp/test/protocol.test.ts
+++ b/packages/drivers/acp/test/protocol.test.ts
@@ -33,6 +33,9 @@ const RequestPermissionRequest = jsonRpcRequest("session/request_permission", Ac
 const RequestPermissionResponse = jsonRpcResponse(AcpSchema.RequestPermissionResponse);
 const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String }));
 const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
+const decodeSessionCancelNotification = Schema.decodeEffect(Schema.fromJsonString(SessionCancelNotification));
+const decodeExtRequest = Schema.decodeEffect(Schema.fromJsonString(ExtRequest));
+const decodeRequestPermissionResponse = Schema.decodeEffect(Schema.fromJsonString(RequestPermissionResponse));
 const childProcessProtocolTestTimeout = 15_000;
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "fixtures/acp-mock-peer.ts")
@@ -68,7 +71,7 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
 
       yield* transport.notify("session/cancel", { sessionId: "session-1" });
       const outbound = yield* Queue.take(output);
-      assert.deepEqual(yield* Schema.decodeEffect(Schema.fromJsonString(SessionCancelNotification))(outbound), {
+      assert.deepEqual(yield* decodeSessionCancelNotification(outbound), {
         jsonrpc: "2.0",
         method: "session/cancel",
         params: {
@@ -184,7 +187,7 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
 
       const response = yield* transport.request("x/test", { hello: "world" }).pipe(Effect.forkScoped);
       const outbound = yield* Queue.take(output);
-      assert.deepEqual(yield* Schema.decodeEffect(Schema.fromJsonString(ExtRequest))(outbound), {
+      assert.deepEqual(yield* decodeExtRequest(outbound), {
         jsonrpc: "2.0",
         id: 1,
         method: "x/test",
@@ -272,7 +275,7 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
       });
 
       const outbound = yield* Queue.take(output);
-      assert.deepEqual(yield* Schema.decodeEffect(Schema.fromJsonString(RequestPermissionResponse))(outbound), {
+      assert.deepEqual(yield* decodeRequestPermissionResponse(outbound), {
         jsonrpc: "2.0",
         id: 0,
         result: {
@@ -300,7 +303,7 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
 
       const response = yield* transport.request("x/test", { hello: "world" }).pipe(Effect.forkScoped);
       const outbound = yield* Queue.take(output);
-      assert.deepEqual(yield* Schema.decodeEffect(Schema.fromJsonString(ExtRequest))(outbound), {
+      assert.deepEqual(yield* decodeExtRequest(outbound), {
         jsonrpc: "2.0",
         id: 1,
         method: "x/test",

--- a/packages/drivers/acp/vitest.config.ts
+++ b/packages/drivers/acp/vitest.config.ts
@@ -5,7 +5,7 @@ export default mergeConfig(
   shared,
   defineConfig({
     test: {
-      // Package-specific overrides
+      testTimeout: 15_000,
     },
   })
 );


### PR DESCRIPTION
## Summary
- Hoist ACP schema decoder/encoder/guard compiler construction to module scope in the generator, protocol internals, shared helpers, and ACP tests.
- Finish the test hoist pass for agent and integration request decoders.
- Stabilize ACP child-process integration tests with a package-local Vitest timeout.
- Add an empty changeset because this is internal/private package maintenance with no release bump.

## Verification
- bun run lint:fix
- bun run --cwd packages/drivers/acp beep:check:tests
- bun run --cwd packages/drivers/acp beep:test
- bun run --cwd packages/drivers/acp type-test
- bun run --cwd packages/drivers/acp beep:test:integration
- bun run --cwd packages/drivers/acp beep:lint
- bash scripts/run-github-checks.sh quality

## Review Notes
- No product/slice imports were introduced in packages/drivers/acp.
- Package exports remain explicit and keep internal/_generated subpaths blocked.
- ACP tests/dtslint continue to import through @beep/acp package aliases.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->