### PR TITLE
ci: restrict Cachix auth to trusted pushes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -312,7 +312,15 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: Setup Cachix
+      - name: Setup Cachix (read-only)
+        if: github.event_name != 'push'
+        uses: cachix/cachix-action@v15
+        with:
+          name: beep-effect
+        continue-on-error: true
+
+      - name: Setup Cachix (trusted push)
+        if: github.event_name == 'push'
         uses: cachix/cachix-action@v15
         with:
           name: beep-effect


### PR DESCRIPTION
### Motivation
- Prevent PR-controlled repository code from running in the same job that configures `secrets.CACHIX_AUTH_TOKEN`, eliminating a CI secret-exposure vector while keeping Nix checks available for `pull_request` runs.

### Description
- Gate the Cachix setup step in the `nix` job by adding `if: github.event_name == 'push'` to the `Setup Cachix` step in `.github/workflows/check.yml` so the action with the auth token only runs on trusted pushes.

### Testing
- Ran `actionlint .github/workflows/check.yml` and it succeeded.
- Ran `git diff --check` and no whitespace/patch issues were reported.
- Attempted `bun run audit:github repo-sanity` which was blocked locally because the checkout has no `origin` remote, so the repo-sanity task could not fetch `origin/main` (this is an environmental limitation, not a change regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fed4256928832c983ed52cc7b294a7)