### PR TITLE
docs(ai-metrics): prepare V1 closeout review

### DIFF
--- a/initiatives/ai-metrics-stack/PLAN.md
+++ b/initiatives/ai-metrics-stack/PLAN.md
@@ -6,13 +6,13 @@ ship without disturbing that proof. P0 bootstrap, P1 source/privacy proof, P2
 durable ingest, P3 OTLP/backend contracts, P4 report-first scorecards, P5
 install/remote deployment, P6a fresh-review hardening, and P6b proof-runner
 isolation are complete. P7a/b hybrid mirror and retention workflows are now
-implemented; P7c
-provider/gateway metrics, P7d dashboard expansion, and P7e
-production-readiness closeout remain pending. Phoenix is live on dankserver,
-Pulumi state is reconciled, the workstation timer owns live collection from an
-isolated pinned proof worktree, and the credited seven-day proof restarted on
-May 9, 2026 02:26 America/Chicago. The earliest credited completion is May 16,
-2026 02:26 America/Chicago.
+implemented. P6c remains the active closeout gate until the credited proof can
+finish on May 16, 2026 02:26 America/Chicago. P7e is the V1 production
+readiness closeout that records the final seven-day report and confirmed
+sanitized mirror. P7c provider/gateway metrics and P7d dashboard/backend
+expansion remain follow-up capabilities, not blockers for V1 completion.
+Phoenix is live on dankserver, Pulumi state is reconciled, and the workstation
+timer owns live collection from an isolated pinned proof worktree.
 
 ## P0: Initiative Bootstrap And Current State
 
@@ -145,6 +145,12 @@ Status: in progress
   [history/outputs/p6-proof-runner-isolation-and-runbook.md](./history/outputs/p6-proof-runner-isolation-and-runbook.md).
 - Track pre-closeout readiness evidence in
   [history/outputs/p6-pre-may16-readiness-ledger.md](./history/outputs/p6-pre-may16-readiness-ledger.md).
+- The May 12 P6c label gate is closed for the active isolated-runner config:
+  the human-approved label for
+  `agent-task-f86914324ec15a092d633bbc488c0805753ffcad47f05264fe7856cc94a899fd`
+  flipped
+  `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52`
+  to `completionReady=true` in the intermediate report.
 - Additional labels require explicit human outcome judgment. Benchmark runs may
   be recorded for real operator workflows with deploy-safe prompt hashes and
   redacted notes.
@@ -211,9 +217,13 @@ Status: in progress
   `remoteMirrorRoot` with default `/srv/data/ai-metrics/p7-derived-mirror`.
   Before May 16, 2026 this remains preview-only infra state; live proofs can
   use the CLI mirror workflow without changing the active proof runner.
-- Still pending: P7c provider/model/tool/token/cost enrichment, P7d
-  dashboard/backend expansion, remote mirror lifecycle automation beyond
-  bundle sync/status, and the final P7e production-readiness closeout.
+- V1 pending: P7e production-readiness closeout after the P6 proof window
+  elapses. P7e must generate the final seven-day report, build a sanitized
+  derived mirror from the active data root, run confirmed `mirror sync` to
+  `/srv/data/ai-metrics/p7-derived-mirror`, and verify remote mirror status.
+- Follow-up, not V1-blocking: P7c provider/model/tool/token/cost enrichment,
+  P7d dashboard/backend expansion, and remote mirror lifecycle automation
+  beyond confirmed bundle sync/status.
 - Planning packet:
   [history/outputs/p7-topology-first-production-plan.md](./history/outputs/p7-topology-first-production-plan.md).
 

--- a/initiatives/ai-metrics-stack/README.md
+++ b/initiatives/ai-metrics-stack/README.md
@@ -12,9 +12,12 @@ gateway activity into privacy-safe raw archives, derived rollups, OTLP traces,
 and weekly scorecards that answer whether agent-facing config changes improved
 coding-agent performance.
 
-Production-complete means the dankserver tailnet stack is deployed, local smoke
-collection works, P6a hardening gates pass, real sources are flowing, and one
-restarted seven-day config-impact scorecard has been generated from live data.
+Production-complete V1 means the dankserver tailnet stack is deployed, local
+smoke collection works, P6a hardening gates pass, real sources are flowing, one
+restarted seven-day config-impact scorecard has been generated from live data,
+and a sanitized derived mirror has been confirmed on dankserver. Provider and
+dashboard enrichment remain follow-up work when the scorecard explicitly marks
+those metrics unavailable and not scored.
 
 ## Read This First
 
@@ -54,7 +57,7 @@ restarted seven-day config-impact scorecard has been generated from live data.
     and the remaining completion gate before May 16
 - [history/outputs/p7-topology-first-production-plan.md](./history/outputs/p7-topology-first-production-plan.md)
   - P7 topology-first production packet, implemented P7a/b mirror and
-    retention workflows, and pending P7c/P7d/P7e work
+    retention workflows, pending P7e V1 closeout, and P7c/P7d follow-up work
 - [research/effect-native-observability.md](./research/effect-native-observability.md)
   - Effect v4 observability package findings
 - [research/backend-shortlist.md](./research/backend-shortlist.md) - backend
@@ -125,14 +128,17 @@ America/Chicago after the P6a closeout gates passed:
   discovery confirms Claude Code and OpenClaw sources exist outside the active
   proof window and are deferred to P7c provider/gateway work.
 - Current P6 work is to keep the timer running through May 16, 2026 02:26
-  America/Chicago, add human-approved labels and real benchmark runs as data
-  accumulates, and generate the final seven-day report.
-- The May 9 readiness pass recorded another successful scheduled timer run and
-  a second isolation benchmark run for the isolated-runner config. That config
-  remains blocked only by the explicit human-label gate plus elapsed proof time.
-- P7c provider/gateway metrics, P7d dashboard/backend expansion, remote mirror
-  lifecycle automation beyond build/sync/status, and P7e production-readiness
-  closeout remain pending.
+  America/Chicago and generate the final seven-day report.
+- The May 12 P6c label pass added one explicit human-approved outcome label for
+  the isolated-runner config and regenerated an intermediate report where that
+  config is `completionReady=true`. The remaining P6 blocker is elapsed proof
+  time.
+- P7e production-readiness closeout remains the V1 closeout pass after May 16.
+  It must record the final report and confirm a sanitized derived mirror on
+  dankserver.
+- P7c provider/gateway metrics, P7d dashboard/backend expansion, and remote
+  mirror lifecycle automation beyond confirmed bundle sync/status remain
+  follow-up work, not V1 blockers.
 
 ## Completion Standard
 
@@ -144,9 +150,14 @@ This initiative is done only when all are true:
 - P6a hardening gates have passed, including subagent attribution, source-aware
   coverage, config diffs, metadata allowlist, timer ownership, and archive
   decrypt drill
-- Codex, Claude Code, OpenClaw, and optional gateway sources have discovery and
-  ingest coverage
+- Codex source discovery and ingest are proven, Claude Code/OpenClaw adapter
+  visibility is explicit, and optional gateway/provider metrics either contain
+  measured rows or are explicitly unavailable and not scored
 - config snapshots are linked to real sessions and benchmark runs
 - CLI label review produces outcome labels for real work
 - one weekly config-impact scorecard is generated from a restarted seven-day
   live window and is marked completion-ready with labels plus benchmark evidence
+- a sanitized derived mirror is confirmed on dankserver after the final
+  seven-day report
+- provider/tool/cost fields either contain real measured rows or are explicitly
+  reported as unavailable and not scored

--- a/initiatives/ai-metrics-stack/SPEC.md
+++ b/initiatives/ai-metrics-stack/SPEC.md
@@ -46,6 +46,8 @@ Out of scope for v1:
 - making `effect/unstable/eventlog` the only deploy-safe raw source of record
 - exposing raw prompt or transcript bodies in observability UIs
 - public internet access to the metrics stack
+- requiring measured provider/gateway token, cost, latency, or tool-call
+  metrics before the first seven-day config-impact scorecard is credited
 
 ## Architectural Boundaries
 
@@ -90,6 +92,11 @@ output.
 - P7 production default: hybrid derived mirror. Raw encrypted archives remain
   workstation-local; only sanitized derived/report/status artifacts may sync to
   dankserver.
+- V1 completion posture: the first production-complete milestone may close
+  with provider/model/tool/token/cost metrics explicitly reported as
+  unavailable and not scored. Provider/gateway enrichment and dashboard
+  expansion remain follow-up P7 work, not blockers for the credited P6
+  scorecard.
 
 ## Data Products
 
@@ -184,10 +191,13 @@ The initiative is complete only when:
 - live collection is owned by the workstation timer for the restarted seven-day
   proof and populates raw and derived storage
 - Phoenix or the selected default UI shows real data
-- source discovery covers Codex, Claude Code, OpenClaw, and optional gateway
-  logs
+- source discovery covers Codex and proves Claude Code/OpenClaw adapter
+  visibility, while optional gateway/provider measured metrics either populate
+  real rows or remain explicit unavailable/not-scored follow-up gaps
 - the CLI label queue can record real outcome labels
 - benchmark runs are linked to config snapshots
 - a restarted seven-day weekly report exists in derived storage and as a
   readable output, with labels and benchmark evidence sufficient for completion
   credit
+- a sanitized derived mirror is built and confirmed on dankserver after the
+  credited proof report, without syncing raw transcript archives

--- a/initiatives/ai-metrics-stack/history/outputs/p6-pre-may16-readiness-ledger.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p6-pre-may16-readiness-ledger.md
@@ -323,13 +323,51 @@ Scorecard summary:
 
 ## Remaining Pre-May-16 Work
 
-- Add at least one human-approved label for
-  `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52`.
-- Regenerate the intermediate weekly report and confirm that the same config
-  snapshot flips to `completionReady=true`.
 - Continue daily timer/Phoenix/source/report health checks without changing the
   proof runner or source window.
+- Keep the credited proof running until May 16, 2026 02:26 America/Chicago,
+  then generate the final seven-day report.
 - Keep additional P7 work limited to P7a/b health proof and documentation until
   the credited proof window completes or is explicitly abandoned. Any P7 proof
   that writes mirror or restore artifacts must run against a disposable copy of
   the proof data root rather than the active root.
+
+## May 12, 2026 P6c Label Gate
+
+Collected at approximately May 12, 2026 10:58 America/Chicago.
+
+This pass used the explicit human clean-pass judgment from the planning session
+and did not change the proof runner, timer cadence, source window, proof data
+root, hash salt, archive key, or pinned proof worktree.
+
+### Label
+
+- Label id:
+  `label-a97eea43d276877eb5a28283a57a39cf00ece92b4b098f82d92f552815d31b84`
+- Agent task:
+  `agent-task-f86914324ec15a092d633bbc488c0805753ffcad47f05264fe7856cc94a899fd`
+- Config snapshot:
+  `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52`
+- Passed: `true`
+- Quality gate: `passed`
+- Rating: `5`
+- Interventions: `0`
+- Follow-up fix: `false`
+- Note: `P6c human review: clean pass; no follow-up fix required; redacted note only.`
+
+### Regenerated Intermediate Report
+
+- Markdown:
+  `.beep/ai-metrics/reports/weekly-1777996696860-1778601496860.md`
+- JSON:
+  `.beep/ai-metrics/reports/weekly-1777996696860-1778601496860.json`
+
+Scorecard summary for the active isolated-runner config:
+
+| configSnapshotId | tasks | labels | benchmarks | completionReady | gaps |
+| --- | ---: | ---: | ---: | --- | --- |
+| `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52` | 58 | 1 | 2 | yes | unavailable model/tool/cost metrics |
+
+The human-label gate is closed for P6c. The remaining closeout gate is elapsed
+proof time through May 16, 2026 02:26 America/Chicago, followed by the final
+seven-day report and V1 mirror closeout.

--- a/initiatives/ai-metrics-stack/history/outputs/p7-topology-first-production-plan.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p7-topology-first-production-plan.md
@@ -3,8 +3,10 @@
 ## Status
 
 Decision-complete and partially implemented. P7a/b landed without disturbing
-the active P6 seven-day proof. P7c provider/gateway metrics, P7d dashboard
-expansion, and final P7e production closeout remain pending.
+the active P6 seven-day proof. Final P7e production closeout remains pending
+until the proof window can be credited. P7c provider/gateway metrics and P7d
+dashboard expansion are follow-up capabilities, not V1 blockers, when their
+metrics remain explicitly unavailable and not scored.
 
 P7 must not rewrite the P6 proof while it is running. This slice turns the
 workstation-owned proof into a hybrid mirror plus retention topology with
@@ -22,9 +24,11 @@ The center of gravity is topology first:
 1. Decide where raw transcript access is owned.
 2. Decide what may sync off the workstation.
 3. Prove retention, deletion, restore, and re-derivation.
-4. Add provider/gateway usage metrics only after the raw/derived boundary is
+4. Close V1 with explicit unavailable/not-scored provider metrics if no real
+   provider source is ready.
+5. Add provider/gateway usage metrics only after the raw/derived boundary is
    explicit.
-5. Expand dashboard backends only when the backend-specific API need is real.
+6. Expand dashboard backends only when the backend-specific API need is real.
 
 ## Implemented Decision
 
@@ -156,7 +160,7 @@ Acceptance gates:
 
 ## P7c: Provider And Gateway Metrics
 
-Status: pending
+Status: follow-up, not V1-blocking
 
 Add real model-call, tool-invocation, token, cost, and latency data only from
 sources that can prove their privacy and attribution contract.
@@ -180,7 +184,7 @@ Acceptance gates:
 
 ## P7d: Dashboard And Backend Expansion
 
-Status: pending
+Status: follow-up, not V1-blocking
 
 Keep Phoenix as the default UI until a second backend has a specific job.
 
@@ -202,13 +206,17 @@ Acceptance gates:
 
 Status: pending
 
-P7 is complete when the stack can survive normal operator use without relying on
-the mutable development checkout.
+P7e is the V1 closeout pass after the credited P6 report exists. V1 is complete
+when the stack can survive normal operator use without relying on the mutable
+development checkout and when unavailable provider/gateway metrics are explicit
+rather than silently treated as measured values.
 
 Completion gates:
 
 - collection topology is implemented and documented
 - timer/scheduler ownership is explicit and observable
+- a sanitized derived mirror is built from the active data root after the final
+  report and confirmed on dankserver
 - sync or mirror failure modes are visible in status artifacts
 - retention, restore, deletion, and compaction workflows are proven
 - real provider/gateway metrics populate measured tables, or remain explicitly

--- a/initiatives/ai-metrics-stack/ops/manifest.json
+++ b/initiatives/ai-metrics-stack/ops/manifest.json
@@ -10,7 +10,7 @@
   },
   "currentSourceOfTruth": "SPEC.md",
   "currentTargetPhase": "P6c",
-  "completionEvidence": "dankserver deployment plus P6a hardening gates plus one restarted seven-day real-data config-impact scorecard",
+  "completionEvidence": "dankserver deployment plus P6a hardening gates plus one restarted seven-day real-data config-impact scorecard plus confirmed sanitized derived mirror",
   "targets": {
     "production": "dankserver",
     "smoke": "local",
@@ -23,6 +23,31 @@
     "rawSpine": "encrypted-jsonl-parquet-archive-with-eventlog-proof",
     "capturePosture": "passive-first-optional-litellm",
     "scoreModel": "outcome-heavy"
+  },
+  "v1Completion": {
+    "status": "in_progress",
+    "activeGate": "P6c",
+    "notBefore": "2026-05-16T02:26:00-05:00",
+    "closedGates": [
+      "dankserver Phoenix deployment",
+      "P6a hardening gates",
+      "P6b pinned proof-runner isolation",
+      "P6c human label for active isolated-runner config",
+      "P6c intermediate completion-ready scorecard"
+    ],
+    "remainingGates": [
+      "keep pinned proof runner unchanged through the credited proof window",
+      "generate the final seven-day scorecard after 2026-05-16T02:26:00-05:00",
+      "build and confirmed-sync the sanitized derived mirror to dankserver after the final report",
+      "verify remote mirror status",
+      "record P7e production-readiness closeout evidence"
+    ],
+    "nonBlockingFollowUps": [
+      "P7c provider/model/tool/token/cost enrichment",
+      "P7d dashboard/backend expansion",
+      "remote mirror lifecycle automation beyond confirmed sync/status",
+      "server-owned collection requiring transcript access/sync and privacy design"
+    ]
   },
   "owningSurfaces": {
     "developerAiAnalytics": "packages/tooling/library/ai-metrics",
@@ -130,18 +155,21 @@
           "id": "P7c",
           "name": "Provider And Gateway Metrics",
           "status": "pending",
+          "v1Blocking": false,
           "output": "history/outputs/p7-topology-first-production-plan.md"
         },
         {
           "id": "P7d",
           "name": "Dashboard And Backend Expansion",
           "status": "pending",
+          "v1Blocking": false,
           "output": "history/outputs/p7-topology-first-production-plan.md"
         },
         {
           "id": "P7e",
           "name": "Production Readiness Closeout",
           "status": "pending",
+          "v1Blocking": true,
           "output": "history/outputs/p7-topology-first-production-plan.md"
         }
       ]
@@ -197,6 +225,18 @@
       "command": "ssh -o BatchMode=yes -o ConnectTimeout=10 dankserver-yubi \"sh -lc 'if test -f /srv/data/ai-metrics/p7-derived-mirror/manifest.json; then echo present; else echo missing; fi'\""
     },
     {
+      "id": "ai-metrics-p7-final-mirror-build",
+      "command": "bun run beep ai-metrics mirror build --target dankserver --data-root /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics --remote-root /srv/data/ai-metrics/p7-derived-mirror --json"
+    },
+    {
+      "id": "ai-metrics-p7-final-mirror-sync",
+      "command": "bun run beep ai-metrics mirror sync --target dankserver --data-root /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics --bundle latest --host dankserver-yubi --remote-root /srv/data/ai-metrics/p7-derived-mirror --confirm p7-derived-mirror --json"
+    },
+    {
+      "id": "ai-metrics-p7-final-mirror-status",
+      "command": "bun run beep ai-metrics mirror status --target dankserver --host dankserver-yubi --remote-root /srv/data/ai-metrics/p7-derived-mirror --json"
+    },
+    {
       "id": "ai-metrics-p7-retention-list",
       "command": "bun run beep ai-metrics retention list --data-root /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics --json"
     },
@@ -224,12 +264,12 @@
   "knownGaps": [
     "The credited seven-day proof window is in progress until at least May 16, 2026 02:26 America/Chicago",
     "The workstation timer now runs from a locked pinned proof worktree while proof data remains under the main checkout .beep/ai-metrics root",
-    "The isolated-runner config has two benchmark runs but still requires at least one explicit human-approved outcome label",
-    "P7a/b hybrid mirror and local retention workflows are implemented, but remote mirror lifecycle automation beyond build, dry-run sync, and status remains pending",
+    "The isolated-runner config has a human-approved outcome label and intermediate completion-ready scorecard, but still requires elapsed proof time and the final seven-day report",
+    "P7a/b hybrid mirror and local retention workflows are implemented, but final confirmed mirror sync/status is deferred until after the credited proof report",
     "Optional LiteLLM deployment remains deferred beyond the Phoenix-only P5b slice",
-    "xAI, Venice, LiteLLM, and gateway enrichment remain deferred to P7c",
-    "Dashboard and backend expansion remains deferred to P7d",
+    "xAI, Venice, LiteLLM, and gateway enrichment remain deferred to non-blocking P7c follow-up",
+    "Dashboard and backend expansion remains deferred to non-blocking P7d follow-up",
     "Server-owned collection remains a future topology target requiring transcript access/sync and privacy design"
   ],
-  "nextAction": "Keep the isolated proof-runner timer running through May 16, 2026 02:26 America/Chicago, add a human-approved label for the isolated-runner config, regenerate the scorecard, and generate the final credited seven-day report after the proof window elapses; keep P7c/P7d deferred until that closeout gate is satisfied."
+  "nextAction": "Keep the isolated proof-runner timer running through May 16, 2026 02:26 America/Chicago, generate the final credited seven-day report after the proof window elapses, then run the P7e sanitized mirror build/sync/status closeout; keep P7c/P7d as non-blocking follow-up work."
 }


### PR DESCRIPTION
## Summary
- document the P6c label gate closure and current completion-ready evidence
- narrow V1 closeout to the final P6 elapsed report plus P7e sanitized derived mirror closeout
- mark P7c/P7d provider/tool/cost work as non-blocking follow-up and align README/SPEC/PLAN/manifest language

## Tests
- bun run lint:fix
- bun run audit:github quality
- jq . initiatives/ai-metrics-stack/ops/manifest.json >/dev/null
- git diff --check
- quality-review-fix-loop local review: fixed 1 completion-standard inconsistency; 0 blockers remaining

## Notes
- The confirmed mirror sync remains intentionally gated until after 2026-05-16 02:26 CDT.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI Metrics Stack project planning documents with refined completion criteria and gating milestones.
  * Clarified production-ready status definitions and V1 blocking vs. follow-up work items.
  * Added explicit completion gates and updated timeline tracking for May 2026 targets.
  * Enhanced manifest configuration with new operational gates and status tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/139)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->