### PR TITLE
fix(codex): pin shadcn MCP command

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -5,8 +5,9 @@
 # linked to that Claude tree.
 
 [mcp_servers.shadcn]
+# Pin the MCP server package instead of executing mutable npx latest.
 command = "npx"
-args = ["shadcn@latest", "mcp"]
+args = ["-y", "shadcn@4.7.0", "mcp"]
 
 [skills]
 include_instructions = true


### PR DESCRIPTION
### Motivation
- The repo-local Codex MCP entry executed `npx shadcn@latest mcp`, which allows a mutable npm `latest` package to run arbitrary code in developer/agent environments and creates a supply-chain execution risk.
- Pin the MCP invocation to a reviewed, recorded version to eliminate the mutable `latest` attack surface while preserving the shadcn MCP workflow.

### Description
- Replaced the `.codex/config.toml` shadcn MCP server command from `npx shadcn@latest mcp` to `npx -y shadcn@4.7.0 mcp` and added a short explanatory comment.
- This keeps the existing Node/npm runner path while making the package version explicit instead of fetching whatever `latest` resolves to at runtime.
- Kept the previously removed `next-devtools` MCP entry out of the rebased branch.

### Testing
- Verified the pinned package is resolvable and exposes the expected MCP subcommand with `npx -y shadcn@4.7.0 --help`.
- Ran `bun run changeset:status:since-main`.
- Ran `bun run audit:github repo-sanity`.
- Ran `bun run check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0641867310832c8bfac166656d7ba9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server configuration with a pinned package version for enhanced stability and consistent tool behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->