### PR TITLE
[codex] Remove unpinned dev helper execution

### DIFF
--- a/.changeset/opip-dev-helper-security.md
+++ b/.changeset/opip-dev-helper-security.md
@@ -1,0 +1,5 @@
+---
+---
+
+Record the OPIP development-helper security hardening without publishing a
+package release for the internal app branch.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -8,10 +8,6 @@
 command = "npx"
 args = ["shadcn@latest", "mcp"]
 
-[mcp_servers.next-devtools]
-command = "npx"
-args = ["-y", "next-devtools-mcp@latest"]
-
 [skills]
 include_instructions = true
 

--- a/apps/opip-web/AGENTS.md
+++ b/apps/opip-web/AGENTS.md
@@ -44,6 +44,4 @@ import { VERSION } from "@beep/opip-web"
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 
-When `next-devtools-mcp` is available in Codex, call its `init` tool at the start
-of Next.js debugging work for this app before inspecting runtime diagnostics.
 <!-- END:nextjs-agent-rules -->

--- a/apps/opip-web/src/app/layout.tsx
+++ b/apps/opip-web/src/app/layout.tsx
@@ -18,6 +18,7 @@ import "./globals.css";
 
 const { metadata: siteMetadata } = opipSiteContent;
 const REACT_GRAB_VERSION = "0.1.34";
+const REACT_GRAB_INTEGRITY = "sha384-J3uUkSxoVuSuDgef6b1qRkPjoviSf3OhttzqVTJd98rv0/hPenLy8KfgE7UEulp2";
 const configStringOptionSync = (name: string): O.Option<string> => Effect.runSync(Config.option(Config.string(name)));
 const configStringEqualsSync = (name: string, expected: string): boolean =>
   pipe(
@@ -236,6 +237,7 @@ export default function RootLayout({
               <Script
                 src={`https://unpkg.com/react-grab@${REACT_GRAB_VERSION}/dist/index.global.js`}
                 crossOrigin="anonymous"
+                integrity={REACT_GRAB_INTEGRITY}
                 nonce={nonce}
                 strategy="beforeInteractive"
               />


### PR DESCRIPTION
## Summary
- remove the repository-local Codex MCP server that executed `next-devtools-mcp@latest` via `npx`
- remove the app-local instruction that encouraged agents to invoke that unpinned MCP server during Next.js debugging
- add SRI to the opt-in React Grab development script while keeping its exact version pin

## Security rationale
The finding is legitimate. The prior Codex config resolved and executed `next-devtools-mcp@latest` at runtime outside workspace lockfile review, and the app AGENTS instructions made that path likely during normal debugging. The React Grab helper was already version-pinned on current `main`, but it still lacked an integrity attribute, so this adds a verified `sha384` SRI value for the exact `react-grab@0.1.34` asset.

## Validation
- verified `react-grab@0.1.34/dist/index.global.js` SRI with `curl | openssl sha384`
- `bunx turbo run check --filter=@beep/opip-web --cache=local:rw`
- `bun run check`
- pre-push `bun run beep quality repo-exports-catalog --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment tooling configuration.

* **Documentation**
  * Removed outdated developer guidance.

* **Refactor**
  * Strengthened security for externally loaded scripts by implementing Subresource Integrity validation, ensuring safe loading and protection against unauthorized modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->