### PR TITLE
docs(stack-installer): restore p1d-active packet truth

### DIFF
--- a/initiatives/stack-installer/PLAN.md
+++ b/initiatives/stack-installer/PLAN.md
@@ -154,20 +154,20 @@ flow.
 
 Exit Criteria:
 
-- [ ] Audited macOS proof artifact exists before the review starts.
-- [ ] Audited Windows proof artifact exists, or an explicit temporary Windows
+- [x] Audited macOS proof artifact exists before the review starts.
+- [x] Audited Windows proof artifact exists, or an explicit temporary Windows
   missing-proof waiver is recorded for P1C start.
-- [ ] Baseline quality commands are green on the current branch.
-- [ ] Reviewer panel covers quality gates, architecture boundaries, schema and
+- [x] Baseline quality commands are green on the current branch.
+- [x] Reviewer panel covers quality gates, architecture boundaries, schema and
   domain models, Effect laws, error boundaries, tests, observability,
   documentation/API, reuse/duplication, and evolution/deprecation.
-- [ ] Reuse opportunities are checked against existing repo modules before new
+- [x] Reuse opportunities are checked against existing repo modules before new
   abstractions are introduced.
-- [ ] Any structural improvements keep modules flat, idiomatic, and aligned
+- [x] Any structural improvements keep modules flat, idiomatic, and aligned
   with repo laws and package boundaries.
-- [ ] Required blockers are fixed, or every remaining blocker has an explicit
+- [x] Required blockers are fixed, or every remaining blocker has an explicit
   waiver record.
-- [ ] Final review round reports zero required blockers or only accepted
+- [x] Final review round reports zero required blockers or only accepted
   waivers.
 
 Required Outputs:

--- a/initiatives/stack-installer/PLAN.md
+++ b/initiatives/stack-installer/PLAN.md
@@ -1,11 +1,11 @@
 # Stack Installer Plan
 
-This plan executes [SPEC.md](./SPEC.md). P0 is complete. P1 is the active
-target: Discord vertical, Manual Mode. P1A is complete as a runnable dry-run
+This plan executes [SPEC.md](./SPEC.md). P0 is complete. P1 remains open:
+Discord vertical, Manual Mode. P1A is complete as a runnable dry-run
 checkpoint. The P1 live harness is implemented. macOS proof is complete and
-audited. Windows proof is still missing, but is temporarily waived only so the
-P1C review/fix loop can start. Full P1 still requires a real Windows proof
-artifact plus the post-proof PR readiness review/fix loop.
+audited. Windows proof is still missing and remains explicit open P1 debt.
+P1C is complete. P1D is now the active next execution lane on Linux while full
+P1 still requires the real Windows proof artifact.
 
 ## P0: Initiative Bootstrap
 
@@ -144,8 +144,7 @@ Stop Conditions:
 
 ### P1C: PR Readiness Review And Fix Loop
 
-Status: pending; may start after audited macOS proof plus either audited
-Windows proof or an explicit temporary Windows missing-proof waiver
+Status: completed under sequencing-only temporary Windows missing-proof waiver
 
 Goal: review the whole implemented P1 initiative surface and directly affected
 code paths before the PR is called ready. The review uses
@@ -238,29 +237,34 @@ Stop Conditions:
 
 ## P1D: App-First Manual Installer UX
 
-Status: pending
+Status: active next execution lane; implementation proceeds on the dedicated
+P1D branch/worktree while full P1 remains open on the missing Windows proof
 
 Goal: move the next meaningful milestone from proof-harness confidence to
 product confidence by making the Tauri app the primary operator surface and
-having it complete one real dependency install or repair action.
+having it complete one real dependency repair action.
 
 Scope notes:
 
 - Stage this milestone on Linux first so the next proof loop can run locally.
 - Keep macOS and Windows as the long-term parity target; Linux-first staging
   does not change the v1 parity doctrine.
-- The first real action is Bun install or repair owned by
-  `installer-dependencies`, not app-local glue code.
+- The first real action is repair-only Bun upgrade for an existing Bun install
+  owned by `installer-dependencies`, not app-local glue code.
+- The required Bun version is an installer-owned config contract. App workflow
+  code must not read repo metadata directly to discover it.
 
 Exit Criteria:
 
 - [ ] `apps/stack-installer` opens as the primary surface for this milestone.
-- [ ] The app detects Bun missing or unhealthy and presents a typed install or
-  repair action.
+- [ ] The app detects Bun unhealthy and presents a typed repair action for an
+  existing Bun install.
 - [ ] The action is approval-first and mutates the host only after explicit
   user approval.
-- [ ] `installer-dependencies` owns the live Bun install/repair contract and
-  server implementation.
+- [ ] `installer-dependencies` owns the live Bun repair contract and server
+  implementation.
+- [ ] `installer-dependencies-config` or equivalent installer-owned config
+  surface owns the required Bun version contract and its live resolution.
 - [ ] After the action runs, the same validation spine reports Bun as present
   or returns a typed failure with visible status.
 - [ ] Linux-first proof artifacts show the app-first Bun flow end to end.
@@ -277,13 +281,15 @@ Required Checks:
 - `bun run config-sync:check`
 - `cd apps/stack-installer && bun run build`
 - `cd apps/stack-installer/src-tauri && cargo check`
-- Linux-first app-driven Bun install/repair proof capture and audit
+- Linux-first app-driven Bun repair proof capture and audit
 
 Stop Conditions:
 
-- Do not start P2 before P1D closes.
+- Do not start P2 before both P1D closes and the real Windows proof audit
+  closes the remaining P1 debt.
 - Do not hide the real dependency mutation in shell scripts owned outside the
   installer slice boundary.
+- Do not broaden this milestone into first-time Bun bootstrap.
 - Do not add plaintext credential handling or broaden this milestone into AI
   Mode, MCP runtime, recovery, portability, signing, or distribution.
 

--- a/initiatives/stack-installer/README.md
+++ b/initiatives/stack-installer/README.md
@@ -25,8 +25,9 @@ driver packages validate 1Password, provider auth, host commands, and Discord
 liveness, and the app exposes Tauri and CLI proof capture commands. Fresh-OS
 macOS proof is complete and audited. Windows proof is temporarily waived only
 to let the P1C review/fix loop start. Full P1 still stays open until a real
-Windows proof artifact and the post-proof PR readiness review are both
-complete.
+Windows proof artifact is returned and audited. P1D is now the active next
+execution lane: the app-first Bun repair milestone proceeds on Linux while the
+Windows proof remains explicit open P1 debt and a hard gate before P2.
 
 ## Read This First
 
@@ -47,11 +48,12 @@ complete.
   - post-proof quality review and fix-loop record, including the temporary
     Windows missing-proof waiver
 - [history/outputs/p1d-app-first-manual-installer-ux.md](./history/outputs/p1d-app-first-manual-installer-ux.md)
-  - next milestone stub: app-first Manual Installer UX with one real action
+  - next milestone stub: app-first Manual Installer UX with one real repair
+    action
 - [ops/handoffs/HANDOFF_P1_DISCORD_MANUAL.md](./ops/handoffs/HANDOFF_P1_DISCORD_MANUAL.md)
   - user-operated macOS and Windows proof runbook
 - [ops/handoffs/HANDOFF_P1D_APP_FIRST_MANUAL_INSTALLER_UX.md](./ops/handoffs/HANDOFF_P1D_APP_FIRST_MANUAL_INSTALLER_UX.md)
-  - next milestone handoff stub for Linux-first app-driven Bun install/repair
+  - next milestone handoff stub for Linux-first app-driven Bun repair
 - [ops/handoffs/GOAL_P1_MACOS_PROOF.md](./ops/handoffs/GOAL_P1_MACOS_PROOF.md)
   - short `/goal` indirection target for the buddy MacBook Pro proof run
 - [research/README.md](./research/README.md) - research index
@@ -69,13 +71,16 @@ complete.
   contracts, and render a deterministic manifest preview.
 - P1 live harness is implemented: app-local proof composition, Tauri command,
   CLI artifact capture/audit, and live driver-backed validators exist. macOS
-  proof is complete. Windows proof is missing but temporarily waived so P1C
-  can start; full P1 remains open until Windows proof is real and audited.
-- P1D is pending after P1C: the app must become the primary operator surface
-  and complete one real machine-changing dependency action, starting on Linux
-  with Bun install/repair.
-- P2 is pending after P1D: AI Mode parity across Claude and Codex with
-  byte-identical manifest output modulo timestamps.
+  proof is complete. Windows proof is missing but temporarily waived only for
+  sequencing; full P1 remains open until Windows proof is real and audited.
+- P1C is complete: the PR readiness review/fix loop is recorded with the
+  temporary Windows missing-proof waiver and zero remaining required blockers.
+- P1D is the active next execution lane: the app must become the primary
+  operator surface and complete one real machine-changing dependency repair
+  action, starting on Linux with Bun repair for an existing Bun install.
+- P2 is pending after both P1D and the real Windows proof: AI Mode parity
+  across Claude and Codex with byte-identical manifest output modulo
+  timestamps.
 - P3 is pending: recovery proof from salted-broken-state machines.
 - P4 is pending: portability proof from exported manifest on Machine A to
   imported validator suite on Machine B.
@@ -91,7 +96,7 @@ This initiative is done only when all are true:
 - [ ] P1 PR readiness review/fix loop is recorded with zero required blockers
   or explicit waivers.
 - [ ] P1D app-first Manual Installer UX is recorded with a real app-driven
-  dependency install/repair action.
+  dependency repair action.
 - [ ] P2 AI Mode parity is recorded for Claude and Codex with a
   byte-identical-manifest gate modulo timestamps.
 - [ ] P3 recovery scenarios prove repair for wrong Node version, invalid

--- a/initiatives/stack-installer/SPEC.md
+++ b/initiatives/stack-installer/SPEC.md
@@ -11,7 +11,7 @@
 ## Created / Updated
 
 - **Created:** 2026-05-14
-- **Updated:** 2026-05-14
+- **Updated:** 2026-05-16
 
 ## Purpose
 
@@ -257,12 +257,15 @@ and does not close P1.
 
 P1D is complete when the Tauri app becomes the primary operator surface for a
 Linux-first proof run and completes one real machine-changing dependency
-install or repair action through installer-owned code, with proof artifacts and
-validation showing the before and after state.
+repair action through installer-owned code, with proof artifacts and
+validation showing the before and after state. For this milestone, the Bun flow
+is repair-only for an existing Bun install, and the required Bun version is an
+installer-owned config contract rather than an app-local repo metadata read.
 
 P2 is complete when the same flow runs in AI Mode for Claude and Codex, with
 screencasts, structured action logs, and a byte-identical-manifest gate modulo
-timestamps between P1D and P2.
+timestamps between P1D and P2. P2 does not start until the real Windows proof
+artifact is returned and audited, closing the remaining P1 debt.
 
 P3 is complete when AI Mode repairs salted broken states for wrong Node
 version, invalid Discord token, and missing 1Password reference, with

--- a/initiatives/stack-installer/history/outputs/p1d-app-first-manual-installer-ux.md
+++ b/initiatives/stack-installer/history/outputs/p1d-app-first-manual-installer-ux.md
@@ -1,6 +1,6 @@
 # P1D App-First Manual Installer UX
 
-Status: pending.
+Status: in progress.
 
 This file records evidence for the active next execution lane after the P1C
 closure pass. Full P1 remains open until the real Windows proof is returned and

--- a/initiatives/stack-installer/history/outputs/p1d-app-first-manual-installer-ux.md
+++ b/initiatives/stack-installer/history/outputs/p1d-app-first-manual-installer-ux.md
@@ -1,0 +1,18 @@
+# P1D App-First Manual Installer UX
+
+Status: pending.
+
+This file records evidence for the active next execution lane after the P1C
+closure pass. Full P1 remains open until the real Windows proof is returned and
+audited, but P1D now proceeds as the next milestone on Linux.
+
+P1D for this milestone is intentionally repair-only:
+
+- the Tauri app is the primary operator surface
+- the Linux-first proof target is an existing Bun install that is present but
+  older than the required version
+- the real host mutation is approval-first Bun repair via `bun upgrade`
+- the required Bun version is owned by installer configuration, not app-local
+  repo metadata reads
+- proof artifacts must capture before/after validation, the app-first flow,
+  and the visible repair result

--- a/initiatives/stack-installer/ops/handoffs/HANDOFF_P1D_APP_FIRST_MANUAL_INSTALLER_UX.md
+++ b/initiatives/stack-installer/ops/handoffs/HANDOFF_P1D_APP_FIRST_MANUAL_INSTALLER_UX.md
@@ -1,0 +1,32 @@
+# Handoff P1D - App-First Manual Installer UX
+
+Status: stub.
+
+## Mission
+
+Make the Tauri app the primary operator surface for the next milestone and
+prove one real dependency repair action end to end.
+
+For this milestone, the first real action is Linux-first Bun repair for an
+existing Bun install owned by `installer-dependencies`.
+
+## Required Startup
+
+- Read `../../SPEC.md`.
+- Read `../../PLAN.md`.
+- Read `../manifest.json`.
+- Read `../../history/outputs/p1-pr-readiness-review.md`.
+- Read `../../history/outputs/p1-completion-audit.md`.
+
+## Scope Guardrails
+
+- Keep the mutation owned by installer slice contracts and server
+  implementation, not app-local shell glue.
+- Keep the required Bun version in installer-owned config, not app-local
+  repo metadata reads.
+- Keep the UX approval-first.
+- Keep this milestone Linux-first for proof staging.
+- Do not broaden this milestone into first-time Bun bootstrap.
+- Do not start P2 AI Mode work from this handoff.
+
+Full prompt to be authored in the dedicated P1D implementation lane.

--- a/initiatives/stack-installer/ops/manifest.json
+++ b/initiatives/stack-installer/ops/manifest.json
@@ -55,7 +55,8 @@
       "closedGates": [
         "P0 packet bootstrap",
         "P1A runnable dry-run spine",
-        "P1 live proof harness implementation"
+        "P1 live proof harness implementation",
+        "P1 PR readiness quality-review-fix-loop"
       ],
       "remainingGates": [
         "P1 Discord vertical, Manual Mode fresh-OS Windows proof",
@@ -326,7 +327,7 @@
     {
       "phase": "P1D",
       "proof": "App-First Manual Installer UX",
-      "status": "pending",
+      "status": "in_progress",
       "evidenceArtifacts": [
         "history/outputs/p1d-app-first-manual-installer-ux.md",
         "ops/handoffs/HANDOFF_P1D_APP_FIRST_MANUAL_INSTALLER_UX.md",
@@ -438,8 +439,8 @@
       "future: verify zero required blockers or explicit waivers before PR-ready status"
     ],
     "p1dAppFirstManualInstallerUx": [
-      "future: Linux-first app-driven Bun install or repair proof",
-      "future: app validation detects Bun missing or unhealthy before mutation",
+      "future: Linux-first app-driven Bun repair proof for an existing install",
+      "future: app validation detects Bun unhealthy before mutation",
       "future: approval-first action path performs one real host mutation",
       "future: post-action validation reports Bun present or returns typed failure",
       "future: targeted package/app quality commands for touched slices"
@@ -475,7 +476,7 @@
     "artifact intake via Taildrop is blocked until the coordinator runs sudo tailscale set --operator=$USER or uses another approved private transfer channel; tokenized temporary tailnet upload is documented as a fallback, but no proof bundles have arrived",
     "coordinator-side Taildrop send to the online Windows peer is blocked because Tailscale reports the peer is owned by a different user",
     "live upload endpoint is reachable through raw tailnet IP and MagicDNS, but upload logs show no PUT or POST artifact upload attempts",
-    "post-proof quality-review-fix-loop not run",
+    "post-proof quality-review-fix-loop completed under temporary Windows missing-proof waiver (P1C closed)",
     "live proof harness validates existing state only and does not install or provision dependencies",
     "MCP executor adapter not built beyond minimal app-local Tauri bridge",
     "skill and instruction bundle generation not built",

--- a/initiatives/stack-installer/ops/manifest.json
+++ b/initiatives/stack-installer/ops/manifest.json
@@ -3,13 +3,13 @@
   "initiative": {
     "id": "stack-installer",
     "title": "Stack Installer",
-    "status": "active-p1c-startable-full-p1-blocked-on-windows-proof",
+    "status": "active-p1d-with-open-p1-windows-proof-debt",
     "created": "2026-05-14",
     "updated": "2026-05-16",
     "packetAnchorDocument": "SPEC.md"
   },
   "currentSourceOfTruth": "SPEC.md",
-  "currentTargetPhase": "P1",
+  "currentTargetPhase": "P1D",
   "reportDirectory": "research",
   "rawOutputDirectory": "history/outputs",
   "completionEvidence": {
@@ -40,9 +40,9 @@
       "summary": "Prompt-to-artifact completion audit records macOS proof complete, Windows proof temporarily waived for P1C start only, and full P1 still blocked on the real Windows artifact."
     },
     "p1dAppFirstManualInstallerUx": {
-      "status": "pending",
+      "status": "in_progress",
       "output": "history/outputs/p1d-app-first-manual-installer-ux.md",
-      "summary": "Next milestone after P1C: make the Tauri app the primary surface and complete one real Linux-first Bun install or repair action through installer-owned code."
+      "summary": "Active next milestone after P1C: make the Tauri app the primary surface and complete one real Linux-first Bun repair action for an existing Bun install through installer-owned code and installer-owned config."
     },
     "p1PauseHandoff": {
       "status": "recorded",
@@ -51,15 +51,14 @@
     },
     "v1": {
       "status": "in_progress",
-      "activeGate": "P1",
+      "activeGate": "P1D",
       "closedGates": [
         "P0 packet bootstrap",
         "P1A runnable dry-run spine",
         "P1 live proof harness implementation"
       ],
       "remainingGates": [
-        "P1 Discord vertical, Manual Mode fresh-OS macOS and Windows proof",
-        "P1 PR readiness quality-review-fix-loop",
+        "P1 Discord vertical, Manual Mode fresh-OS Windows proof",
         "P1D app-first Manual Installer UX",
         "P2 AI Mode parity",
         "P3 Recovery",
@@ -104,15 +103,15 @@
   },
   "v1Completion": {
     "status": "in_progress",
-    "activeGate": "P1",
+    "activeGate": "P1D",
     "closedGates": [
       "P0 packet bootstrap",
       "P1A runnable dry-run spine",
-      "P1 live proof harness implementation"
+      "P1 live proof harness implementation",
+      "P1 PR readiness quality-review-fix-loop"
     ],
     "remainingGates": [
-      "P1 Discord vertical, Manual Mode fresh-OS macOS and Windows proof",
-      "P1 PR readiness quality-review-fix-loop",
+      "P1 Discord vertical, Manual Mode fresh-OS Windows proof",
       "P1D app-first Manual Installer UX",
       "P2 AI Mode parity across Claude and Codex",
       "P3 salted recovery proof",
@@ -242,9 +241,9 @@
     {
       "id": "P1D",
       "name": "App-First Manual Installer UX",
-      "status": "pending",
+      "status": "in_progress",
       "output": "history/outputs/p1d-app-first-manual-installer-ux.md",
-      "exitCriteriaSummary": "The Tauri app becomes the primary operator surface and completes one real Linux-first Bun install or repair action through installer-owned code."
+      "exitCriteriaSummary": "The Tauri app becomes the primary operator surface and completes one real Linux-first Bun repair action for an existing Bun install through installer-owned code and installer-owned config."
     },
     {
       "id": "P2",
@@ -332,7 +331,7 @@
         "history/outputs/p1d-app-first-manual-installer-ux.md",
         "ops/handoffs/HANDOFF_P1D_APP_FIRST_MANUAL_INSTALLER_UX.md",
         "future evidence: app-open screencast",
-        "future evidence: Bun missing-to-installed proof",
+        "future evidence: Bun repair proof for existing install",
         "future evidence: approval-first action log",
         "future evidence: before/after validation output"
       ]
@@ -499,5 +498,5 @@
     "P1 live drivers live under packages/drivers and are consumed by slice server packages",
     "P1 live proof remains app-local runtime composition, not a tooling God Layer"
   ],
-  "nextAction": "Resume from history/outputs/p1-pause-handoff-2026-05-14.md. Start a fresh proof upload window and detached watcher, then run full P1 live Manual Mode proof on fresh macOS and Windows using ops/handoffs/HANDOFF_P1_DISCORD_MANUAL.md: 1Password validation, provider auth validation, Discord liveness, sanitized proof JSON, screencasts, and test messages. Recreate the local Windows VM only if using the local VM route; otherwise use another real Windows environment. Configure Taildrop on the coordinator with sudo tailscale set --operator=$USER, use the documented tokenized temporary tailnet upload fallback, or use another approved private transfer channel. Place the returned bundles under output/stack-installer/p1-live, and run p1:proof:intake followed by p1:proof:audit-all. After proof artifacts are audited, run the P1 PR readiness quality-review-fix-loop before declaring the branch PR ready."
+  "nextAction": "Keep P1 explicitly open on the missing Windows proof while making P1D the active execution lane. Resume the dedicated P1D branch/worktree from this packet truth, record the successful Linux-first repair-only Bun proof with installer-owned config and visible app-state evidence, then close and publish P1D. After P1D closes, run the real Windows proof intake/audit before starting P2."
 }

--- a/initiatives/stack-installer/ops/p1-completion-check.mjs
+++ b/initiatives/stack-installer/ops/p1-completion-check.mjs
@@ -173,8 +173,8 @@ addCheck(
   `manifest completionEvidence.p1LiveHarness.status=${p1LiveEvidence}`
 );
 addCheck(
-  manifest.currentTargetPhase === "P1",
-  "Active manifest target remains P1",
+  manifest.currentTargetPhase === "P1D",
+  "Active manifest target is P1D while full P1 remains open",
   `manifest currentTargetPhase=${manifest.currentTargetPhase}`
 );
 addCheck(p2Phase?.status === "pending", "P2 remains pending", `manifest P2 status=${p2Phase?.status ?? "missing"}`);

--- a/initiatives/stack-installer/ops/p1-completion-check.mjs
+++ b/initiatives/stack-installer/ops/p1-completion-check.mjs
@@ -252,14 +252,18 @@ addCheck(
 
 const allComplete = checks.every((check) => check.ok);
 
-console.log(`Stack Installer P1 completion check for ${rel(outputRoot)}`);
+console.log(`Stack Installer P1/P1D readiness check for ${rel(outputRoot)}`);
 for (const check of checks) {
   console.log(`${check.ok ? "[pass]" : "[block]"} ${check.label}: ${check.detail}`);
 }
 if (!allComplete && p1cStartStatus.ok) {
   console.log("P1C may start, but full P1 completion remains blocked.");
 }
-console.log(allComplete ? "P1 completion check passed." : "P1 completion check blocked.");
+console.log(
+  allComplete
+    ? "P1D readiness check passed; full P1 remains open until the real Windows proof is returned and audited."
+    : "P1/P1D readiness check blocked."
+);
 
 if (!allComplete) {
   process.exitCode = 1;


### PR DESCRIPTION
## Summary
- restore stack-installer packet truth on top of current `main`
- keep full `P1` explicitly open on missing Windows proof
- mark `P1D` as the active next lane without claiming it is complete yet

## What changed
- update the stack-installer README, plan, spec, manifest, and completion checker
- add the missing P1D output and handoff stub documents referenced by the packet
- keep `P2` pending and untouched

## Why this is separate
This is a packet-truth follow-up only. The actual P1D implementation and closure remain on `feat/stack-installer-p1d-bun-repair` and will be published after this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Stack Installer initiative planning documents including phase status, requirements, and detailed execution sequencing.
  * Added new handoff guidance and completion standard documentation for the P1D execution lane.
  * Clarified milestone requirements, scope guardrails, and operational specifications for installer-driven dependency repair actions.
  * Updated execution phase tracking, status reporting, and next-action guidance to reflect current initiative state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->