### PR TITLE
fix(ai-metrics): export fresh forwarder OTLP spans

### DIFF
--- a/.changeset/lazy-lilies-post.md
+++ b/.changeset/lazy-lilies-post.md
@@ -1,0 +1,4 @@
+---
+---
+
+Record the AI metrics forwarder OTLP export freshness fix without forcing a package release decision on this internal tooling branch.

--- a/apps/architecture-lab-proof/src/index.ts
+++ b/apps/architecture-lab-proof/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @beep/architecture-lab-proof
+ * Package entry point for `@beep/architecture-lab-proof`.
  *
  * @since 0.0.0
  */
@@ -8,4 +8,4 @@
  * @since 0.0.0
  * @category Configuration
  */
-export const VERSION = "0.0.0" as const
+export const VERSION = "0.0.0" as const;

--- a/initiatives/ai-metrics-stack/history/outputs/p6-proof-runner-isolation-and-runbook.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p6-proof-runner-isolation-and-runbook.md
@@ -60,6 +60,25 @@ move the proof data root.
   - HTTP status: `200`
   - `x-phoenix-server-version: 15.5.0`
 
+## Phoenix UI Interpretation
+
+The installed P6 proof runner remains pinned at the isolation commit until the
+credited proof window closes. During that window, Phoenix health should be
+interpreted alongside the local forwarder status artifact and derived DuckDB
+state.
+
+Phoenix's root-spans table can appear empty when the UI asks for root spans
+without treating orphan spans as roots. That state does not by itself prove
+collection stopped; confirm collection from `forwarder/status/latest.json`,
+derived turn counts, Parquet export paths, and Phoenix project trace counts.
+
+Phoenix sessions advance when derived agent spans carrying `session.id` are
+exported. Post-P6, the main checkout changes `forwarder run --otlp` so the
+scheduled path persists raw/derived data first and then records a tagged
+`otlpExport` status for the same ingest run. Do not update the pinned proof
+runner or re-render the installed timer with that behavior until after the
+credited proof window closes or is explicitly abandoned.
+
 ## Source Availability
 
 Recent source discovery remains Codex-only for the credited proof window:

--- a/packages/architecture-lab/client/src/index.ts
+++ b/packages/architecture-lab/client/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @beep/architecture-lab-client
+ * Package entry point for `@beep/architecture-lab-client`.
  *
  * @since 0.0.0
  */
@@ -8,4 +8,4 @@
  * @since 0.0.0
  * @category Configuration
  */
-export const VERSION = "0.0.0" as const
+export const VERSION = "0.0.0" as const;

--- a/packages/architecture-lab/config/src/index.ts
+++ b/packages/architecture-lab/config/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @beep/architecture-lab-config
+ * Package entry point for `@beep/architecture-lab-config`.
  *
  * @since 0.0.0
  */
@@ -8,4 +8,4 @@
  * @since 0.0.0
  * @category Configuration
  */
-export const VERSION = "0.0.0" as const
+export const VERSION = "0.0.0" as const;

--- a/packages/architecture-lab/domain/src/index.ts
+++ b/packages/architecture-lab/domain/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @beep/architecture-lab-domain
+ * Package entry point for `@beep/architecture-lab-domain`.
  *
  * @since 0.0.0
  */
@@ -8,4 +8,4 @@
  * @since 0.0.0
  * @category Configuration
  */
-export const VERSION = "0.0.0" as const
+export const VERSION = "0.0.0" as const;

--- a/packages/architecture-lab/server/src/index.ts
+++ b/packages/architecture-lab/server/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @beep/architecture-lab-server
+ * Package entry point for `@beep/architecture-lab-server`.
  *
  * @since 0.0.0
  */
@@ -8,4 +8,4 @@
  * @since 0.0.0
  * @category Configuration
  */
-export const VERSION = "0.0.0" as const
+export const VERSION = "0.0.0" as const;

--- a/packages/architecture-lab/tables/src/index.ts
+++ b/packages/architecture-lab/tables/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @beep/architecture-lab-tables
+ * Package entry point for `@beep/architecture-lab-tables`.
  *
  * @since 0.0.0
  */
@@ -8,4 +8,4 @@
  * @since 0.0.0
  * @category Configuration
  */
-export const VERSION = "0.0.0" as const
+export const VERSION = "0.0.0" as const;

--- a/packages/architecture-lab/ui/src/index.ts
+++ b/packages/architecture-lab/ui/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @beep/architecture-lab-ui
+ * Package entry point for `@beep/architecture-lab-ui`.
  *
  * @since 0.0.0
  */
@@ -8,4 +8,4 @@
  * @since 0.0.0
  * @category Configuration
  */
-export const VERSION = "0.0.0" as const
+export const VERSION = "0.0.0" as const;

--- a/packages/architecture-lab/use-cases/src/index.ts
+++ b/packages/architecture-lab/use-cases/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @beep/architecture-lab-use-cases
+ * Package entry point for `@beep/architecture-lab-use-cases`.
  *
  * @since 0.0.0
  */
@@ -8,4 +8,4 @@
  * @since 0.0.0
  * @category Configuration
  */
-export const VERSION = "0.0.0" as const
+export const VERSION = "0.0.0" as const;

--- a/packages/foundation/modeling/identity/src/packages.ts
+++ b/packages/foundation/modeling/identity/src/packages.ts
@@ -113,7 +113,15 @@ const composers = $I.compose(
   "xai",
   "acp",
   "openai-compat",
-  "workspace-tables", "architecture-lab-domain", "architecture-lab-use-cases", "architecture-lab-config", "architecture-lab-server", "architecture-lab-tables", "architecture-lab-client", "architecture-lab-ui", "architecture-lab-proof"
+  "workspace-tables",
+  "architecture-lab-domain",
+  "architecture-lab-use-cases",
+  "architecture-lab-config",
+  "architecture-lab-server",
+  "architecture-lab-tables",
+  "architecture-lab-client",
+  "architecture-lab-ui",
+  "architecture-lab-proof"
 );
 
 // --- foundation ---
@@ -900,64 +908,153 @@ export const $AcpId: Identity.IdentityComposer<"@beep/acp"> = composers.$AcpId;
 export const $OpenaiCompatId: Identity.IdentityComposer<"@beep/openai-compat"> = composers.$OpenaiCompatId;
 
 /**
+ * Identity composer for `@beep/workspace-tables`.
+ *
+ * @example
+ * ```typescript
+ * import { $WorkspaceTablesId } from "@beep/identity"
+ *
+ * const id = $WorkspaceTablesId.make("WorkspaceTable")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/workspace-tables">}
  */
 export const $WorkspaceTablesId: Identity.IdentityComposer<"@beep/workspace-tables"> = composers.$WorkspaceTablesId;
 
 /**
+ * Identity composer for `@beep/architecture-lab-domain`.
+ *
+ * @example
+ * ```typescript
+ * import { $ArchitectureLabDomainId } from "@beep/identity"
+ *
+ * const id = $ArchitectureLabDomainId.make("Specimen")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/architecture-lab-domain">}
  */
-export const $ArchitectureLabDomainId: Identity.IdentityComposer<"@beep/architecture-lab-domain"> = composers.$ArchitectureLabDomainId;
+export const $ArchitectureLabDomainId: Identity.IdentityComposer<"@beep/architecture-lab-domain"> =
+  composers.$ArchitectureLabDomainId;
 
 /**
+ * Identity composer for `@beep/architecture-lab-use-cases`.
+ *
+ * @example
+ * ```typescript
+ * import { $ArchitectureLabUseCasesId } from "@beep/identity"
+ *
+ * const id = $ArchitectureLabUseCasesId.make("SpecimenService")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/architecture-lab-use-cases">}
  */
-export const $ArchitectureLabUseCasesId: Identity.IdentityComposer<"@beep/architecture-lab-use-cases"> = composers.$ArchitectureLabUseCasesId;
+export const $ArchitectureLabUseCasesId: Identity.IdentityComposer<"@beep/architecture-lab-use-cases"> =
+  composers.$ArchitectureLabUseCasesId;
 
 /**
+ * Identity composer for `@beep/architecture-lab-config`.
+ *
+ * @example
+ * ```typescript
+ * import { $ArchitectureLabConfigId } from "@beep/identity"
+ *
+ * const id = $ArchitectureLabConfigId.make("Config")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/architecture-lab-config">}
  */
-export const $ArchitectureLabConfigId: Identity.IdentityComposer<"@beep/architecture-lab-config"> = composers.$ArchitectureLabConfigId;
+export const $ArchitectureLabConfigId: Identity.IdentityComposer<"@beep/architecture-lab-config"> =
+  composers.$ArchitectureLabConfigId;
 
 /**
+ * Identity composer for `@beep/architecture-lab-server`.
+ *
+ * @example
+ * ```typescript
+ * import { $ArchitectureLabServerId } from "@beep/identity"
+ *
+ * const id = $ArchitectureLabServerId.make("Layer")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/architecture-lab-server">}
  */
-export const $ArchitectureLabServerId: Identity.IdentityComposer<"@beep/architecture-lab-server"> = composers.$ArchitectureLabServerId;
+export const $ArchitectureLabServerId: Identity.IdentityComposer<"@beep/architecture-lab-server"> =
+  composers.$ArchitectureLabServerId;
 
 /**
+ * Identity composer for `@beep/architecture-lab-tables`.
+ *
+ * @example
+ * ```typescript
+ * import { $ArchitectureLabTablesId } from "@beep/identity"
+ *
+ * const id = $ArchitectureLabTablesId.make("SpecimenTable")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/architecture-lab-tables">}
  */
-export const $ArchitectureLabTablesId: Identity.IdentityComposer<"@beep/architecture-lab-tables"> = composers.$ArchitectureLabTablesId;
+export const $ArchitectureLabTablesId: Identity.IdentityComposer<"@beep/architecture-lab-tables"> =
+  composers.$ArchitectureLabTablesId;
 
 /**
+ * Identity composer for `@beep/architecture-lab-client`.
+ *
+ * @example
+ * ```typescript
+ * import { $ArchitectureLabClientId } from "@beep/identity"
+ *
+ * const id = $ArchitectureLabClientId.make("SpecimenClient")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/architecture-lab-client">}
  */
-export const $ArchitectureLabClientId: Identity.IdentityComposer<"@beep/architecture-lab-client"> = composers.$ArchitectureLabClientId;
+export const $ArchitectureLabClientId: Identity.IdentityComposer<"@beep/architecture-lab-client"> =
+  composers.$ArchitectureLabClientId;
 
 /**
+ * Identity composer for `@beep/architecture-lab-ui`.
+ *
+ * @example
+ * ```typescript
+ * import { $ArchitectureLabUiId } from "@beep/identity"
+ *
+ * const id = $ArchitectureLabUiId.make("SpecimenDetail")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/architecture-lab-ui">}
  */
-export const $ArchitectureLabUiId: Identity.IdentityComposer<"@beep/architecture-lab-ui"> = composers.$ArchitectureLabUiId;
+export const $ArchitectureLabUiId: Identity.IdentityComposer<"@beep/architecture-lab-ui"> =
+  composers.$ArchitectureLabUiId;
 
 /**
+ * Identity composer for `@beep/architecture-lab-proof`.
+ *
+ * @example
+ * ```typescript
+ * import { $ArchitectureLabProofId } from "@beep/identity"
+ *
+ * const id = $ArchitectureLabProofId.make("Proof")
+ * void id
+ * ```
+ *
  * @since 0.0.0
  * @category configuration
- * @type {Identity.IdentityComposer<"@beep/architecture-lab-proof">}
  */
-export const $ArchitectureLabProofId: Identity.IdentityComposer<"@beep/architecture-lab-proof"> = composers.$ArchitectureLabProofId;
+export const $ArchitectureLabProofId: Identity.IdentityComposer<"@beep/architecture-lab-proof"> =
+  composers.$ArchitectureLabProofId;

--- a/packages/tooling/library/ai-metrics/README.md
+++ b/packages/tooling/library/ai-metrics/README.md
@@ -27,3 +27,10 @@ concrete deployment steps, and no local or remote mutation. P5b keeps real
 dankserver mutation in `@beep/infra`, where Pulumi remote commands deploy
 Phoenix to the dedicated tailnet URL
 `https://dankserver.tailc7c348.ts.net:8447`.
+
+P6 keeps `forwarder run --otlp` additive: the forwarder still persists
+encrypted raw archive objects plus derived DuckDB/Parquet outputs first, then
+attempts a derived OTLP export for the same ingest run. The forwarder JSON
+contains `otlpExport` only when OTLP is requested, with a tagged `exported` or
+`failed` status so local collection evidence remains readable even when the
+backend export fails.

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -132,6 +132,94 @@ export class AiMetricsForwarderSourceCoverage extends S.Class<AiMetricsForwarder
 ) {}
 
 /**
+ * Successful derived OTLP export status attached to a forwarder run.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsForwarderOtlpExported } from "@beep/repo-ai-metrics"
+ * console.log(AiMetricsForwarderOtlpExported)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class AiMetricsForwarderOtlpExported extends S.Class<AiMetricsForwarderOtlpExported>(
+  $I`AiMetricsForwarderOtlpExported`
+)(
+  {
+    endpointTraceUrl: S.String,
+    ingestRunId: S.String,
+    sessionSpanCount: S.Number,
+    spanCount: S.Number,
+    status: S.Literal("exported"),
+    target: AiMetricsDeployTarget,
+    turnSpanCount: S.Number,
+  },
+  $I.annote("AiMetricsForwarderOtlpExported", {
+    description: "Safe counts recorded when a forwarder run also exports derived AI metrics spans through OTLP.",
+  })
+) {}
+
+/**
+ * Failed derived OTLP export status attached to a forwarder run.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsForwarderOtlpExportFailed } from "@beep/repo-ai-metrics"
+ * console.log(AiMetricsForwarderOtlpExportFailed)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class AiMetricsForwarderOtlpExportFailed extends S.Class<AiMetricsForwarderOtlpExportFailed>(
+  $I`AiMetricsForwarderOtlpExportFailed`
+)(
+  {
+    endpointTraceUrl: S.String,
+    ingestRunId: S.String,
+    message: S.String,
+    status: S.Literal("failed"),
+    target: AiMetricsDeployTarget,
+  },
+  $I.annote("AiMetricsForwarderOtlpExportFailed", {
+    description: "Sanitized failure recorded when post-forwarder derived OTLP export does not complete.",
+  })
+) {}
+
+/**
+ * Tagged derived OTLP export status attached to a forwarder run.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsForwarderOtlpExport } from "@beep/repo-ai-metrics"
+ * console.log(AiMetricsForwarderOtlpExport)
+ * ```
+ * @category schemas
+ * @since 0.0.0
+ */
+export const AiMetricsForwarderOtlpExport = S.Union([
+  AiMetricsForwarderOtlpExported,
+  AiMetricsForwarderOtlpExportFailed,
+]).pipe(
+  $I.annoteSchema("AiMetricsForwarderOtlpExport", {
+    description: "Tagged post-forwarder derived OTLP export status for the same ingest run.",
+  })
+);
+
+/**
+ * Runtime type for {@link AiMetricsForwarderOtlpExport}.
+ *
+ * @example
+ * ```ts
+ * import type { AiMetricsForwarderOtlpExport } from "@beep/repo-ai-metrics"
+ * const status: AiMetricsForwarderOtlpExport["status"] = "exported"
+ * console.log(status)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export type AiMetricsForwarderOtlpExport = typeof AiMetricsForwarderOtlpExport.Type;
+
+/**
  * Safe result emitted by one durable AI metrics forwarder run.
  *
  * @example
@@ -148,6 +236,7 @@ export class AiMetricsForwarderRunResult extends S.Class<AiMetricsForwarderRunRe
     configSnapshotId: S.String,
     duckDbPath: S.String,
     ingestRunId: S.String,
+    otlpExport: S.optionalKey(AiMetricsForwarderOtlpExport),
     parquetExportDir: S.String,
     parquetTables: S.Array(S.String),
     rawArchiveDir: S.String,

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -17,6 +17,10 @@ import {
   AiMetricsDeployTarget,
   type AiMetricsForwarderError,
   AiMetricsForwarderInput,
+  type AiMetricsForwarderOtlpExport,
+  AiMetricsForwarderOtlpExported,
+  AiMetricsForwarderOtlpExportFailed,
+  AiMetricsForwarderRunResult,
   AiMetricsForwarderTimerInput,
   type AiMetricsIngestError,
   type AiMetricsInstallConfigurationError,
@@ -30,6 +34,7 @@ import {
   AiMetricsOtlpEndpointSpec,
   type AiMetricsOtlpExportError,
   AiMetricsOtlpExportInput,
+  type AiMetricsOtlpExportResult,
   AiMetricsOutcomeLabelInput,
   type AiMetricsPrivacyError,
   AiMetricsPrivacyMode,
@@ -87,6 +92,7 @@ import {
   DateTime,
   Duration,
   Effect,
+  Exit,
   FileSystem,
   Layer,
   Order,
@@ -1153,6 +1159,97 @@ const makePrivacyCheckProgram = Effect.fn("AIMetrics.makePrivacyCheckProgram")(f
   yield* Console.log(`accepted events: ${result.sanitized.acceptedEvents}`);
 });
 
+const forwarderRunResultWithOtlpExport = (
+  result: AiMetricsForwarderRunResult,
+  otlpExport: AiMetricsForwarderOtlpExport
+): AiMetricsForwarderRunResult =>
+  new AiMetricsForwarderRunResult({
+    archiveObjectCount: result.archiveObjectCount,
+    configSnapshotId: result.configSnapshotId,
+    duckDbPath: result.duckDbPath,
+    ingestRunId: result.ingestRunId,
+    otlpExport,
+    parquetExportDir: result.parquetExportDir,
+    parquetTables: result.parquetTables,
+    rawArchiveDir: result.rawArchiveDir,
+    sourceCoverage: result.sourceCoverage,
+    sourceFileCount: result.sourceFileCount,
+    target: result.target,
+    turnCount: result.turnCount,
+  });
+
+const forwarderOtlpExported = (result: AiMetricsOtlpExportResult): AiMetricsForwarderOtlpExported =>
+  new AiMetricsForwarderOtlpExported({
+    endpointTraceUrl: result.endpointTraceUrl,
+    ingestRunId: result.ingestRunId,
+    sessionSpanCount: result.sessionSpanCount,
+    spanCount: result.spanCount,
+    status: "exported",
+    target: result.target,
+    turnSpanCount: result.turnSpanCount,
+  });
+
+const forwarderOtlpExportFailed = ({
+  endpoint,
+  forwarderResult,
+  message,
+  target,
+}: {
+  readonly endpoint: AiMetricsOtlpEndpointSpec;
+  readonly forwarderResult: AiMetricsForwarderRunResult;
+  readonly message: string;
+  readonly target: AiMetricsDeployTarget;
+}): AiMetricsForwarderOtlpExportFailed =>
+  new AiMetricsForwarderOtlpExportFailed({
+    endpointTraceUrl: endpoint.traceUrl,
+    ingestRunId: forwarderResult.ingestRunId,
+    message,
+    status: "failed",
+    target,
+  });
+
+const emitForwarderRuntimeSummary = Effect.fn("AIMetrics.emitForwarderRuntimeSummary")(
+  (result: AiMetricsForwarderRunResult) =>
+    Effect.void.pipe(
+      Effect.withSpan("repo_ai_metrics.forwarder.run", {
+        attributes: {
+          "ai_metrics.ingest_run_id": result.ingestRunId,
+          "ai_metrics.source_file_count": result.sourceFileCount,
+          "ai_metrics.target": result.target,
+          "ai_metrics.turn_count": result.turnCount,
+        },
+      })
+    )
+);
+
+const exportForwarderDerivedOtlp = Effect.fn("AIMetrics.exportForwarderDerivedOtlp")(function* ({
+  endpoint,
+  forwarderResult,
+  target,
+}: {
+  readonly endpoint: AiMetricsOtlpEndpointSpec;
+  readonly forwarderResult: AiMetricsForwarderRunResult;
+  readonly target: AiMetricsDeployTarget;
+}) {
+  yield* emitForwarderRuntimeSummary(forwarderResult);
+  return yield* runAiMetricsOtlpExport(
+    new AiMetricsOtlpExportInput({
+      duckDbPath: forwarderResult.duckDbPath,
+      endpoint,
+      ingestRunId: forwarderResult.ingestRunId,
+      target,
+    })
+  ).pipe(
+    Effect.matchEffect({
+      onFailure: Effect.fn(function* (error) {
+        yield* Console.error(`ai-metrics: OTLP export failed after forwarder run: ${error.message}`);
+        return forwarderOtlpExportFailed({ endpoint, forwarderResult, message: error.message, target });
+      }),
+      onSuccess: (result) => Effect.succeed(forwarderOtlpExported(result)),
+    })
+  );
+});
+
 const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(function* ({
   all,
   dataRoot,
@@ -1211,38 +1308,47 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
   );
   const resolvedRawArchiveKey = yield* resolveRawArchiveKey();
   const sinceEpochMillis = all ? undefined : yield* parseSinceEpochMillis(since);
-  const forwarderEffect = runAiMetricsForwarder(
-    new AiMetricsForwarderInput({
-      ...(resolvedDataRoot === undefined ? {} : { dataRoot: resolvedDataRoot }),
-      ...(resolvedHashSalt === undefined ? {} : { hashSalt: resolvedHashSalt }),
-      ...(resolvedHashSaltSecretRef === undefined ? {} : { hashSaltSecretRef: resolvedHashSaltSecretRef }),
-      ...(resolvedRawArchiveKeySecretRef === undefined
-        ? {}
-        : { rawArchiveKeySecretRef: resolvedRawArchiveKeySecretRef }),
-      homeDir: yield* resolveHomeDir(homeDir),
-      includeAll: all,
-      ...(O.isSome(maxFileBytes) ? { maxFileBytes: maxFileBytes.value } : {}),
-      maxFiles,
-      ...(O.isSome(openClawUnit) ? { openClawUnitPath: openClawUnit.value } : {}),
-      rawArchiveKey: resolvedRawArchiveKey,
-      repoRoot: yield* resolveRepoRoot(repoRoot),
-      ...(sinceEpochMillis === undefined ? {} : { sinceEpochMillis }),
-      target,
-    })
-  ).pipe(
+  const forwarderInput = new AiMetricsForwarderInput({
+    ...(resolvedDataRoot === undefined ? {} : { dataRoot: resolvedDataRoot }),
+    ...(resolvedHashSalt === undefined ? {} : { hashSalt: resolvedHashSalt }),
+    ...(resolvedHashSaltSecretRef === undefined ? {} : { hashSaltSecretRef: resolvedHashSaltSecretRef }),
+    ...(resolvedRawArchiveKeySecretRef === undefined ? {} : { rawArchiveKeySecretRef: resolvedRawArchiveKeySecretRef }),
+    homeDir: yield* resolveHomeDir(homeDir),
+    includeAll: all,
+    ...(O.isSome(maxFileBytes) ? { maxFileBytes: maxFileBytes.value } : {}),
+    maxFiles,
+    ...(O.isSome(openClawUnit) ? { openClawUnitPath: openClawUnit.value } : {}),
+    rawArchiveKey: resolvedRawArchiveKey,
+    repoRoot: yield* resolveRepoRoot(repoRoot),
+    ...(sinceEpochMillis === undefined ? {} : { sinceEpochMillis }),
+    target,
+  });
+  const duckDbLayer = DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: spec.storage.duckDbPath }));
+  const forwarderResult = yield* runAiMetricsForwarder(forwarderInput).pipe(
     // @effect-diagnostics-next-line strictEffectProvide:off
-    Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: spec.storage.duckDbPath })))
+    Effect.provide(duckDbLayer)
   );
   const result = otlp
-    ? yield* forwarderEffect.pipe(
-        // @effect-diagnostics-next-line strictEffectProvide:off
-        Effect.provide(
-          layerNodeSdkServerTraces(
-            serverObservabilityConfigFor(target, yield* defaultServiceEndpoint(spec, otlpBaseUrl))
-          )
-        )
-      )
-    : yield* forwarderEffect;
+    ? yield* Effect.gen(function* () {
+        const endpoint = yield* defaultServiceEndpoint(spec, otlpBaseUrl);
+        const otlpExit = yield* exportForwarderDerivedOtlp({ endpoint, forwarderResult, target }).pipe(
+          // @effect-diagnostics-next-line strictEffectProvide:off
+          Effect.provide(
+            Layer.mergeAll(duckDbLayer, layerNodeSdkServerTraces(serverObservabilityConfigFor(target, endpoint)))
+          ),
+          Effect.exit
+        );
+        const otlpExport = Exit.isFailure(otlpExit)
+          ? yield* Effect.gen(function* () {
+              const message = "OTLP exporter failed while flushing spans.";
+              yield* Console.error(`ai-metrics: OTLP export failed after forwarder run: ${message}`);
+              return forwarderOtlpExportFailed({ endpoint, forwarderResult, message, target });
+            })
+          : otlpExit.value;
+
+        return forwarderRunResultWithOtlpExport(forwarderResult, otlpExport);
+      })
+    : forwarderResult;
 
   if (json) {
     yield* Console.log(yield* forwarderRunResultToJson(result));
@@ -1264,6 +1370,17 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
   const parquetLocation = result.parquetExportDir;
   yield* Console.log(`derived duckdb: ${duckDbLocation}`);
   yield* Console.log(`parquet export: ${parquetLocation}`);
+  const otlpExport = O.fromNullishOr(result.otlpExport);
+  if (O.isSome(otlpExport)) {
+    yield* Console.log(`otlp export: ${otlpExport.value.status}`);
+    if (otlpExport.value.status === "exported") {
+      yield* Console.log(`otlp spans: ${otlpExport.value.spanCount}`);
+      yield* Console.log(`otlp sessions: ${otlpExport.value.sessionSpanCount}`);
+      yield* Console.log(`otlp turns: ${otlpExport.value.turnSpanCount}`);
+    } else {
+      yield* Console.log(`otlp failure: ${otlpExport.value.message}`);
+    }
+  }
 });
 
 const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram")(function* ({

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -1189,6 +1189,8 @@ const forwarderOtlpExported = (result: AiMetricsOtlpExportResult): AiMetricsForw
     turnSpanCount: result.turnSpanCount,
   });
 
+const forwarderOtlpExportFailureMessage = "OTLP export did not complete after the forwarder run.";
+
 const forwarderOtlpExportFailed = ({
   endpoint,
   forwarderResult,
@@ -1208,20 +1210,6 @@ const forwarderOtlpExportFailed = ({
     target,
   });
 
-const emitForwarderRuntimeSummary = Effect.fn("AIMetrics.emitForwarderRuntimeSummary")(
-  (result: AiMetricsForwarderRunResult) =>
-    Effect.void.pipe(
-      Effect.withSpan("repo_ai_metrics.forwarder.run", {
-        attributes: {
-          "ai_metrics.ingest_run_id": result.ingestRunId,
-          "ai_metrics.source_file_count": result.sourceFileCount,
-          "ai_metrics.target": result.target,
-          "ai_metrics.turn_count": result.turnCount,
-        },
-      })
-    )
-);
-
 const exportForwarderDerivedOtlp = Effect.fn("AIMetrics.exportForwarderDerivedOtlp")(function* ({
   endpoint,
   forwarderResult,
@@ -1231,7 +1219,6 @@ const exportForwarderDerivedOtlp = Effect.fn("AIMetrics.exportForwarderDerivedOt
   readonly forwarderResult: AiMetricsForwarderRunResult;
   readonly target: AiMetricsDeployTarget;
 }) {
-  yield* emitForwarderRuntimeSummary(forwarderResult);
   return yield* runAiMetricsOtlpExport(
     new AiMetricsOtlpExportInput({
       duckDbPath: forwarderResult.duckDbPath,
@@ -1241,9 +1228,16 @@ const exportForwarderDerivedOtlp = Effect.fn("AIMetrics.exportForwarderDerivedOt
     })
   ).pipe(
     Effect.matchEffect({
-      onFailure: Effect.fn(function* (error) {
-        yield* Console.error(`ai-metrics: OTLP export failed after forwarder run: ${error.message}`);
-        return forwarderOtlpExportFailed({ endpoint, forwarderResult, message: error.message, target });
+      onFailure: Effect.fn(function* () {
+        yield* Console.error(
+          `ai-metrics: OTLP export failed after forwarder run: ${forwarderOtlpExportFailureMessage}`
+        );
+        return forwarderOtlpExportFailed({
+          endpoint,
+          forwarderResult,
+          message: forwarderOtlpExportFailureMessage,
+          target,
+        });
       }),
       onSuccess: (result) => Effect.succeed(forwarderOtlpExported(result)),
     })
@@ -1340,9 +1334,15 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
         );
         const otlpExport = Exit.isFailure(otlpExit)
           ? yield* Effect.gen(function* () {
-              const message = "OTLP exporter failed while flushing spans.";
-              yield* Console.error(`ai-metrics: OTLP export failed after forwarder run: ${message}`);
-              return forwarderOtlpExportFailed({ endpoint, forwarderResult, message, target });
+              yield* Console.error(
+                `ai-metrics: OTLP export failed after forwarder run: ${forwarderOtlpExportFailureMessage}`
+              );
+              return forwarderOtlpExportFailed({
+                endpoint,
+                forwarderResult,
+                message: forwarderOtlpExportFailureMessage,
+                target,
+              });
             })
           : otlpExit.value;
 

--- a/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
+++ b/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
@@ -780,11 +780,13 @@ describe("ai-metrics command", () => {
                 if (otlpExport.value.status === "failed") {
                   expect(otlpExport.value.endpointTraceUrl).toBe(`${otlpBaseUrl}/v1/traces`);
                   expect(otlpExport.value.ingestRunId).toBe(result.ingestRunId);
+                  expect(otlpExport.value.message).toBe("OTLP export did not complete after the forwarder run.");
                   expect(otlpExport.value.message).not.toContain("private-forwarder-failed-otlp");
                   expect(otlpExport.value.message).not.toContain(tmpDir);
                 }
               }
               expect(errorOutput).toContain("OTLP export failed after forwarder run");
+              expect(errorOutput).toContain("OTLP export did not complete after the forwarder run.");
               expect(errorOutput).not.toContain("private-forwarder-failed-otlp");
               expect(errorOutput).not.toContain(tmpDir);
               expect(resultJson).not.toContain("private-forwarder-failed-otlp");

--- a/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
+++ b/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
@@ -85,7 +85,8 @@ const withRawArchiveKeyEnv = <A, E, R>(rawArchiveKey: string, use: Effect.Effect
   );
 
 const withOtlpSink = <A, E, R>(
-  use: (baseUrl: string, requests: ReadonlyArray<CapturedOtlpRequest>) => Effect.Effect<A, E, R>
+  use: (baseUrl: string, requests: ReadonlyArray<CapturedOtlpRequest>) => Effect.Effect<A, E, R>,
+  responseStatus = 200
 ) =>
   Effect.acquireUseRelease(
     Effect.sync(() => {
@@ -99,7 +100,7 @@ const withOtlpSink = <A, E, R>(
             contentType: request.headers.get("content-type") ?? "",
             path: new URL(request.url).pathname,
           });
-          return new Response(null, { status: 200 });
+          return new Response(null, { status: responseStatus });
         },
         hostname: "127.0.0.1",
         port: 0,
@@ -267,6 +268,7 @@ describe("ai-metrics command", () => {
           expect(output).toContain("capture PATH at render time");
           expect(output).toContain("/usr/bin/env PATH=");
           expect(output).toContain(" bun packages/tooling/tool/cli/src/bin.ts -- ai-metrics forwarder run");
+          expect(output).toContain("--otlp --otlp-base-url");
           expect(output).toContain("beep-ai-metrics-forwarder.timer");
           expect(output).not.toContain("--max-files 200");
           expect(process.exitCode ?? 0).toBe(0);
@@ -649,6 +651,148 @@ describe("ai-metrics command", () => {
           expect(output).not.toContain(rawArchiveKey);
           expect(process.exitCode ?? 0).toBe(0);
         })
+      )
+    );
+  });
+
+  it("runs forwarder with derived OTLP export status without exposing raw transcript text", async () => {
+    await Effect.runPromise(
+      withOtlpSink((otlpBaseUrl, requests) =>
+        withTempDirectory((tmpDir) =>
+          Effect.gen(function* () {
+            const path = yield* Path.Path;
+            const homeDir = path.join(tmpDir, "home");
+            const repoRoot = path.join(tmpDir, "repo");
+            const dataRoot = path.join(tmpDir, "metrics");
+            const rawArchiveKey = Encoding.encodeBase64(new Uint8Array(32).fill(23));
+
+            yield* writeText(
+              path.join(homeDir, ".codex/sessions/codex-session.jsonl"),
+              [
+                '{"type":"session_meta","timestamp":"2026-05-05T10:00:00Z"}',
+                '{"type":"tool_result","timestamp":"2026-05-05T10:01:00Z","message":"private-forwarder-otlp-secret"}',
+              ].join("\n")
+            );
+            yield* writeText(path.join(repoRoot, "AGENTS.md"), "root guide\n");
+
+            yield* withRawArchiveKeyEnv(
+              rawArchiveKey,
+              runAiMetricsCommand([
+                "forwarder",
+                "run",
+                "--repo-root",
+                repoRoot,
+                "--home-dir",
+                homeDir,
+                "--data-root",
+                dataRoot,
+                "--all",
+                "--hash-salt",
+                "test-salt",
+                "--otlp",
+                "--otlp-base-url",
+                otlpBaseUrl,
+                "--json",
+              ])
+            );
+
+            const resultJson = yield* lastLoggedLine();
+            const result = yield* decodeForwarderResult(resultJson);
+            const otlpExport = O.fromNullishOr(result.otlpExport);
+            const traceRequest = yield* waitForCapturedOtlpTraceRequest(requests);
+
+            expect(O.isSome(otlpExport)).toBe(true);
+            if (O.isSome(otlpExport)) {
+              expect(otlpExport.value.status).toBe("exported");
+              if (otlpExport.value.status === "exported") {
+                expect(otlpExport.value.endpointTraceUrl).toBe(`${otlpBaseUrl}/v1/traces`);
+                expect(otlpExport.value.ingestRunId).toBe(result.ingestRunId);
+                expect(otlpExport.value.spanCount).toBeGreaterThan(0);
+                expect(otlpExport.value.sessionSpanCount).toBeGreaterThan(0);
+                expect(otlpExport.value.turnSpanCount).toBeGreaterThan(0);
+              }
+            }
+            expect(traceRequest.contentType).toContain("application/x-protobuf");
+            expect(traceRequest.bodyByteLength).toBeGreaterThan(0);
+            expect(traceRequest.bodyText).not.toContain("private-forwarder-otlp-secret");
+            expect(traceRequest.bodyText).not.toContain(tmpDir);
+            expect(resultJson).not.toContain("private-forwarder-otlp-secret");
+            expect(resultJson).not.toContain(rawArchiveKey);
+            expect(process.exitCode ?? 0).toBe(0);
+          })
+        )
+      )
+    );
+  });
+
+  it("keeps forwarder successful when derived OTLP export reports a sanitized failure", async () => {
+    await Effect.runPromise(
+      withOtlpSink(
+        (otlpBaseUrl) =>
+          withTempDirectory((tmpDir) =>
+            Effect.gen(function* () {
+              const path = yield* Path.Path;
+              const homeDir = path.join(tmpDir, "home");
+              const repoRoot = path.join(tmpDir, "repo");
+              const dataRoot = path.join(tmpDir, "metrics");
+              const rawArchiveKey = Encoding.encodeBase64(new Uint8Array(32).fill(29));
+
+              yield* writeText(
+                path.join(homeDir, ".codex/sessions/codex-session.jsonl"),
+                [
+                  '{"type":"session_meta","timestamp":"2026-05-05T10:00:00Z"}',
+                  '{"type":"event_msg","timestamp":"2026-05-05T10:01:00Z","message":"private-forwarder-failed-otlp"}',
+                ].join("\n")
+              );
+              yield* writeText(path.join(repoRoot, "AGENTS.md"), "root guide\n");
+
+              yield* withRawArchiveKeyEnv(
+                rawArchiveKey,
+                runAiMetricsCommand([
+                  "forwarder",
+                  "run",
+                  "--repo-root",
+                  repoRoot,
+                  "--home-dir",
+                  homeDir,
+                  "--data-root",
+                  dataRoot,
+                  "--all",
+                  "--hash-salt",
+                  "test-salt",
+                  "--otlp",
+                  "--otlp-base-url",
+                  otlpBaseUrl,
+                  "--json",
+                ])
+              );
+
+              const resultJson = yield* lastLoggedLine();
+              const result = yield* decodeForwarderResult(resultJson);
+              const otlpExport = O.fromNullishOr(result.otlpExport);
+              const errorOutput = pipe(yield* TestConsole.errorLines, A.join("\n"));
+
+              expect(result.sourceFileCount).toBe(1);
+              expect(result.turnCount).toBeGreaterThan(0);
+              expect(O.isSome(otlpExport)).toBe(true);
+              if (O.isSome(otlpExport)) {
+                expect(otlpExport.value.status).toBe("failed");
+                if (otlpExport.value.status === "failed") {
+                  expect(otlpExport.value.endpointTraceUrl).toBe(`${otlpBaseUrl}/v1/traces`);
+                  expect(otlpExport.value.ingestRunId).toBe(result.ingestRunId);
+                  expect(otlpExport.value.message).not.toContain("private-forwarder-failed-otlp");
+                  expect(otlpExport.value.message).not.toContain(tmpDir);
+                }
+              }
+              expect(errorOutput).toContain("OTLP export failed after forwarder run");
+              expect(errorOutput).not.toContain("private-forwarder-failed-otlp");
+              expect(errorOutput).not.toContain(tmpDir);
+              expect(resultJson).not.toContain("private-forwarder-failed-otlp");
+              expect(resultJson).not.toContain(rawArchiveKey);
+              expect(process.exitCode ?? 0).toBe(0);
+            })
+          ),
+        500
       )
     );
   });


### PR DESCRIPTION
## Summary
- make `ai-metrics forwarder run --otlp` persist encrypted raw archive, derived DuckDB, and Parquet outputs before attempting OTLP export for the same ingest run
- add tagged `otlpExport` JSON/human status so local collection evidence stays readable when backend export fails
- document Phoenix UI interpretation for the pinned P6 proof window and clear generated TSDoc warnings required by the root quality loop

## Validation
- `bun run lint:fix`
- `bun run audit:github quality`
- `bunx --bun vitest run test/ai-metrics-command.test.ts`
- `git diff --check` / `git diff --cached --check`

## Review Loop
- quality-review-fix-loop run locally with changed-surface review
- no required local reviewer blockers remaining
- no waivers recorded

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OTLP export to the AI metrics forwarder with explicit exported/failed status reported.

* **Documentation**
  * Runbook updated with P6 proof-runner isolation guidance and Phoenix UI interpretation notes.
  * README expanded to describe the OTLP export workflow and output semantics.

* **Tests**
  * Added end-to-end tests covering OTLP export success/failure and output sanitization.

* **Style**
  * Minor package entrypoint comment and formatting refinements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/134)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->