### PR TITLE
refactor: migrate schema annotations to $I.annoteSchema

### DIFF
--- a/.changeset/fix-schema-annotation-pipe-pattern.md
+++ b/.changeset/fix-schema-annotation-pipe-pattern.md
@@ -1,0 +1,7 @@
+---
+---
+
+Migrate all hand-wired schema annotations from `S.annotate($I.annote(...))` (and the
+direct `schema.annotate($I.annote(...))` method form) to `$I.annoteSchema(...)` across
+the repo, and correct the standards/skill docs that taught the old pattern. Internal
+refactor only — no public API or release impact.

--- a/.claude/skills/effect-first-development/SKILL.md
+++ b/.claude/skills/effect-first-development/SKILL.md
@@ -240,9 +240,9 @@ const ContainsScopeSeparator = S.String.check(
   })
 ).pipe(
   S.brand("ContainsScopeSeparator"),
-  S.annotate($I.annote("ContainsScopeSeparator", {
+  $I.annoteSchema("ContainsScopeSeparator", {
     description: "A string containing the topic scope separator `:`."
-  }))
+  })
 )
 
 const isContainsScopeSeparator = S.is(ContainsScopeSeparator)
@@ -256,9 +256,9 @@ const TopicSegment = S.NonEmptyString.check(
   })
 ).pipe(
   S.brand("TopicSegment"),
-  S.annotate($I.annote("TopicSegment", {
+  $I.annoteSchema("TopicSegment", {
     description: "A non-empty topic segment without the scope separator."
-  }))
+  })
 )
 
 const isTopicSegment = S.is(TopicSegment)
@@ -305,9 +305,9 @@ export const TopicName = S.NonEmptyString.check(
   )
 ).pipe(
   S.brand("TopicName"),
-  S.annotate($I.annote("TopicName", {
+  $I.annoteSchema("TopicName", {
     description: "A topic name composed from valid plain or scoped segments."
-  }))
+  })
 )
 ```
 

--- a/apps/oip-web/src/contact/ContactSubmission.model.ts
+++ b/apps/oip-web/src/contact/ContactSubmission.model.ts
@@ -17,11 +17,9 @@ const contactEmailPattern =
 
 const TrimmedContactText = S.NonEmptyString.pipe(
   S.decode(SchemaTransformation.trim()),
-  S.annotate(
-    $I.annote("TrimmedContactText", {
-      description: "Trimmed non-empty contact form text.",
-    })
-  )
+  $I.annoteSchema("TrimmedContactText", {
+    description: "Trimmed non-empty contact form text.",
+  })
 );
 
 const ContactName = TrimmedContactText.check(
@@ -29,11 +27,9 @@ const ContactName = TrimmedContactText.check(
     message: "Name must include at least 2 characters.",
   })
 ).pipe(
-  S.annotate(
-    $I.annote("ContactName", {
-      description: "Normalized contact form name.",
-    })
-  )
+  $I.annoteSchema("ContactName", {
+    description: "Normalized contact form name.",
+  })
 );
 
 const ContactEmail = TrimmedContactText.pipe(S.decode(SchemaTransformation.toLowerCase()))
@@ -46,11 +42,9 @@ const ContactEmail = TrimmedContactText.pipe(S.decode(SchemaTransformation.toLow
     })
   )
   .pipe(
-    S.annotate(
-      $I.annote("ContactEmail", {
-        description: "Normalized contact form email address.",
-      })
-    )
+    $I.annoteSchema("ContactEmail", {
+      description: "Normalized contact form email address.",
+    })
   );
 
 const ContactMessage = TrimmedContactText.check(
@@ -58,11 +52,9 @@ const ContactMessage = TrimmedContactText.check(
     message: "Message must include at least 10 characters.",
   })
 ).pipe(
-  S.annotate(
-    $I.annote("ContactMessage", {
-      description: "Normalized contact form message.",
-    })
-  )
+  $I.annoteSchema("ContactMessage", {
+    description: "Normalized contact form message.",
+  })
 );
 
 /**
@@ -79,8 +71,8 @@ const ContactMessage = TrimmedContactText.check(
  * @category schemas
  * @since 0.0.0
  */
-export const ContactSubmissionStatus = LiteralKit(["accepted", "rejected"]).annotate(
-  $I.annote("ContactSubmissionStatus", {
+export const ContactSubmissionStatus = LiteralKit(["accepted", "rejected"]).pipe(
+  $I.annoteSchema("ContactSubmissionStatus", {
     description: "Public contact submission result status.",
   })
 );

--- a/apps/oip-web/src/content/OipContent.model.ts
+++ b/apps/oip-web/src/content/OipContent.model.ts
@@ -26,8 +26,8 @@ const $I = $OipWebId.create("content/OipContent.model");
  * @category schemas
  * @since 0.0.0
  */
-export const ReviewStatus = LiteralKit(["approved", "needs_review"]).annotate(
-  $I.annote("ReviewStatus", {
+export const ReviewStatus = LiteralKit(["approved", "needs_review"]).pipe(
+  $I.annoteSchema("ReviewStatus", {
     description: "Review state for public OIP website claims.",
   })
 );
@@ -128,8 +128,8 @@ export const SocialPlatform = LiteralKit([
   "reddit",
   "discord",
   "pinterest",
-]).annotate(
-  $I.annote("SocialPlatform", {
+]).pipe(
+  $I.annoteSchema("SocialPlatform", {
     description: "Social platform the OIP firm maintains a public profile on.",
   })
 );

--- a/packages/agent-capability/domain/src/entities/Agent/Agent.values.ts
+++ b/packages/agent-capability/domain/src/entities/Agent/Agent.values.ts
@@ -23,8 +23,8 @@ const $I = $AgentCapabilityDomainId.create("entities/Agent/Agent.values");
  * @category schemas
  * @since 0.0.0
  */
-export const AgentMode = LiteralKit(["deterministic_fixture"]).annotate(
-  $I.annote("AgentMode", {
+export const AgentMode = LiteralKit(["deterministic_fixture"]).pipe(
+  $I.annoteSchema("AgentMode", {
     description: "Execution mode vocabulary for proof agents.",
   })
 );

--- a/packages/drivers/acp/src/AcpProtocol.service.ts
+++ b/packages/drivers/acp/src/AcpProtocol.service.ts
@@ -729,9 +729,7 @@ export const makeAcpPatchedProtocol = Effect.fn($I`makeAcpPatchedProtocol`)(func
   function sendRequest(
     method: string,
     payload?: unknown
-  ):
-    | Effect.Effect<unknown, AcpError.AcpError>
-    | ((payload: unknown) => Effect.Effect<unknown, AcpError.AcpError>) {
+  ): Effect.Effect<unknown, AcpError.AcpError> | ((payload: unknown) => Effect.Effect<unknown, AcpError.AcpError>) {
     if (arguments.length === 1) {
       return (curriedPayload: unknown) => sendRequestEffect(method, curriedPayload);
     }

--- a/packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts
+++ b/packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts
@@ -54,13 +54,12 @@ interface AiProviderCliShape {
 class AiProviderCliPaths extends S.Class<AiProviderCliPaths>($I`AiProviderCliPaths`)(
   {
     claudePath: S.optionalKey(S.String),
-    codexPath: S.optionalKey(S.String)
+    codexPath: S.optionalKey(S.String),
   },
   $I.annote("AiProviderCliPaths", {
-    description: "Configuration for the AI provider CLI executable paths"
+    description: "Configuration for the AI provider CLI executable paths",
   })
 ) {}
-
 
 const commandFor = (
   paths: AiProviderCliPaths,

--- a/packages/drivers/phoenix/src/Phoenix.models.ts
+++ b/packages/drivers/phoenix/src/Phoenix.models.ts
@@ -133,8 +133,8 @@ export type PhoenixAnnotatorKind = typeof PhoenixAnnotatorKind.Type;
  * @category models
  * @since 0.0.0
  */
-export const PhoenixAnnotationValue = S.Union([S.Boolean, S.Number, S.String]).annotate(
-  $I.annote("PhoenixAnnotationValue", {
+export const PhoenixAnnotationValue = S.Union([S.Boolean, S.Number, S.String]).pipe(
+  $I.annoteSchema("PhoenixAnnotationValue", {
     description: "Primitive annotation value accepted by repo-owned Phoenix annotations.",
   })
 );

--- a/packages/drivers/postgres/src/PostgresSqlState.models.ts
+++ b/packages/drivers/postgres/src/PostgresSqlState.models.ts
@@ -1458,8 +1458,8 @@ const PgErrorAliasesLookup: Readonly<Record<string, A.NonEmptyReadonlyArray<PgEr
  * @category schemas
  * @since 0.0.0
  */
-export const PgErrorCode = LiteralKit(PgErrorCodeValues).annotate(
-  $I.annote("PgErrorCode", {
+export const PgErrorCode = LiteralKit(PgErrorCodeValues).pipe(
+  $I.annoteSchema("PgErrorCode", {
     description: "PostgreSQL SQLSTATE code literal domain.",
   })
 );
@@ -1480,8 +1480,8 @@ export const PgErrorCode = LiteralKit(PgErrorCodeValues).annotate(
  * @category schemas
  * @since 0.0.0
  */
-export const PgErrorName = LiteralKit(PgErrorNameValues).annotate(
-  $I.annote("PgErrorName", {
+export const PgErrorName = LiteralKit(PgErrorNameValues).pipe(
+  $I.annoteSchema("PgErrorName", {
     description: "PostgreSQL SQLSTATE name literal domain.",
   })
 );

--- a/packages/epistemic/domain/src/values/ClaimLifecycle/ClaimLifecycle.model.ts
+++ b/packages/epistemic/domain/src/values/ClaimLifecycle/ClaimLifecycle.model.ts
@@ -22,8 +22,8 @@ const $I = $EpistemicDomainId.create("values/ClaimLifecycle/ClaimLifecycle.model
  * @category schemas
  * @since 0.0.0
  */
-export const ClaimLifecycle = LiteralKit(["candidate"]).annotate(
-  $I.annote("ClaimLifecycle", {
+export const ClaimLifecycle = LiteralKit(["candidate"]).pipe(
+  $I.annoteSchema("ClaimLifecycle", {
     description: "Lifecycle state for epistemic claims produced by the runtime proof.",
   })
 );

--- a/packages/foundation/capability/nlp/src/Core/Document.ts
+++ b/packages/foundation/capability/nlp/src/Core/Document.ts
@@ -42,11 +42,9 @@ const getRangeEnd = (
  */
 export const DocumentId = S.NonEmptyString.pipe(
   S.brand("DocumentId"),
-  S.annotate(
-    $I.annote("DocumentId", {
-      description: "Stable identifier for an NLP document.",
-    })
-  )
+  $I.annoteSchema("DocumentId", {
+    description: "Stable identifier for an NLP document.",
+  })
 );
 
 /**

--- a/packages/foundation/capability/nlp/src/Core/Pattern.ts
+++ b/packages/foundation/capability/nlp/src/Core/Pattern.ts
@@ -158,11 +158,9 @@ const DisambiguatedLiteralPatternOptionChoice = S.makeFilter(
 export const POSPatternOption = S.NonEmptyArray(S.Union([WinkPOSTag, EmptyPatternChoice]))
   .check(MeaningfulPatternOptionChoice)
   .pipe(
-    S.annotate(
-      $I.annote("POSPatternOption", {
-        description: "One or more POS tag alternatives for a pattern position.",
-      })
-    )
+    $I.annoteSchema("POSPatternOption", {
+      description: "One or more POS tag alternatives for a pattern position.",
+    })
   );
 
 /**
@@ -196,11 +194,9 @@ export type POSPatternOption = typeof POSPatternOption.Type;
 export const EntityPatternOption = S.NonEmptyArray(S.Union([WinkEntityType, EmptyPatternChoice]))
   .check(MeaningfulPatternOptionChoice)
   .pipe(
-    S.annotate(
-      $I.annote("EntityPatternOption", {
-        description: "One or more entity-type alternatives for a pattern position.",
-      })
-    )
+    $I.annoteSchema("EntityPatternOption", {
+      description: "One or more entity-type alternatives for a pattern position.",
+    })
   );
 
 /**
@@ -235,11 +231,9 @@ export const LiteralPatternOption = S.NonEmptyArray(S.Union([S.NonEmptyString, E
   .check(MeaningfulPatternOptionChoice)
   .check(DisambiguatedLiteralPatternOptionChoice)
   .pipe(
-    S.annotate(
-      $I.annote("LiteralPatternOption", {
-        description: "One or more literal-text alternatives for a pattern position.",
-      })
-    )
+    $I.annoteSchema("LiteralPatternOption", {
+      description: "One or more literal-text alternatives for a pattern position.",
+    })
   );
 
 /**
@@ -340,11 +334,9 @@ export class LiteralPatternElement extends S.TaggedClass<LiteralPatternElement>(
  * @category models
  */
 export const PatternElement = S.Union([POSPatternElement, EntityPatternElement, LiteralPatternElement]).pipe(
-  S.annotate(
-    $I.annote("PatternElement", {
-      description: "Tagged union of supported NLP pattern element variants.",
-    })
-  )
+  $I.annoteSchema("PatternElement", {
+    description: "Tagged union of supported NLP pattern element variants.",
+  })
 );
 
 /**
@@ -377,11 +369,9 @@ export type PatternElement = typeof PatternElement.Type;
  */
 export const PatternId = S.NonEmptyString.pipe(
   S.brand("PatternId"),
-  S.annotate(
-    $I.annote("PatternId", {
-      description: "Stable identifier for a reusable NLP pattern.",
-    })
-  )
+  $I.annoteSchema("PatternId", {
+    description: "Stable identifier for a reusable NLP pattern.",
+  })
 );
 
 /**
@@ -413,11 +403,9 @@ export type PatternId = typeof PatternId.Type;
  * @category models
  */
 export const MarkRange = S.Tuple([NonNegativeInt, NonNegativeInt]).pipe(
-  S.annotate(
-    $I.annote("MarkRange", {
-      description: "Inclusive [start, end] range of marked pattern elements.",
-    })
-  )
+  $I.annoteSchema("MarkRange", {
+    description: "Inclusive [start, end] range of marked pattern elements.",
+  })
 );
 
 /**

--- a/packages/foundation/capability/nlp/src/Core/PatternParsers.ts
+++ b/packages/foundation/capability/nlp/src/Core/PatternParsers.ts
@@ -111,11 +111,9 @@ export const BracketStringToPOSPatternElement = S.String.pipe(
     ),
     encode: SchemaGetter.transform((element) => Pattern.POS.toBracketString(element.value)),
   }),
-  S.annotate(
-    $I.annote("BracketStringToPOSPatternElement", {
-      description: "Decoder for POS bracket strings such as [ADJ|NOUN].",
-    })
-  )
+  $I.annoteSchema("BracketStringToPOSPatternElement", {
+    description: "Decoder for POS bracket strings such as [ADJ|NOUN].",
+  })
 );
 
 /**
@@ -144,11 +142,9 @@ export const BracketStringToEntityPatternElement = S.String.pipe(
     ),
     encode: SchemaGetter.transform((element) => Pattern.Entity.toBracketString(element.value)),
   }),
-  S.annotate(
-    $I.annote("BracketStringToEntityPatternElement", {
-      description: "Decoder for entity bracket strings such as [DATE|TIME].",
-    })
-  )
+  $I.annoteSchema("BracketStringToEntityPatternElement", {
+    description: "Decoder for entity bracket strings such as [DATE|TIME].",
+  })
 );
 
 /**
@@ -177,11 +173,9 @@ export const BracketStringToLiteralPatternElement = S.String.pipe(
     ),
     encode: SchemaGetter.transform((element) => Pattern.Literal.toBracketString(element.value)),
   }),
-  S.annotate(
-    $I.annote("BracketStringToLiteralPatternElement", {
-      description: "Decoder for literal bracket strings such as [Apple|Google].",
-    })
-  )
+  $I.annoteSchema("BracketStringToLiteralPatternElement", {
+    description: "Decoder for literal bracket strings such as [Apple|Google].",
+  })
 );
 
 /**
@@ -202,11 +196,9 @@ export const BracketStringToPatternElement = S.String.pipe(
     decode: SchemaGetter.transformOrFail(decodePatternElement),
     encode: SchemaGetter.transform(encodePatternElement),
   }),
-  S.annotate(
-    $I.annote("BracketStringToPatternElement", {
-      description: "Decoder for bracket strings that resolve to exactly one supported pattern element variant.",
-    })
-  )
+  $I.annoteSchema("BracketStringToPatternElement", {
+    description: "Decoder for bracket strings that resolve to exactly one supported pattern element variant.",
+  })
 );
 
 /**

--- a/packages/foundation/capability/nlp/src/Wink/WinkEngine.ts
+++ b/packages/foundation/capability/nlp/src/Wink/WinkEngine.ts
@@ -50,11 +50,9 @@ type WinkCustomEntityRecord = {
  */
 export const InstanceId = S.NonEmptyString.pipe(
   S.brand("InstanceId"),
-  S.annotate(
-    $I.annote("InstanceId", {
-      description: "Stable identifier for one live wink engine instance.",
-    })
-  )
+  $I.annoteSchema("InstanceId", {
+    description: "Stable identifier for one live wink engine instance.",
+  })
 );
 
 /**

--- a/packages/foundation/capability/nlp/src/Wink/WinkPattern.ts
+++ b/packages/foundation/capability/nlp/src/Wink/WinkPattern.ts
@@ -63,11 +63,9 @@ const patternElementToBracketString = (pattern: Pattern): ReadonlyArray<string> 
  */
 export const EntityGroupName = S.NonEmptyString.pipe(
   S.brand("EntityGroupName"),
-  S.annotate(
-    $I.annote("EntityGroupName", {
-      description: "Stable identifier for a learned wink custom-entity group.",
-    })
-  )
+  $I.annoteSchema("EntityGroupName", {
+    description: "Stable identifier for a learned wink custom-entity group.",
+  })
 );
 
 /**

--- a/packages/foundation/capability/nlp/src/internal/numbers.ts
+++ b/packages/foundation/capability/nlp/src/internal/numbers.ts
@@ -42,8 +42,8 @@ const UnitIntervalChecks = S.makeFilterGroup(
  * @since 0.0.0
  * @category validation
  */
-export const UnitInterval = S.Number.check(UnitIntervalChecks).annotate(
-  $I.annote("UnitInterval", {
+export const UnitInterval = S.Number.check(UnitIntervalChecks).pipe(
+  $I.annoteSchema("UnitInterval", {
     description: "A numeric value between 0 and 1 inclusive.",
   })
 );
@@ -81,8 +81,8 @@ export const PositiveNumber = S.Number.check(
     description: "A number greater than 0.",
     message: "Expected a number greater than 0",
   })
-).annotate(
-  $I.annote("PositiveNumber", {
+).pipe(
+  $I.annoteSchema("PositiveNumber", {
     description: "A numeric value greater than 0.",
   })
 );

--- a/packages/foundation/capability/observability/src/Observed.ts
+++ b/packages/foundation/capability/observability/src/Observed.ts
@@ -38,11 +38,9 @@ const $I = $ObservabilityId.create("Observed");
  * @category models
  */
 export const ObservedError = S.Error.pipe(
-  S.annotate(
-    $I.annote("ObservedError", {
-      description: "A transport-safe schema for expected errors.",
-    })
-  )
+  $I.annoteSchema("ObservedError", {
+    description: "A transport-safe schema for expected errors.",
+  })
 );
 
 /**
@@ -78,11 +76,9 @@ export type ObservedError = typeof ObservedError.Type;
  * @category models
  */
 export const ObservedErrorWithStack = S.ErrorWithStack.pipe(
-  S.annotate(
-    $I.annote("ObservedErrorWithStack", {
-      description: "A transport-safe schema for expected errors that preserves stacks.",
-    })
-  )
+  $I.annoteSchema("ObservedErrorWithStack", {
+    description: "A transport-safe schema for expected errors that preserves stacks.",
+  })
 );
 
 /**
@@ -118,11 +114,9 @@ export type ObservedErrorWithStack = typeof ObservedErrorWithStack.Type;
  * @category models
  */
 export const ObservedDefect = S.Defect.pipe(
-  S.annotate(
-    $I.annote("ObservedDefect", {
-      description: "A transport-safe schema for defects.",
-    })
-  )
+  $I.annoteSchema("ObservedDefect", {
+    description: "A transport-safe schema for defects.",
+  })
 );
 
 /**
@@ -158,11 +152,9 @@ export type ObservedDefect = typeof ObservedDefect.Type;
  * @category models
  */
 export const ObservedDefectWithStack = S.DefectWithStack.pipe(
-  S.annotate(
-    $I.annote("ObservedDefectWithStack", {
-      description: "A transport-safe schema for defects that preserves stacks when possible.",
-    })
-  )
+  $I.annoteSchema("ObservedDefectWithStack", {
+    description: "A transport-safe schema for defects that preserves stacks when possible.",
+  })
 );
 
 /**
@@ -195,11 +187,9 @@ export type ObservedDefectWithStack = typeof ObservedDefectWithStack.Type;
  * @category models
  */
 export const ObservedCauseReason = S.CauseReason(ObservedErrorWithStack, ObservedDefectWithStack).pipe(
-  S.annotate(
-    $I.annote("ObservedCauseReason", {
-      description: "One serialized failure reason from a Cause.",
-    })
-  )
+  $I.annoteSchema("ObservedCauseReason", {
+    description: "One serialized failure reason from a Cause.",
+  })
 );
 
 /**
@@ -232,11 +222,9 @@ export type ObservedCauseReason = typeof ObservedCauseReason.Type;
  * @category models
  */
 export const ObservedCause = S.Cause(ObservedErrorWithStack, ObservedDefectWithStack).pipe(
-  S.annotate(
-    $I.annote("ObservedCause", {
-      description: "A transport-safe schema for full Effect causes.",
-    })
-  )
+  $I.annoteSchema("ObservedCause", {
+    description: "A transport-safe schema for full Effect causes.",
+  })
 );
 
 /**
@@ -269,11 +257,9 @@ export type ObservedCause = typeof ObservedCause.Type;
  * @category models
  */
 export const ObservedExit = S.Exit(S.Unknown, ObservedErrorWithStack, ObservedDefectWithStack).pipe(
-  S.annotate(
-    $I.annote("ObservedExit", {
-      description: "A transport-safe schema for exits carrying unknown success values.",
-    })
-  )
+  $I.annoteSchema("ObservedExit", {
+    description: "A transport-safe schema for exits carrying unknown success values.",
+  })
 );
 
 /**

--- a/packages/foundation/capability/observability/src/server/NodeSdk.ts
+++ b/packages/foundation/capability/observability/src/server/NodeSdk.ts
@@ -49,35 +49,27 @@ const OTelSpanProcessor = S.declare<SpanProcessor>(isOTelSpanProcessor, {
 });
 
 const NodeSdkLogRecordProcessorOption = S.Union([OTelLogRecordProcessor, S.Array(OTelLogRecordProcessor)]).pipe(
-  S.annotate(
-    $I.annote("NodeSdkLogRecordProcessorOption", {
-      description: "One or more OpenTelemetry log record processors for the shared Node SDK layer.",
-    })
-  )
+  $I.annoteSchema("NodeSdkLogRecordProcessorOption", {
+    description: "One or more OpenTelemetry log record processors for the shared Node SDK layer.",
+  })
 );
 
 const NodeSdkMetricReaderOption = S.Union([OTelMetricReader, S.Array(OTelMetricReader)]).pipe(
-  S.annotate(
-    $I.annote("NodeSdkMetricReaderOption", {
-      description: "One or more OpenTelemetry metric readers for the shared Node SDK layer.",
-    })
-  )
+  $I.annoteSchema("NodeSdkMetricReaderOption", {
+    description: "One or more OpenTelemetry metric readers for the shared Node SDK layer.",
+  })
 );
 
 const NodeSdkSpanProcessorOption = S.Union([OTelSpanProcessor, S.Array(OTelSpanProcessor)]).pipe(
-  S.annotate(
-    $I.annote("NodeSdkSpanProcessorOption", {
-      description: "One or more OpenTelemetry span processors for the shared Node SDK layer.",
-    })
-  )
+  $I.annoteSchema("NodeSdkSpanProcessorOption", {
+    description: "One or more OpenTelemetry span processors for the shared Node SDK layer.",
+  })
 );
 
 const NodeSdkMetricTemporality = LiteralKit(["cumulative", "delta"]).pipe(
-  S.annotate(
-    $I.annote("NodeSdkMetricTemporality", {
-      description: "Metric temporality preference accepted by the Effect OpenTelemetry Node SDK.",
-    })
-  )
+  $I.annoteSchema("NodeSdkMetricTemporality", {
+    description: "Metric temporality preference accepted by the Effect OpenTelemetry Node SDK.",
+  })
 );
 
 /**

--- a/packages/foundation/capability/sandbox/src/Agent.provider.ts
+++ b/packages/foundation/capability/sandbox/src/Agent.provider.ts
@@ -24,8 +24,8 @@ const TOOL_ARG_FIELDS: Readonly<Record<string, string>> = {
   WebSearch: "query",
 };
 
-const ClaudeContentBlockType = LiteralKit(["text", "tool_use"]).annotate(
-  $I.annote("ClaudeContentBlockType", {
+const ClaudeContentBlockType = LiteralKit(["text", "tool_use"]).pipe(
+  $I.annoteSchema("ClaudeContentBlockType", {
     description: "Claude stream content block discriminator.",
   })
 );
@@ -74,8 +74,8 @@ class ClaudeMessage extends S.Class<ClaudeMessage>($I`ClaudeMessage`)(
   })
 ) {}
 
-const ClaudeStreamLineType = LiteralKit(["assistant", "result", "system"]).annotate(
-  $I.annote("ClaudeStreamLineType", {
+const ClaudeStreamLineType = LiteralKit(["assistant", "result", "system"]).pipe(
+  $I.annoteSchema("ClaudeStreamLineType", {
     description: "Claude stream line discriminator.",
   })
 );
@@ -105,8 +105,8 @@ type ClaudeAssistantStreamLine = Extract<
   }
 >;
 
-const CodexItemType = LiteralKit(["agent_message", "command_execution"]).annotate(
-  $I.annote("CodexItemType", {
+const CodexItemType = LiteralKit(["agent_message", "command_execution"]).pipe(
+  $I.annoteSchema("CodexItemType", {
     description: "Codex stream item discriminator.",
   })
 );
@@ -141,8 +141,8 @@ const CodexErrorPayload = S.Union([S.String, CodexErrorMessagePayload]).pipe(
 
 type CodexErrorPayload = typeof CodexErrorPayload.Type;
 
-const CodexStreamLineType = LiteralKit(["item.completed", "item.started", "error"]).annotate(
-  $I.annote("CodexStreamLineType", {
+const CodexStreamLineType = LiteralKit(["item.completed", "item.started", "error"]).pipe(
+  $I.annoteSchema("CodexStreamLineType", {
     description: "Codex stream line discriminator.",
   })
 );
@@ -172,8 +172,8 @@ type CodexErrorStreamLine = Extract<
   }
 >;
 
-const PiAssistantMessageEventType = LiteralKit(["text_delta"]).annotate(
-  $I.annote("PiAssistantMessageEventType", {
+const PiAssistantMessageEventType = LiteralKit(["text_delta"]).pipe(
+  $I.annoteSchema("PiAssistantMessageEventType", {
     description: "Pi assistant message event discriminator.",
   })
 );
@@ -214,8 +214,8 @@ const PiStreamLineType = LiteralKit([
   "error",
   "message_update",
   "tool_execution_start",
-]).annotate(
-  $I.annote("PiStreamLineType", {
+]).pipe(
+  $I.annoteSchema("PiStreamLineType", {
     description: "Pi stream line discriminator.",
   })
 );
@@ -363,8 +363,8 @@ export type ParsedStreamEvent = typeof ParsedStreamEvent.Type;
  * @category schemas
  * @since 0.0.0
  */
-export const CodexEffort = LiteralKit(["low", "medium", "high", "xhigh"]).annotate(
-  $I.annote("CodexEffort", {
+export const CodexEffort = LiteralKit(["low", "medium", "high", "xhigh"]).pipe(
+  $I.annoteSchema("CodexEffort", {
     description: "Reasoning effort accepted by the Codex provider.",
   })
 );
@@ -383,8 +383,8 @@ export type CodexEffort = typeof CodexEffort.Type;
  * @category schemas
  * @since 0.0.0
  */
-export const ClaudeEffort = LiteralKit(["low", "medium", "high", "max"]).annotate(
-  $I.annote("ClaudeEffort", {
+export const ClaudeEffort = LiteralKit(["low", "medium", "high", "max"]).pipe(
+  $I.annoteSchema("ClaudeEffort", {
     description: "Reasoning effort accepted by the Claude Code provider.",
   })
 );

--- a/packages/foundation/capability/sandbox/src/Display.ts
+++ b/packages/foundation/capability/sandbox/src/Display.ts
@@ -22,8 +22,8 @@ const sanitizeDisplayText = redactSensitiveText;
  * @category schemas
  * @since 0.0.0
  */
-export const Severity = LiteralKit(["Info", "Success", "Warn", "Error"]).annotate(
-  $I.annote("Severity", {
+export const Severity = LiteralKit(["Info", "Success", "Warn", "Error"]).pipe(
+  $I.annoteSchema("Severity", {
     description: "Severity - The severity of the display message.",
   })
 );

--- a/packages/foundation/capability/sandbox/src/Image.ts
+++ b/packages/foundation/capability/sandbox/src/Image.ts
@@ -24,8 +24,8 @@ const $I = $SandboxId.create("Image");
  * @category schemas
  * @since 0.0.0
  */
-export const ContainerImageRuntime = LiteralKit(["docker", "podman"]).annotate(
-  $I.annote("ContainerImageRuntime", {
+export const ContainerImageRuntime = LiteralKit(["docker", "podman"]).pipe(
+  $I.annoteSchema("ContainerImageRuntime", {
     description: "Container runtime used for local sandbox images.",
   })
 );

--- a/packages/foundation/capability/sandbox/src/Init.ts
+++ b/packages/foundation/capability/sandbox/src/Init.ts
@@ -35,8 +35,8 @@ export const SANDBOX_CONFIG_DIR = ".sandcastle" as const;
  * @category schemas
  * @since 0.0.0
  */
-export const SandboxAgentName = LiteralKit(["claude-code", "codex", "opencode", "pi"]).annotate(
-  $I.annote("SandboxAgentName", {
+export const SandboxAgentName = LiteralKit(["claude-code", "codex", "opencode", "pi"]).pipe(
+  $I.annoteSchema("SandboxAgentName", {
     description: "Supported init-time agent choices.",
   })
 );
@@ -55,8 +55,8 @@ export type SandboxAgentName = typeof SandboxAgentName.Type;
  * @category schemas
  * @since 0.0.0
  */
-export const SandboxInitProviderName = LiteralKit(["docker", "podman"]).annotate(
-  $I.annote("SandboxInitProviderName", {
+export const SandboxInitProviderName = LiteralKit(["docker", "podman"]).pipe(
+  $I.annoteSchema("SandboxInitProviderName", {
     description: "Supported local container providers for generated configuration.",
   })
 );

--- a/packages/foundation/capability/sandbox/src/Prompt.ts
+++ b/packages/foundation/capability/sandbox/src/Prompt.ts
@@ -55,8 +55,8 @@ export const BUILT_IN_PROMPT_ARG_KEY_SET: HashSet.HashSet<string> = HashSet.from
  * @category schemas
  * @since 0.0.0
  */
-export const BuiltInPromptArgKey = LiteralKit(BUILT_IN_PROMPT_ARG_KEYS).annotate(
-  $I.annote("BuiltInPromptArgKey", {
+export const BuiltInPromptArgKey = LiteralKit(BUILT_IN_PROMPT_ARG_KEYS).pipe(
+  $I.annoteSchema("BuiltInPromptArgKey", {
     description: "Built-in prompt argument key domain.",
   })
 );
@@ -117,8 +117,8 @@ const promptArgValueToText = (value: PromptArgValue): string => value.toString()
  * @category schemas
  * @since 0.0.0
  */
-export const PromptSource = LiteralKit(["Inline", "Template"]).annotate(
-  $I.annote("PromptSource", {
+export const PromptSource = LiteralKit(["Inline", "Template"]).pipe(
+  $I.annoteSchema("PromptSource", {
     description: "Prompt source discriminator.",
   })
 );

--- a/packages/foundation/capability/sandbox/src/RecoveryMessage.ts
+++ b/packages/foundation/capability/sandbox/src/RecoveryMessage.ts
@@ -26,8 +26,8 @@ const $I = $SandboxId.create("RecoveryMessage");
  * @category models
  * @since 0.0.0
  */
-export const FailedStep = LiteralKit(["commits", "diff", "untracked"]).annotate(
-  $I.annote("FailedStep", {
+export const FailedStep = LiteralKit(["commits", "diff", "untracked"]).pipe(
+  $I.annoteSchema("FailedStep", {
     description: "Sync-out step that failed during patch application.",
   })
 );

--- a/packages/foundation/capability/sandbox/src/Run.ts
+++ b/packages/foundation/capability/sandbox/src/Run.ts
@@ -80,8 +80,8 @@ export const DEFAULT_MAX_ITERATIONS = 1 as const;
  * @category schemas
  * @since 0.0.0
  */
-export const LoggingOptionKind = LiteralKit(["File", "Stdout"]).annotate(
-  $I.annote("LoggingOptionKind", {
+export const LoggingOptionKind = LiteralKit(["File", "Stdout"]).pipe(
+  $I.annoteSchema("LoggingOptionKind", {
     description: "Logging option discriminator.",
   })
 );

--- a/packages/foundation/capability/sandbox/src/Sandbox.provider.ts
+++ b/packages/foundation/capability/sandbox/src/Sandbox.provider.ts
@@ -21,8 +21,8 @@ const $I = $SandboxId.create("Sandbox.provider");
  * @category schemas
  * @since 0.0.0
  */
-export const SandboxProviderKind = LiteralKit(["BindMount", "Isolated", "None"]).annotate(
-  $I.annote("SandboxProviderKind", {
+export const SandboxProviderKind = LiteralKit(["BindMount", "Isolated", "None"]).pipe(
+  $I.annoteSchema("SandboxProviderKind", {
     description: "Sandbox provider kind.",
   })
 );

--- a/packages/foundation/capability/sandbox/src/Template.ts
+++ b/packages/foundation/capability/sandbox/src/Template.ts
@@ -22,8 +22,8 @@ const $I = $SandboxId.create("Template");
  * @category schemas
  * @since 0.0.0
  */
-export const SandboxTemplateName = LiteralKit(["blank", "simple-loop"]).annotate(
-  $I.annote("SandboxTemplateName", {
+export const SandboxTemplateName = LiteralKit(["blank", "simple-loop"]).pipe(
+  $I.annoteSchema("SandboxTemplateName", {
     description: "Supported scaffold template names.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/adapters/web-annotation.ts
+++ b/packages/foundation/capability/semantic-web/src/adapters/web-annotation.ts
@@ -140,8 +140,8 @@ export const WebAnnotationSelector = S.Union([
   WebAnnotationTextQuoteSelector,
   WebAnnotationTextPositionSelector,
   WebAnnotationFragmentSelector,
-]).annotate(
-  $I.annote("WebAnnotationSelector", {
+]).pipe(
+  $I.annoteSchema("WebAnnotationSelector", {
     description: "Web Annotation selector union.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/evidence.ts
+++ b/packages/foundation/capability/semantic-web/src/evidence.ts
@@ -29,8 +29,8 @@ const $I = $SemanticWebId.create("evidence");
  * @since 0.0.0
  * @category models
  */
-export const EvidenceSelectorKind = LiteralKit(["text-quote", "text-position", "fragment"]).annotate(
-  $I.annote("EvidenceSelectorKind", {
+export const EvidenceSelectorKind = LiteralKit(["text-quote", "text-position", "fragment"]).pipe(
+  $I.annoteSchema("EvidenceSelectorKind", {
     description: "Evidence selector discriminator.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/iri.ts
+++ b/packages/foundation/capability/semantic-web/src/iri.ts
@@ -858,11 +858,9 @@ const iriChecks = makeNonEmptyReferenceChecks("IRI", "IRI", "An RFC 3987 IRI.", 
  */
 export const IRIReference = S.String.check(iriReferenceChecks).pipe(
   S.brand("IRIReference"),
-  S.annotate(
-    $I.annote("IRIReference", {
-      description: "RFC 3987 IRI reference syntax, including both absolute and relative forms.",
-    })
-  )
+  $I.annoteSchema("IRIReference", {
+    description: "RFC 3987 IRI reference syntax, including both absolute and relative forms.",
+  })
 );
 
 /**
@@ -898,11 +896,9 @@ export type IRIReference = typeof IRIReference.Type;
  */
 export const RelativeIRIReference = S.String.check(relativeIriReferenceChecks).pipe(
   S.brand("RelativeIRIReference"),
-  S.annotate(
-    $I.annote("RelativeIRIReference", {
-      description: "RFC 3987 relative IRI reference syntax (`irelative-ref`).",
-    })
-  )
+  $I.annoteSchema("RelativeIRIReference", {
+    description: "RFC 3987 relative IRI reference syntax (`irelative-ref`).",
+  })
 );
 
 /**
@@ -938,11 +934,9 @@ export type RelativeIRIReference = typeof RelativeIRIReference.Type;
  */
 export const AbsoluteIRI = S.String.check(absoluteIriChecks).pipe(
   S.brand("AbsoluteIRI"),
-  S.annotate(
-    $I.annote("AbsoluteIRI", {
-      description: "RFC 3987 absolute IRI syntax without a fragment component.",
-    })
-  )
+  $I.annoteSchema("AbsoluteIRI", {
+    description: "RFC 3987 absolute IRI syntax without a fragment component.",
+  })
 );
 
 /**
@@ -978,11 +972,9 @@ export type AbsoluteIRI = typeof AbsoluteIRI.Type;
  */
 export const IRI = S.String.check(iriChecks).pipe(
   S.brand("IRI"),
-  S.annotate(
-    $I.annote("IRI", {
-      description: "RFC 3987 IRI syntax.",
-    })
-  )
+  $I.annoteSchema("IRI", {
+    description: "RFC 3987 IRI syntax.",
+  })
 );
 
 /**

--- a/packages/foundation/capability/semantic-web/src/jsonld.ts
+++ b/packages/foundation/capability/semantic-web/src/jsonld.ts
@@ -14,8 +14,8 @@ import { makeSemanticSchemaMetadata } from "./semantic-schema-metadata.ts";
 
 const $I = $SemanticWebId.create("jsonld");
 
-const JsonLdScalar = S.Union([S.String, S.Number, S.Boolean]).annotate(
-  $I.annote("JsonLdScalar", {
+const JsonLdScalar = S.Union([S.String, S.Number, S.Boolean]).pipe(
+  $I.annoteSchema("JsonLdScalar", {
     description: "Scalar JSON-LD literal value input used by bounded document helpers.",
   })
 );
@@ -60,8 +60,8 @@ export const JsonLdKeyword = LiteralKit([
   "@type",
   "@value",
   "@vocab",
-]).annotate(
-  $I.annote("JsonLdKeyword", {
+]).pipe(
+  $I.annoteSchema("JsonLdKeyword", {
     description: "JSON-LD keyword surface used by the bounded v1 model.",
   })
 );
@@ -167,21 +167,19 @@ export class JsonLdContext extends S.Class<JsonLdContext>($I`JsonLdContext`)(
  */
 export const JsonLdBlankNodeIdentifier = S.String.check(jsonLdBlankNodeIdentifierChecks).pipe(
   S.brand("JsonLdBlankNodeIdentifier"),
-  S.annotate(
-    $I.annote("JsonLdBlankNodeIdentifier", {
-      description: "JSON-LD blank-node identifier used by the bounded document model.",
-      semanticSchemaMetadata: makeSemanticSchemaMetadata({
-        kind: "identifier",
-        canonicalName: "JsonLdBlankNodeIdentifier",
-        overview: "JSON-LD blank-node identifier used by the bounded document model.",
-        status: "stable",
-        specifications: [{ name: "JSON-LD 1.1", section: "Node Identifiers", disposition: "normative" }],
-        equivalenceBasis: "Exact blank-node identifier equality within a bounded document.",
-        canonicalizationRequired: true,
-        representations: [{ kind: "JSON-LD" }, { kind: "RDF/JS", note: "Bridges to RDF blank-node labels." }],
-      }),
-    })
-  )
+  $I.annoteSchema("JsonLdBlankNodeIdentifier", {
+    description: "JSON-LD blank-node identifier used by the bounded document model.",
+    semanticSchemaMetadata: makeSemanticSchemaMetadata({
+      kind: "identifier",
+      canonicalName: "JsonLdBlankNodeIdentifier",
+      overview: "JSON-LD blank-node identifier used by the bounded document model.",
+      status: "stable",
+      specifications: [{ name: "JSON-LD 1.1", section: "Node Identifiers", disposition: "normative" }],
+      equivalenceBasis: "Exact blank-node identifier equality within a bounded document.",
+      canonicalizationRequired: true,
+      representations: [{ kind: "JSON-LD" }, { kind: "RDF/JS", note: "Bridges to RDF blank-node labels." }],
+    }),
+  })
 );
 
 /**
@@ -213,8 +211,8 @@ export type JsonLdBlankNodeIdentifier = typeof JsonLdBlankNodeIdentifier.Type;
  * @since 0.0.0
  * @category models
  */
-export const JsonLdNodeIdentifier = S.Union([IRIReference, JsonLdBlankNodeIdentifier]).annotate(
-  $I.annote("JsonLdNodeIdentifier", {
+export const JsonLdNodeIdentifier = S.Union([IRIReference, JsonLdBlankNodeIdentifier]).pipe(
+  $I.annoteSchema("JsonLdNodeIdentifier", {
     description: "JSON-LD node identifier used by the bounded document model.",
     semanticSchemaMetadata: makeSemanticSchemaMetadata({
       kind: "identifier",
@@ -323,8 +321,8 @@ export class JsonLdLiteralValue extends S.Class<JsonLdLiteralValue>($I`JsonLdLit
  * @since 0.0.0
  * @category models
  */
-export const JsonLdPropertyValue = S.Union([JsonLdReferenceValue, JsonLdLiteralValue]).annotate(
-  $I.annote("JsonLdPropertyValue", {
+export const JsonLdPropertyValue = S.Union([JsonLdReferenceValue, JsonLdLiteralValue]).pipe(
+  $I.annoteSchema("JsonLdPropertyValue", {
     description: "JSON-LD property value union used by bounded node objects.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/prov.ts
+++ b/packages/foundation/capability/semantic-web/src/prov.ts
@@ -74,20 +74,18 @@ const provDateTimeChecks = S.makeFilterGroup(
  */
 export const ObjectRef = S.String.check(provObjectRefChecks).pipe(
   S.brand("ProvObjectRef"),
-  S.annotate(
-    $I.annote("ObjectRef", {
-      description: "PROV object reference encoded as an IRI, CURIE, or local identifier.",
-      semanticSchemaMetadata: makeSemanticSchemaMetadata({
-        kind: "provenanceConstruct",
-        canonicalName: "ObjectRef",
-        overview: "PROV object reference encoded as an IRI, CURIE, or local identifier.",
-        status: "stable",
-        specifications: [{ name: "PROV-O", section: "Qualified Relations", disposition: "normative" }],
-        equivalenceBasis: "Exact reference-string equality inside a bounded provenance bundle.",
-        provenanceProfile: "minimal-core-v1",
-      }),
-    })
-  )
+  $I.annoteSchema("ObjectRef", {
+    description: "PROV object reference encoded as an IRI, CURIE, or local identifier.",
+    semanticSchemaMetadata: makeSemanticSchemaMetadata({
+      kind: "provenanceConstruct",
+      canonicalName: "ObjectRef",
+      overview: "PROV object reference encoded as an IRI, CURIE, or local identifier.",
+      status: "stable",
+      specifications: [{ name: "PROV-O", section: "Qualified Relations", disposition: "normative" }],
+      equivalenceBasis: "Exact reference-string equality inside a bounded provenance bundle.",
+      provenanceProfile: "minimal-core-v1",
+    }),
+  })
 );
 
 /**
@@ -121,20 +119,18 @@ export type ObjectRef = typeof ObjectRef.Type;
  */
 export const ProvDateTimeEncoded = S.String.check(provDateTimeChecks).pipe(
   S.brand("ProvDateTimeEncoded"),
-  S.annotate(
-    $I.annote("ProvDateTimeEncoded", {
-      description: "Encoded PROV timestamp string.",
-      semanticSchemaMetadata: makeSemanticSchemaMetadata({
-        kind: "provenanceConstruct",
-        canonicalName: "ProvDateTimeEncoded",
-        overview: "Encoded PROV timestamp string.",
-        status: "stable",
-        specifications: [{ name: "PROV-O", section: "Time", disposition: "normative" }],
-        equivalenceBasis: "Canonical ISO string equality after decoding and re-encoding.",
-        timeSemantics: "PROV activity and lifecycle timestamps remain distinct from domain lifecycle fields.",
-      }),
-    })
-  )
+  $I.annoteSchema("ProvDateTimeEncoded", {
+    description: "Encoded PROV timestamp string.",
+    semanticSchemaMetadata: makeSemanticSchemaMetadata({
+      kind: "provenanceConstruct",
+      canonicalName: "ProvDateTimeEncoded",
+      overview: "Encoded PROV timestamp string.",
+      status: "stable",
+      specifications: [{ name: "PROV-O", section: "Time", disposition: "normative" }],
+      equivalenceBasis: "Canonical ISO string equality after decoding and re-encoding.",
+      timeSemantics: "PROV activity and lifecycle timestamps remain distinct from domain lifecycle fields.",
+    }),
+  })
 );
 
 /**
@@ -168,20 +164,18 @@ export type ProvDateTimeEncoded = typeof ProvDateTimeEncoded.Type;
  */
 export const ProvDateTime = ProvDateTimeEncoded.pipe(
   S.decodeTo(S.DateTimeUtcFromString),
-  S.annotate(
-    $I.annote("ProvDateTime", {
-      description: "PROV timestamp decoded to DateTime.Utc.",
-      semanticSchemaMetadata: makeSemanticSchemaMetadata({
-        kind: "provenanceConstruct",
-        canonicalName: "ProvDateTime",
-        overview: "PROV timestamp decoded to DateTime.Utc.",
-        status: "stable",
-        specifications: [{ name: "PROV-O", section: "Time", disposition: "normative" }],
-        equivalenceBasis: "UTC instant equality.",
-        timeSemantics: "PROV timestamps express activity and influence time, not all domain lifecycle semantics.",
-      }),
-    })
-  )
+  $I.annoteSchema("ProvDateTime", {
+    description: "PROV timestamp decoded to DateTime.Utc.",
+    semanticSchemaMetadata: makeSemanticSchemaMetadata({
+      kind: "provenanceConstruct",
+      canonicalName: "ProvDateTime",
+      overview: "PROV timestamp decoded to DateTime.Utc.",
+      status: "stable",
+      specifications: [{ name: "PROV-O", section: "Time", disposition: "normative" }],
+      equivalenceBasis: "UTC instant equality.",
+      timeSemantics: "PROV timestamps express activity and influence time, not all domain lifecycle semantics.",
+    }),
+  })
 );
 
 /**
@@ -851,8 +845,8 @@ export const ProvRecord = S.Union([
   Revision,
   Start,
   End,
-]).annotate(
-  $I.annote("ProvRecord", {
+]).pipe(
+  $I.annoteSchema("ProvRecord", {
     description: "Public PROV record union for the stable semantic-web surface.",
     semanticSchemaMetadata: makeSemanticSchemaMetadata({
       kind: "provenanceConstruct",
@@ -931,8 +925,8 @@ export class ProvBundle extends S.Class<ProvBundle>($I`ProvBundle`)(
  * @since 0.0.0
  * @category models
  */
-export const ProvO = S.Union([ProvBundle, ProvRecord]).annotate(
-  $I.annote("ProvO", {
+export const ProvO = S.Union([ProvBundle, ProvRecord]).pipe(
+  $I.annoteSchema("ProvO", {
     description: "Public provenance entrypoint union.",
     semanticSchemaMetadata: makeSemanticSchemaMetadata({
       kind: "provenanceConstruct",

--- a/packages/foundation/capability/semantic-web/src/rdf.ts
+++ b/packages/foundation/capability/semantic-web/src/rdf.ts
@@ -213,24 +213,22 @@ const BlankNodeLabelChecks = S.makeFilterGroup(
  */
 export const PrefixLabel = S.String.check(PrefixLabelChecks).pipe(
   S.brand("PrefixLabel"),
-  S.annotate(
-    $I.annote("PrefixLabel", {
-      description: "Prefix label used by RDF namespace bindings.",
-      semanticSchemaMetadata: makeSemanticSchemaMetadata({
-        kind: "identifier",
-        canonicalName: "PrefixLabel",
-        overview: "Prefix label used by RDF namespace bindings.",
-        status: "stable",
-        specifications: [
-          {
-            name: "RDF 1.1 Concepts",
-            disposition: "informative",
-          },
-        ],
-        equivalenceBasis: "Exact string equality.",
-      }),
-    })
-  )
+  $I.annoteSchema("PrefixLabel", {
+    description: "Prefix label used by RDF namespace bindings.",
+    semanticSchemaMetadata: makeSemanticSchemaMetadata({
+      kind: "identifier",
+      canonicalName: "PrefixLabel",
+      overview: "Prefix label used by RDF namespace bindings.",
+      status: "stable",
+      specifications: [
+        {
+          name: "RDF 1.1 Concepts",
+          disposition: "informative",
+        },
+      ],
+      equivalenceBasis: "Exact string equality.",
+    }),
+  })
 );
 
 /**
@@ -264,12 +262,10 @@ export type PrefixLabel = typeof PrefixLabel.Type;
  */
 export const Curie = S.String.check(CurieChecks).pipe(
   S.brand("Curie"),
-  S.annotate(
-    $I.annote("Curie", {
-      description: "CURIE-style compact IRI expression.",
-      semanticSchemaMetadata: curieMetadata,
-    })
-  )
+  $I.annoteSchema("Curie", {
+    description: "CURIE-style compact IRI expression.",
+    semanticSchemaMetadata: curieMetadata,
+  })
 );
 
 /**
@@ -303,25 +299,23 @@ export type Curie = typeof Curie.Type;
  */
 export const LanguageTag = S.String.check(LanguageTagChecks).pipe(
   S.brand("LanguageTag"),
-  S.annotate(
-    $I.annote("LanguageTag", {
-      description: "RDF literal language tag.",
-      semanticSchemaMetadata: makeSemanticSchemaMetadata({
-        kind: "rdfConstruct",
-        canonicalName: "LanguageTag",
-        overview: "Language tag attached to RDF literals.",
-        status: "stable",
-        specifications: [
-          {
-            name: "RDF 1.1 Concepts",
-            section: "Language-Tagged Strings",
-            disposition: "normative",
-          },
-        ],
-        equivalenceBasis: "Lower-cased language-tag equality.",
-      }),
-    })
-  )
+  $I.annoteSchema("LanguageTag", {
+    description: "RDF literal language tag.",
+    semanticSchemaMetadata: makeSemanticSchemaMetadata({
+      kind: "rdfConstruct",
+      canonicalName: "LanguageTag",
+      overview: "Language tag attached to RDF literals.",
+      status: "stable",
+      specifications: [
+        {
+          name: "RDF 1.1 Concepts",
+          section: "Language-Tagged Strings",
+          disposition: "normative",
+        },
+      ],
+      equivalenceBasis: "Lower-cased language-tag equality.",
+    }),
+  })
 );
 
 /**
@@ -712,8 +706,8 @@ export class NamespaceBinding extends S.Class<NamespaceBinding>($I`NamespaceBind
  * @since 0.0.0
  * @category models
  */
-export const PrefixMap = S.Record(PrefixLabel, IRI).annotate(
-  $I.annote("PrefixMap", {
+export const PrefixMap = S.Record(PrefixLabel, IRI).pipe(
+  $I.annoteSchema("PrefixMap", {
     description: "Prefix map keyed by RDF prefix labels.",
     semanticSchemaMetadata: makeSemanticSchemaMetadata({
       kind: "rdfConstruct",

--- a/packages/foundation/capability/semantic-web/src/semantic-schema-metadata.ts
+++ b/packages/foundation/capability/semantic-web/src/semantic-schema-metadata.ts
@@ -42,8 +42,8 @@ export const SemanticSchemaMetadataKind = LiteralKit([
   "provenanceConstruct",
   "serviceContract",
   "adapterBoundary",
-]).annotate(
-  $I.annote("SemanticSchemaMetadataKind", {
+]).pipe(
+  $I.annoteSchema("SemanticSchemaMetadataKind", {
     description: "Closed v1 metadata kind domain for semantic-web schemas.",
   })
 );
@@ -77,8 +77,8 @@ export type SemanticSchemaMetadataKind = typeof SemanticSchemaMetadataKind.Type;
  * @since 0.0.0
  * @category models
  */
-export const SemanticSchemaStatus = LiteralKit(["experimental", "stable", "deprecated"]).annotate(
-  $I.annote("SemanticSchemaStatus", {
+export const SemanticSchemaStatus = LiteralKit(["experimental", "stable", "deprecated"]).pipe(
+  $I.annoteSchema("SemanticSchemaStatus", {
     description: "Stability classification for semantic-web schema metadata.",
   })
 );
@@ -112,8 +112,8 @@ export type SemanticSchemaStatus = typeof SemanticSchemaStatus.Type;
  * @since 0.0.0
  * @category models
  */
-export const SemanticSchemaSpecificationDisposition = LiteralKit(["normative", "informative"]).annotate(
-  $I.annote("SemanticSchemaSpecificationDisposition", {
+export const SemanticSchemaSpecificationDisposition = LiteralKit(["normative", "informative"]).pipe(
+  $I.annoteSchema("SemanticSchemaSpecificationDisposition", {
     description: "Specification disposition attached to a semantic schema reference.",
   })
 );
@@ -154,8 +154,8 @@ export const SemanticRepresentationKind = LiteralKit([
   "TriG",
   "RDF/XML",
   "JSON Schema",
-]).annotate(
-  $I.annote("SemanticRepresentationKind", {
+]).pipe(
+  $I.annoteSchema("SemanticRepresentationKind", {
     description: "Representation label for semantic-web values.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/services/canonicalization.ts
+++ b/packages/foundation/capability/semantic-web/src/services/canonicalization.ts
@@ -45,8 +45,8 @@ const serviceContractMetadata = (canonicalName: string, overview: string) =>
  * @since 0.0.0
  * @category models
  */
-export const CanonicalizationAlgorithm = LiteralKit(["rdfc-1.0", "lexical-sort-v1"]).annotate(
-  $I.annote("CanonicalizationAlgorithm", {
+export const CanonicalizationAlgorithm = LiteralKit(["rdfc-1.0", "lexical-sort-v1"]).pipe(
+  $I.annoteSchema("CanonicalizationAlgorithm", {
     description: "Canonicalization algorithm name with an explicit graph-safe default and lexical fallback.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/services/jsonld-context.ts
+++ b/packages/foundation/capability/semantic-web/src/services/jsonld-context.ts
@@ -41,8 +41,8 @@ const serviceContractMetadata = (canonicalName: string, overview: string) =>
  * @since 0.0.0
  * @category models
  */
-export const JsonLdContextErrorReason = LiteralKit(["unknownTerm", "policyViolation", "compactionFailure"]).annotate(
-  $I.annote("JsonLdContextErrorReason", {
+export const JsonLdContextErrorReason = LiteralKit(["unknownTerm", "policyViolation", "compactionFailure"]).pipe(
+  $I.annoteSchema("JsonLdContextErrorReason", {
     description: "JSON-LD context error reason.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/services/jsonld-document.ts
+++ b/packages/foundation/capability/semantic-web/src/services/jsonld-document.ts
@@ -50,8 +50,8 @@ export const JsonLdDocumentErrorReason = LiteralKit([
   "framingFailure",
   "loaderPolicyViolation",
   "normalizationFailure",
-]).annotate(
-  $I.annote("JsonLdDocumentErrorReason", {
+]).pipe(
+  $I.annoteSchema("JsonLdDocumentErrorReason", {
     description: "JSON-LD document error reason.",
   })
 );
@@ -207,8 +207,8 @@ export class JsonLdDocumentLoaderPolicy extends S.Class<JsonLdDocumentLoaderPoli
  * @since 0.0.0
  * @category models
  */
-export const JsonLdDocumentNormalizationProfile = LiteralKit(["bounded-v1", "expanded-v1"]).annotate(
-  $I.annote("JsonLdDocumentNormalizationProfile", {
+export const JsonLdDocumentNormalizationProfile = LiteralKit(["bounded-v1", "expanded-v1"]).pipe(
+  $I.annoteSchema("JsonLdDocumentNormalizationProfile", {
     description: "JSON-LD document normalization profile.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/services/jsonld-stream-parse.ts
+++ b/packages/foundation/capability/semantic-web/src/services/jsonld-stream-parse.ts
@@ -46,8 +46,8 @@ const serviceContractMetadata = (canonicalName: string, overview: string) =>
  * @since 0.0.0
  * @category models
  */
-export const JsonLdStreamMode = LiteralKit(["true-streaming", "buffered-fallback"]).annotate(
-  $I.annote("JsonLdStreamMode", {
+export const JsonLdStreamMode = LiteralKit(["true-streaming", "buffered-fallback"]).pipe(
+  $I.annoteSchema("JsonLdStreamMode", {
     description: "Streaming adapter mode.",
   })
 );
@@ -232,8 +232,8 @@ export const JsonLdStreamParseErrorReason = LiteralKit([
   "parseFailure",
   "loaderPolicyViolation",
   "unsupportedEncoding",
-]).annotate(
-  $I.annote("JsonLdStreamParseErrorReason", {
+]).pipe(
+  $I.annoteSchema("JsonLdStreamParseErrorReason", {
     description: "Streaming parse error reason.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/services/jsonld-stream-serialize.ts
+++ b/packages/foundation/capability/semantic-web/src/services/jsonld-stream-serialize.ts
@@ -105,8 +105,8 @@ export class JsonLdStreamSerializeResult extends S.Class<JsonLdStreamSerializeRe
  * @since 0.0.0
  * @category models
  */
-export const JsonLdStreamSerializeErrorReason = LiteralKit(["serializeFailure", "invalidChunkSize"]).annotate(
-  $I.annote("JsonLdStreamSerializeErrorReason", {
+export const JsonLdStreamSerializeErrorReason = LiteralKit(["serializeFailure", "invalidChunkSize"]).pipe(
+  $I.annoteSchema("JsonLdStreamSerializeErrorReason", {
     description: "Streaming serialize error reason.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/services/provenance.ts
+++ b/packages/foundation/capability/semantic-web/src/services/provenance.ts
@@ -61,8 +61,8 @@ const serviceContractMetadata = (canonicalName: string, overview: string) =>
  * @since 0.0.0
  * @category models
  */
-export const ProvenanceExportProfile = LiteralKit(["prov-core-v1", "prov-core-extensions-v1"]).annotate(
-  $I.annote("ProvenanceExportProfile", {
+export const ProvenanceExportProfile = LiteralKit(["prov-core-v1", "prov-core-extensions-v1"]).pipe(
+  $I.annoteSchema("ProvenanceExportProfile", {
     description: "Provenance export profile.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/services/shacl-validation.ts
+++ b/packages/foundation/capability/semantic-web/src/services/shacl-validation.ts
@@ -44,8 +44,8 @@ const serviceContractMetadata = (canonicalName: string, overview: string) =>
  * @since 0.0.0
  * @category models
  */
-export const ShaclSeverity = LiteralKit(["info", "warning", "violation"]).annotate(
-  $I.annote("ShaclSeverity", {
+export const ShaclSeverity = LiteralKit(["info", "warning", "violation"]).pipe(
+  $I.annoteSchema("ShaclSeverity", {
     description: "SHACL report severity.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/services/sparql-query.ts
+++ b/packages/foundation/capability/semantic-web/src/services/sparql-query.ts
@@ -39,8 +39,8 @@ const serviceContractMetadata = (canonicalName: string, overview: string) =>
  * @since 0.0.0
  * @category models
  */
-export const SparqlQueryProfile = LiteralKit(["select", "ask", "construct"]).annotate(
-  $I.annote("SparqlQueryProfile", {
+export const SparqlQueryProfile = LiteralKit(["select", "ask", "construct"]).pipe(
+  $I.annoteSchema("SparqlQueryProfile", {
     description: "Minimal v1 SPARQL profile.",
   })
 );

--- a/packages/foundation/capability/semantic-web/src/uri.ts
+++ b/packages/foundation/capability/semantic-web/src/uri.ts
@@ -203,12 +203,10 @@ const uriChecks = makeNonEmptyReferenceChecks("URI", "URI", "An RFC 3986 URI.", 
  */
 export const URIReference = S.String.check(uriReferenceChecks).pipe(
   S.brand("URIReference"),
-  S.annotate(
-    $I.annote("URIReference", {
-      description: "RFC 3986 URI reference syntax, including both absolute and relative forms.",
-      semanticSchemaMetadata: uriReferenceMetadata,
-    })
-  )
+  $I.annoteSchema("URIReference", {
+    description: "RFC 3986 URI reference syntax, including both absolute and relative forms.",
+    semanticSchemaMetadata: uriReferenceMetadata,
+  })
 );
 
 /**
@@ -244,12 +242,10 @@ export type URIReference = typeof URIReference.Type;
  */
 export const RelativeURIReference = S.String.check(relativeUriReferenceChecks).pipe(
   S.brand("RelativeURIReference"),
-  S.annotate(
-    $I.annote("RelativeURIReference", {
-      description: "RFC 3986 relative URI reference syntax (`relative-ref`).",
-      semanticSchemaMetadata: relativeUriReferenceMetadata,
-    })
-  )
+  $I.annoteSchema("RelativeURIReference", {
+    description: "RFC 3986 relative URI reference syntax (`relative-ref`).",
+    semanticSchemaMetadata: relativeUriReferenceMetadata,
+  })
 );
 
 /**
@@ -285,12 +281,10 @@ export type RelativeURIReference = typeof RelativeURIReference.Type;
  */
 export const AbsoluteURI = S.String.check(absoluteUriChecks).pipe(
   S.brand("AbsoluteURI"),
-  S.annotate(
-    $I.annote("AbsoluteURI", {
-      description: "RFC 3986 absolute URI syntax without a fragment component.",
-      semanticSchemaMetadata: absoluteUriMetadata,
-    })
-  )
+  $I.annoteSchema("AbsoluteURI", {
+    description: "RFC 3986 absolute URI syntax without a fragment component.",
+    semanticSchemaMetadata: absoluteUriMetadata,
+  })
 );
 
 /**
@@ -326,12 +320,10 @@ export type AbsoluteURI = typeof AbsoluteURI.Type;
  */
 export const URI = S.String.check(uriChecks).pipe(
   S.brand("URI"),
-  S.annotate(
-    $I.annote("URI", {
-      description: "RFC 3986 URI syntax.",
-      semanticSchemaMetadata: uriMetadata,
-    })
-  )
+  $I.annoteSchema("URI", {
+    description: "RFC 3986 URI syntax.",
+    semanticSchemaMetadata: uriMetadata,
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/ArrayOf.ts
+++ b/packages/foundation/modeling/schema/src/ArrayOf.ts
@@ -25,8 +25,8 @@ const $I = $SchemaId.create("ArrayOf");
  * @since 0.0.0
  * @category validation
  */
-export const ArrayOfStrings = S.Array(S.String).annotate(
-  $I.annote("ArrayOfStrings", {
+export const ArrayOfStrings = S.Array(S.String).pipe(
+  $I.annoteSchema("ArrayOfStrings", {
     description: "An array of strings",
   })
 );
@@ -54,8 +54,8 @@ export type ArrayOfStrings = S.Schema.Type<typeof ArrayOfStrings>;
  * @since 0.0.0
  * @category validation
  */
-export const NonEmptyArrayOfStrings = S.NonEmptyArray(S.String).annotate(
-  $I.annote("NonEmptyArrayOfStrings", {
+export const NonEmptyArrayOfStrings = S.NonEmptyArray(S.String).pipe(
+  $I.annoteSchema("NonEmptyArrayOfStrings", {
     description: "An array of non-empty strings",
   })
 );
@@ -83,8 +83,8 @@ export type NonEmptyArrayOfStrings = S.Schema.Type<typeof NonEmptyArrayOfStrings
  * @since 0.0.0
  * @category validation
  */
-export const ArrayOfNonEmptyStrings = S.Array(S.NonEmptyString).annotate(
-  $I.annote("ArrayOfNonEmptyStrings", {
+export const ArrayOfNonEmptyStrings = S.Array(S.NonEmptyString).pipe(
+  $I.annoteSchema("ArrayOfNonEmptyStrings", {
     description: "An array of non-empty strings",
   })
 );
@@ -112,8 +112,8 @@ export type ArrayOfNonEmptyStrings = S.Schema.Type<typeof ArrayOfNonEmptyStrings
  * @since 0.0.0
  * @category validation
  */
-export const NonEmptyArrayOfNonEmptyStrings = S.NonEmptyArray(S.NonEmptyString).annotate(
-  $I.annote("NonEmptyArrayOfNonEmptyStrings", {
+export const NonEmptyArrayOfNonEmptyStrings = S.NonEmptyArray(S.NonEmptyString).pipe(
+  $I.annoteSchema("NonEmptyArrayOfNonEmptyStrings", {
     description: "An array of non-empty non-empty strings",
   })
 );
@@ -141,8 +141,8 @@ export type NonEmptyArrayOfNonEmptyStrings = S.Schema.Type<typeof NonEmptyArrayO
  * @since 0.0.0
  * @category validation
  */
-export const ArrayOfNumbers = S.Array(S.Number).annotate(
-  $I.annote("ArrayOfNumbers", {
+export const ArrayOfNumbers = S.Array(S.Number).pipe(
+  $I.annoteSchema("ArrayOfNumbers", {
     description: "An array of numbers",
   })
 );
@@ -170,8 +170,8 @@ export type ArrayOfNumbers = S.Schema.Type<typeof ArrayOfNumbers>;
  * @since 0.0.0
  * @category validation
  */
-export const NonEmptyArrayOfNumbers = S.NonEmptyArray(S.Number).annotate(
-  $I.annote("NonEmptyArrayOfNumbers", {
+export const NonEmptyArrayOfNumbers = S.NonEmptyArray(S.Number).pipe(
+  $I.annoteSchema("NonEmptyArrayOfNumbers", {
     description: "An array of non-empty numbers",
   })
 );
@@ -199,8 +199,8 @@ export type NonEmptyArrayOfNumbers = S.Schema.Type<typeof NonEmptyArrayOfNumbers
  * @since 0.0.0
  * @category validation
  */
-export const ArrayOfInts = S.Array(S.Int).annotate(
-  $I.annote("ArrayOfInts", {
+export const ArrayOfInts = S.Array(S.Int).pipe(
+  $I.annoteSchema("ArrayOfInts", {
     description: "An array of integers",
   })
 );
@@ -228,8 +228,8 @@ export type ArrayOfInts = S.Schema.Type<typeof ArrayOfInts>;
  * @since 0.0.0
  * @category validation
  */
-export const NonEmptyArrayOfInts = S.NonEmptyArray(S.Int).annotate(
-  $I.annote("NonEmptyArrayOfInts", {
+export const NonEmptyArrayOfInts = S.NonEmptyArray(S.Int).pipe(
+  $I.annoteSchema("NonEmptyArrayOfInts", {
     description: "An array of non-empty integers",
   })
 );

--- a/packages/foundation/modeling/schema/src/Color/Color.adjust.ts
+++ b/packages/foundation/modeling/schema/src/Color/Color.adjust.ts
@@ -82,11 +82,9 @@ const withAlphaValue = ({ color, alpha }: WithAlphaInput): RgbaColorString => {
  */
 export const RgbaColorString = S.String.check(RgbaColorStringChecks).pipe(
   S.brand("RgbaColorString"),
-  S.annotate(
-    $I.annote("RgbaColorString", {
-      description: "A CSS rgba color string in the form rgba(r, g, b, a).",
-    })
-  )
+  $I.annoteSchema("RgbaColorString", {
+    description: "A CSS rgba color string in the form rgba(r, g, b, a).",
+  })
 );
 
 /**
@@ -105,11 +103,9 @@ export type RgbaColorString = typeof RgbaColorString.Type;
  */
 export const ColorAmount = S.Finite.pipe(
   S.brand("ColorAmount"),
-  S.annotate(
-    $I.annote("ColorAmount", {
-      description: "A finite numeric amount used by color transformation helpers.",
-    })
-  )
+  $I.annoteSchema("ColorAmount", {
+    description: "A finite numeric amount used by color transformation helpers.",
+  })
 );
 
 /**
@@ -148,11 +144,9 @@ export const MixColors = MixColorsInput.pipe(
     decode: SchemaGetter.transform(mixColorsValue),
     encode: SchemaGetter.forbidden(() => "Encoding MixColors results back to the original request is not supported"),
   }),
-  S.annotate(
-    $I.annote("MixColors", {
-      description: "Mixes two hex colors in OKLCH space and returns a canonical hex color.",
-    })
-  )
+  $I.annoteSchema("MixColors", {
+    description: "Mixes two hex colors in OKLCH space and returns a canonical hex color.",
+  })
 );
 
 /**
@@ -190,11 +184,9 @@ export const Lighten = LightenInput.pipe(
     decode: SchemaGetter.transform(lightenValue),
     encode: SchemaGetter.forbidden(() => "Encoding Lighten results back to the original request is not supported"),
   }),
-  S.annotate(
-    $I.annote("Lighten", {
-      description: "Lightens a hex color in OKLCH space and returns a canonical hex color.",
-    })
-  )
+  $I.annoteSchema("Lighten", {
+    description: "Lightens a hex color in OKLCH space and returns a canonical hex color.",
+  })
 );
 
 /**
@@ -232,11 +224,9 @@ export const Darken = DarkenInput.pipe(
     decode: SchemaGetter.transform(darkenValue),
     encode: SchemaGetter.forbidden(() => "Encoding Darken results back to the original request is not supported"),
   }),
-  S.annotate(
-    $I.annote("Darken", {
-      description: "Darkens a hex color in OKLCH space and returns a canonical hex color.",
-    })
-  )
+  $I.annoteSchema("Darken", {
+    description: "Darkens a hex color in OKLCH space and returns a canonical hex color.",
+  })
 );
 
 /**
@@ -274,11 +264,9 @@ export const WithAlpha = WithAlphaInput.pipe(
     decode: SchemaGetter.transform(withAlphaValue),
     encode: SchemaGetter.forbidden(() => "Encoding WithAlpha results back to the original request is not supported"),
   }),
-  S.annotate(
-    $I.annote("WithAlpha", {
-      description: "Renders a canonical hex color plus alpha as a CSS rgba string.",
-    })
-  )
+  $I.annoteSchema("WithAlpha", {
+    description: "Renders a canonical hex color plus alpha as a CSS rgba string.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Color/Color.hex.ts
+++ b/packages/foundation/modeling/schema/src/Color/Color.hex.ts
@@ -103,11 +103,9 @@ export const rgbToHexValue = ({ r, g, b }: RgbEncoded): HexColor =>
  * @category validation
  */
 export const HexColorInput = S.String.check(HexColorInputChecks).pipe(
-  S.annotate(
-    $I.annote("HexColorInput", {
-      description: "A hex color string accepted at boundaries in #rgb or #rrggbb form.",
-    })
-  )
+  $I.annoteSchema("HexColorInput", {
+    description: "A hex color string accepted at boundaries in #rgb or #rrggbb form.",
+  })
 );
 
 /**
@@ -126,11 +124,9 @@ export type HexColorInput = typeof HexColorInput.Type;
  */
 export const HexColor = S.String.check(HexColorChecks).pipe(
   S.brand("HexColor"),
-  S.annotate(
-    $I.annote("HexColor", {
-      description: "A canonical lowercase six-digit hex color string.",
-    })
-  )
+  $I.annoteSchema("HexColor", {
+    description: "A canonical lowercase six-digit hex color string.",
+  })
 );
 
 /**
@@ -155,11 +151,9 @@ export const NormalizeHexColor = HexColorInput.pipe(
       encode: identity,
     })
   ),
-  S.annotate(
-    $I.annote("NormalizeHexColor", {
-      description: "Normalizes #rgb or #rrggbb input into canonical lowercase #rrggbb hex.",
-    })
-  )
+  $I.annoteSchema("NormalizeHexColor", {
+    description: "Normalizes #rgb or #rrggbb input into canonical lowercase #rrggbb hex.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Color/Color.oklch.ts
+++ b/packages/foundation/modeling/schema/src/Color/Color.oklch.ts
@@ -130,11 +130,9 @@ export const oklchToRgbValue = ({ l: lightness, c: chroma, h: hue }: OklchEncode
  */
 export const OklchCoordinate = S.Finite.pipe(
   S.brand("OklchCoordinate"),
-  S.annotate(
-    $I.annote("OklchCoordinate", {
-      description: "A finite OKLCH coordinate component.",
-    })
-  )
+  $I.annoteSchema("OklchCoordinate", {
+    description: "A finite OKLCH coordinate component.",
+  })
 );
 
 /**
@@ -154,11 +152,9 @@ export type OklchCoordinate = typeof OklchCoordinate.Type;
 export const OklchLightness = OklchCoordinate.pipe(
   S.check(OklchLightnessRangeCheck),
   S.brand("OklchLightness"),
-  S.annotate(
-    $I.annote("OklchLightness", {
-      description: "OKLCH lightness normalized to the range 0 through 1.",
-    })
-  )
+  $I.annoteSchema("OklchLightness", {
+    description: "OKLCH lightness normalized to the range 0 through 1.",
+  })
 );
 
 /**
@@ -178,11 +174,9 @@ export type OklchLightness = typeof OklchLightness.Type;
 export const OklchChroma = OklchCoordinate.pipe(
   S.check(OklchChromaCheck),
   S.brand("OklchChroma"),
-  S.annotate(
-    $I.annote("OklchChroma", {
-      description: "A non-negative OKLCH chroma value.",
-    })
-  )
+  $I.annoteSchema("OklchChroma", {
+    description: "A non-negative OKLCH chroma value.",
+  })
 );
 
 /**
@@ -202,11 +196,9 @@ export type OklchChroma = typeof OklchChroma.Type;
 export const OklchHue = OklchCoordinate.pipe(
   S.check(OklchHueRangeCheck),
   S.brand("OklchHue"),
-  S.annotate(
-    $I.annote("OklchHue", {
-      description: "An OKLCH hue angle in degrees from 0 through 360.",
-    })
-  )
+  $I.annoteSchema("OklchHue", {
+    description: "An OKLCH hue angle in degrees from 0 through 360.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Color/Color.rgb.ts
+++ b/packages/foundation/modeling/schema/src/Color/Color.rgb.ts
@@ -29,11 +29,9 @@ const RgbChannelRangeCheck = S.isBetween(
  */
 export const RgbInputChannel = S.Finite.pipe(
   S.brand("RgbInputChannel"),
-  S.annotate(
-    $I.annote("RgbInputChannel", {
-      description: "A finite RGB channel value before clamping or normalization.",
-    })
-  )
+  $I.annoteSchema("RgbInputChannel", {
+    description: "A finite RGB channel value before clamping or normalization.",
+  })
 );
 
 /**
@@ -53,11 +51,9 @@ export type RgbInputChannel = typeof RgbInputChannel.Type;
 export const RgbChannel = RgbInputChannel.pipe(
   S.check(RgbChannelRangeCheck),
   S.brand("RgbChannel"),
-  S.annotate(
-    $I.annote("RgbChannel", {
-      description: "A normalized RGB channel value in the range 0 through 1.",
-    })
-  )
+  $I.annoteSchema("RgbChannel", {
+    description: "A normalized RGB channel value in the range 0 through 1.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Color/Color.scale.ts
+++ b/packages/foundation/modeling/schema/src/Color/Color.scale.ts
@@ -125,11 +125,9 @@ export const HexColorScale12 = S.Array(HexColor)
   .check(HexColorScale12Checks)
   .pipe(
     S.brand("HexColorScale12"),
-    S.annotate(
-      $I.annote("HexColorScale12", {
-        description: "A fixed-size 12-step scale of canonical hex colors.",
-      })
-    )
+    $I.annoteSchema("HexColorScale12", {
+      description: "A fixed-size 12-step scale of canonical hex colors.",
+    })
   );
 
 /**
@@ -143,11 +141,9 @@ export type HexColorScale12 = typeof HexColorScale12.Type;
 const HexColorScale12Input = S.Array(NormalizeHexColor)
   .check(HexColorScale12Checks)
   .pipe(
-    S.annotate(
-      $I.annote("HexColorScale12Input", {
-        description: "A 12-step hex color scale accepted at boundaries before canonical normalization.",
-      })
-    )
+    $I.annoteSchema("HexColorScale12Input", {
+      description: "A 12-step hex color scale accepted at boundaries before canonical normalization.",
+    })
   );
 
 /**
@@ -179,11 +175,9 @@ export const GenerateScale = GenerateScaleInput.pipe(
       () => "Encoding GenerateScale results back to the original request is not supported"
     ),
   }),
-  S.annotate(
-    $I.annote("GenerateScale", {
-      description: "Generates a 12-step chromatic scale from a seed hex color.",
-    })
-  )
+  $I.annoteSchema("GenerateScale", {
+    description: "Generates a 12-step chromatic scale from a seed hex color.",
+  })
 );
 
 /**
@@ -223,11 +217,9 @@ export const GenerateNeutralScale = GenerateNeutralScaleInput.pipe(
       () => "Encoding GenerateNeutralScale results back to the original request is not supported"
     ),
   }),
-  S.annotate(
-    $I.annote("GenerateNeutralScale", {
-      description: "Generates a 12-step neutral scale from a seed hex color.",
-    })
-  )
+  $I.annoteSchema("GenerateNeutralScale", {
+    description: "Generates a 12-step neutral scale from a seed hex color.",
+  })
 );
 
 /**
@@ -267,11 +259,9 @@ export const GenerateAlphaScale = GenerateAlphaScaleInput.pipe(
       () => "Encoding GenerateAlphaScale results back to the original request is not supported"
     ),
   }),
-  S.annotate(
-    $I.annote("GenerateAlphaScale", {
-      description: "Generates a 12-step alpha-blended scale from a canonical 12-step base scale.",
-    })
-  )
+  $I.annoteSchema("GenerateAlphaScale", {
+    description: "Generates a 12-step alpha-blended scale from a canonical 12-step base scale.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Color/Color.transforms.ts
+++ b/packages/foundation/modeling/schema/src/Color/Color.transforms.ts
@@ -43,11 +43,9 @@ export const HexToRgb = NormalizeHexColor.pipe(
       encode: rgbToHexValue,
     })
   ),
-  S.annotate(
-    $I.annote("HexToRgb", {
-      description: "Decodes canonical or shorthand hex colors into normalized RGB values.",
-    })
-  )
+  $I.annoteSchema("HexToRgb", {
+    description: "Decodes canonical or shorthand hex colors into normalized RGB values.",
+  })
 );
 
 /**
@@ -69,11 +67,9 @@ export const RgbToHex = RgbInput.pipe(
     decode: SchemaGetter.transform(rgbToHexValue),
     encode: SchemaGetter.forbidden(() => "Encoding RgbToHex results back to RGB is not supported"),
   }),
-  S.annotate(
-    $I.annote("RgbToHex", {
-      description: "Encodes finite RGB input channels into canonical hex by clamping and rounding.",
-    })
-  )
+  $I.annoteSchema("RgbToHex", {
+    description: "Encodes finite RGB input channels into canonical hex by clamping and rounding.",
+  })
 );
 
 /**
@@ -95,11 +91,9 @@ export const RgbToOklch = Rgb.pipe(
     decode: SchemaGetter.transform(rgbToOklchValue),
     encode: SchemaGetter.forbidden(() => "Encoding RgbToOklch results back to RGB is not supported"),
   }),
-  S.annotate(
-    $I.annote("RgbToOklch", {
-      description: "Decodes normalized RGB values into canonical OKLCH coordinates.",
-    })
-  )
+  $I.annoteSchema("RgbToOklch", {
+    description: "Decodes normalized RGB values into canonical OKLCH coordinates.",
+  })
 );
 
 /**
@@ -121,11 +115,9 @@ export const OklchToRgb = OklchInput.pipe(
     decode: SchemaGetter.transform(oklchToRgbValue),
     encode: SchemaGetter.forbidden(() => "Encoding OklchToRgb results back to OKLCH is not supported"),
   }),
-  S.annotate(
-    $I.annote("OklchToRgb", {
-      description: "Encodes finite OKLCH coordinates into finite RGB channel values.",
-    })
-  )
+  $I.annoteSchema("OklchToRgb", {
+    description: "Encodes finite OKLCH coordinates into finite RGB channel values.",
+  })
 );
 
 /**
@@ -150,11 +142,9 @@ export const HexToOklch = NormalizeHexColor.pipe(
       encode: oklchToHexValue,
     })
   ),
-  S.annotate(
-    $I.annote("HexToOklch", {
-      description: "Decodes shorthand or canonical hex colors into canonical OKLCH coordinates.",
-    })
-  )
+  $I.annoteSchema("HexToOklch", {
+    description: "Decodes shorthand or canonical hex colors into canonical OKLCH coordinates.",
+  })
 );
 
 /**
@@ -176,11 +166,9 @@ export const OklchToHex = OklchInput.pipe(
     decode: SchemaGetter.transform(oklchToHexValue),
     encode: SchemaGetter.forbidden(() => "Encoding OklchToHex results back to OKLCH is not supported"),
   }),
-  S.annotate(
-    $I.annote("OklchToHex", {
-      description: "Encodes finite OKLCH coordinates into canonical hex colors.",
-    })
-  )
+  $I.annoteSchema("OklchToHex", {
+    description: "Encodes finite OKLCH coordinates into canonical hex colors.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/CommonTextSchemas.ts
+++ b/packages/foundation/modeling/schema/src/CommonTextSchemas.ts
@@ -41,11 +41,9 @@ export const TrimmedNonEmptyText = S.String.pipe(
       encode: identity,
     })
   ),
-  S.annotate(
-    $I.annote("TrimmedNonEmptyText", {
-      description: "Trimmed text that must be non-empty after normalization.",
-    })
-  )
+  $I.annoteSchema("TrimmedNonEmptyText", {
+    description: "Trimmed text that must be non-empty after normalization.",
+  })
 );
 
 /**
@@ -86,11 +84,9 @@ export const CommaSeparatedList = S.String.pipe(
       encode: (values: ReadonlyArray<string>) => A.join(values, ","),
     })
   ),
-  S.annotate(
-    $I.annote("CommaSeparatedList", {
-      description: "Comma-separated text decoded into a trimmed non-empty string list.",
-    })
-  )
+  $I.annoteSchema("CommaSeparatedList", {
+    description: "Comma-separated text decoded into a trimmed non-empty string list.",
+  })
 );
 
 /**
@@ -131,11 +127,9 @@ export const NormalizedBooleanString = S.String.pipe(
       encode: String,
     })
   ),
-  S.annotate(
-    $I.annote("NormalizedBooleanString", {
-      description: "Normalized boolean value decoded from common boolean string values.",
-    })
-  )
+  $I.annoteSchema("NormalizedBooleanString", {
+    description: "Normalized boolean value decoded from common boolean string values.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts
+++ b/packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts
@@ -59,11 +59,9 @@ const CryptoTxnHashChecks = S.makeFilterGroup(
  */
 export const CryptoTxnHash = S.NonEmptyString.check(CryptoTxnHashChecks).pipe(
   S.brand("CryptoTxnHash"),
-  S.annotate(
-    $I.annote("CryptoTxnHash", {
-      description: "Canonical mainnet transaction identifier for supported EVM, Bitcoin, and Solana networks.",
-    })
-  )
+  $I.annoteSchema("CryptoTxnHash", {
+    description: "Canonical mainnet transaction identifier for supported EVM, Bitcoin, and Solana networks.",
+  })
 );
 
 /**
@@ -85,11 +83,9 @@ export const CryptoTxnHashRedacted = CryptoTxnHash.pipe(
   SchemaUtils.withStatics(() => ({
     makeRedacted: flow(CryptoTxnHash.make, Redacted.make),
   })),
-  S.annotate(
-    $I.annote("CryptoTxnHashRedacted", {
-      description: "Redacted canonical mainnet transaction identifier for supported EVM, Bitcoin, and Solana networks.",
-    })
-  )
+  $I.annoteSchema("CryptoTxnHashRedacted", {
+    description: "Redacted canonical mainnet transaction identifier for supported EVM, Bitcoin, and Solana networks.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts
+++ b/packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts
@@ -180,11 +180,9 @@ const CryptoWalletAddressChecks = S.makeFilterGroup(
  */
 export const CryptoWalletAddress = S.NonEmptyString.check(CryptoWalletAddressChecks).pipe(
   S.brand("CryptoWalletAddress"),
-  S.annotate(
-    $I.annote("CryptoWalletAddress", {
-      description: "Canonical mainnet wallet address for supported EVM, Bitcoin, and Solana networks.",
-    })
-  )
+  $I.annoteSchema("CryptoWalletAddress", {
+    description: "Canonical mainnet wallet address for supported EVM, Bitcoin, and Solana networks.",
+  })
 );
 
 /**
@@ -206,12 +204,9 @@ export const CryptoWalletAddressRedacted = CryptoWalletAddress.pipe(
   SchemaUtils.withStatics(() => ({
     makeRedacted: flow(CryptoWalletAddress.make, Redacted.make),
   })),
-  S.annotate(
-    $I.annote("CryptoWalletAddressRedacted", {
-      description:
-        "Redacted Canonical mainnet wallet address for supported" + " EVM," + " Bitcoin, and Solana networks.",
-    })
-  )
+  $I.annoteSchema("CryptoWalletAddressRedacted", {
+    description: "Redacted Canonical mainnet wallet address for supported" + " EVM," + " Bitcoin, and Solana networks.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Csv/Csv.schema.ts
+++ b/packages/foundation/modeling/schema/src/Csv/Csv.schema.ts
@@ -24,11 +24,9 @@ const $I = $SchemaId.create("Csv");
 
 const CsvText = S.String.pipe(
   S.brand("CSV"),
-  S.annotate(
-    $I.annote("CsvText", {
-      description: "Branded CSV document text.",
-    })
-  )
+  $I.annoteSchema("CsvText", {
+    description: "Branded CSV document text.",
+  })
 );
 
 /**
@@ -81,11 +79,9 @@ const CsvEffect = <RowSchema extends RowSchemaWithFields>(
         encode: (rows) => encodeRows(rows).pipe(Effect.mapError((error) => toSchemaIssue(rows, error))),
       })
     ),
-    S.annotate(
-      $I.annote("Csv", {
-        description: "Schema factory for branded CSV text decoded into typed row arrays.",
-      })
-    )
+    $I.annoteSchema("Csv", {
+      description: "Schema factory for branded CSV text decoded into typed row arrays.",
+    })
   );
 };
 

--- a/packages/foundation/modeling/schema/src/CsvCodecOptions/CsvCodecOptions.schema.ts
+++ b/packages/foundation/modeling/schema/src/CsvCodecOptions/CsvCodecOptions.schema.ts
@@ -23,8 +23,8 @@ const SingleCharacterText = S.String.check(
     description: "A string that must contain exactly one character.",
     message: "CSV option values must be one character long",
   })
-).annotate(
-  $I.annote("SingleCharacterText", {
+).pipe(
+  $I.annoteSchema("SingleCharacterText", {
     description: "A string that must contain exactly one character.",
   })
 );

--- a/packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts
+++ b/packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts
@@ -40,11 +40,9 @@ export const DateTimeInputKind = LiteralKit([
   "Instant",
   "InstantWithZone",
 ]).pipe(
-  S.annotate(
-    $I.annote("DateTimeInputKind", {
-      description: "Discriminator values for DateTime.Input transport representations.",
-    })
-  )
+  $I.annoteSchema("DateTimeInputKind", {
+    description: "Discriminator values for DateTime.Input transport representations.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Duration/Duration.input.ts
+++ b/packages/foundation/modeling/schema/src/Duration/Duration.input.ts
@@ -80,11 +80,9 @@ export const DurationUnit = LiteralKit([
   "week",
   "weeks",
 ]).pipe(
-  S.annotate(
-    $I.annote("DurationUnit", {
-      description: "A unit of time measurement accepted by duration input schemas.",
-    })
-  )
+  $I.annoteSchema("DurationUnit", {
+    description: "A unit of time measurement accepted by duration input schemas.",
+  })
 );
 
 /**
@@ -172,12 +170,10 @@ export const DurationInput = S.Union([
   S.TemplateLiteral([S.Number, " ", DurationUnit]),
   NonEmptyDurationObject,
 ]).pipe(
-  S.annotate(
-    $I.annote("DurationInput", {
-      description:
-        "Duration input accepted as an existing Duration, numeric transport, duration string, or additive object.",
-    })
-  )
+  $I.annoteSchema("DurationInput", {
+    description:
+      "Duration input accepted as an existing Duration, numeric transport, duration string, or additive object.",
+  })
 );
 
 /**
@@ -230,11 +226,9 @@ export const DurationFromInput = DurationInput.pipe(
       () => "Encoding DurationFromInput results back to the original duration input is not supported"
     ),
   }),
-  S.annotate(
-    $I.annote("DurationFromInput", {
-      description: "A one-way schema that normalizes supported duration inputs into an Effect Duration value.",
-    })
-  )
+  $I.annoteSchema("DurationFromInput", {
+    description: "A one-way schema that normalizes supported duration inputs into an Effect Duration value.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts
+++ b/packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts
@@ -31,11 +31,9 @@ const EthAmountInputChecks = S.makeFilterGroup(
 
 const EthAmountInput = S.Finite.pipe(
   S.check(EthAmountInputChecks),
-  S.annotate(
-    $I.annote("EthAmountInput", {
-      description: "Finite non-negative JSON number accepted at ETH amount boundaries.",
-    })
-  )
+  $I.annoteSchema("EthAmountInput", {
+    description: "Finite non-negative JSON number accepted at ETH amount boundaries.",
+  })
 );
 
 /**
@@ -50,11 +48,9 @@ export const EthAmount = EthAmountInput.pipe(
     decode: SchemaGetter.transform(BigDecimal.fromNumberUnsafe),
     encode: SchemaGetter.transform(BigDecimal.toNumberUnsafe),
   }),
-  S.annotate(
-    $I.annote("EthAmount", {
-      description: "ETH-denominated amount decoded from a non-negative JSON number into Effect BigDecimal.",
-    })
-  )
+  $I.annoteSchema("EthAmount", {
+    description: "ETH-denominated amount decoded from a non-negative JSON number into Effect BigDecimal.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts
+++ b/packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts
@@ -40,11 +40,9 @@ const EthereumValidatorPublicKeyChecks = S.makeFilterGroup(
  */
 export const EthereumValidatorPublicKey = S.String.check(EthereumValidatorPublicKeyChecks).pipe(
   S.brand("EthereumValidatorPublicKey"),
-  S.annotate(
-    $I.annote("EthereumValidatorPublicKey", {
-      description: "Canonical lowercase 0x-prefixed compressed Ethereum validator public key.",
-    })
-  )
+  $I.annoteSchema("EthereumValidatorPublicKey", {
+    description: "Canonical lowercase 0x-prefixed compressed Ethereum validator public key.",
+  })
 );
 
 /**
@@ -66,11 +64,9 @@ export const EthereumValidatorPublicKeyRedacted = EthereumValidatorPublicKey.pip
   SchemaUtils.withStatics(() => ({
     makeRedacted: flow(EthereumValidatorPublicKey.make, Redacted.make),
   })),
-  S.annotate(
-    $I.annote("EthereumValidatorPublicKeyRedacted", {
-      description: "Redacted canonical lowercase 0x-prefixed compressed Ethereum validator public key.",
-    })
-  )
+  $I.annoteSchema("EthereumValidatorPublicKeyRedacted", {
+    description: "Redacted canonical lowercase 0x-prefixed compressed Ethereum validator public key.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts
+++ b/packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts
@@ -77,11 +77,9 @@ const EvmAddressChecks = S.makeFilterGroup(
  */
 export const EvmAddress = S.NonEmptyString.check(EvmAddressChecks).pipe(
   S.brand("EvmAddress"),
-  S.annotate(
-    $I.annote("EvmAddress", {
-      description: "Canonical mainnet EVM address in lowercase or valid EIP-55 checksum form.",
-    })
-  )
+  $I.annoteSchema("EvmAddress", {
+    description: "Canonical mainnet EVM address in lowercase or valid EIP-55 checksum form.",
+  })
 );
 
 /**
@@ -103,11 +101,9 @@ export const EvmAddressRedacted = EvmAddress.pipe(
   SchemaUtils.withStatics(() => ({
     makeRedacted: flow(EvmAddress.make, Redacted.make),
   })),
-  S.annotate(
-    $I.annote("EvmAddressRedacted", {
-      description: "Redacted canonical mainnet EVM address in lowercase or valid EIP-55 checksum form.",
-    })
-  )
+  $I.annoteSchema("EvmAddressRedacted", {
+    description: "Redacted canonical mainnet EVM address in lowercase or valid EIP-55 checksum form.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts
+++ b/packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts
@@ -35,11 +35,9 @@ export const HasNullByte = S.String.check(
   })
 ).pipe(
   S.brand("HasNullByte"),
-  S.annotate(
-    $I.annote("HasNullByte", {
-      description: "A string that contains an embedded NUL byte.",
-    })
-  )
+  $I.annoteSchema("HasNullByte", {
+    description: "A string that contains an embedded NUL byte.",
+  })
 );
 
 /**
@@ -66,11 +64,9 @@ export const SupportedWindowsNamespace = S.NonEmptyString.check(
   })
 ).pipe(
   S.brand("SupportedWindowsNamespace"),
-  S.annotate(
-    $I.annote("SupportedWindowsNamespace", {
-      description: "A non-empty path string that does not use unsupported Windows namespace prefixes.",
-    })
-  )
+  $I.annoteSchema("SupportedWindowsNamespace", {
+    description: "A non-empty path string that does not use unsupported Windows namespace prefixes.",
+  })
 );
 
 /**
@@ -96,11 +92,9 @@ export const UsesPosixSeparator = S.String.check(
   })
 ).pipe(
   S.brand("UsesPosixSeparator"),
-  S.annotate(
-    $I.annote("UsesPosixSeparator", {
-      description: "A string that contains the POSIX path separator /.",
-    })
-  )
+  $I.annoteSchema("UsesPosixSeparator", {
+    description: "A string that contains the POSIX path separator /.",
+  })
 );
 
 /**
@@ -126,11 +120,9 @@ export const UsesWindowsSeparator = S.String.check(
   })
 ).pipe(
   S.brand("UsesWindowsSeparator"),
-  S.annotate(
-    $I.annote("UsesWindowsSeparator", {
-      description: "A string that contains the Windows path separator \\.",
-    })
-  )
+  $I.annoteSchema("UsesWindowsSeparator", {
+    description: "A string that contains the Windows path separator \\.",
+  })
 );
 
 /**
@@ -156,11 +148,9 @@ export const EndsWithSeparator = S.String.check(
   })
 ).pipe(
   S.brand("EndsWithSeparator"),
-  S.annotate(
-    $I.annote("EndsWithSeparator", {
-      description: "A string that ends with either the POSIX or Windows path separator.",
-    })
-  )
+  $I.annoteSchema("EndsWithSeparator", {
+    description: "A string that ends with either the POSIX or Windows path separator.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts
+++ b/packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts
@@ -25,11 +25,9 @@ export const WindowsDriveRoot = S.String.check(
   })
 ).pipe(
   S.brand("WindowsDriveRoot"),
-  S.annotate(
-    $I.annote("WindowsDriveRoot", {
-      description: "A Windows drive root such as C: or C:\\.",
-    })
-  )
+  $I.annoteSchema("WindowsDriveRoot", {
+    description: "A Windows drive root such as C: or C:\\.",
+  })
 );
 
 /**
@@ -55,11 +53,9 @@ export const WindowsUncRoot = S.String.check(
   })
 ).pipe(
   S.brand("WindowsUncRoot"),
-  S.annotate(
-    $I.annote("WindowsUncRoot", {
-      description: "A Windows UNC root such as \\\\server\\share.",
-    })
-  )
+  $I.annoteSchema("WindowsUncRoot", {
+    description: "A Windows UNC root such as \\\\server\\share.",
+  })
 );
 
 /**
@@ -116,11 +112,9 @@ export const HasLeafSegment = S.NonEmptyString.check(
   )
 ).pipe(
   S.brand("HasLeafSegment"),
-  S.annotate(
-    $I.annote("HasLeafSegment", {
-      description: "A non-empty path string that is not just a root and does not end with a separator.",
-    })
-  )
+  $I.annoteSchema("HasLeafSegment", {
+    description: "A non-empty path string that is not just a root and does not end with a separator.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts
+++ b/packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts
@@ -28,8 +28,8 @@ const SupportedPathFamilyKit = LiteralKit([
  * @since 0.0.0
  * @category validation
  */
-export const SupportedPathFamily = SupportedPathFamilyKit.annotate(
-  $I.annote("SupportedPathFamily", {
+export const SupportedPathFamily = SupportedPathFamilyKit.pipe(
+  $I.annoteSchema("SupportedPathFamily", {
     description: "The supported filesystem path families recognized by FilePath.",
   })
 );
@@ -138,11 +138,9 @@ const FilePathChecks = S.makeFilterGroup(
  */
 export const FilePath = S.String.check(FilePathChecks).pipe(
   S.brand("FilePath"),
-  S.annotate(
-    $I.annote("FilePath", {
-      description: "A file path string valid for at least one supported operating-system path family.",
-    })
-  )
+  $I.annoteSchema("FilePath", {
+    description: "A file path string valid for at least one supported operating-system path family.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts
+++ b/packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts
@@ -22,8 +22,8 @@ const WindowsDotSegmentKit = LiteralKit([".", ".."]);
  * @since 0.0.0
  * @category validation
  */
-export const WindowsDotSegment = WindowsDotSegmentKit.annotate(
-  $I.annote("WindowsDotSegment", {
+export const WindowsDotSegment = WindowsDotSegmentKit.pipe(
+  $I.annoteSchema("WindowsDotSegment", {
     description: "Windows dot-segment markers used for current and parent directory traversal.",
   })
 );
@@ -73,11 +73,9 @@ export const ValidWindowsPlainPathSegment = S.NonEmptyString.check(
   )
 ).pipe(
   S.brand("ValidWindowsPlainPathSegment"),
-  S.annotate(
-    $I.annote("ValidWindowsPlainPathSegment", {
-      description: "A non-empty Windows path segment without separators, reserved characters, or trailing dots/spaces.",
-    })
-  )
+  $I.annoteSchema("ValidWindowsPlainPathSegment", {
+    description: "A non-empty Windows path segment without separators, reserved characters, or trailing dots/spaces.",
+  })
 );
 
 /**
@@ -105,11 +103,9 @@ export const ValidWindowsRootSegment = ValidWindowsPlainPathSegment.check(
   })
 ).pipe(
   S.brand("ValidWindowsRootSegment"),
-  S.annotate(
-    $I.annote("ValidWindowsRootSegment", {
-      description: "A Windows root segment suitable for drive roots and UNC server/share segments.",
-    })
-  )
+  $I.annoteSchema("ValidWindowsRootSegment", {
+    description: "A Windows root segment suitable for drive roots and UNC server/share segments.",
+  })
 );
 
 /**
@@ -129,11 +125,9 @@ export type ValidWindowsRootSegment = typeof ValidWindowsRootSegment.Type;
  */
 export const ValidWindowsPathSegment = S.Union([WindowsDotSegment, ValidWindowsPlainPathSegment]).pipe(
   S.brand("ValidWindowsPathSegment"),
-  S.annotate(
-    $I.annote("ValidWindowsPathSegment", {
-      description: "A Windows path segment that is either a valid plain segment or a dot-segment marker.",
-    })
-  )
+  $I.annoteSchema("ValidWindowsPathSegment", {
+    description: "A Windows path segment that is either a valid plain segment or a dot-segment marker.",
+  })
 );
 
 /**
@@ -152,11 +146,9 @@ export type ValidWindowsPathSegment = typeof ValidWindowsPathSegment.Type;
  */
 export const WindowsSegments = S.NonEmptyArray(ValidWindowsPathSegment).pipe(
   S.brand("WindowsSegments"),
-  S.annotate(
-    $I.annote("WindowsSegments", {
-      description: "A non-empty Windows path segment list.",
-    })
-  )
+  $I.annoteSchema("WindowsSegments", {
+    description: "A non-empty Windows path segment list.",
+  })
 );
 
 /**
@@ -176,11 +168,9 @@ export type WindowsSegments = typeof WindowsSegments.Type;
  */
 export const ValidWindowsUncRest = S.NonEmptyArray(ValidWindowsPathSegment).pipe(
   S.brand("ValidWindowsUncRest"),
-  S.annotate(
-    $I.annote("ValidWindowsUncRest", {
-      description: "The non-empty remainder segment list of a UNC file path after the server and share segments.",
-    })
-  )
+  $I.annoteSchema("ValidWindowsUncRest", {
+    description: "The non-empty remainder segment list of a UNC file path after the server and share segments.",
+  })
 );
 
 /**
@@ -202,11 +192,9 @@ export const ValidWindowsUncSegments = S.TupleWithRest(
   [ValidWindowsPathSegment]
 ).pipe(
   S.brand("ValidWindowsUncSegments"),
-  S.annotate(
-    $I.annote("ValidWindowsUncSegments", {
-      description: "A UNC segment list with server, share, and at least one leaf segment.",
-    })
-  )
+  $I.annoteSchema("ValidWindowsUncSegments", {
+    description: "A UNC segment list with server, share, and at least one leaf segment.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts
+++ b/packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts
@@ -68,11 +68,9 @@ export const WindowsDrivePath = S.NonEmptyString.check(
   )
 ).pipe(
   S.brand("WindowsDrivePath"),
-  S.annotate(
-    $I.annote("WindowsDrivePath", {
-      description: "A Windows drive path with a drive prefix and at least one leaf segment.",
-    })
-  )
+  $I.annoteSchema("WindowsDrivePath", {
+    description: "A Windows drive path with a drive prefix and at least one leaf segment.",
+  })
 );
 
 /**
@@ -132,11 +130,9 @@ export const WindowsUncPath = S.NonEmptyString.check(
   )
 ).pipe(
   S.brand("WindowsUncPath"),
-  S.annotate(
-    $I.annote("WindowsUncPath", {
-      description: "A Windows UNC file path with valid server, share, and leaf segments.",
-    })
-  )
+  $I.annoteSchema("WindowsUncPath", {
+    description: "A Windows UNC file path with valid server, share, and leaf segments.",
+  })
 );
 
 /**
@@ -208,11 +204,9 @@ export const WindowsRelativePath = S.NonEmptyString.check(
   )
 ).pipe(
   S.brand("WindowsRelativePath"),
-  S.annotate(
-    $I.annote("WindowsRelativePath", {
-      description: "A Windows relative path that uses backslashes and contains a leaf segment.",
-    })
-  )
+  $I.annoteSchema("WindowsRelativePath", {
+    description: "A Windows relative path that uses backslashes and contains a leaf segment.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Glob/Glob.schema.ts
+++ b/packages/foundation/modeling/schema/src/Glob/Glob.schema.ts
@@ -104,11 +104,9 @@ const GlobChecks = S.makeFilterGroup(
  */
 export const Glob = S.String.check(GlobChecks).pipe(
   S.brand("Glob"),
-  S.annotate(
-    $I.annote("Glob", {
-      description: "A portable non-empty glob pattern string accepted by the current Bun glob parser.",
-    })
-  )
+  $I.annoteSchema("Glob", {
+    description: "A portable non-empty glob pattern string accepted by the current Bun glob parser.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Int.ts
+++ b/packages/foundation/modeling/schema/src/Int.ts
@@ -33,8 +33,8 @@ export const Int = S.Int.pipe(S.brand("Int"))
       description: "A finite integer",
     })
   )
-  .annotate(
-    $I.annote("Int", {
+  .pipe(
+    $I.annoteSchema("Int", {
       description: "A an integer value",
     })
   );
@@ -76,8 +76,8 @@ export const PosInt = Int.pipe(S.brand("PosInt"))
       description: "A positive integer",
     })
   )
-  .annotate(
-    $I.annote("PosInt", {
+  .pipe(
+    $I.annoteSchema("PosInt", {
       description: "A positive integer",
     })
   );
@@ -114,8 +114,8 @@ export type PosInt = typeof PosInt.Type;
  */
 export const PostgresSerialInt = Int.pipe(S.brand("PostgresSerialInt"))
   .check(isPostgresSerialInt)
-  .annotate(
-    $I.annote("PostgresSerialInt", {
+  .pipe(
+    $I.annoteSchema("PostgresSerialInt", {
       description: "A positive integer in the PostgreSQL serial int4 range.",
     })
   );
@@ -158,8 +158,8 @@ export const NegInt = Int.pipe(S.brand("NegInt"))
       description: "A negative integer",
     })
   )
-  .annotate(
-    $I.annote("NegInt", {
+  .pipe(
+    $I.annoteSchema("NegInt", {
       description: "A negative integer",
     })
   );
@@ -201,8 +201,8 @@ export const NonPositiveInt = Int.pipe(S.brand("NonPositiveInt"))
       description: "A non-positive integer",
     })
   )
-  .annotate(
-    $I.annote("NonPositiveInt", {
+  .pipe(
+    $I.annoteSchema("NonPositiveInt", {
       description: "A non-positive integer",
     })
   );

--- a/packages/foundation/modeling/schema/src/Jsonc.ts
+++ b/packages/foundation/modeling/schema/src/Jsonc.ts
@@ -95,11 +95,9 @@ export const JsoncTextToUnknown = S.String.pipe(
       encode: encodeUnsupported,
     })
   ),
-  S.annotate(
-    $I.annote("JsoncTextToUnknown", {
-      description: "Schema transformation that parses JSONC text into unknown values.",
-    })
-  )
+  $I.annoteSchema("JsoncTextToUnknown", {
+    description: "Schema transformation that parses JSONC text into unknown values.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Jsonl.ts
+++ b/packages/foundation/modeling/schema/src/Jsonl.ts
@@ -104,11 +104,9 @@ export const JsonlTextToUnknown = S.String.pipe(
     decode: SchemaGetter.transformOrFail(decodeJsonlUnknown),
     encode: SchemaGetter.transformOrFail(encodeUnsupported),
   }),
-  S.annotate(
-    $I.annote("JsonlTextToUnknown", {
-      description: "Schema transformation that parses strict JSONL text into unknown values.",
-    })
-  )
+  $I.annoteSchema("JsonlTextToUnknown", {
+    description: "Schema transformation that parses strict JSONL text into unknown values.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Logs.ts
+++ b/packages/foundation/modeling/schema/src/Logs.ts
@@ -28,8 +28,8 @@ const $I = $SchemaId.create("Logs");
  * @since 0.0.0
  * @category models
  */
-export const LogLevel = LiteralKit(["All", "Fatal", "Error", "Warn", "Info", "Debug", "Trace", "None"]).annotate(
-  $I.annote("LogLevel", {
+export const LogLevel = LiteralKit(["All", "Fatal", "Error", "Warn", "Info", "Debug", "Trace", "None"]).pipe(
+  $I.annoteSchema("LogLevel", {
     description: "Log levels supported",
   })
 );
@@ -59,8 +59,8 @@ export type LogLevel = typeof LogLevel.Type;
  * @since 0.0.0
  * @category models
  */
-export const LogSeverity = LiteralKit(["Fatal", "Error", "Warn", "Info", "Debug", "Trace"]).annotate(
-  $I.annote("LogSeverity", {
+export const LogSeverity = LiteralKit(["Fatal", "Error", "Warn", "Info", "Debug", "Trace"]).pipe(
+  $I.annoteSchema("LogSeverity", {
     description: "Log severities supported",
   })
 );

--- a/packages/foundation/modeling/schema/src/Markdown.ts
+++ b/packages/foundation/modeling/schema/src/Markdown.ts
@@ -124,12 +124,10 @@ export const Markdown = S.String.pipe(
     decode: SchemaGetter.transformOrFail(decodeMarkdownText),
     encode: SchemaGetter.transform((content: string): string => content),
   }),
-  S.annotate(
-    $I.annote("Markdown", {
-      description:
-        "A Markdown document string accepted by Bun Markdown or the platform-agnostic micromark GFM fallback parser.",
-    })
-  )
+  $I.annoteSchema("Markdown", {
+    description:
+      "A Markdown document string accepted by Bun Markdown or the platform-agnostic micromark GFM fallback parser.",
+  })
 );
 
 /**
@@ -174,11 +172,9 @@ export const MarkdownTextToHtml = (options?: MarkdownRenderOptions) => {
       decode: SchemaGetter.transformOrFail(renderMarkdownHtml),
       encode: SchemaGetter.transformOrFail(encodeUnsupported),
     }),
-    S.annotate(
-      $I.annote("MarkdownTextToHtml", {
-        description: "Schema factory that renders Markdown text into HTML text with Bun's Markdown runtime.",
-      })
-    )
+    $I.annoteSchema("MarkdownTextToHtml", {
+      description: "Schema factory that renders Markdown text into HTML text with Bun's Markdown runtime.",
+    })
   );
 };
 

--- a/packages/foundation/modeling/schema/src/MimeType.ts
+++ b/packages/foundation/modeling/schema/src/MimeType.ts
@@ -115,8 +115,8 @@ export const MimeType: MimeTypeSchema = pipe(
       ...Image.Options,
       ...Audio.Options,
       ...Misc.Options,
-    ]).annotate(
-      $I.annote("MimeType", {
+    ]).pipe(
+      $I.annoteSchema("MimeType", {
         description: "a mime type.",
       })
     );

--- a/packages/foundation/modeling/schema/src/Number.ts
+++ b/packages/foundation/modeling/schema/src/Number.ts
@@ -191,8 +191,8 @@ export const NonNegativeInt = S.Int.pipe(S.brand("Int"))
       description: "A non-negative integer",
     })
   )
-  .annotate(
-    $I.annote("NonNegativeInt", {
+  .pipe(
+    $I.annoteSchema("NonNegativeInt", {
       description: "A non-negative integer",
     })
   );

--- a/packages/foundation/modeling/schema/src/ParserOptions/ParserOptions.schema.ts
+++ b/packages/foundation/modeling/schema/src/ParserOptions/ParserOptions.schema.ts
@@ -29,8 +29,8 @@ const SingleCharacterText = S.String.check(
     description: "A string that must contain exactly one character.",
     message: "delimiter option must be one character long",
   })
-).annotate(
-  $I.annote("SingleCharacterText", {
+).pipe(
+  $I.annoteSchema("SingleCharacterText", {
     description: "A string that must contain exactly one character.",
   })
 );

--- a/packages/foundation/modeling/schema/src/PosixPath.ts
+++ b/packages/foundation/modeling/schema/src/PosixPath.ts
@@ -30,11 +30,9 @@ const POSIX_PATH_PATTERN = /^[^\\]*$/;
  */
 export const PosixPath = S.String.check(S.isPattern(POSIX_PATH_PATTERN)).pipe(
   S.brand("PosixPath"),
-  S.annotate(
-    $I.annote("PosixPath", {
-      description: "Path string normalized to use '/' separators only.",
-    })
-  )
+  $I.annoteSchema("PosixPath", {
+    description: "Path string normalized to use '/' separators only.",
+  })
 );
 
 /**
@@ -75,11 +73,9 @@ export const NativePathToPosixPath = S.String.pipe(
       encode: identity,
     })
   ),
-  S.annotate(
-    $I.annote("NativePathToPosixPath", {
-      description: "Schema transformation that normalizes native path separators to posix format.",
-    })
-  )
+  $I.annoteSchema("NativePathToPosixPath", {
+    description: "Schema transformation that normalizes native path separators to posix format.",
+  })
 );
 
 const decodePosixPath = S.decodeUnknownResult(NativePathToPosixPath);

--- a/packages/foundation/modeling/schema/src/RegExp.ts
+++ b/packages/foundation/modeling/schema/src/RegExp.ts
@@ -57,11 +57,9 @@ const decodeRegExp = (value: string): Effect.Effect<globalThis.RegExp, SchemaIss
  */
 export const RegExpStr = S.String.check(RegExpStrCheck).pipe(
   S.brand("RegExpStr"),
-  S.annotate(
-    $I.annote("RegExpStr", {
-      description: "A string that can be converted directly to a JavaScript RegExp using new RegExp(value).",
-    })
-  )
+  $I.annoteSchema("RegExpStr", {
+    description: "A string that can be converted directly to a JavaScript RegExp using new RegExp(value).",
+  })
 );
 
 /**
@@ -112,11 +110,9 @@ export const RegExpFromStr = RegExpStr.pipe(
       encode: encodeRegExpStrForbidden,
     })
   ),
-  S.annotate(
-    $I.annote("RegExpFromStr", {
-      description: "A one-way schema that decodes RegExp-compatible pattern strings into JavaScript RegExp values.",
-    })
-  )
+  $I.annoteSchema("RegExpFromStr", {
+    description: "A one-way schema that decodes RegExp-compatible pattern strings into JavaScript RegExp values.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/SeverityLevel.ts
+++ b/packages/foundation/modeling/schema/src/SeverityLevel.ts
@@ -27,8 +27,8 @@ const SeverityLevelBase = LiteralKit(["low", "medium", "high", "critical"]);
  * @since 0.0.0
  * @category validation
  */
-export const SeverityLevel = SeverityLevelBase.annotate(
-  $I.annote("SeverityLevel", {
+export const SeverityLevel = SeverityLevelBase.pipe(
+  $I.annoteSchema("SeverityLevel", {
     description: "Generic four-level severity scale shared across beep packages.",
   })
 );

--- a/packages/foundation/modeling/schema/src/Sha256.ts
+++ b/packages/foundation/modeling/schema/src/Sha256.ts
@@ -56,11 +56,9 @@ const computeSha256Hex = (input: Uint8Array): Effect.Effect<string, SchemaIssue.
  */
 export const Sha256Hex = S.String.check(Sha256HexChecks).pipe(
   S.brand("Sha256Hex"),
-  S.annotate(
-    $I.annote("Sha256Hex", {
-      description: "A canonical lowercase SHA-256 hex digest.",
-    })
-  )
+  $I.annoteSchema("Sha256Hex", {
+    description: "A canonical lowercase SHA-256 hex digest.",
+  })
 );
 
 /**
@@ -103,11 +101,9 @@ export const Sha256HexFromBytes = S.Uint8Array.pipe(
     decode: SchemaGetter.transformOrFail(computeSha256Hex),
     encode: SchemaGetter.forbidden(() => "Encoding Sha256Hex back to original bytes is not supported"),
   }),
-  S.annotate(
-    $I.annote("Sha256HexFromBytes", {
-      description: "A one-way schema that hashes bytes into a canonical lowercase SHA-256 hex digest.",
-    })
-  )
+  $I.annoteSchema("Sha256HexFromBytes", {
+    description: "A one-way schema that hashes bytes into a canonical lowercase SHA-256 hex digest.",
+  })
 );
 
 /**
@@ -146,11 +142,9 @@ export type Sha256HexFromBytes = typeof Sha256HexFromBytes.Type;
  */
 export const Sha256HexFromHexBytes = S.Uint8ArrayFromHex.pipe(
   S.decodeTo(Sha256HexFromBytes),
-  S.annotate(
-    $I.annote("Sha256HexFromHexBytes", {
-      description: "A one-way schema that hashes hex-encoded bytes into a canonical lowercase SHA-256 hex digest.",
-    })
-  )
+  $I.annoteSchema("Sha256HexFromHexBytes", {
+    description: "A one-way schema that hashes hex-encoded bytes into a canonical lowercase SHA-256 hex digest.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Slug.ts
+++ b/packages/foundation/modeling/schema/src/Slug.ts
@@ -82,11 +82,9 @@ const SlugChecks = S.makeFilterGroup(
  */
 export const Slug = S.NonEmptyString.check(SlugChecks).pipe(
   S.brand("Slug"),
-  S.annotate(
-    $I.annote("Slug", {
-      description: "Canonical lowercase kebab-case slug safe for a single URL path segment.",
-    })
-  )
+  $I.annoteSchema("Slug", {
+    description: "Canonical lowercase kebab-case slug safe for a single URL path segment.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Toml.ts
+++ b/packages/foundation/modeling/schema/src/Toml.ts
@@ -96,11 +96,9 @@ export const TomlTextToUnknown = S.String.pipe(
     decode: SchemaGetter.transformOrFail(decodeTomlUnknown),
     encode: SchemaGetter.transformOrFail(encodeUnsupported),
   }),
-  S.annotate(
-    $I.annote("TomlTextToUnknown", {
-      description: "Schema transformation that parses TOML text into unknown values.",
-    })
-  )
+  $I.annoteSchema("TomlTextToUnknown", {
+    description: "Schema transformation that parses TOML text into unknown values.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Xml.ts
+++ b/packages/foundation/modeling/schema/src/Xml.ts
@@ -84,11 +84,9 @@ export const XmlTextToUnknown = S.String.pipe(
       encode: encodeUnsupported,
     })
   ),
-  S.annotate(
-    $I.annote("XmlTextToUnknown", {
-      description: "Schema transformation that parses XML text into unknown values.",
-    })
-  )
+  $I.annoteSchema("XmlTextToUnknown", {
+    description: "Schema transformation that parses XML text into unknown values.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/Yaml.ts
+++ b/packages/foundation/modeling/schema/src/Yaml.ts
@@ -98,11 +98,9 @@ export const YamlTextToUnknown = S.String.pipe(
     decode: SchemaGetter.transformOrFail(decodeYamlUnknown),
     encode: SchemaGetter.transformOrFail(encodeUnsupported),
   }),
-  S.annotate(
-    $I.annote("YamlTextToUnknown", {
-      description: "Schema transformation that parses YAML text into unknown values.",
-    })
-  )
+  $I.annoteSchema("YamlTextToUnknown", {
+    description: "Schema transformation that parses YAML text into unknown values.",
+  })
 );
 
 /**

--- a/packages/foundation/modeling/schema/src/internal/email.ts
+++ b/packages/foundation/modeling/schema/src/internal/email.ts
@@ -72,7 +72,7 @@ const EmailBranded = NormalizedString.check(emailChecks).pipe(S.brand("Email"));
  * @since 0.0.0
  */
 export const Email = S.RedactedFromValue(EmailBranded, { label: "Email" }).pipe(
-  S.annotate($I.annote("Email", { description: "RFC 5322 compliant email address" }))
+  $I.annoteSchema("Email", { description: "RFC 5322 compliant email address" })
 );
 
 /**

--- a/packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts
+++ b/packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts
@@ -82,11 +82,9 @@ const NumberInputText = S.String.check(
     message: "Number input text must be a valid editable numeric string.",
   })
 ).pipe(
-  S.annotate(
-    $I.annote("NumberInputText", {
-      description: "Editable text accepted by the number input during typing.",
-    })
-  )
+  $I.annoteSchema("NumberInputText", {
+    description: "Editable text accepted by the number input during typing.",
+  })
 );
 
 const isNumberInputText = S.is(NumberInputText);
@@ -95,11 +93,9 @@ const isCoarseStepModifier = P.Tuple([P.isTruthy, P.isUnknown]);
 const isFineStepModifier = P.Tuple([P.isUnknown, P.isTruthy]);
 
 const NonNegativePrecision = S.Number.check(S.isInt(), S.isGreaterThanOrEqualTo(0)).pipe(
-  S.annotate(
-    $I.annote("NonNegativePrecision", {
-      description: "A non-negative integer precision used for fixed-point formatting.",
-    })
-  )
+  $I.annoteSchema("NonNegativePrecision", {
+    description: "A non-negative integer precision used for fixed-point formatting.",
+  })
 );
 
 const normalizeEventKey = (event: KeyboardLikeEvent): O.Option<NumberInputEventKey> =>

--- a/packages/law-practice/domain/src/entities/LegalClient/LegalClient.values.ts
+++ b/packages/law-practice/domain/src/entities/LegalClient/LegalClient.values.ts
@@ -23,8 +23,8 @@ const $I = $LawPracticeDomainId.create("entities/LegalClient/LegalClient.values"
  * @category schemas
  * @since 0.0.0
  */
-export const LegalClientStatus = LiteralKit(["active_client"]).annotate(
-  $I.annote("LegalClientStatus", {
+export const LegalClientStatus = LiteralKit(["active_client"]).pipe(
+  $I.annoteSchema("LegalClientStatus", {
     description: "Legal client status vocabulary represented in proof seeds.",
   })
 );

--- a/packages/law-practice/domain/src/entities/LegalContact/LegalContact.values.ts
+++ b/packages/law-practice/domain/src/entities/LegalContact/LegalContact.values.ts
@@ -23,8 +23,8 @@ const $I = $LawPracticeDomainId.create("entities/LegalContact/LegalContact.value
  * @category schemas
  * @since 0.0.0
  */
-export const LegalContactRole = LiteralKit(["founder"]).annotate(
-  $I.annote("LegalContactRole", {
+export const LegalContactRole = LiteralKit(["founder"]).pipe(
+  $I.annoteSchema("LegalContactRole", {
     description: "Legal contact role vocabulary represented in proof seeds.",
   })
 );

--- a/packages/law-practice/domain/src/entities/Matter/Matter.values.ts
+++ b/packages/law-practice/domain/src/entities/Matter/Matter.values.ts
@@ -23,8 +23,8 @@ const $I = $LawPracticeDomainId.create("entities/Matter/Matter.values");
  * @category schemas
  * @since 0.0.0
  */
-export const MatterType = LiteralKit(["patent_application"]).annotate(
-  $I.annote("MatterType", {
+export const MatterType = LiteralKit(["patent_application"]).pipe(
+  $I.annoteSchema("MatterType", {
     description: "Legal matter type vocabulary represented in proof seeds.",
   })
 );

--- a/packages/law-practice/domain/src/entities/PatentAsset/PatentAsset.values.ts
+++ b/packages/law-practice/domain/src/entities/PatentAsset/PatentAsset.values.ts
@@ -23,8 +23,8 @@ const $I = $LawPracticeDomainId.create("entities/PatentAsset/PatentAsset.values"
  * @category schemas
  * @since 0.0.0
  */
-export const PatentAssetStatus = LiteralKit(["pre_filing"]).annotate(
-  $I.annote("PatentAssetStatus", {
+export const PatentAssetStatus = LiteralKit(["pre_filing"]).pipe(
+  $I.annoteSchema("PatentAssetStatus", {
     description: "Patent asset status vocabulary represented in proof seeds.",
   })
 );

--- a/packages/shared/domain/src/entities/Membership/Membership.values.ts
+++ b/packages/shared/domain/src/entities/Membership/Membership.values.ts
@@ -23,8 +23,8 @@ const $I = $SharedDomainId.create("entities/Membership/Membership.values");
  * @category schemas
  * @since 0.0.0
  */
-export const Role = LiteralKit(["owner", "member"]).annotate(
-  $I.annote("Role", {
+export const Role = LiteralKit(["owner", "member"]).pipe(
+  $I.annoteSchema("Role", {
     description: "Shared organization membership role.",
   })
 );
@@ -58,8 +58,8 @@ export type Role = typeof Role.Type;
  * @category schemas
  * @since 0.0.0
  */
-export const Status = LiteralKit(["active"]).annotate(
-  $I.annote("Status", {
+export const Status = LiteralKit(["active"]).pipe(
+  $I.annoteSchema("Status", {
     description: "Shared organization membership lifecycle status.",
   })
 );

--- a/packages/shared/domain/src/entities/Organization/Organization.values.ts
+++ b/packages/shared/domain/src/entities/Organization/Organization.values.ts
@@ -31,8 +31,8 @@ const $I = $SharedDomainId.create("entities/Organization/Organization.values");
  * @category schemas
  * @since 0.0.0
  */
-export const LicenseTier = LiteralKit(["solo", "team", "enterprise"]).annotate(
-  $I.annote("LicenseTier", {
+export const LicenseTier = LiteralKit(["solo", "team", "enterprise"]).pipe(
+  $I.annoteSchema("LicenseTier", {
     description: "Commercial license tier assigned to a shared-kernel organization.",
   })
 );

--- a/packages/shared/domain/src/entity/Principal.ts
+++ b/packages/shared/domain/src/entity/Principal.ts
@@ -25,8 +25,8 @@ const $I = $SharedDomainId.create("entity/Principal");
  * @since 0.0.0
  * @category schemas
  */
-export const SystemComponent = LiteralKit(["Runtime", "Sync", "Migration", "Policy", "Generator"]).annotate(
-  $I.annote("SystemComponent", {
+export const SystemComponent = LiteralKit(["Runtime", "Sync", "Migration", "Policy", "Generator"]).pipe(
+  $I.annoteSchema("SystemComponent", {
     description: "System component allowed to appear in a system principal.",
   })
 );

--- a/packages/shared/domain/src/entity/SourceKind.ts
+++ b/packages/shared/domain/src/entity/SourceKind.ts
@@ -23,8 +23,8 @@ const $I = $SharedDomainId.create("entity/SourceKind");
  * @since 0.0.0
  * @category schemas
  */
-export const SourceKind = LiteralKit(["User", "Agent", "Admin", "Application", "System", "Sync", "Connector"]).annotate(
-  $I.annote("SourceKind", {
+export const SourceKind = LiteralKit(["User", "Agent", "Admin", "Application", "System", "Sync", "Connector"]).pipe(
+  $I.annoteSchema("SourceKind", {
     description: "Canonical denormalized source of persisted entity data.",
   })
 );

--- a/packages/tooling/library/ai-metrics/src/agent-effectiveness.ts
+++ b/packages/tooling/library/ai-metrics/src/agent-effectiveness.ts
@@ -87,8 +87,8 @@ query AgentEffectivenessPhoenixInventory {
  * @category models
  * @since 0.0.0
  */
-export const AgentEffectivenessStatus = LiteralKit(["passed", "warning", "failed", "unavailable"]).annotate(
-  $I.annote("AgentEffectivenessStatus", {
+export const AgentEffectivenessStatus = LiteralKit(["passed", "warning", "failed", "unavailable"]).pipe(
+  $I.annoteSchema("AgentEffectivenessStatus", {
     description: "Non-blocking status used by agent-effectiveness trust-gate reports.",
   })
 );
@@ -112,8 +112,8 @@ export type AgentEffectivenessStatus = typeof AgentEffectivenessStatus.Type;
  * @category models
  * @since 0.0.0
  */
-export const AgentEffectivenessAnnotationValue = S.Union([S.String, S.Number, S.Boolean]).annotate(
-  $I.annote("AgentEffectivenessAnnotationValue", {
+export const AgentEffectivenessAnnotationValue = S.Union([S.String, S.Number, S.Boolean]).pipe(
+  $I.annoteSchema("AgentEffectivenessAnnotationValue", {
     description: "Sanitized primitive value allowed in an agent-effectiveness annotation plan.",
   })
 );
@@ -640,8 +640,8 @@ export const AgentEffectivenessDatasetKind = LiteralKit([
   "agent-outcomes",
   "jsdoc-worker-model-suitability",
   "source-coverage",
-]).annotate(
-  $I.annote("AgentEffectivenessDatasetKind", {
+]).pipe(
+  $I.annoteSchema("AgentEffectivenessDatasetKind", {
     description: "Phoenix dataset kinds owned by the agent-effectiveness loop.",
   })
 );
@@ -767,8 +767,8 @@ export class AgentEffectivenessDatasetBundle extends S.Class<AgentEffectivenessD
  * @category models
  * @since 0.0.0
  */
-export const AgentEffectivenessPromptRole = LiteralKit(["system", "user"]).annotate(
-  $I.annote("AgentEffectivenessPromptRole", {
+export const AgentEffectivenessPromptRole = LiteralKit(["system", "user"]).pipe(
+  $I.annoteSchema("AgentEffectivenessPromptRole", {
     description: "Prompt roles used by repo-owned agent-effectiveness prompt templates.",
   })
 );
@@ -1141,8 +1141,8 @@ class WorkerEvalPolicyViolationObject extends S.Class<WorkerEvalPolicyViolationO
   })
 ) {}
 
-const WorkerEvalPolicyViolation = S.Union([S.String, WorkerEvalPolicyViolationObject]).annotate(
-  $I.annote("WorkerEvalPolicyViolation", {
+const WorkerEvalPolicyViolation = S.Union([S.String, WorkerEvalPolicyViolationObject]).pipe(
+  $I.annoteSchema("WorkerEvalPolicyViolation", {
     description: "Internal worker-eval policy violation code in either legacy object or current string form.",
   })
 );

--- a/packages/tooling/library/ai-metrics/src/install.ts
+++ b/packages/tooling/library/ai-metrics/src/install.ts
@@ -279,8 +279,8 @@ export const AiMetricsInstallPlanStepKind = LiteralKit([
   "retention_drill",
   "weekly_report",
   "pulumi",
-]).annotate(
-  $I.annote("AiMetricsInstallPlanStepKind", {
+]).pipe(
+  $I.annoteSchema("AiMetricsInstallPlanStepKind", {
     description: "Typed step categories emitted by the AI metrics P5a install planner.",
   })
 );
@@ -365,8 +365,8 @@ export class AiMetricsInstallPlan extends S.Class<AiMetricsInstallPlan>($I`AiMet
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsInstallDoctorCheckStatus = LiteralKit(["passed", "warning", "failed", "skipped"]).annotate(
-  $I.annote("AiMetricsInstallDoctorCheckStatus", {
+export const AiMetricsInstallDoctorCheckStatus = LiteralKit(["passed", "warning", "failed", "skipped"]).pipe(
+  $I.annoteSchema("AiMetricsInstallDoctorCheckStatus", {
     description: "Bounded status for one AI metrics install doctor check.",
   })
 );
@@ -396,8 +396,8 @@ export type AiMetricsInstallDoctorCheckStatus = typeof AiMetricsInstallDoctorChe
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsInstallDoctorStatus = LiteralKit(["passed", "warning", "failed"]).annotate(
-  $I.annote("AiMetricsInstallDoctorStatus", {
+export const AiMetricsInstallDoctorStatus = LiteralKit(["passed", "warning", "failed"]).pipe(
+  $I.annoteSchema("AiMetricsInstallDoctorStatus", {
     description: "Aggregate AI metrics install doctor status.",
   })
 );

--- a/packages/tooling/library/ai-metrics/src/models.ts
+++ b/packages/tooling/library/ai-metrics/src/models.ts
@@ -23,8 +23,8 @@ const $I = $RepoAiMetricsId.create("models");
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsDeployTarget = LiteralKit(["local", "dankserver"]).annotate(
-  $I.annote("AiMetricsDeployTarget", {
+export const AiMetricsDeployTarget = LiteralKit(["local", "dankserver"]).pipe(
+  $I.annoteSchema("AiMetricsDeployTarget", {
     description: "Deploy targets supported by the repo AI metrics install module.",
   })
 );
@@ -54,8 +54,8 @@ export type AiMetricsDeployTarget = typeof AiMetricsDeployTarget.Type;
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsTool = LiteralKit(["langfuse", "phoenix", "opik", "posthog"]).annotate(
-  $I.annote("AiMetricsTool", {
+export const AiMetricsTool = LiteralKit(["langfuse", "phoenix", "opik", "posthog"]).pipe(
+  $I.annoteSchema("AiMetricsTool", {
     description: "LLM analytics or evaluation tools that AI metrics exports can target.",
   })
 );
@@ -85,8 +85,8 @@ export type AiMetricsTool = typeof AiMetricsTool.Type;
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsTranscriptSource = LiteralKit(["codex", "claude", "openclaw"]).annotate(
-  $I.annote("AiMetricsTranscriptSource", {
+export const AiMetricsTranscriptSource = LiteralKit(["codex", "claude", "openclaw"]).pipe(
+  $I.annoteSchema("AiMetricsTranscriptSource", {
     description: "AI stack transcript sources supported by the repo ingest layer.",
   })
 );
@@ -116,8 +116,8 @@ export type AiMetricsTranscriptSource = typeof AiMetricsTranscriptSource.Type;
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsSourceRole = LiteralKit(["primary", "subagent", "gateway_metadata"]).annotate(
-  $I.annote("AiMetricsSourceRole", {
+export const AiMetricsSourceRole = LiteralKit(["primary", "subagent", "gateway_metadata"]).pipe(
+  $I.annoteSchema("AiMetricsSourceRole", {
     description: "Privacy-safe role of a discovered source file or metadata record.",
   })
 );
@@ -174,12 +174,8 @@ export class AiMetricsSourceAttribution extends S.Class<AiMetricsSourceAttributi
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsPrivacyMode = LiteralKit([
-  "encrypted_raw_redacted_ui",
-  "raw_tailnet_ui",
-  "redacted_only",
-]).annotate(
-  $I.annote("AiMetricsPrivacyMode", {
+export const AiMetricsPrivacyMode = LiteralKit(["encrypted_raw_redacted_ui", "raw_tailnet_ui", "redacted_only"]).pipe(
+  $I.annoteSchema("AiMetricsPrivacyMode", {
     description: "Privacy boundary for raw transcripts and derived observability UI payloads.",
   })
 );
@@ -209,8 +205,8 @@ export type AiMetricsPrivacyMode = typeof AiMetricsPrivacyMode.Type;
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsOtlpProtocol = LiteralKit(["http/protobuf"]).annotate(
-  $I.annote("AiMetricsOtlpProtocol", {
+export const AiMetricsOtlpProtocol = LiteralKit(["http/protobuf"]).pipe(
+  $I.annoteSchema("AiMetricsOtlpProtocol", {
     description: "OTLP wire protocol variants supported by the AI metrics backend contract.",
   })
 );
@@ -240,8 +236,8 @@ export type AiMetricsOtlpProtocol = typeof AiMetricsOtlpProtocol.Type;
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsOtlpSignalScope = LiteralKit(["traces_only"]).annotate(
-  $I.annote("AiMetricsOtlpSignalScope", {
+export const AiMetricsOtlpSignalScope = LiteralKit(["traces_only"]).pipe(
+  $I.annoteSchema("AiMetricsOtlpSignalScope", {
     description: "Telemetry signal scope exported to the AI metrics backend.",
   })
 );
@@ -271,8 +267,8 @@ export type AiMetricsOtlpSignalScope = typeof AiMetricsOtlpSignalScope.Type;
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsQualityGateStatus = LiteralKit(["passed", "failed", "not_run", "unknown"]).annotate(
-  $I.annote("AiMetricsQualityGateStatus", {
+export const AiMetricsQualityGateStatus = LiteralKit(["passed", "failed", "not_run", "unknown"]).pipe(
+  $I.annoteSchema("AiMetricsQualityGateStatus", {
     description: "Bounded quality-gate outcome used by AI metrics labels and benchmark runs.",
   })
 );

--- a/packages/tooling/library/ai-metrics/src/privacy.ts
+++ b/packages/tooling/library/ai-metrics/src/privacy.ts
@@ -53,8 +53,8 @@ const countMatches = (pattern: RegExp, content: string): number =>
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsHashSaltStatus = LiteralKit(["provided", "insecure_default"]).annotate(
-  $I.annote("AiMetricsHashSaltStatus", {
+export const AiMetricsHashSaltStatus = LiteralKit(["provided", "insecure_default"]).pipe(
+  $I.annoteSchema("AiMetricsHashSaltStatus", {
     description: "Salt source status for private AI metrics identifier hashes.",
   })
 );

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -42,8 +42,8 @@ const DEFAULT_MAX_FILES = 200;
  * @category models
  * @since 0.0.0
  */
-export const AiMetricsSourceStatus = LiteralKit(["available", "missing", "unavailable"]).annotate(
-  $I.annote("AiMetricsSourceStatus", {
+export const AiMetricsSourceStatus = LiteralKit(["available", "missing", "unavailable"]).pipe(
+  $I.annoteSchema("AiMetricsSourceStatus", {
     description: "Availability status for a discovered AI metrics source root.",
   })
 );

--- a/packages/tooling/library/repo-codegraph/src/RepoCodegraphLookup.model.ts
+++ b/packages/tooling/library/repo-codegraph/src/RepoCodegraphLookup.model.ts
@@ -24,8 +24,8 @@ const $I = $RepoCodegraphId.create("RepoCodegraphLookup.model");
  * @category models
  * @since 0.0.0
  */
-export const RepoCodegraphLookupSchemaVersion = LiteralKit(["repo-codegraph.lookup/v1"]).annotate(
-  $I.annote("RepoCodegraphLookupSchemaVersion", {
+export const RepoCodegraphLookupSchemaVersion = LiteralKit(["repo-codegraph.lookup/v1"]).pipe(
+  $I.annoteSchema("RepoCodegraphLookupSchemaVersion", {
     description: "Schema version for deterministic repo-codegraph lookup results.",
   })
 );
@@ -55,8 +55,8 @@ export type RepoCodegraphLookupSchemaVersion = typeof RepoCodegraphLookupSchemaV
  * @category models
  * @since 0.0.0
  */
-export const RepoCodegraphFreshnessStatus = LiteralKit(["unchecked", "current"]).annotate(
-  $I.annote("RepoCodegraphFreshnessStatus", {
+export const RepoCodegraphFreshnessStatus = LiteralKit(["unchecked", "current"]).pipe(
+  $I.annoteSchema("RepoCodegraphFreshnessStatus", {
     description: "Freshness posture of the export catalog used by a lookup request.",
   })
 );
@@ -86,8 +86,8 @@ export type RepoCodegraphFreshnessStatus = typeof RepoCodegraphFreshnessStatus.T
  * @category models
  * @since 0.0.0
  */
-export const RepoCodegraphBoundaryStatus = LiteralKit(["allowed", "advisory", "blocked", "unknown"]).annotate(
-  $I.annote("RepoCodegraphBoundaryStatus", {
+export const RepoCodegraphBoundaryStatus = LiteralKit(["allowed", "advisory", "blocked", "unknown"]).pipe(
+  $I.annoteSchema("RepoCodegraphBoundaryStatus", {
     description: "Advisory architecture-boundary status for a candidate import.",
   })
 );

--- a/packages/tooling/library/repo-codegraph/src/RepoExportsCatalog.model.ts
+++ b/packages/tooling/library/repo-codegraph/src/RepoExportsCatalog.model.ts
@@ -22,8 +22,8 @@ const $I = $RepoCodegraphId.create("RepoExportsCatalog.model");
  * @category models
  * @since 0.0.0
  */
-export const RepoExportsCatalogStandard = LiteralKit(["repo-exports-catalog"]).annotate(
-  $I.annote("RepoExportsCatalogStandard", {
+export const RepoExportsCatalogStandard = LiteralKit(["repo-exports-catalog"]).pipe(
+  $I.annoteSchema("RepoExportsCatalogStandard", {
     description: "Standard identifier for the generated repo export catalog.",
   })
 );
@@ -53,8 +53,8 @@ export type RepoExportsCatalogStandard = typeof RepoExportsCatalogStandard.Type;
  * @category models
  * @since 0.0.0
  */
-export const RepoExportsCatalogSchemaVersion = LiteralKit(["repo-exports-catalog/v1"]).annotate(
-  $I.annote("RepoExportsCatalogSchemaVersion", {
+export const RepoExportsCatalogSchemaVersion = LiteralKit(["repo-exports-catalog/v1"]).pipe(
+  $I.annoteSchema("RepoExportsCatalogSchemaVersion", {
     description: "Schema version for the generated repo export catalog consumed by lookup.",
   })
 );

--- a/packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts
@@ -48,8 +48,8 @@ export class JSDocParam extends S.Opaque<JSDocParam & JSDocTagMember<"param">>()
     relatedTags: ["returns", "template", "callback"],
     isDeprecated: false,
     example: `/** @param {string} name - The user's display name */`,
-  }).annotate(
-    $I.annote("JSDocParam", {
+  }).pipe(
+    $I.annoteSchema("JSDocParam", {
       // description:
     })
   )
@@ -88,8 +88,8 @@ export class JSDocReturns extends S.Opaque<JSDocReturns & JSDocTagMember<"return
     relatedTags: ["param", "throws", "yields"],
     isDeprecated: false,
     example: `/** @returns {Promise<User>} The resolved user object */`,
-  }).annotate(
-    $I.annote("JSDocReturns", {
+  }).pipe(
+    $I.annoteSchema("JSDocReturns", {
       // description:
     })
   )
@@ -525,14 +525,12 @@ export const StructuralJSDoc = S.Union([
   JSDocYields,
 ]).pipe(
   S.toTaggedUnion("_tag"),
-  S.annotate(
-    $I.annote("StructuralJSDoc", {
-      description: "A Structural JSDoc Tag",
-      documentation:
-        "STRUCTURAL TAGS — AST-derivable (Layer 1)\n" +
-        "These tags can be 100% or mostly derived from the TypeScript AST.",
-    })
-  )
+  $I.annoteSchema("StructuralJSDoc", {
+    description: "A Structural JSDoc Tag",
+    documentation:
+      "STRUCTURAL TAGS — AST-derivable (Layer 1)\n" +
+      "These tags can be 100% or mostly derived from the TypeScript AST.",
+  })
 );
 
 /**
@@ -1154,7 +1152,7 @@ export const AccessModifierJSDoc = S.Union([
   JSDocSatisfies,
   JSDocImport,
   JSDocThis,
-]).pipe(S.toTaggedUnion("_tag"), S.annotate($I.annote("AccessModifierJSDoc")));
+]).pipe(S.toTaggedUnion("_tag"), $I.annoteSchema("AccessModifierJSDoc"));
 
 /**
  * JSDoc tag metadata export.
@@ -1543,7 +1541,7 @@ export const DocumentationContentJSDoc = S.Union([
   JSDocVersion,
   JSDocAuthor,
   JSDocTodo,
-]).pipe(S.toTaggedUnion("_tag"), S.annotate($I.annote("DocumentationContentJSDoc")));
+]).pipe(S.toTaggedUnion("_tag"), $I.annoteSchema("DocumentationContentJSDoc"));
 
 /**
  * JSDoc tag metadata export.
@@ -1968,7 +1966,7 @@ export const TSDocSpecificJSDoc = S.Union([
   JSDocLabel,
   JSDocDecorator,
   JSDocEventProperty,
-]).pipe(S.toTaggedUnion("_tag"), S.annotate($I.annote("TSDocSpecificJSDoc")));
+]).pipe(S.toTaggedUnion("_tag"), $I.annoteSchema("TSDocSpecificJSDoc"));
 
 /**
  * JSDoc tag metadata export.
@@ -2083,7 +2081,7 @@ export class JSDocInheritDoc extends S.Opaque<JSDocInheritDoc & JSDocTagMember<"
  */
 export const InlineJSDoc = S.Union([JSDocLink, JSDocInheritDoc]).pipe(
   S.toTaggedUnion("_tag"),
-  S.annotate($I.annote("InlineJSDoc"))
+  $I.annoteSchema("InlineJSDoc")
 );
 
 /**
@@ -2373,7 +2371,7 @@ export const OrganizationalJSDoc = S.Union([
   JSDocProperty,
   JSDocInterface,
   JSDocFunction,
-]).pipe(S.toTaggedUnion("_tag"), S.annotate($I.annote("OrganizationalJSDoc")));
+]).pipe(S.toTaggedUnion("_tag"), $I.annoteSchema("OrganizationalJSDoc"));
 
 /**
  * JSDoc tag metadata export.
@@ -2554,7 +2552,7 @@ export class JSDocRequires extends S.Opaque<JSDocRequires & JSDocTagMember<"requ
  */
 export const EventDependencyJSDoc = S.Union([JSDocFires, JSDocListens, JSDocEvent, JSDocRequires]).pipe(
   S.toTaggedUnion("_tag"),
-  S.annotate($I.annote("EventDependencyJSDoc"))
+  $I.annoteSchema("EventDependencyJSDoc")
 );
 
 /**
@@ -3297,7 +3295,7 @@ export const RemainingJSDoc = S.Union([
   JSDocName,
   JSDocVariation,
   JSDocTutorial,
-]).pipe(S.toTaggedUnion("_tag"), S.annotate($I.annote("RemainingJSDoc")));
+]).pipe(S.toTaggedUnion("_tag"), $I.annoteSchema("RemainingJSDoc"));
 
 /**
  * JSDoc tag metadata export.
@@ -3853,7 +3851,7 @@ export const ClosureSpecificJSDoc = S.Union([
   JSDocRecord,
   JSDocNoCollapse,
   JSDocNoInline,
-]).pipe(S.toTaggedUnion("_tag"), S.annotate($I.annote("ClosureSpecificJSDoc")));
+]).pipe(S.toTaggedUnion("_tag"), $I.annoteSchema("ClosureSpecificJSDoc"));
 
 /**
  * JSDoc tag metadata export.
@@ -4239,7 +4237,7 @@ export const TypeDocSpecificJSDoc = S.Union([
   JSDocPrimaryExport,
   JSDocSortStrategy,
   JSDocUseDeclaredType,
-]).pipe(S.toTaggedUnion("_tag"), S.annotate($I.annote("TypeDocSpecificJSDoc")));
+]).pipe(S.toTaggedUnion("_tag"), $I.annoteSchema("TypeDocSpecificJSDoc"));
 
 /**
  * JSDoc tag metadata export.
@@ -4320,7 +4318,7 @@ export class JSDocOverload extends S.Opaque<JSDocOverload & JSDocTagMember<"over
  */
 export const TypeScriptSpecificJSDoc = S.Union([JSDocOverload]).pipe(
   S.toTaggedUnion("_tag"),
-  S.annotate($I.annote("TypeScriptSpecificJSDoc"))
+  $I.annoteSchema("TypeScriptSpecificJSDoc")
 );
 
 /**
@@ -4376,7 +4374,7 @@ export const JSDocTag = S.Union([
   ClosureSpecificJSDoc,
   TypeDocSpecificJSDoc,
   TypeScriptSpecificJSDoc,
-]).pipe(S.toTaggedUnion("_tag"), S.annotate($I.annote("JSDocTag")));
+]).pipe(S.toTaggedUnion("_tag"), $I.annoteSchema("JSDocTag"));
 
 /**
  * JSDoc tag metadata export.

--- a/packages/tooling/library/repo-utils/src/JSDoc/models/ASTDerivability.model.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/models/ASTDerivability.model.ts
@@ -27,8 +27,8 @@ const $I = $RepoUtilsId.create("JSDoc/models/ASTDerivability.model");
  * @category models
  * @since 0.0.0
  */
-export const ASTDerivability = LiteralKit(["full", "partial", "none"]).annotate(
-  $I.annote("ASTDerivability", {
+export const ASTDerivability = LiteralKit(["full", "partial", "none"]).pipe(
+  $I.annoteSchema("ASTDerivability", {
     description: "Whether this tag's content can be deterministically derived from the TypeScript AST.",
     documentation:
       'Whether this tag\'s content can be deterministically derived from the TypeScript AST.\nThis is the KEY field for the knowledge graph pipeline:\n  - "full"    → Layer 1 (certainty=1.0): 100% derivable from AST, no human input needed\n  - "partial" → Layer 2 (certainty=0.85-0.95): Structurally derivable but may need human context\n  - "none"    → Layer 3 (certainty=0.6-0.85): Requires human authoring or LLM inference',

--- a/packages/tooling/library/repo-utils/src/JSDoc/models/ApplicableTo.model.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/models/ApplicableTo.model.ts
@@ -50,8 +50,8 @@ export const ApplicableTo = LiteralKit([
   "event",
   "mixin",
   "any", // can attach to anything
-]).annotate(
-  $I.annote("ApplicableTo", {
+]).pipe(
+  $I.annoteSchema("ApplicableTo", {
     description: "AST-level attachment surface for a documentation tag.",
   })
 );

--- a/packages/tooling/library/repo-utils/src/JSDoc/models/ArchitecturalLayer.model.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/models/ArchitecturalLayer.model.ts
@@ -33,8 +33,8 @@ export const ArchitecturalLayer = LiteralKit([
   "Adapter",
   "Core",
   "CrossCutting",
-]).annotate(
-  $I.annote("ArchitecturalLayer", {
+]).pipe(
+  $I.annoteSchema("ArchitecturalLayer", {
     description:
       'Architectural layer mappings across established patterns.\nEnables cross-framework queries such as "show me all code in the\ndomain core that depends on infrastructure".',
   })

--- a/packages/tooling/library/repo-utils/src/JSDoc/models/DependencyProfile.model.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/models/DependencyProfile.model.ts
@@ -23,8 +23,8 @@ const $I = $RepoUtilsId.create("JSDoc/models/DependencyProfile.model");
  * @category models
  * @since 0.0.0
  */
-export const FanValue = LiteralKit(["low", "medium", "high"]).annotate(
-  $I.annote("FanValue", {
+export const FanValue = LiteralKit(["low", "medium", "high"]).pipe(
+  $I.annoteSchema("FanValue", {
     description: "",
   })
 );

--- a/packages/tooling/library/repo-utils/src/JSDoc/models/HasJSDocApplicableToMapEntry.model.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/models/HasJSDocApplicableToMapEntry.model.ts
@@ -59,8 +59,8 @@ export const HasJSDocApplicableToMapEntry = ApplicableTo.toTaggedUnion("applicab
   event: fields,
   mixin: fields,
   any: fields, // can attach to anything
-}).annotate(
-  $I.annote("HasJSDocApplicableToMapEntry", {
+}).pipe(
+  $I.annoteSchema("HasJSDocApplicableToMapEntry", {
     description: "One mapping row from a TypeScript `HasJSDoc` member name to an `ApplicableTo` classification.",
   })
 );

--- a/packages/tooling/library/repo-utils/src/JSDoc/models/Specification.model.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/models/Specification.model.ts
@@ -40,8 +40,8 @@ export const Specification = LiteralKit([
   "typedoc",
   // User-defined / non-standard
   "custom",
-]).annotate(
-  $I.annote("Specification", {
+]).pipe(
+  $I.annoteSchema("Specification", {
     description: "Which specification(s) define this tag",
   })
 );

--- a/packages/tooling/library/repo-utils/src/JSDoc/models/TSCategory.model.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/models/TSCategory.model.ts
@@ -42,8 +42,8 @@ const TS_CATEGORY_TAG_VALUES = [
  * @category models
  * @since 0.0.0
  */
-const TSCategoryTagBase = LiteralKit(TS_CATEGORY_TAG_VALUES).annotate(
-  $I.annote("TSCategoryTag", {
+const TSCategoryTagBase = LiteralKit(TS_CATEGORY_TAG_VALUES).pipe(
+  $I.annoteSchema("TSCategoryTag", {
     description: "Strict literal union for all supported TypeDoc @category values.",
   })
 );
@@ -68,8 +68,8 @@ type TSCategoryTagBase = typeof TSCategoryTagBase.Type;
  * @category models
  * @since 0.0.0
  */
-export const CategoryPurity = LiteralKit(["pure", "effectful", "mixed"]).annotate(
-  $I.annote("CategoryPurity", {
+export const CategoryPurity = LiteralKit(["pure", "effectful", "mixed"]).pipe(
+  $I.annoteSchema("CategoryPurity", {
     description: "Purity classification",
     documentation:
       "- pure: no observable side effects\\n- effectful: performs IO, mutation, or external effects\\n- mixed: both pure and effectful patterns",
@@ -418,8 +418,8 @@ const DomainModel = make("DomainModel", {
   typicalImportPatterns: ["**/domain/**/*.ts", "**/model/**/*.ts", "**/entities/**/*.ts"],
   dependencyProfile: { typicalFanIn: "high", typicalFanOut: "low" },
   documentationPriority: 1,
-}).annotate(
-  $I.annote("DomainModel", {
+}).pipe(
+  $I.annoteSchema("DomainModel", {
     description: "Literal schema for DomainModel category.",
   })
 );
@@ -478,8 +478,8 @@ const DomainLogic = make("DomainLogic", {
   typicalImportPatterns: ["**/domain/**/*.ts", "**/policies/**/*.ts", "**/rules/**/*.ts"],
   dependencyProfile: { typicalFanIn: "high", typicalFanOut: "low" },
   documentationPriority: 2,
-}).annotate(
-  $I.annote("DomainLogic", {
+}).pipe(
+  $I.annoteSchema("DomainLogic", {
     description: "Literal schema for DomainLogic category.",
   })
 );
@@ -536,8 +536,8 @@ const PortContract = make("PortContract", {
   typicalImportPatterns: ["**/*Port.ts", "**/*Repository.ts", "**/*Gateway.ts"],
   dependencyProfile: { typicalFanIn: "high", typicalFanOut: "low" },
   documentationPriority: 4,
-}).annotate(
-  $I.annote("PortContract", {
+}).pipe(
+  $I.annoteSchema("PortContract", {
     description: "Literal schema for PortContract category.",
   })
 );
@@ -584,8 +584,8 @@ const Validation = make("Validation", {
   typicalImportPatterns: ["@effect/schema*", "effect/Schema*", "zod*", "valibot*", "arktype*", "**/schemas/**/*.ts"],
   dependencyProfile: { typicalFanIn: "medium", typicalFanOut: "low" },
   documentationPriority: 5,
-}).annotate(
-  $I.annote("Validation", {
+}).pipe(
+  $I.annoteSchema("Validation", {
     description: "Literal schema for Validation category.",
   })
 );
@@ -625,8 +625,8 @@ const Utility = make("Utility", {
   typicalImportPatterns: ["**/utils.ts", "**/helpers.ts", "**/lib/**/*.ts"],
   dependencyProfile: { typicalFanIn: "medium", typicalFanOut: "low" },
   documentationPriority: 6,
-}).annotate(
-  $I.annote("Utility", {
+}).pipe(
+  $I.annoteSchema("Utility", {
     description: "Literal schema for Utility category.",
   })
 );
@@ -667,8 +667,8 @@ const UseCase = make("UseCase", {
   typicalImportPatterns: ["**/*UseCase.ts", "**/*Handler.ts", "**/application/**/*.ts"],
   dependencyProfile: { typicalFanIn: "medium", typicalFanOut: "high" },
   documentationPriority: 7,
-}).annotate(
-  $I.annote("UseCase", {
+}).pipe(
+  $I.annoteSchema("UseCase", {
     description: "Literal schema for UseCase category.",
   })
 );
@@ -721,8 +721,8 @@ const Presentation = make("Presentation", {
   typicalImportPatterns: ["next/*", "react*", "**/app/**/page.tsx", "**/api/**/route.ts"],
   dependencyProfile: { typicalFanIn: "medium", typicalFanOut: "high" },
   documentationPriority: 8,
-}).annotate(
-  $I.annote("Presentation", {
+}).pipe(
+  $I.annoteSchema("Presentation", {
     description: "Literal schema for Presentation category.",
   })
 );
@@ -768,8 +768,8 @@ const DataAccess = make("DataAccess", {
   typicalImportPatterns: ["drizzle-orm*", "prisma*", "**/db/**/*.ts", "**/repository/**/*.ts"],
   dependencyProfile: { typicalFanIn: "low", typicalFanOut: "medium" },
   documentationPriority: 9,
-}).annotate(
-  $I.annote("DataAccess", {
+}).pipe(
+  $I.annoteSchema("DataAccess", {
     description: "Literal schema for DataAccess category.",
   })
 );
@@ -810,8 +810,8 @@ const Integration = make("Integration", {
   typicalImportPatterns: ["openai*", "stripe*", "@aws-sdk/*", "**/client.ts", "**/gateway/**/*.ts"],
   dependencyProfile: { typicalFanIn: "low", typicalFanOut: "medium" },
   documentationPriority: 10,
-}).annotate(
-  $I.annote("Integration", {
+}).pipe(
+  $I.annoteSchema("Integration", {
     description: "Literal schema for Integration category.",
   })
 );
@@ -857,8 +857,8 @@ const Configuration = make("Configuration", {
   typicalImportPatterns: ["**/config/**/*.ts", "**/*Config.ts", "**/*Settings.ts", "**/env/**/*.ts"],
   dependencyProfile: { typicalFanIn: "high", typicalFanOut: "medium" },
   documentationPriority: 3,
-}).annotate(
-  $I.annote("Configuration", {
+}).pipe(
+  $I.annoteSchema("Configuration", {
     description: "Literal schema for Configuration category.",
   })
 );
@@ -904,8 +904,8 @@ const CrossCutting = make("CrossCutting", {
   typicalImportPatterns: ["**/middleware/**/*.ts", "**/logger/**/*.ts", "**/auth/**/*.ts", "**/metrics/**/*.ts"],
   dependencyProfile: { typicalFanIn: "medium", typicalFanOut: "medium" },
   documentationPriority: 11,
-}).annotate(
-  $I.annote("CrossCutting", {
+}).pipe(
+  $I.annoteSchema("CrossCutting", {
     description: "Literal schema for CrossCutting category.",
   })
 );
@@ -951,8 +951,8 @@ const Uncategorized = make("Uncategorized", {
   typicalImportPatterns: [],
   dependencyProfile: { typicalFanIn: "low", typicalFanOut: "low" },
   documentationPriority: 99,
-}).annotate(
-  $I.annote("Uncategorized", {
+}).pipe(
+  $I.annoteSchema("Uncategorized", {
     description: "Literal schema for Uncategorized category.",
   })
 );
@@ -983,8 +983,8 @@ export const TSCategoryTag = LiteralKit([
   Configuration.literal,
   CrossCutting.literal,
   Uncategorized.literal,
-]).annotate(
-  $I.annote("TSCategoryTag", {
+]).pipe(
+  $I.annoteSchema("TSCategoryTag", {
     description: "Strict literal union for all supported TypeDoc @category values.",
   })
 );

--- a/packages/tooling/library/repo-utils/src/JSDoc/models/TagKind.model.ts
+++ b/packages/tooling/library/repo-utils/src/JSDoc/models/TagKind.model.ts
@@ -28,8 +28,8 @@ export const TagKind = LiteralKit([
   "inline",
   // @tag (no content, indicates a quality/flag)
   "modifier",
-]).annotate(
-  $I.annote("TagKind", {
+]).pipe(
+  $I.annoteSchema("TagKind", {
     description: "The kind of tag",
   })
 );

--- a/packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts
+++ b/packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts
@@ -29,11 +29,9 @@ export const ReuseCatalogOrigin = S.Union([
   S.Literal("repo-tooling"),
   S.Literal("effect-v4-curated"),
 ]).pipe(
-  S.annotate(
-    $I.annote("ReuseCatalogOrigin", {
-      description: "Origin classification for a reuse-catalog entry.",
-    })
-  )
+  $I.annoteSchema("ReuseCatalogOrigin", {
+    description: "Origin classification for a reuse-catalog entry.",
+  })
 );
 
 /**
@@ -63,11 +61,9 @@ export type ReuseCatalogOrigin = typeof ReuseCatalogOrigin.Type;
  * @since 0.0.0
  */
 export const ReuseWorkUnitKind = LiteralKit(["scout", "specialist"]).pipe(
-  S.annotate(
-    $I.annote("ReuseWorkUnitKind", {
-      description: "Kind of reuse-analysis work unit emitted for future orchestration.",
-    })
-  )
+  $I.annoteSchema("ReuseWorkUnitKind", {
+    description: "Kind of reuse-analysis work unit emitted for future orchestration.",
+  })
 );
 
 /**
@@ -102,11 +98,9 @@ export const ReuseCandidateKind = S.Union([
   S.Literal("extract-type"),
   S.Literal("replace-with-existing"),
 ]).pipe(
-  S.annotate(
-    $I.annote("ReuseCandidateKind", {
-      description: "High-level remediation class for a reuse opportunity.",
-    })
-  )
+  $I.annoteSchema("ReuseCandidateKind", {
+    description: "High-level remediation class for a reuse opportunity.",
+  })
 );
 
 /**

--- a/packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts
+++ b/packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts
@@ -120,11 +120,9 @@ const symbolKindOptions = TSSyntaxKind.pickOptions([
  */
 export const RepoRootPath = FilePath.pipe(
   S.brand("RepoRootPath"),
-  S.annotate(
-    $I.annote("RepoRootPath", {
-      description: "Absolute or repo-anchored path representing the repository root directory.",
-    })
-  )
+  $I.annoteSchema("RepoRootPath", {
+    description: "Absolute or repo-anchored path representing the repository root directory.",
+  })
 );
 
 /**
@@ -153,11 +151,9 @@ export type RepoRootPath = typeof RepoRootPath.Type;
  */
 export const WorkspaceDirectoryPath = FilePath.pipe(
   S.brand("WorkspaceDirectoryPath"),
-  S.annotate(
-    $I.annote("WorkspaceDirectoryPath", {
-      description: "Directory path representing a workspace root inside the repository.",
-    })
-  )
+  $I.annoteSchema("WorkspaceDirectoryPath", {
+    description: "Directory path representing a workspace root inside the repository.",
+  })
 );
 
 /**
@@ -186,11 +182,9 @@ export type WorkspaceDirectoryPath = typeof WorkspaceDirectoryPath.Type;
  */
 export const TsConfigFilePath = FilePath.check(tsConfigFilePathChecks).pipe(
   S.brand("TsConfigFilePath"),
-  S.annotate(
-    $I.annote("TsConfigFilePath", {
-      description: "A tsconfig*.json file path that is safe to embed in TSMorph scope identities.",
-    })
-  )
+  $I.annoteSchema("TsConfigFilePath", {
+    description: "A tsconfig*.json file path that is safe to embed in TSMorph scope identities.",
+  })
 );
 
 /**
@@ -219,11 +213,9 @@ export type TsConfigFilePath = typeof TsConfigFilePath.Type;
  */
 export const TypeScriptImplementationFilePath = FilePath.check(typeScriptImplementationFilePathChecks).pipe(
   S.brand("TypeScriptImplementationFilePath"),
-  S.annotate(
-    $I.annote("TypeScriptImplementationFilePath", {
-      description: "A TypeScript implementation file path for .ts, .tsx, .mts, or .cts files.",
-    })
-  )
+  $I.annoteSchema("TypeScriptImplementationFilePath", {
+    description: "A TypeScript implementation file path for .ts, .tsx, .mts, or .cts files.",
+  })
 );
 
 /**
@@ -252,11 +244,9 @@ export type TypeScriptImplementationFilePath = typeof TypeScriptImplementationFi
  */
 export const TypeScriptDeclarationFilePath = FilePath.check(typeScriptDeclarationFilePathChecks).pipe(
   S.brand("TypeScriptDeclarationFilePath"),
-  S.annotate(
-    $I.annote("TypeScriptDeclarationFilePath", {
-      description: "A TypeScript declaration file path for .d.ts, .d.mts, or .d.cts files.",
-    })
-  )
+  $I.annoteSchema("TypeScriptDeclarationFilePath", {
+    description: "A TypeScript declaration file path for .d.ts, .d.mts, or .d.cts files.",
+  })
 );
 
 /**
@@ -284,11 +274,9 @@ export type TypeScriptDeclarationFilePath = typeof TypeScriptDeclarationFilePath
  * @since 0.0.0
  */
 export const TypeScriptFilePath = S.Union([TypeScriptImplementationFilePath, TypeScriptDeclarationFilePath]).pipe(
-  S.annotate(
-    $I.annote("TypeScriptFilePath", {
-      description: "A TypeScript source file path covering implementation and declaration files.",
-    })
-  )
+  $I.annoteSchema("TypeScriptFilePath", {
+    description: "A TypeScript source file path covering implementation and declaration files.",
+  })
 );
 
 /**
@@ -317,11 +305,9 @@ export type TypeScriptFilePath = typeof TypeScriptFilePath.Type;
  */
 export const SymbolFilePath = TypeScriptImplementationFilePath.check(symbolIdSafePathChecks).pipe(
   S.brand("SymbolFilePath"),
-  S.annotate(
-    $I.annote("SymbolFilePath", {
-      description: "A TypeScript implementation file path that is safe to embed in symbol identities.",
-    })
-  )
+  $I.annoteSchema("SymbolFilePath", {
+    description: "A TypeScript implementation file path that is safe to embed in symbol identities.",
+  })
 );
 
 /**
@@ -350,11 +336,9 @@ export type SymbolFilePath = typeof SymbolFilePath.Type;
  */
 export const SymbolNameSegment = S.String.check(S.isPattern(SYMBOL_NAME_SEGMENT_PATTERN)).pipe(
   S.brand("SymbolNameSegment"),
-  S.annotate(
-    $I.annote("SymbolNameSegment", {
-      description: "A single identifier-like segment in a TypeScript symbol path.",
-    })
-  )
+  $I.annoteSchema("SymbolNameSegment", {
+    description: "A single identifier-like segment in a TypeScript symbol path.",
+  })
 );
 
 /**
@@ -383,11 +367,9 @@ export type SymbolNameSegment = typeof SymbolNameSegment.Type;
  */
 export const SymbolQualifiedName = S.String.check(S.isPattern(SYMBOL_QUALIFIED_NAME_PATTERN)).pipe(
   S.brand("SymbolQualifiedName"),
-  S.annotate(
-    $I.annote("SymbolQualifiedName", {
-      description: "Dot-delimited symbol path such as UserService.login.",
-    })
-  )
+  $I.annoteSchema("SymbolQualifiedName", {
+    description: "Dot-delimited symbol path such as UserService.login.",
+  })
 );
 
 /**
@@ -496,11 +478,9 @@ export const SymbolKindToCategory = SymbolKind.pipe(
       () => "Encoding SymbolCategory back to SymbolKind is not supported by SymbolKindToCategory."
     ),
   }),
-  S.annotate(
-    $I.annote("SymbolKindToCategory", {
-      description: "One-way schema transformation from exact TypeScript declaration kind to coarse symbol category.",
-    })
-  )
+  $I.annoteSchema("SymbolKindToCategory", {
+    description: "One-way schema transformation from exact TypeScript declaration kind to coarse symbol category.",
+  })
 );
 
 /**
@@ -529,11 +509,9 @@ export type SymbolKindToCategory = typeof SymbolKindToCategory.Type;
  */
 export const SourceText = S.NonEmptyString.pipe(
   S.brand("SourceText"),
-  S.annotate(
-    $I.annote("SourceText", {
-      description: "Non-empty source text extracted from a TypeScript file or declaration.",
-    })
-  )
+  $I.annoteSchema("SourceText", {
+    description: "Non-empty source text extracted from a TypeScript file or declaration.",
+  })
 );
 
 /**
@@ -562,11 +540,9 @@ export type SourceText = typeof SourceText.Type;
  */
 export const LineNumber = S.Int.check(S.isGreaterThan(0)).pipe(
   S.brand("LineNumber"),
-  S.annotate(
-    $I.annote("LineNumber", {
-      description: "A positive 1-based line number.",
-    })
-  )
+  $I.annoteSchema("LineNumber", {
+    description: "A positive 1-based line number.",
+  })
 );
 
 /**
@@ -595,11 +571,9 @@ export type LineNumber = typeof LineNumber.Type;
  */
 export const ColumnNumber = S.Int.check(S.isGreaterThan(0)).pipe(
   S.brand("ColumnNumber"),
-  S.annotate(
-    $I.annote("ColumnNumber", {
-      description: "A positive 1-based column number.",
-    })
-  )
+  $I.annoteSchema("ColumnNumber", {
+    description: "A positive 1-based column number.",
+  })
 );
 
 /**
@@ -628,11 +602,9 @@ export type ColumnNumber = typeof ColumnNumber.Type;
  */
 export const ByteOffset = NonNegativeInt.pipe(
   S.brand("ByteOffset"),
-  S.annotate(
-    $I.annote("ByteOffset", {
-      description: "A non-negative byte offset within a source file.",
-    })
-  )
+  $I.annoteSchema("ByteOffset", {
+    description: "A non-negative byte offset within a source file.",
+  })
 );
 
 /**
@@ -661,11 +633,9 @@ export type ByteOffset = typeof ByteOffset.Type;
  */
 export const ByteLength = NonNegativeInt.pipe(
   S.brand("ByteLength"),
-  S.annotate(
-    $I.annote("ByteLength", {
-      description: "A non-negative byte length for a source span.",
-    })
-  )
+  $I.annoteSchema("ByteLength", {
+    description: "A non-negative byte length for a source span.",
+  })
 );
 
 /**
@@ -694,11 +664,9 @@ export type ByteLength = typeof ByteLength.Type;
  */
 export const ContentHash = Sha256Hex.pipe(
   S.brand("ContentHash"),
-  S.annotate(
-    $I.annote("ContentHash", {
-      description: "Canonical SHA-256 digest for source text or symbol content.",
-    })
-  )
+  $I.annoteSchema("ContentHash", {
+    description: "Canonical SHA-256 digest for source text or symbol content.",
+  })
 );
 
 /**
@@ -787,11 +755,9 @@ const resolvedProjectIdentity = S.TemplateLiteral([
  */
 export const ProjectScopeId = resolvedProjectIdentity.pipe(
   S.brand("ProjectScopeId"),
-  S.annotate(
-    $I.annote("ProjectScopeId", {
-      description: "Stable resolved ts-morph scope identity string: tsconfig::mode#referencePolicy.",
-    })
-  )
+  $I.annoteSchema("ProjectScopeId", {
+    description: "Stable resolved ts-morph scope identity string: tsconfig::mode#referencePolicy.",
+  })
 );
 
 /**
@@ -824,8 +790,8 @@ export const ProjectScopeIdParts = S.TemplateLiteralParser([
   TsMorphScopeMode,
   "#",
   TsMorphReferencePolicy,
-]).annotate(
-  $I.annote("ProjectScopeIdParts", {
+]).pipe(
+  $I.annoteSchema("ProjectScopeIdParts", {
     description: "Parsed project scope identity tuple for tsconfig path, scope mode, and reference policy.",
   })
 );
@@ -843,11 +809,9 @@ export const ProjectScopeIdParts = S.TemplateLiteralParser([
  */
 export const ProjectCacheKey = resolvedProjectIdentity.pipe(
   S.brand("ProjectCacheKey"),
-  S.annotate(
-    $I.annote("ProjectCacheKey", {
-      description: "Cache-key string for a memoized ts-morph project instance.",
-    })
-  )
+  $I.annoteSchema("ProjectCacheKey", {
+    description: "Cache-key string for a memoized ts-morph project instance.",
+  })
 );
 
 /**
@@ -876,11 +840,9 @@ export type ProjectCacheKey = typeof ProjectCacheKey.Type;
  */
 export const SymbolId = S.TemplateLiteral([SymbolFilePath, "::", SymbolQualifiedName, "#", SymbolKind]).pipe(
   S.brand("SymbolId"),
-  S.annotate(
-    $I.annote("SymbolId", {
-      description: "Stable TypeScript symbol identity string: file::qualifiedName#kind",
-    })
-  )
+  $I.annoteSchema("SymbolId", {
+    description: "Stable TypeScript symbol identity string: file::qualifiedName#kind",
+  })
 );
 
 /**
@@ -907,14 +869,8 @@ export type SymbolId = typeof SymbolId.Type;
  * @category models
  * @since 0.0.0
  */
-export const SymbolIdParts = S.TemplateLiteralParser([
-  SymbolFilePath,
-  "::",
-  SymbolQualifiedName,
-  "#",
-  SymbolKind,
-]).annotate(
-  $I.annote("SymbolIdParts", {
+export const SymbolIdParts = S.TemplateLiteralParser([SymbolFilePath, "::", SymbolQualifiedName, "#", SymbolKind]).pipe(
+  $I.annoteSchema("SymbolIdParts", {
     description: "Parsed symbol id parts for file path, qualified name, and exact kind.",
   })
 );
@@ -935,11 +891,9 @@ export const FilePathToTsConfigFilePath = FilePath.pipe(
     decode: SchemaGetter.passthrough({ strict: false }),
     encode: SchemaGetter.passthrough({ strict: false }),
   }),
-  S.annotate(
-    $I.annote("FilePathToTsConfigFilePath", {
-      description: "Schema transformation from a generic file path to a validated tsconfig file path.",
-    })
-  )
+  $I.annoteSchema("FilePathToTsConfigFilePath", {
+    description: "Schema transformation from a generic file path to a validated tsconfig file path.",
+  })
 );
 
 /**
@@ -958,11 +912,9 @@ export const FilePathToTypeScriptImplementationFilePath = FilePath.pipe(
     decode: SchemaGetter.passthrough({ strict: false }),
     encode: SchemaGetter.passthrough({ strict: false }),
   }),
-  S.annotate(
-    $I.annote("FilePathToTypeScriptImplementationFilePath", {
-      description: "Schema transformation from a generic file path to a TypeScript implementation file path.",
-    })
-  )
+  $I.annoteSchema("FilePathToTypeScriptImplementationFilePath", {
+    description: "Schema transformation from a generic file path to a TypeScript implementation file path.",
+  })
 );
 
 /**
@@ -981,11 +933,9 @@ export const FilePathToTypeScriptDeclarationFilePath = FilePath.pipe(
     decode: SchemaGetter.passthrough({ strict: false }),
     encode: SchemaGetter.passthrough({ strict: false }),
   }),
-  S.annotate(
-    $I.annote("FilePathToTypeScriptDeclarationFilePath", {
-      description: "Schema transformation from a generic file path to a TypeScript declaration file path.",
-    })
-  )
+  $I.annoteSchema("FilePathToTypeScriptDeclarationFilePath", {
+    description: "Schema transformation from a generic file path to a TypeScript declaration file path.",
+  })
 );
 
 /**
@@ -1004,11 +954,9 @@ export const FilePathToTypeScriptFilePath = FilePath.pipe(
     decode: SchemaGetter.passthrough({ strict: false }),
     encode: SchemaGetter.passthrough({ strict: false }),
   }),
-  S.annotate(
-    $I.annote("FilePathToTypeScriptFilePath", {
-      description: "Schema transformation from a generic file path to a TypeScript source file path.",
-    })
-  )
+  $I.annoteSchema("FilePathToTypeScriptFilePath", {
+    description: "Schema transformation from a generic file path to a TypeScript source file path.",
+  })
 );
 
 /**
@@ -1027,11 +975,9 @@ export const TypeScriptImplementationFilePathToSymbolFilePath = TypeScriptImplem
     decode: SchemaGetter.passthrough({ strict: false }),
     encode: SchemaGetter.passthrough({ strict: false }),
   }),
-  S.annotate(
-    $I.annote("TypeScriptImplementationFilePathToSymbolFilePath", {
-      description: "Schema transformation from a TypeScript implementation file path to a symbol-id-safe file path.",
-    })
-  )
+  $I.annoteSchema("TypeScriptImplementationFilePathToSymbolFilePath", {
+    description: "Schema transformation from a TypeScript implementation file path to a symbol-id-safe file path.",
+  })
 );
 
 const decodeSymbolIdResult = S.decodeUnknownResult(SymbolId);
@@ -1062,11 +1008,9 @@ export const ContentHashFromBytes = S.Uint8Array.pipe(
       () => "Encoding ContentHash back to original bytes is not supported by ContentHashFromBytes."
     ),
   }),
-  S.annotate(
-    $I.annote("ContentHashFromBytes", {
-      description: "Effectful one-way schema transformation from source bytes to a canonical content hash.",
-    })
-  )
+  $I.annoteSchema("ContentHashFromBytes", {
+    description: "Effectful one-way schema transformation from source bytes to a canonical content hash.",
+  })
 );
 
 const textEncoder = new TextEncoder();
@@ -1092,11 +1036,9 @@ export const ContentHashFromSourceText = SourceText.pipe(
       () => "Encoding ContentHash back to original source text is not supported by ContentHashFromSourceText."
     ),
   }),
-  S.annotate(
-    $I.annote("ContentHashFromSourceText", {
-      description: "Effectful one-way schema transformation from source text to a canonical content hash.",
-    })
-  )
+  $I.annoteSchema("ContentHashFromSourceText", {
+    description: "Effectful one-way schema transformation from source text to a canonical content hash.",
+  })
 );
 
 /**
@@ -1112,11 +1054,9 @@ export const ContentHashFromSourceText = SourceText.pipe(
  * @since 0.0.0
  */
 export const InternalTsMorphProject = S.instanceOf(Project).pipe(
-  S.annotate(
-    $I.annote("InternalTsMorphProject", {
-      description: "Internal runtime schema for a live ts-morph Project instance.",
-    })
-  )
+  $I.annoteSchema("InternalTsMorphProject", {
+    description: "Internal runtime schema for a live ts-morph Project instance.",
+  })
 );
 
 /**
@@ -1133,11 +1073,9 @@ export const InternalTsMorphProject = S.instanceOf(Project).pipe(
 export const InternalTsMorphSourceFile = S.declare<SourceFile>(
   (value): value is SourceFile => value instanceof SourceFile
 ).pipe(
-  S.annotate(
-    $I.annote("InternalTsMorphSourceFile", {
-      description: "Internal runtime schema for a live ts-morph SourceFile instance.",
-    })
-  )
+  $I.annoteSchema("InternalTsMorphSourceFile", {
+    description: "Internal runtime schema for a live ts-morph SourceFile instance.",
+  })
 );
 
 /**
@@ -1154,11 +1092,9 @@ export const InternalTsMorphSourceFile = S.declare<SourceFile>(
 export const InternalTsMorphNode = S.declare<TsMorphNode>(
   (value): value is TsMorphNode => value instanceof TsMorphNode
 ).pipe(
-  S.annotate(
-    $I.annote("InternalTsMorphNode", {
-      description: "Internal runtime schema for a live ts-morph Node instance.",
-    })
-  )
+  $I.annoteSchema("InternalTsMorphNode", {
+    description: "Internal runtime schema for a live ts-morph Node instance.",
+  })
 );
 
 /**
@@ -1411,26 +1347,23 @@ class TsMorphScopeEntrypointFile extends S.Class<TsMorphScopeEntrypointFile>($I`
  * @category models
  * @since 0.0.0
  */
-export const TsMorphScopeEntrypoint = S.Union([TsMorphScopeEntrypointTsConfig, TsMorphScopeEntrypointFile])
-  .annotate(
-    $I.annote("TsMorphScopeEntrypointBase", {
-      description: "Tagged union describing how a ts-morph scope should be resolved.",
-    })
-  )
-  .pipe(
-    S.toTaggedUnion("_tag"),
-    SchemaUtils.withStatics(() => {
-      const make = Match.type<string>().pipe(
-        Match.when(S.is(TsConfigFilePath), TsMorphScopeEntrypointTsConfig.new),
-        Match.when(S.is(TypeScriptFilePath), TsMorphScopeEntrypointFile.new),
-        Match.orElseAbsurd
-      );
+export const TsMorphScopeEntrypoint = S.Union([TsMorphScopeEntrypointTsConfig, TsMorphScopeEntrypointFile]).pipe(
+  $I.annoteSchema("TsMorphScopeEntrypointBase", {
+    description: "Tagged union describing how a ts-morph scope should be resolved.",
+  }),
+  S.toTaggedUnion("_tag"),
+  SchemaUtils.withStatics(() => {
+    const make = Match.type<string>().pipe(
+      Match.when(S.is(TsConfigFilePath), TsMorphScopeEntrypointTsConfig.new),
+      Match.when(S.is(TypeScriptFilePath), TsMorphScopeEntrypointFile.new),
+      Match.orElseAbsurd
+    );
 
-      return {
-        make,
-      };
-    })
-  );
+    return {
+      make,
+    };
+  })
+);
 
 /**
  * Decoded ts-morph scope entrypoint union.
@@ -1662,11 +1595,9 @@ export class TsMorphSymbolLookupResult extends S.Class<TsMorphSymbolLookupResult
  */
 export const TsMorphSearchLimit = S.Int.check(S.isGreaterThan(0)).pipe(
   S.brand("TsMorphSearchLimit"),
-  S.annotate(
-    $I.annote("TsMorphSearchLimit", {
-      description: "Positive result limit for ts-morph-backed search operations.",
-    })
-  )
+  $I.annoteSchema("TsMorphSearchLimit", {
+    description: "Positive result limit for ts-morph-backed search operations.",
+  })
 );
 
 /**
@@ -1876,13 +1807,12 @@ export const TsMorphDiagnostic = TsMorphDiagnosticCategory.mapMembers(
     () => TsMorphDiagnosticSuggestion,
     () => TsMorphDiagnosticMessage,
   ])
-)
-  .annotate(
-    $I.annote("TsMorphDiagnostic", {
-      description: "Tagged union of normalized TypeScript diagnostics keyed by category.",
-    })
-  )
-  .pipe(S.toTaggedUnion("category"));
+).pipe(
+  $I.annoteSchema("TsMorphDiagnostic", {
+    description: "Tagged union of normalized TypeScript diagnostics keyed by category.",
+  }),
+  S.toTaggedUnion("category")
+);
 
 /**
  * Decoded normalized TypeScript diagnostic union.

--- a/packages/tooling/library/repo-utils/src/schemas/JSDocCategories.ts
+++ b/packages/tooling/library/repo-utils/src/schemas/JSDocCategories.ts
@@ -137,8 +137,8 @@ export type JSDocCategory = (typeof CANONICAL_JSDOC_CATEGORIES)[number];
  * @category models
  * @since 0.0.0
  */
-export const JSDocCategoryNormalizationStatus = LiteralKit(["canonical", "alias", "rejected", "unknown"]).annotate(
-  $I.annote("JSDocCategoryNormalizationStatus", {
+export const JSDocCategoryNormalizationStatus = LiteralKit(["canonical", "alias", "rejected", "unknown"]).pipe(
+  $I.annoteSchema("JSDocCategoryNormalizationStatus", {
     description: "Normalization status for an observed @category value.",
   })
 );

--- a/packages/tooling/library/repo-utils/src/schemas/PackageJson.ts
+++ b/packages/tooling/library/repo-utils/src/schemas/PackageJson.ts
@@ -34,8 +34,8 @@ const exportConditionPattern = /^(?:[^.0-9]+|types@.+)$/;
 const NpmPackageName = S.String.check(S.isMinLength(1))
   .check(S.isMaxLength(214))
   .check(S.isPattern(npmPackageNamePattern))
-  .annotate(
-    $I.annote("NpmPackageName", {
+  .pipe(
+    $I.annoteSchema("NpmPackageName", {
       title: "Npm Package Name",
       description: "An npm package name that satisfies the package.json SchemaStore constraints.",
     })
@@ -44,108 +44,108 @@ const NpmPackageName = S.String.check(S.isMinLength(1))
 const RepoPackageName = S.String.check(S.isMinLength(1))
   .check(S.isMaxLength(214))
   .check(S.isPattern(repoPackageNamePattern))
-  .annotate(
-    $I.annote("RepoPackageName", {
+  .pipe(
+    $I.annoteSchema("RepoPackageName", {
       title: "Repo Package Name",
       description:
         "A repo-local package name, including the legacy mixed-case workspace names currently present in this monorepo.",
     })
   );
 
-const PackageManager = S.String.check(S.isPattern(packageManagerPattern)).annotate(
-  $I.annote("PackageManager", {
+const PackageManager = S.String.check(S.isPattern(packageManagerPattern)).pipe(
+  $I.annoteSchema("PackageManager", {
     title: "Package Manager",
     description: "A Corepack-style package manager pin such as bun@1.3.10 or pnpm@9.0.0.",
   })
 );
 
-const RelativeDotPath = S.String.check(S.isPattern(relativeDotPathPattern)).annotate(
-  $I.annote("RelativeDotPath", {
+const RelativeDotPath = S.String.check(S.isPattern(relativeDotPathPattern)).pipe(
+  $I.annoteSchema("RelativeDotPath", {
     title: "Relative Dot Path",
     description: "A relative path that starts with ./, used by exports and publishConfig.",
   })
 );
 
-const ExportTopLevelKey = S.String.check(S.isPattern(exportTopLevelPattern)).annotate(
-  $I.annote("ExportTopLevelKey", {
+const ExportTopLevelKey = S.String.check(S.isPattern(exportTopLevelPattern)).pipe(
+  $I.annoteSchema("ExportTopLevelKey", {
     title: "Export Top Level Key",
     description: "A top-level package exports key such as . or ./subpath.",
   })
 );
 
-const ImportSpecifierKey = S.String.check(S.isPattern(importSpecifierPattern)).annotate(
-  $I.annote("ImportSpecifierKey", {
+const ImportSpecifierKey = S.String.check(S.isPattern(importSpecifierPattern)).pipe(
+  $I.annoteSchema("ImportSpecifierKey", {
     title: "Import Specifier Key",
     description: "A package imports specifier key such as #internal or #config/*.",
   })
 );
 
-const ExportConditionKey = S.String.check(S.isPattern(exportConditionPattern)).annotate(
-  $I.annote("ExportConditionKey", {
+const ExportConditionKey = S.String.check(S.isPattern(exportConditionPattern)).pipe(
+  $I.annoteSchema("ExportConditionKey", {
     title: "Export Condition Key",
     description: "A conditional exports/imports key such as import, require, default, node, or types@>=5.",
   })
 );
 
-const StringArray = S.Array(S.String).annotate(
-  $I.annote("StringArray", {
+const StringArray = S.Array(S.String).pipe(
+  $I.annoteSchema("StringArray", {
     title: "String Array",
     description: "An array of strings used for package metadata fields such as files, man, os, and cpu.",
   })
 );
 
-const NonEmptyStringValue = S.String.check(S.isMinLength(1)).annotate(
-  $I.annote("NonEmptyStringValue", {
+const NonEmptyStringValue = S.String.check(S.isMinLength(1)).pipe(
+  $I.annoteSchema("NonEmptyStringValue", {
     title: "Non Empty String Value",
     description: "A non-empty string value used for package metadata fields that should not be blank.",
   })
 );
 
-const StringRecord = S.Record(S.String, S.String).annotate(
-  $I.annote("StringRecord", {
+const StringRecord = S.Record(S.String, S.String).pipe(
+  $I.annoteSchema("StringRecord", {
     title: "String Record",
     description: "A record mapping string keys to string values, used for dependency maps, scripts, and engines.",
   })
 );
 
-const NpmDependencyRecord = S.Record(NpmPackageName, NonEmptyStringValue).annotate(
-  $I.annote("NpmDependencyRecord", {
+const NpmDependencyRecord = S.Record(NpmPackageName, NonEmptyStringValue).pipe(
+  $I.annoteSchema("NpmDependencyRecord", {
     title: "Npm Dependency Record",
     description: "A record of npm package names to non-empty version or protocol specifiers.",
   })
 );
 
-const RepoDependencyRecord = S.Record(RepoPackageName, NonEmptyStringValue).annotate(
-  $I.annote("RepoDependencyRecord", {
+const RepoDependencyRecord = S.Record(RepoPackageName, NonEmptyStringValue).pipe(
+  $I.annoteSchema("RepoDependencyRecord", {
     title: "Repo Dependency Record",
     description:
       "A record of repo-local package names to non-empty version or protocol specifiers, including legacy mixed-case workspace packages.",
   })
 );
 
-const NonEmptyStringRecord = S.Record(NonEmptyStringValue, NonEmptyStringValue).annotate(
-  $I.annote("NonEmptyStringRecord", {
+const NonEmptyStringRecord = S.Record(NonEmptyStringValue, NonEmptyStringValue).pipe(
+  $I.annoteSchema("NonEmptyStringRecord", {
     title: "Non Empty String Record",
     description: "A record whose keys and values are non-empty strings.",
   })
 );
 
-const BeepFoundationKind = S.Literals(["primitive", "modeling", "capability", "ui-system"] as const).annotate(
-  $I.annote("BeepFoundationKind", {
+const BeepFoundationKind = S.Literals(["primitive", "modeling", "capability", "ui-system"] as const).pipe(
+  $I.annoteSchema("BeepFoundationKind", {
     title: "Beep Foundation Kind",
     description: "Canonical foundation package kind metadata from the repo architecture.",
   })
 );
 
-const BeepToolingKind = S.Literals(["library", "tool", "policy-pack", "test-kit"] as const).annotate(
-  $I.annote("BeepToolingKind", {
+const BeepToolingKind = S.Literals(["library", "tool", "policy-pack", "test-kit"] as const).pipe(
+  $I.annoteSchema("BeepToolingKind", {
     title: "Beep Tooling Kind",
     description: "Canonical tooling package kind metadata from the repo architecture.",
   })
 );
 
-const BeepPackageFamily = LiteralKit(["foundation", "drivers", "tooling"]).annotate(
-  $I.annote("BeepPackageFamily", {
+const BeepPackageFamily = LiteralKit(["foundation", "drivers", "tooling"]).pipe(
+  $I.annoteSchema("BeepPackageFamily", {
     title: "Beep Package Family",
     description: "Canonical package family discriminator for repo-local package metadata.",
   })
@@ -154,8 +154,8 @@ const BeepPackageFamily = LiteralKit(["foundation", "drivers", "tooling"]).annot
 const BeepFoundationMetadata = S.Struct({
   family: S.Literal("foundation"),
   kind: BeepFoundationKind,
-}).annotate(
-  $I.annote("BeepFoundationMetadata", {
+}).pipe(
+  $I.annoteSchema("BeepFoundationMetadata", {
     title: "Beep Foundation Metadata",
     description: "Repo-local package metadata for foundation packages.",
   })
@@ -163,8 +163,8 @@ const BeepFoundationMetadata = S.Struct({
 
 const BeepDriverMetadata = S.Struct({
   family: S.Literal("drivers"),
-}).annotate(
-  $I.annote("BeepDriverMetadata", {
+}).pipe(
+  $I.annoteSchema("BeepDriverMetadata", {
     title: "Beep Driver Metadata",
     description: "Repo-local package metadata for flat driver packages.",
   })
@@ -173,8 +173,8 @@ const BeepDriverMetadata = S.Struct({
 const BeepToolingMetadata = S.Struct({
   family: S.Literal("tooling"),
   kind: BeepToolingKind,
-}).annotate(
-  $I.annote("BeepToolingMetadata", {
+}).pipe(
+  $I.annoteSchema("BeepToolingMetadata", {
     title: "Beep Tooling Metadata",
     description: "Repo-local package metadata for tooling packages.",
   })
@@ -182,17 +182,16 @@ const BeepToolingMetadata = S.Struct({
 
 const BeepPackageMetadata = BeepPackageFamily.mapMembers(
   Tuple.evolve([() => BeepFoundationMetadata, () => BeepDriverMetadata, () => BeepToolingMetadata])
-)
-  .pipe(S.toTaggedUnion("family"))
-  .annotate(
-    $I.annote("BeepPackageMetadata", {
-      title: "Beep Package Metadata",
-      description: "Machine-readable repo architecture metadata for non-slice code packages.",
-    })
-  );
+).pipe(
+  S.toTaggedUnion("family"),
+  $I.annoteSchema("BeepPackageMetadata", {
+    title: "Beep Package Metadata",
+    description: "Machine-readable repo architecture metadata for non-slice code packages.",
+  })
+);
 
-const PackageTypeField = S.String.check(S.isPattern(packageTypePattern)).annotate(
-  $I.annote("PackageTypeField", {
+const PackageTypeField = S.String.check(S.isPattern(packageTypePattern)).pipe(
+  $I.annoteSchema("PackageTypeField", {
     title: "Package Type Field",
     description: "The package type field constrained to the supported Node.js package types.",
   })
@@ -202,15 +201,15 @@ type Json = string | number | boolean | null | ReadonlyArray<Json> | { readonly 
 
 const Json: S.Codec<Json, Json> = S.suspend(() =>
   S.Union([S.String, S.Number, S.Boolean, S.Null, S.Array(Json), S.Record(S.String, Json)])
-).annotate(
-  $I.annote("Json", {
+).pipe(
+  $I.annoteSchema("Json", {
     title: "JSON Value",
     description: "A recursive JSON value used for schema-backed escape hatches like config and publishConfig extras.",
   })
 );
 
-const BrowserReplacement = S.Union([S.String, S.Literal(false)]).annotate(
-  $I.annote("BrowserReplacement", {
+const BrowserReplacement = S.Union([S.String, S.Literal(false)]).pipe(
+  $I.annoteSchema("BrowserReplacement", {
     title: "Browser Replacement",
     description: "A browser field replacement target, either a module path string or false to disable the module.",
   })
@@ -274,8 +273,8 @@ class FundingEntry extends S.Class<FundingEntry>($I`FundingEntry`)(
  * @category validation
  * @since 0.0.0
  */
-export const Person = S.Union([S.String, PersonObject]).annotate(
-  $I.annote("Person", {
+export const Person = S.Union([S.String, PersonObject]).pipe(
+  $I.annoteSchema("Person", {
     title: "Person",
     description:
       "A package author, contributor, or maintainer, either as a string or a structured object with a required name.",
@@ -294,8 +293,8 @@ export const Person = S.Union([S.String, PersonObject]).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const Author = Person.annotate(
-  $I.annote("Author", {
+export const Author = Person.pipe(
+  $I.annoteSchema("Author", {
     title: "Author",
     description: "Package author, either as a string or a structured object with a required name.",
   })
@@ -313,8 +312,8 @@ export const Author = Person.annotate(
  * @category validation
  * @since 0.0.0
  */
-export const Contributors = S.Array(Person).annotate(
-  $I.annote("Contributors", {
+export const Contributors = S.Array(Person).pipe(
+  $I.annoteSchema("Contributors", {
     title: "Contributors",
     description: "A list of people who contributed to the package.",
   })
@@ -332,8 +331,8 @@ export const Contributors = S.Array(Person).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const Maintainers = S.Array(Person).annotate(
-  $I.annote("Maintainers", {
+export const Maintainers = S.Array(Person).pipe(
+  $I.annoteSchema("Maintainers", {
     title: "Maintainers",
     description: "A list of people who maintain the package.",
   })
@@ -351,8 +350,8 @@ export const Maintainers = S.Array(Person).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const Repository = S.Union([S.String, RepositoryObject]).annotate(
-  $I.annote("Repository", {
+export const Repository = S.Union([S.String, RepositoryObject]).pipe(
+  $I.annoteSchema("Repository", {
     title: "Repository",
     description:
       "A package repository reference represented as a shorthand string or a structured object with required type and url.",
@@ -371,8 +370,8 @@ export const Repository = S.Union([S.String, RepositoryObject]).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const Bugs = S.Union([S.String, BugsObject]).annotate(
-  $I.annote("Bugs", {
+export const Bugs = S.Union([S.String, BugsObject]).pipe(
+  $I.annoteSchema("Bugs", {
     title: "Bugs",
     description:
       "A package bug tracker reference represented as a URL string or a structured object with optional url and email.",
@@ -391,8 +390,8 @@ export const Bugs = S.Union([S.String, BugsObject]).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const Funding = S.Union([S.String, FundingEntry, S.NonEmptyArray(S.Union([S.String, FundingEntry]))]).annotate(
-  $I.annote("Funding", {
+export const Funding = S.Union([S.String, FundingEntry, S.NonEmptyArray(S.Union([S.String, FundingEntry]))]).pipe(
+  $I.annoteSchema("Funding", {
     title: "Funding",
     description:
       "Package funding metadata represented as a URL string, a structured funding object, or a non-empty array of those.",
@@ -411,8 +410,8 @@ export const Funding = S.Union([S.String, FundingEntry, S.NonEmptyArray(S.Union(
  * @category validation
  * @since 0.0.0
  */
-export const Bin = S.Union([S.String, StringRecord]).annotate(
-  $I.annote("Bin", {
+export const Bin = S.Union([S.String, StringRecord]).pipe(
+  $I.annoteSchema("Bin", {
     title: "Bin",
     description: "Executable binaries, either as a single file path string or a record mapping command names to paths.",
   })
@@ -430,8 +429,8 @@ export const Bin = S.Union([S.String, StringRecord]).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const Browser = S.Union([S.String, S.Record(S.String, BrowserReplacement)]).annotate(
-  $I.annote("Browser", {
+export const Browser = S.Union([S.String, S.Record(S.String, BrowserReplacement)]).pipe(
+  $I.annoteSchema("Browser", {
     title: "Browser",
     description:
       "Browser-specific entry points represented as a replacement path string or a record of module replacements.",
@@ -477,8 +476,8 @@ const peerDependencyMetaEntryFields = {
   optional: S.optionalKey(S.Boolean),
 } as const;
 
-const PeerDependencyMetaEntry = S.Struct(peerDependencyMetaEntryFields).annotate(
-  $I.annote("PeerDependencyMetaEntry", {
+const PeerDependencyMetaEntry = S.Struct(peerDependencyMetaEntryFields).pipe(
+  $I.annoteSchema("PeerDependencyMetaEntry", {
     title: "Peer Dependency Meta Entry",
     description: "Structured metadata for a peer dependency, including whether it is optional.",
   })
@@ -496,8 +495,8 @@ const PeerDependencyMetaEntry = S.Struct(peerDependencyMetaEntryFields).annotate
  * @category validation
  * @since 0.0.0
  */
-export const Man = S.Union([S.String, StringArray]).annotate(
-  $I.annote("Man", {
+export const Man = S.Union([S.String, StringArray]).pipe(
+  $I.annoteSchema("Man", {
     title: "Man",
     description: "A man page reference represented as a single file path or an array of file paths.",
   })
@@ -515,8 +514,8 @@ export const Man = S.Union([S.String, StringArray]).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const SideEffects = S.Union([S.Boolean, StringArray]).annotate(
-  $I.annote("SideEffects", {
+export const SideEffects = S.Union([S.Boolean, StringArray]).pipe(
+  $I.annoteSchema("SideEffects", {
     title: "Side Effects",
     description: "Whether the package has side effects, represented as a boolean or an array of glob patterns.",
   })
@@ -534,8 +533,8 @@ export const SideEffects = S.Union([S.Boolean, StringArray]).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const BundleDependencies = S.Union([S.Boolean, StringArray]).annotate(
-  $I.annote("BundleDependencies", {
+export const BundleDependencies = S.Union([S.Boolean, StringArray]).pipe(
+  $I.annoteSchema("BundleDependencies", {
     title: "Bundle Dependencies",
     description: "Bundled dependency metadata represented as a boolean or an array of package names.",
   })
@@ -556,8 +555,8 @@ export const BundleDependencies = S.Union([S.Boolean, StringArray]).annotate(
 export const PeerDependenciesMeta = S.Record(
   S.String,
   S.StructWithRest(PeerDependencyMetaEntry, [S.Record(S.String, Json)])
-).annotate(
-  $I.annote("PeerDependenciesMeta", {
+).pipe(
+  $I.annoteSchema("PeerDependenciesMeta", {
     title: "Peer Dependencies Meta",
     description: "Metadata describing peer dependency usage, including whether a peer dependency is optional.",
   })
@@ -575,8 +574,8 @@ export const PeerDependenciesMeta = S.Record(
  * @category validation
  * @since 0.0.0
  */
-export const TypesVersions = S.Record(S.String, S.Record(S.String, StringArray)).annotate(
-  $I.annote("TypesVersions", {
+export const TypesVersions = S.Record(S.String, S.Record(S.String, StringArray)).pipe(
+  $I.annoteSchema("TypesVersions", {
     title: "Types Versions",
     description: "TypeScript version-specific path mappings for declarations.",
   })
@@ -615,8 +614,8 @@ class DevEngineDependencyShape extends S.Class<DevEngineDependencyShape>($I`DevE
  */
 export const DevEngineDependency = DevEngineDependencyShape;
 
-const DevEngineRequirement = S.Union([DevEngineDependency, S.Array(DevEngineDependency)]).annotate(
-  $I.annote("DevEngineRequirement", {
+const DevEngineRequirement = S.Union([DevEngineDependency, S.Array(DevEngineDependency)]).pipe(
+  $I.annoteSchema("DevEngineRequirement", {
     title: "Dev Engine Requirement",
     description:
       "A development environment requirement represented as a single dependency entry or an array of dependency entries.",
@@ -661,8 +660,8 @@ type PackageExportsEntry = string | null | { readonly [key: string]: PackageExpo
 
 type PackageExportsEntryOrFallback = PackageExportsEntry | ReadonlyArray<PackageExportsEntry>;
 
-const PackageExportsEntryPath = S.Union([RelativeDotPath, S.Null]).annotate(
-  $I.annote("PackageExportsEntryPath", {
+const PackageExportsEntryPath = S.Union([RelativeDotPath, S.Null]).pipe(
+  $I.annoteSchema("PackageExportsEntryPath", {
     title: "Package Exports Entry Path",
     description: "An exports target path starting with ./, or null to explicitly block the target.",
   })
@@ -671,8 +670,8 @@ const PackageExportsEntryPath = S.Union([RelativeDotPath, S.Null]).annotate(
 const PackageExportsEntryObject: S.Codec<
   { readonly [key: string]: PackageExportsEntryOrFallback },
   { readonly [key: string]: PackageExportsEntryOrFallback }
-> = S.suspend(() => S.Record(ExportConditionKey, PackageExportsEntryOrFallback)).annotate(
-  $I.annote("PackageExportsEntryObject", {
+> = S.suspend(() => S.Record(ExportConditionKey, PackageExportsEntryOrFallback)).pipe(
+  $I.annoteSchema("PackageExportsEntryObject", {
     title: "Package Exports Entry Object",
     description:
       "A conditional exports object keyed by conditions such as import, require, default, or types@ selectors.",
@@ -681,15 +680,15 @@ const PackageExportsEntryObject: S.Codec<
 
 const PackageExportsEntry: S.Codec<PackageExportsEntry, PackageExportsEntry> = S.suspend(() =>
   S.Union([PackageExportsEntryPath, PackageExportsEntryObject])
-).annotate(
-  $I.annote("PackageExportsEntry", {
+).pipe(
+  $I.annoteSchema("PackageExportsEntry", {
     title: "Package Exports Entry",
     description: "A single exports entry represented as a relative path, null, or a conditional exports object.",
   })
 );
 
-const PackageExportsFallback = S.NonEmptyArray(PackageExportsEntry).annotate(
-  $I.annote("PackageExportsFallback", {
+const PackageExportsFallback = S.NonEmptyArray(PackageExportsEntry).pipe(
+  $I.annoteSchema("PackageExportsFallback", {
     title: "Package Exports Fallback",
     description: "A non-empty fallback array of exports entries evaluated in order.",
   })
@@ -697,15 +696,15 @@ const PackageExportsFallback = S.NonEmptyArray(PackageExportsEntry).annotate(
 
 const PackageExportsEntryOrFallback: S.Codec<PackageExportsEntryOrFallback, PackageExportsEntryOrFallback> = S.suspend(
   () => S.Union([PackageExportsEntry, PackageExportsFallback])
-).annotate(
-  $I.annote("PackageExportsEntryOrFallback", {
+).pipe(
+  $I.annoteSchema("PackageExportsEntryOrFallback", {
     title: "Package Exports Entry Or Fallback",
     description: "An exports target represented as a single entry or a non-empty fallback array of entries.",
   })
 );
 
-const PackageExportsSubpathMap = S.Record(ExportTopLevelKey, PackageExportsEntryOrFallback).annotate(
-  $I.annote("PackageExportsSubpathMap", {
+const PackageExportsSubpathMap = S.Record(ExportTopLevelKey, PackageExportsEntryOrFallback).pipe(
+  $I.annoteSchema("PackageExportsSubpathMap", {
     title: "Package Exports Subpath Map",
     description: "An exports map whose keys are . or ./subpath targets and whose values are exports entries.",
   })
@@ -728,8 +727,8 @@ export const PackageExports = S.Union([
   PackageExportsSubpathMap,
   PackageExportsEntryObject,
   PackageExportsFallback,
-]).annotate(
-  $I.annote("PackageExports", {
+]).pipe(
+  $I.annoteSchema("PackageExports", {
     title: "Package Exports",
     description:
       "The package exports field modeled as a path target, conditional exports object, subpath map, or fallback array.",
@@ -740,8 +739,8 @@ type PackageImportsEntry = string | null | { readonly [key: string]: PackageImpo
 
 type PackageImportsEntryOrFallback = PackageImportsEntry | ReadonlyArray<PackageImportsEntry>;
 
-const PackageImportsEntryPath = S.Union([S.String, S.Null]).annotate(
-  $I.annote("PackageImportsEntryPath", {
+const PackageImportsEntryPath = S.Union([S.String, S.Null]).pipe(
+  $I.annoteSchema("PackageImportsEntryPath", {
     title: "Package Imports Entry Path",
     description: "An imports target path or null to explicitly block the target.",
   })
@@ -750,8 +749,8 @@ const PackageImportsEntryPath = S.Union([S.String, S.Null]).annotate(
 const PackageImportsEntryObject: S.Codec<
   { readonly [key: string]: PackageImportsEntryOrFallback },
   { readonly [key: string]: PackageImportsEntryOrFallback }
-> = S.suspend(() => S.Record(ExportConditionKey, PackageImportsEntryOrFallback)).annotate(
-  $I.annote("PackageImportsEntryObject", {
+> = S.suspend(() => S.Record(ExportConditionKey, PackageImportsEntryOrFallback)).pipe(
+  $I.annoteSchema("PackageImportsEntryObject", {
     title: "Package Imports Entry Object",
     description:
       "A conditional imports object keyed by conditions such as import, require, default, or types@ selectors.",
@@ -760,15 +759,15 @@ const PackageImportsEntryObject: S.Codec<
 
 const PackageImportsEntry: S.Codec<PackageImportsEntry, PackageImportsEntry> = S.suspend(() =>
   S.Union([PackageImportsEntryPath, PackageImportsEntryObject])
-).annotate(
-  $I.annote("PackageImportsEntry", {
+).pipe(
+  $I.annoteSchema("PackageImportsEntry", {
     title: "Package Imports Entry",
     description: "A single imports entry represented as a path, null, or a conditional imports object.",
   })
 );
 
-const PackageImportsFallback = S.NonEmptyArray(PackageImportsEntry).annotate(
-  $I.annote("PackageImportsFallback", {
+const PackageImportsFallback = S.NonEmptyArray(PackageImportsEntry).pipe(
+  $I.annoteSchema("PackageImportsFallback", {
     title: "Package Imports Fallback",
     description: "A non-empty fallback array of imports entries evaluated in order.",
   })
@@ -776,8 +775,8 @@ const PackageImportsFallback = S.NonEmptyArray(PackageImportsEntry).annotate(
 
 const PackageImportsEntryOrFallback: S.Codec<PackageImportsEntryOrFallback, PackageImportsEntryOrFallback> = S.suspend(
   () => S.Union([PackageImportsEntry, PackageImportsFallback])
-).annotate(
-  $I.annote("PackageImportsEntryOrFallback", {
+).pipe(
+  $I.annoteSchema("PackageImportsEntryOrFallback", {
     title: "Package Imports Entry Or Fallback",
     description: "An imports target represented as a single entry or a non-empty fallback array of entries.",
   })
@@ -795,8 +794,8 @@ const PackageImportsEntryOrFallback: S.Codec<PackageImportsEntryOrFallback, Pack
  * @category validation
  * @since 0.0.0
  */
-export const PackageImports = S.Record(ImportSpecifierKey, PackageImportsEntryOrFallback).annotate(
-  $I.annote("PackageImports", {
+export const PackageImports = S.Record(ImportSpecifierKey, PackageImportsEntryOrFallback).pipe(
+  $I.annoteSchema("PackageImports", {
     title: "Package Imports",
     description: "Private package import mappings keyed by # specifiers.",
   })
@@ -806,8 +805,8 @@ type OverrideValue = string | { readonly [key: string]: OverrideValue };
 
 const OverrideValue: S.Codec<OverrideValue, OverrideValue> = S.suspend(() =>
   S.Union([S.String, S.Record(S.String, OverrideValue)])
-).annotate(
-  $I.annote("OverrideValue", {
+).pipe(
+  $I.annoteSchema("OverrideValue", {
     title: "Override Value",
     description: "An npm overrides value represented as a version string or a nested override object.",
   })
@@ -833,8 +832,8 @@ const publishConfigBaseFields = {
   exports: S.optionalKey(PackageExports),
 } as const;
 
-const PublishConfigBase = S.Struct(publishConfigBaseFields).annotate(
-  $I.annote("PublishConfigBase", {
+const PublishConfigBase = S.Struct(publishConfigBaseFields).pipe(
+  $I.annoteSchema("PublishConfigBase", {
     title: "Publish Config Base",
     description:
       "Structured npm publish configuration fields modeled explicitly before allowing additional JSON-valued keys.",
@@ -853,8 +852,8 @@ const PublishConfigBase = S.Struct(publishConfigBaseFields).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const Workspaces = S.Union([StringArray, WorkspacesObject]).annotate(
-  $I.annote("Workspaces", {
+export const Workspaces = S.Union([StringArray, WorkspacesObject]).pipe(
+  $I.annoteSchema("Workspaces", {
     title: "Workspaces",
     description:
       "Workspace package globs represented as an array of strings or an object with packages and optional nohoist.",
@@ -873,8 +872,8 @@ export const Workspaces = S.Union([StringArray, WorkspacesObject]).annotate(
  * @category validation
  * @since 0.0.0
  */
-export const PublishConfig = S.StructWithRest(PublishConfigBase, [S.Record(S.String, Json)]).annotate(
-  $I.annote("PublishConfig", {
+export const PublishConfig = S.StructWithRest(PublishConfigBase, [S.Record(S.String, Json)]).pipe(
+  $I.annoteSchema("PublishConfig", {
     title: "Publish Config",
     description:
       "npm publish configuration with explicit support for access, tag, registry, provenance, bin, exports, and additional JSON-valued config keys.",

--- a/packages/tooling/library/repo-utils/src/schemas/TSConfig.ts
+++ b/packages/tooling/library/repo-utils/src/schemas/TSConfig.ts
@@ -198,8 +198,8 @@ const TS_NODE_EXPERIMENTAL_SPECIFIER_RESOLUTION_VALUES = ["explicit", "node"] as
 
 const TS_NODE_MODULE_TYPE_VALUES = ["cjs", "esm", "package"] as const;
 
-const JsonRecord = S.Record(S.String, S.Json).annotate(
-  $I.annote("TSConfigJsonRecord", {
+const JsonRecord = S.Record(S.String, S.Json).pipe(
+  $I.annoteSchema("TSConfigJsonRecord", {
     description: "A JSON object used for open tsconfig extension points such as plugin extras and ts-node overrides.",
   })
 );
@@ -281,11 +281,9 @@ const makeLooseJsonObject = <Fields extends S.Struct.Fields>(fields: Fields, nam
         )
       ),
     }),
-    S.annotate(
-      $I.annote(name, {
-        description,
-      })
-    )
+    $I.annoteSchema(name, {
+      description,
+    })
   );
 };
 
@@ -318,11 +316,9 @@ const makeCaseInsensitiveLiteralSchema = <const Values extends A.NonEmptyReadonl
       }),
       encode: SchemaGetter.transform((value) => value),
     }),
-    S.annotate(
-      $I.annote(name, {
-        description,
-      })
-    )
+    $I.annoteSchema(name, {
+      description,
+    })
   );
 };
 
@@ -341,20 +337,18 @@ const makeUniqueArraySchema = <Item extends S.Top>(item: Item, name: string, des
         }
       )
     )
-    .annotate(
-      $I.annote(name, {
+    .pipe(
+      $I.annoteSchema(name, {
         description,
       })
     );
 };
 
 const optionalField = <Schema extends S.Top>(schema: Schema, name: string, description: string) =>
-  schema.pipe(S.OptionFromOptionalKey, S.annotate($I.annote(name, { description }))).annotateKey({ description });
+  schema.pipe(S.OptionFromOptionalKey, $I.annoteSchema(name, { description })).annotateKey({ description });
 
 const nullableOptionalField = <Schema extends S.Top>(schema: Schema, name: string, description: string) =>
-  Model.optionalOption(schema)
-    .pipe(S.annotate($I.annote(name, { description })))
-    .annotateKey({ description });
+  Model.optionalOption(schema).pipe($I.annoteSchema(name, { description })).annotateKey({ description });
 
 const toOptionalValue = <Value>(value: O.Option<Value> | Value | null | undefined): O.Option<Value> => {
   if (value === undefined || value === null) {
@@ -473,8 +467,8 @@ const TSNodeModuleType = makeCaseInsensitiveLiteralSchema(
   "Canonical ts-node module type override values accepted by tsconfig."
 );
 
-const TSConfigExtends = S.Union([S.String, S.Array(S.String)]).annotate(
-  $I.annote("TSConfigExtends", {
+const TSConfigExtends = S.Union([S.String, S.Array(S.String)]).pipe(
+  $I.annoteSchema("TSConfigExtends", {
     description: "A tsconfig extends reference represented as a single base config path or an ordered array of paths.",
   })
 );
@@ -521,56 +515,56 @@ const TSConfigCompilerPlugin = makeLooseJsonObject(
   "A TypeScript language service plugin entry with a required name and plugin-specific JSON extras."
 );
 
-const TSConfigCompilerPlugins = S.Array(TSConfigCompilerPlugin).annotate(
-  $I.annote("TSConfigCompilerPlugins", {
+const TSConfigCompilerPlugins = S.Array(TSConfigCompilerPlugin).pipe(
+  $I.annoteSchema("TSConfigCompilerPlugins", {
     description: "An ordered array of compiler plugin entries.",
   })
 );
 
-const TSConfigPathTargets = S.NullOr(TSConfigUniqueStringArray).annotate(
-  $I.annote("TSConfigPathTargets", {
+const TSConfigPathTargets = S.NullOr(TSConfigUniqueStringArray).pipe(
+  $I.annoteSchema("TSConfigPathTargets", {
     description: "A tsconfig `paths` entry target array or null when explicitly disabled in the encoded document.",
   })
 );
 
-const TSConfigPaths = S.Record(S.String, TSConfigPathTargets).annotate(
-  $I.annote("TSConfigPaths", {
+const TSConfigPaths = S.Record(S.String, TSConfigPathTargets).pipe(
+  $I.annoteSchema("TSConfigPaths", {
     description: "The compilerOptions.paths map from module specifier aliases to arrays of target paths or null.",
   })
 );
 
-const TSNodeIgnoreDiagnostic = S.Union([S.String, S.Number]).annotate(
-  $I.annote("TSNodeIgnoreDiagnostic", {
+const TSNodeIgnoreDiagnostic = S.Union([S.String, S.Number]).pipe(
+  $I.annoteSchema("TSNodeIgnoreDiagnostic", {
     description: "A single ts-node ignored diagnostic identifier represented as a string or numeric code.",
   })
 );
 
-const TSNodeIgnoreDiagnostics = S.Array(TSNodeIgnoreDiagnostic).annotate(
-  $I.annote("TSNodeIgnoreDiagnostics", {
+const TSNodeIgnoreDiagnostics = S.Array(TSNodeIgnoreDiagnostic).pipe(
+  $I.annoteSchema("TSNodeIgnoreDiagnostics", {
     description: "An ordered list of ts-node ignored TypeScript diagnostics.",
   })
 );
 
-const TSNodeRequire = S.Array(S.String).annotate(
-  $I.annote("TSNodeRequire", {
+const TSNodeRequire = S.Array(S.String).pipe(
+  $I.annoteSchema("TSNodeRequire", {
     description: "An ordered list of modules to require before ts-node execution.",
   })
 );
 
-const TSNodeTranspilerTuple = S.Tuple([S.NullOr(S.String), S.NullOr(JsonRecord)]).annotate(
-  $I.annote("TSNodeTranspilerTuple", {
+const TSNodeTranspilerTuple = S.Tuple([S.NullOr(S.String), S.NullOr(JsonRecord)]).pipe(
+  $I.annoteSchema("TSNodeTranspilerTuple", {
     description: "Tuple form of the ts-node transpiler setting with a transpiler id and optional JSON options object.",
   })
 );
 
-const TSNodeTranspiler = S.Union([S.String, TSNodeTranspilerTuple]).annotate(
-  $I.annote("TSNodeTranspiler", {
+const TSNodeTranspiler = S.Union([S.String, TSNodeTranspilerTuple]).pipe(
+  $I.annoteSchema("TSNodeTranspiler", {
     description: "The ts-node transpiler setting represented as either a string id or a `[id, options]` tuple.",
   })
 );
 
-const TSNodeModuleTypes = S.Record(S.String, TSNodeModuleType).annotate(
-  $I.annote("TSNodeModuleTypes", {
+const TSNodeModuleTypes = S.Record(S.String, TSNodeModuleType).pipe(
+  $I.annoteSchema("TSNodeModuleTypes", {
     description: "A ts-node module type override map from glob patterns to `cjs`, `esm`, or `package`.",
   })
 );
@@ -1215,8 +1209,8 @@ const TSConfigCompilerOptionsChecks = S.makeFilterGroup(
   }
 );
 
-const TSConfigCompilerOptionsSemantic = TSConfigCompilerOptionsShape.check(TSConfigCompilerOptionsChecks).annotate(
-  $I.annote("TSConfigCompilerOptionsSemantic", {
+const TSConfigCompilerOptionsSemantic = TSConfigCompilerOptionsShape.check(TSConfigCompilerOptionsChecks).pipe(
+  $I.annoteSchema("TSConfigCompilerOptionsSemantic", {
     description: "Compiler options shape with additional semantic refinement checks applied for strict decode helpers.",
   })
 );
@@ -1580,8 +1574,8 @@ const TSConfigSemanticChecks = S.makeFilterGroup(
   }
 );
 
-const TSConfigSemantic = TSConfigShape.check(TSConfigSemanticChecks).annotate(
-  $I.annote("TSConfigSemantic", {
+const TSConfigSemantic = TSConfigShape.check(TSConfigSemanticChecks).pipe(
+  $I.annoteSchema("TSConfigSemantic", {
     description: "Strict tsconfig shape with cross-field semantic checks used by the decode helpers.",
   })
 );

--- a/packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts
+++ b/packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts
@@ -24,8 +24,8 @@ const $I = $RepoUtilsId.create("schemas/WorkspaceDeps");
  * @category models
  * @since 0.0.0
  */
-export const DependencyRecord = S.Record(S.String, S.String).annotate(
-  $I.annote("DependencyRecord", {
+export const DependencyRecord = S.Record(S.String, S.String).pipe(
+  $I.annoteSchema("DependencyRecord", {
     description: "A mapping of dependency package names to version specifiers.",
   })
 );

--- a/packages/tooling/test-kit/test-utils/src/SqlTest.ts
+++ b/packages/tooling/test-kit/test-utils/src/SqlTest.ts
@@ -30,20 +30,20 @@ const PgExternalClientEndTimeout = Duration.seconds(1);
 const PgExternalSchemaDropTimeout = Duration.seconds(10);
 let pgliteImageBuild = O.none<Promise<GenericContainer>>();
 
-const SqlTestHarnessPhase = LiteralKit(["provision", "migrate", "seed", "teardown"]).annotate(
-  $I.annote("SqlTestHarnessPhase", {
+const SqlTestHarnessPhase = LiteralKit(["provision", "migrate", "seed", "teardown"]).pipe(
+  $I.annoteSchema("SqlTestHarnessPhase", {
     description: "Lifecycle phases for reusable SQL integration-test harness failures.",
   })
 );
 
-const TestDatabaseDriver = LiteralKit(["bun-sqlite", "node-sqlite", "pglite-testcontainers", "pg-external"]).annotate(
-  $I.annote("TestDatabaseDriver", {
+const TestDatabaseDriver = LiteralKit(["bun-sqlite", "node-sqlite", "pglite-testcontainers", "pg-external"]).pipe(
+  $I.annoteSchema("TestDatabaseDriver", {
     description: "Driver identifier for reusable SQL integration-test harnesses.",
   })
 );
 
-const PgExternalIsolationMode = LiteralKit(["schema", "none"]).annotate(
-  $I.annote("PgExternalIsolationMode", {
+const PgExternalIsolationMode = LiteralKit(["schema", "none"]).pipe(
+  $I.annoteSchema("PgExternalIsolationMode", {
     description: "Isolation mode for shared external PostgreSQL SQL test drivers.",
   })
 );
@@ -61,8 +61,8 @@ const PgliteTcpPort = S.Int.check(
       title: "PGLite TCP Port Range",
     }
   )
-).annotate(
-  $I.annote("PgliteTcpPort", {
+).pipe(
+  $I.annoteSchema("PgliteTcpPort", {
     description: "TCP port number used by the PGLite Testcontainers SQL test driver.",
   })
 );
@@ -74,8 +74,8 @@ const PglitePositiveInteger = S.Int.check(
     message: "PGLite numeric configuration values must be greater than zero",
     title: "PGLite Positive Integer",
   })
-).annotate(
-  $I.annote("PglitePositiveInteger", {
+).pipe(
+  $I.annoteSchema("PglitePositiveInteger", {
     description: "Positive integer used by the PGLite Testcontainers SQL test driver.",
   })
 );
@@ -87,8 +87,8 @@ const PgExternalSchemaPrefix = S.String.check(
     message: "PostgreSQL test schema prefixes must be valid unquoted identifiers",
     title: "PostgreSQL External Schema Prefix",
   })
-).annotate(
-  $I.annote("PgExternalSchemaPrefix", {
+).pipe(
+  $I.annoteSchema("PgExternalSchemaPrefix", {
     description: "Identifier-safe prefix used when creating external PostgreSQL test schemas.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts
@@ -44,29 +44,23 @@ const JS_IMPORT_PATH_PATTERN = /^\.\/.+\.js$/;
 
 const TypeScriptSourceFileName = S.String.check(S.isPattern(TYPE_SCRIPT_SOURCE_FILE_PATTERN)).pipe(
   S.brand("TypeScriptSourceFileName"),
-  S.annotate(
-    $I.annote("TypeScriptSourceFileName", {
-      description: "TypeScript source filename ending with .ts or .tsx.",
-    })
-  )
+  $I.annoteSchema("TypeScriptSourceFileName", {
+    description: "TypeScript source filename ending with .ts or .tsx.",
+  })
 );
 const decodeTypeScriptSourceFileNameResult = S.decodeUnknownResult(TypeScriptSourceFileName);
 
 const TypeScriptTestFileName = S.String.check(S.isPattern(TYPE_SCRIPT_TEST_FILE_PATTERN)).pipe(
   S.brand("TypeScriptTestFileName"),
-  S.annotate(
-    $I.annote("TypeScriptTestFileName", {
-      description: "TypeScript test filename ending with .test.ts[x] or .spec.ts[x].",
-    })
-  )
+  $I.annoteSchema("TypeScriptTestFileName", {
+    description: "TypeScript test filename ending with .test.ts[x] or .spec.ts[x].",
+  })
 );
 
 const JSImportPath = S.String.check(S.isPattern(JS_IMPORT_PATH_PATTERN)).pipe(
-  S.annotate(
-    $I.annote("JSImportPath", {
-      description: "Relative ESM import path with .js extension.",
-    })
-  )
+  $I.annoteSchema("JSImportPath", {
+    description: "Relative ESM import path with .js extension.",
+  })
 );
 
 const TypeScriptSourceToJSImportPath = TypeScriptSourceFileName.pipe(
@@ -86,21 +80,19 @@ const TypeScriptSourceToJSImportPath = TypeScriptSourceFileName.pipe(
         ),
     })
   ),
-  S.annotate(
-    $I.annote("TypeScriptSourceToJSImportPath", {
-      description: "Schema transformation from a TypeScript module filename to its .js import path.",
-    })
-  )
+  $I.annoteSchema("TypeScriptSourceToJSImportPath", {
+    description: "Schema transformation from a TypeScript module filename to its .js import path.",
+  })
 );
 
-const InternalDirectoryName = S.Literal("internal").annotate(
-  $I.annote("InternalDirectoryName", {
+const InternalDirectoryName = S.Literal("internal").pipe(
+  $I.annoteSchema("InternalDirectoryName", {
     description: "Directory name excluded from barrel generation.",
   })
 );
 
-const RootIndexFileName = S.Literal("index.ts").annotate(
-  $I.annote("RootIndexFileName", {
+const RootIndexFileName = S.Literal("index.ts").pipe(
+  $I.annoteSchema("RootIndexFileName", {
     description: "Root index module excluded from generated barrel inputs.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts
+++ b/packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts
@@ -118,20 +118,16 @@ const TSTYCHE_TEST_FILE_MATCH_PATTERN = /\/dtslint\/\*\*\/\*\.tst\.\*$/;
 
 const PackagePath = S.String.check(S.isPattern(PACKAGE_PATH_PATTERN)).pipe(
   S.brand("PackagePath"),
-  S.annotate(
-    $I.annote("PackagePath", {
-      description: "Repo-relative package path segment used by root config updaters.",
-    })
-  )
+  $I.annoteSchema("PackagePath", {
+    description: "Repo-relative package path segment used by root config updaters.",
+  })
 );
 
 const TstycheTestFileMatchPattern = S.String.check(S.isPattern(TSTYCHE_TEST_FILE_MATCH_PATTERN)).pipe(
   S.brand("TstycheTestFileMatchPattern"),
-  S.annotate(
-    $I.annote("TstycheTestFileMatchPattern", {
-      description: "tstyche testFileMatch glob pattern for dtslint test files.",
-    })
-  )
+  $I.annoteSchema("TstycheTestFileMatchPattern", {
+    description: "tstyche testFileMatch glob pattern for dtslint test files.",
+  })
 );
 
 const PackagePathToTstychePattern = PackagePath.pipe(
@@ -142,11 +138,9 @@ const PackagePathToTstychePattern = PackagePath.pipe(
       encode: flow(Str.replace(TSTYCHE_TEST_FILE_MATCH_PATTERN, Str.empty), PackagePath.make),
     })
   ),
-  S.annotate(
-    $I.annote("PackagePathToTstychePattern", {
-      description: "Schema transformation from package path to tstyche testFileMatch glob.",
-    })
-  )
+  $I.annoteSchema("PackagePathToTstychePattern", {
+    description: "Schema transformation from package path to tstyche testFileMatch glob.",
+  })
 );
 
 const decodeTstychePattern = S.decodeUnknownOption(PackagePathToTstychePattern);
@@ -158,8 +152,8 @@ const toTstychePattern = (packagePath: string): string =>
   );
 const isPackagePath = S.is(PackagePath);
 const stringArrayEquivalence = S.toEquivalence(S.Array(S.String));
-const JsoncUnknownObject = S.Record(S.String, S.Unknown).annotate(
-  $I.annote("JsoncUnknownObject", {
+const JsoncUnknownObject = S.Record(S.String, S.Unknown).pipe(
+  $I.annoteSchema("JsoncUnknownObject", {
     description: "Generic decoded JSONC object document map.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts
+++ b/packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts
@@ -129,8 +129,8 @@ export class FileGenerationPlanInput extends S.Class<FileGenerationPlanInput>($I
  * @category models
  * @since 0.0.0
  */
-export const GenerationActionKind = LiteralKit(["mkdir", "write-file", "symlink"]).annotate(
-  $I.annote("GenerationActionKind", {
+export const GenerationActionKind = LiteralKit(["mkdir", "write-file", "symlink"]).pipe(
+  $I.annoteSchema("GenerationActionKind", {
     description: "Planned action kinds for deterministic generation.",
   })
 );
@@ -181,24 +181,25 @@ class GenerationActionSymlink extends S.Class<GenerationActionSymlink>($I`Genera
  * @category models
  * @since 0.0.0
  */
-export const GenerationAction = S.Union([GenerationActionMkdir, GenerationActionWriteFile, GenerationActionSymlink])
-  .annotate(
-    $I.annote("GenerationAction", {
-      description: "Planned generation action.",
-    })
-  )
-  .pipe(
-    S.toTaggedUnion("kind"),
-    SchemaUtils.withStatics((schema) => ({
-      toStr: flow(
-        schema.match({
-          mkdir: (action) => `mkdir ${action.relativePath}`,
-          "write-file": (action) => `write ${action.relativePath}`,
-          symlink: (action) => `symlink ${action.relativePath} -> ${action.target}`,
-        })
-      ),
-    }))
-  );
+export const GenerationAction = S.Union([
+  GenerationActionMkdir,
+  GenerationActionWriteFile,
+  GenerationActionSymlink,
+]).pipe(
+  $I.annoteSchema("GenerationAction", {
+    description: "Planned generation action.",
+  }),
+  S.toTaggedUnion("kind"),
+  SchemaUtils.withStatics((schema) => ({
+    toStr: flow(
+      schema.match({
+        mkdir: (action) => `mkdir ${action.relativePath}`,
+        "write-file": (action) => `write ${action.relativePath}`,
+        symlink: (action) => `symlink ${action.relativePath} -> ${action.target}`,
+      })
+    ),
+  }))
+);
 /**
  * Planned generation action.
  *

--- a/packages/tooling/tool/cli/src/commands/CreatePackage/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/CreatePackage/Handler.ts
@@ -108,8 +108,8 @@ const VALID_TOOLING_KINDS = ["library", "tool", "policy-pack", "test-kit"] as co
 const PACKAGE_NAME_PATTERN = /^[a-z_][a-z0-9._-]*$/;
 const PARENT_DIR_PATTERN = /^(?!.*\/\/)(?!.*\/$)(?!.*(?:^|\/)\.{1,2}(?:\/|$))[a-z0-9][a-z0-9/_-]*$/;
 
-const PackageType = LiteralKit(VALID_TYPES).annotate(
-  $I.annote("PackageType", {
+const PackageType = LiteralKit(VALID_TYPES).pipe(
+  $I.annoteSchema("PackageType", {
     description: "Supported package scaffold type.",
   })
 );
@@ -132,8 +132,8 @@ const decodePackageFamilyEffect = (input: unknown) =>
   );
 const packageFamilyEquivalence = SchemaUtils.toEquivalence(PackageFamily);
 
-const FoundationKind = LiteralKit(VALID_FOUNDATION_KINDS).annotate(
-  $I.annote("FoundationKind", {
+const FoundationKind = LiteralKit(VALID_FOUNDATION_KINDS).pipe(
+  $I.annoteSchema("FoundationKind", {
     description: "Supported foundation package kinds.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/CreatePackage/TemplateService.ts
+++ b/packages/tooling/tool/cli/src/commands/CreatePackage/TemplateService.ts
@@ -95,11 +95,9 @@ const UnknownToTemplateHelperString = S.Unknown.pipe(
       encode: identity,
     })
   ),
-  S.annotate(
-    $I.annote("UnknownToTemplateHelperString", {
-      description: "Schema transformation that normalizes helper arguments to template-safe strings.",
-    })
-  )
+  $I.annoteSchema("UnknownToTemplateHelperString", {
+    description: "Schema transformation that normalizes helper arguments to template-safe strings.",
+  })
 );
 
 const decodeTemplateHelperString = S.decodeUnknownOption(UnknownToTemplateHelperString);

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Local.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Local.ts
@@ -143,8 +143,8 @@ const collectOptions = <T>(options: ReadonlyArray<O.Option<T>>): ReadonlyArray<T
  * @category models
  * @since 0.0.0
  */
-export const DocgenLocalMode = LiteralKit(["scoped", "full", "full-required", "noop"]).annotate(
-  $I.annote("DocgenLocalMode", {
+export const DocgenLocalMode = LiteralKit(["scoped", "full", "full-required", "noop"]).pipe(
+  $I.annoteSchema("DocgenLocalMode", {
     description: "Local docgen execution mode selected by the planner.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
@@ -100,8 +100,8 @@ const decodeContentHashFromSourceText = S.decodeUnknownEffect(ContentHashFromSou
  * @category models
  * @since 0.0.0
  */
-export const DocgenQualityScopeMode = LiteralKit(["affected", "package", "changed-files", "all"]).annotate(
-  $I.annote("DocgenQualityScopeMode", {
+export const DocgenQualityScopeMode = LiteralKit(["affected", "package", "changed-files", "all"]).pipe(
+  $I.annoteSchema("DocgenQualityScopeMode", {
     description: "Scope mode supported by docgen quality.",
   })
 );
@@ -133,8 +133,8 @@ export type DocgenQualityScopeMode = typeof DocgenQualityScopeMode.Type;
  * @category models
  * @since 0.0.0
  */
-export const DocgenQualityScoreMode = LiteralKit(["none", "rubric", "codex"]).annotate(
-  $I.annote("DocgenQualityScoreMode", {
+export const DocgenQualityScoreMode = LiteralKit(["none", "rubric", "codex"]).pipe(
+  $I.annoteSchema("DocgenQualityScoreMode", {
     description: "Optional advisory scoring mode for docgen quality.",
   })
 );
@@ -166,8 +166,8 @@ export type DocgenQualityScoreMode = typeof DocgenQualityScoreMode.Type;
  * @category models
  * @since 0.0.0
  */
-export const DocgenQualityTier = LiteralKit(["pass", "warn", "fail"]).annotate(
-  $I.annote("DocgenQualityTier", {
+export const DocgenQualityTier = LiteralKit(["pass", "warn", "fail"]).pipe(
+  $I.annoteSchema("DocgenQualityTier", {
     description: "Quality tier assigned to a JSDoc review subject.",
   })
 );
@@ -187,8 +187,8 @@ export const DocgenQualityTier = LiteralKit(["pass", "warn", "fail"]).annotate(
  */
 export type DocgenQualityTier = typeof DocgenQualityTier.Type;
 
-const DocgenQualityPackageStatus = LiteralKit(["completed", "partial", "failed"]).annotate(
-  $I.annote("DocgenQualityPackageStatus", {
+const DocgenQualityPackageStatus = LiteralKit(["completed", "partial", "failed"]).pipe(
+  $I.annoteSchema("DocgenQualityPackageStatus", {
     description: "Completion status for a package-local docgen quality analysis.",
   })
 );
@@ -219,8 +219,8 @@ export const DocgenQualityFindingCode = LiteralKit([
   "example-lacks-observable-result",
   "missing-effects-for-effectful-symbol",
   "insufficient-agent-context",
-]).annotate(
-  $I.annote("DocgenQualityFindingCode", {
+]).pipe(
+  $I.annoteSchema("DocgenQualityFindingCode", {
     description: "Typed finding code emitted by the v1 quality rubric.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts
@@ -86,8 +86,8 @@ const decodeCodexSdkPackageMetadataJson = S.decodeUnknownEffect(S.fromJsonString
  * @category models
  * @since 0.0.0
  */
-export const DocgenQualityWorkerEvalProvider = LiteralKit(["codex", "ollama", "lmstudio"]).annotate(
-  $I.annote("DocgenQualityWorkerEvalProvider", {
+export const DocgenQualityWorkerEvalProvider = LiteralKit(["codex", "ollama", "lmstudio"]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerEvalProvider", {
     description: "Worker provider supported by docgen quality-worker-eval.",
   })
 );
@@ -119,14 +119,8 @@ export type DocgenQualityWorkerEvalProvider = typeof DocgenQualityWorkerEvalProv
  * @category models
  * @since 0.0.0
  */
-export const DocgenQualityWorkerEvalReasoningEffort = LiteralKit([
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-]).annotate(
-  $I.annote("DocgenQualityWorkerEvalReasoningEffort", {
+export const DocgenQualityWorkerEvalReasoningEffort = LiteralKit(["minimal", "low", "medium", "high", "xhigh"]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerEvalReasoningEffort", {
     description: "Codex reasoning effort supported by docgen quality-worker-eval.",
   })
 );
@@ -158,8 +152,8 @@ export type DocgenQualityWorkerEvalReasoningEffort = typeof DocgenQualityWorkerE
  * @category models
  * @since 0.0.0
  */
-export const DocgenQualityWorkerEvalScope = LiteralKit(["input", "package", "all"]).annotate(
-  $I.annote("DocgenQualityWorkerEvalScope", {
+export const DocgenQualityWorkerEvalScope = LiteralKit(["input", "package", "all"]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerEvalScope", {
     description: "Source mode used to build a worker eval queue.",
   })
 );
@@ -191,8 +185,8 @@ export type DocgenQualityWorkerEvalScope = typeof DocgenQualityWorkerEvalScope.T
  * @category models
  * @since 0.0.0
  */
-export const DocgenQualityWorkerEvalPacketStatus = LiteralKit(["completed", "failed", "timed-out"]).annotate(
-  $I.annote("DocgenQualityWorkerEvalPacketStatus", {
+export const DocgenQualityWorkerEvalPacketStatus = LiteralKit(["completed", "failed", "timed-out"]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerEvalPacketStatus", {
     description: "Read-only packet execution status for worker eval.",
   })
 );
@@ -224,12 +218,8 @@ export type DocgenQualityWorkerEvalPacketStatus = typeof DocgenQualityWorkerEval
  * @category models
  * @since 0.0.0
  */
-export const DocgenQualityWorkerEvalReviewDisposition = LiteralKit([
-  "candidate",
-  "needs-human-review",
-  "reject",
-]).annotate(
-  $I.annote("DocgenQualityWorkerEvalReviewDisposition", {
+export const DocgenQualityWorkerEvalReviewDisposition = LiteralKit(["candidate", "needs-human-review", "reject"]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerEvalReviewDisposition", {
     description: "Advisory disposition assigned to a worker draft.",
   })
 );
@@ -273,8 +263,8 @@ export const DocgenQualityWorkerEvalPolicyViolationCode = LiteralKit([
   "noisy-conditional-tag",
   "runtime-behavior-change",
   "other",
-]).annotate(
-  $I.annote("DocgenQualityWorkerEvalPolicyViolationCode", {
+]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerEvalPolicyViolationCode", {
     description: "Closed repo-policy issue code emitted by a worker eval.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts
@@ -98,20 +98,20 @@ const DocgenQualityWorkerRunpodEvalTemplateStrategy = LiteralKit([
   "explicit-template",
   "existing-template",
   "fallback-image",
-]).annotate(
-  $I.annote("DocgenQualityWorkerRunpodEvalTemplateStrategy", {
+]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerRunpodEvalTemplateStrategy", {
     description: "How the Runpod worker eval pod image or template was selected.",
   })
 );
 
-const DocgenQualityWorkerRunpodEvalCleanupStatus = LiteralKit(["completed", "failed", "skipped-debug-keep"]).annotate(
-  $I.annote("DocgenQualityWorkerRunpodEvalCleanupStatus", {
+const DocgenQualityWorkerRunpodEvalCleanupStatus = LiteralKit(["completed", "failed", "skipped-debug-keep"]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerRunpodEvalCleanupStatus", {
     description: "Cleanup outcome for a Runpod worker eval pod.",
   })
 );
 
-const DocgenQualityWorkerRunpodEvalOtlpStatus = LiteralKit(["disabled", "exported", "failed"]).annotate(
-  $I.annote("DocgenQualityWorkerRunpodEvalOtlpStatus", {
+const DocgenQualityWorkerRunpodEvalOtlpStatus = LiteralKit(["disabled", "exported", "failed"]).pipe(
+  $I.annoteSchema("DocgenQualityWorkerRunpodEvalOtlpStatus", {
     description: "OTLP export outcome for a Runpod worker eval wrapper report.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts
@@ -17,8 +17,8 @@ import { docsAggregateCommand } from "./Docs.aggregate.js";
 
 const $I = $RepoCliId.create("docs");
 
-const DocsSectionName = LiteralKit(["laws", "skills", "policies"]).annotate(
-  $I.annote("DocsSectionName", {
+const DocsSectionName = LiteralKit(["laws", "skills", "policies"]).pipe(
+  $I.annoteSchema("DocsSectionName", {
     description: "Name of a docs section.",
   })
 );
@@ -77,13 +77,12 @@ class DocsSectionPolicies extends S.Class<DocsSectionPolicies>($I`DocsSectionPol
  */
 export const DocsSection = DocsSectionName.mapMembers(
   Tuple.evolve([() => DocsSectionLaws, () => DocsSectionSkills, () => DocsSectionPolicies])
-)
-  .pipe(S.toTaggedUnion("name"))
-  .annotate(
-    $I.annote("DocsSection", {
-      description: "A section of documentation.",
-    })
-  );
+).pipe(
+  S.toTaggedUnion("name"),
+  $I.annoteSchema("DocsSection", {
+    description: "A section of documentation.",
+  })
+);
 /**
  * Documentation section model.
  *

--- a/packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyConfig.ts
+++ b/packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyConfig.ts
@@ -26,7 +26,7 @@ const makeDefaultedStringField = (name: string, fallback: string, description: s
     }),
     S.withConstructorDefault(Effect.succeed(fallback)),
     S.withDecodingDefault(Effect.succeed(fallback)),
-    S.annotate($I.annote(name, { description }))
+    $I.annoteSchema(name, { description })
   );
 
 const makeDefaultedPositiveIntField = (name: string, fallback: number, description: string) =>
@@ -41,7 +41,7 @@ const makeDefaultedPositiveIntField = (name: string, fallback: number, descripti
     }),
     S.withConstructorDefault(Effect.succeed(fallback)),
     S.withDecodingDefault(Effect.succeed(`${fallback}`)),
-    S.annotate($I.annote(name, { description }))
+    $I.annoteSchema(name, { description })
   );
 
 const makeDefaultedBooleanField = (name: string, fallback: boolean, description: string) =>
@@ -55,7 +55,7 @@ const makeDefaultedBooleanField = (name: string, fallback: boolean, description:
     }),
     S.withConstructorDefault(Effect.succeed(fallback)),
     S.withDecodingDefault(Effect.succeed(booleanToNormalizedString(fallback))),
-    S.annotate($I.annote(name, { description }))
+    $I.annoteSchema(name, { description })
   );
 
 const makeDefaultedUrlField = (name: string, fallback: string, description: string) =>
@@ -69,7 +69,7 @@ const makeDefaultedUrlField = (name: string, fallback: string, description: stri
     }),
     S.withConstructorDefault(Effect.succeed(fallback)),
     S.withDecodingDefault(Effect.succeed(fallback)),
-    S.annotate($I.annote(name, { description }))
+    $I.annoteSchema(name, { description })
   );
 
 class GraphitiProxyConfigInput extends S.Class<GraphitiProxyConfigInput>($I`GraphitiProxyConfigInput`)(

--- a/packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts
+++ b/packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts
@@ -52,8 +52,8 @@ const $I = $RepoCliId.create("commands/Graphiti/internal/ProxyServices");
  * @category models
  * @since 0.0.0
  */
-export const ContainerHealthState = LiteralKit(["unknown", "healthy", "unhealthy", "starting"]).annotate(
-  $I.annote("ContainerHealthState", {
+export const ContainerHealthState = LiteralKit(["unknown", "healthy", "unhealthy", "starting"]).pipe(
+  $I.annoteSchema("ContainerHealthState", {
     description: "Container health status as reported by docker inspect.",
   })
 );
@@ -68,26 +68,26 @@ export const ContainerHealthState = LiteralKit(["unknown", "healthy", "unhealthy
  * @category models
  * @since 0.0.0
  */
-export const DependencyHealthState = LiteralKit(["unknown", "ok", "degraded"]).annotate(
-  $I.annote("DependencyHealthState", {
+export const DependencyHealthState = LiteralKit(["unknown", "ok", "degraded"]).pipe(
+  $I.annoteSchema("DependencyHealthState", {
     description: "Dependency health status used by graphiti proxy.",
   })
 );
 
-const ProxyErrorKind = LiteralKit(["queue_full", "upstream_failure", "upstream_timeout", "shutting_down"]).annotate(
-  $I.annote("ProxyErrorKind", {
+const ProxyErrorKind = LiteralKit(["queue_full", "upstream_failure", "upstream_timeout", "shutting_down"]).pipe(
+  $I.annoteSchema("ProxyErrorKind", {
     description: "Structured graphiti proxy error identifiers.",
   })
 );
 
-const ProxyHealthStatus = LiteralKit(["ok", "degraded"]).annotate(
-  $I.annote("ProxyHealthStatus", {
+const ProxyHealthStatus = LiteralKit(["ok", "degraded"]).pipe(
+  $I.annoteSchema("ProxyHealthStatus", {
     description: "Health endpoint status values.",
   })
 );
 
-const ProxyLane = LiteralKit(["queued", "fast"]).annotate(
-  $I.annote("ProxyLane", {
+const ProxyLane = LiteralKit(["queued", "fast"]).pipe(
+  $I.annoteSchema("ProxyLane", {
     description: "Graphiti proxy forwarding lanes.",
   })
 );
@@ -100,15 +100,15 @@ const GraphitiProxyFastMcpMethod = LiteralKit([
   "prompts/list",
   "resources/list",
   "tools/list",
-]).annotate(
-  $I.annote("GraphitiProxyFastMcpMethod", {
+]).pipe(
+  $I.annoteSchema("GraphitiProxyFastMcpMethod", {
     description: "Cheap MCP methods allowed to bypass serialized Graphiti memory work.",
   })
 );
 const isGraphitiProxyFastMcpMethod = S.is(GraphitiProxyFastMcpMethod);
 
-const GraphitiProxyFastMcpToolName = LiteralKit(["get_status"]).annotate(
-  $I.annote("GraphitiProxyFastMcpToolName", {
+const GraphitiProxyFastMcpToolName = LiteralKit(["get_status"]).pipe(
+  $I.annoteSchema("GraphitiProxyFastMcpToolName", {
     description: "Cheap Graphiti MCP tools allowed to bypass serialized Graphiti memory work.",
   })
 );
@@ -243,11 +243,9 @@ const urlSearchParamsSchema = S.instanceOf(URLSearchParams).pipe(
       },
     })
   ),
-  S.annotate(
-    $I.annote("UrlSearchParamsToUrlParams", {
-      description: "Schema transformation from URLSearchParams into Effect UrlParams.",
-    })
-  )
+  $I.annoteSchema("UrlSearchParamsToUrlParams", {
+    description: "Schema transformation from URLSearchParams into Effect UrlParams.",
+  })
 );
 
 const decodeUrlSearchParams = S.decodeUnknownEffect(urlSearchParamsSchema);

--- a/packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts
+++ b/packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts
@@ -36,18 +36,16 @@ const ALLOWLIST_SNAPSHOT_PATH =
   "packages/tooling/policy-pack/repo-configs/src/internal/eslint/generated/EffectLawsAllowlistSnapshot.ts";
 const NO_NATIVE_RUNTIME_RULE_ID = "beep-laws/no-native-runtime";
 
-const NonEmptyString = S.String.check(
-  S.makeFilter((value) => value.length > 0 || "Expected non-empty string.")
-).annotate(
-  $I.annote("NonEmptyString", {
+const NonEmptyString = S.String.check(S.makeFilter((value) => value.length > 0 || "Expected non-empty string.")).pipe(
+  $I.annoteSchema("NonEmptyString", {
     description: "Non-empty string value used for effect-laws allowlist fields.",
   })
 );
 
 const DateYmdString = S.String.check(
   S.makeFilter(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test || "Expected YYYY-MM-DD date string format.")
-).annotate(
-  $I.annote("DateYmdString", {
+).pipe(
+  $I.annoteSchema("DateYmdString", {
     description: "Calendar date string in YYYY-MM-DD format for allowlist expiration.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Laws/DualArity.ts
+++ b/packages/tooling/tool/cli/src/commands/Laws/DualArity.ts
@@ -55,14 +55,14 @@ const DualArityEntryKind = LiteralKit([
   "exported-const-function",
   "static-method",
   "static-function-property",
-]).annotate(
-  $I.annote("DualArityEntryKind", {
+]).pipe(
+  $I.annoteSchema("DualArityEntryKind", {
     description: "Kinds of public helper APIs tracked by the dual-arity law.",
   })
 );
 
-const DualArityEntryStatus = LiteralKit(["candidate", "exception"]).annotate(
-  $I.annote("DualArityEntryStatus", {
+const DualArityEntryStatus = LiteralKit(["candidate", "exception"]).pipe(
+  $I.annoteSchema("DualArityEntryStatus", {
     description: "Tracked status for a dual-arity inventory entry.",
   })
 );
@@ -75,8 +75,8 @@ const DualArityDiagnosticKind = LiteralKit([
   "too-many-positional-params",
   "third-param-not-object-like",
   "obvious-wrong-first-parameter",
-]).annotate(
-  $I.annote("DualArityDiagnosticKind", {
+]).pipe(
+  $I.annoteSchema("DualArityDiagnosticKind", {
     description: "Diagnostic kinds emitted by the public API dual-arity law.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts
+++ b/packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts
@@ -35,18 +35,14 @@ const NON_SCHEMA_SIGNAL_PATTERN =
 
 const stringifyJsonPretty = SchemaGetter.stringifyJson({ space: 2 });
 
-const SchemaFirstEntryKind = LiteralKit([
-  "exported-interface",
-  "exported-type-literal",
-  "object-struct-schema",
-]).annotate(
-  $I.annote("SchemaFirstEntryKind", {
+const SchemaFirstEntryKind = LiteralKit(["exported-interface", "exported-type-literal", "object-struct-schema"]).pipe(
+  $I.annoteSchema("SchemaFirstEntryKind", {
     description: "Kinds of schema-first inventory findings.",
   })
 );
 
-const SchemaFirstEntryStatus = LiteralKit(["candidate", "exception"]).annotate(
-  $I.annote("SchemaFirstEntryStatus", {
+const SchemaFirstEntryStatus = LiteralKit(["candidate", "exception"]).pipe(
+  $I.annoteSchema("SchemaFirstEntryStatus", {
     description: "Tracked status for a schema-first inventory finding.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -135,8 +135,8 @@ type TsgoDiagnosticOutput = {
  * @category models
  * @since 0.0.0
  */
-export const GithubCheckMode = LiteralKit(GITHUB_CHECK_MODES).annotate(
-  $I.annote("GithubCheckMode", {
+export const GithubCheckMode = LiteralKit(GITHUB_CHECK_MODES).pipe(
+  $I.annoteSchema("GithubCheckMode", {
     description: "GitHub verification mode handled by the repo-cli quality command group.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -66,8 +66,8 @@ const GITHUB_CHECK_MODES = ["quality", "repo-sanity", "secrets", "security", "sa
  * @category models
  * @since 0.0.0
  */
-export const QualityTaskName = LiteralKit(QUALITY_TASK_NAMES).annotate(
-  $I.annote("QualityTaskName", {
+export const QualityTaskName = LiteralKit(QUALITY_TASK_NAMES).pipe(
+  $I.annoteSchema("QualityTaskName", {
     description: "Canonical quality task name handled by beep-cli.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts
+++ b/packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts
@@ -24,11 +24,9 @@ const causeMessage = (cause: unknown): string =>
  * @since 0.0.0
  */
 export const CodexRunnerStage = LiteralKit(["findRepoRoot", "import", "construct", "startThread"]).pipe(
-  S.annotate(
-    $I.annote("CodexRunnerStage", {
-      description: "Bounded lifecycle stage used when the Codex smoke path fails.",
-    })
-  )
+  $I.annoteSchema("CodexRunnerStage", {
+    description: "Bounded lifecycle stage used when the Codex smoke path fails.",
+  })
 );
 
 /**

--- a/packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts
+++ b/packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts
@@ -29,8 +29,8 @@ const SyncDataSourceFormatKit = LiteralKit(["json", "csv", "xml"]);
  * @category models
  * @since 0.0.0
  */
-export const SyncDataSourceFormat = SyncDataSourceFormatKit.annotate(
-  $I.annote("SyncDataSourceFormat", {
+export const SyncDataSourceFormat = SyncDataSourceFormatKit.pipe(
+  $I.annoteSchema("SyncDataSourceFormat", {
     description: "Supported source formats for sync-data-to-ts targets.",
   })
 );
@@ -51,8 +51,8 @@ const SyncDataRunModeKit = LiteralKit(["write", "check", "dry-run"]);
  * @category models
  * @since 0.0.0
  */
-export const SyncDataRunMode = SyncDataRunModeKit.annotate(
-  $I.annote("SyncDataRunMode", {
+export const SyncDataRunMode = SyncDataRunModeKit.pipe(
+  $I.annoteSchema("SyncDataRunMode", {
     description: "Command execution mode for sync-data-to-ts.",
   })
 );
@@ -139,13 +139,12 @@ class SyncDataTargetXml extends S.Class<SyncDataTargetXml>($I`SyncDataTargetXml`
  */
 export const SyncDataTarget = SyncDataSourceFormat.mapMembers(
   Tuple.evolve([() => SyncDataTargetJson, () => SyncDataTargetCsv, () => SyncDataTargetXml])
-)
-  .annotate(
-    $I.annote("SyncDataTarget", {
-      description: "Checked-in sync target definition.",
-    })
-  )
-  .pipe(S.toTaggedUnion("format"));
+).pipe(
+  $I.annoteSchema("SyncDataTarget", {
+    description: "Checked-in sync target definition.",
+  }),
+  S.toTaggedUnion("format")
+);
 
 /**
  * {@inheritDoc SyncDataTarget}

--- a/packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts
+++ b/packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts
@@ -40,11 +40,9 @@ class Iso4217CurrencyNameWithMetadata extends S.Class<Iso4217CurrencyNameWithMet
 ) {}
 
 const Iso4217CurrencyName = S.Union([S.String, Iso4217CurrencyNameWithMetadata]).pipe(
-  S.annotate(
-    $I.annote("Iso4217CurrencyName", {
-      description: "Currency name node emitted by the ISO 4217 XML parser.",
-    })
-  )
+  $I.annoteSchema("Iso4217CurrencyName", {
+    description: "Currency name node emitted by the ISO 4217 XML parser.",
+  })
 );
 
 class Iso4217CurrencyCountry extends S.Class<Iso4217CurrencyCountry>($I`Iso4217CurrencyCountry`)(

--- a/packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts
+++ b/packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts
@@ -85,8 +85,8 @@ const ROOT_TSTYCHE_TSCONFIG = "./tsconfig.dtslint.json" as const;
  */
 const ROOT_DEP_INDEX_KEY = "@beep/root" as const;
 const $I = $RepoCliId.create("commands/TsconfigSync/TsconfigSync.command");
-const RootDepIndexKey = S.Literal(ROOT_DEP_INDEX_KEY).annotate(
-  $I.annote("RootDepIndexKey", {
+const RootDepIndexKey = S.Literal(ROOT_DEP_INDEX_KEY).pipe(
+  $I.annoteSchema("RootDepIndexKey", {
     description: "Synthetic root dependency index key from repo-utils dependency maps.",
   })
 );
@@ -106,24 +106,20 @@ const CANONICAL_ALIAS_KEY_PATTERN = /^@beep\/[^/*]+(?:\/(?!\*)[^*]+)*(?:\/\*)?$/
 
 const CanonicalAliasKey = S.String.check(S.isPattern(CANONICAL_ALIAS_KEY_PATTERN)).pipe(
   S.brand("CanonicalAliasKey"),
-  S.annotate(
-    $I.annote("CanonicalAliasKey", {
-      description: "Canonical @beep path alias key in root tsconfig paths.",
-    })
-  )
+  $I.annoteSchema("CanonicalAliasKey", {
+    description: "Canonical @beep path alias key in root tsconfig paths.",
+  })
 );
 
 const BeepScopedPackageName = S.String.check(S.isStartsWith("@beep/")).pipe(
   S.brand("BeepScopedPackageName"),
-  S.annotate(
-    $I.annote("BeepScopedPackageName", {
-      description: "Package name under the @beep scope.",
-    })
-  )
+  $I.annoteSchema("BeepScopedPackageName", {
+    description: "Package name under the @beep scope.",
+  })
 );
 
-const StringArray = S.Array(S.String).annotate(
-  $I.annote("StringArray", {
+const StringArray = S.Array(S.String).pipe(
+  $I.annoteSchema("StringArray", {
     description: "Reusable schema for arrays of strings.",
   })
 );
@@ -186,8 +182,8 @@ const TsconfigSyncModeKit = LiteralKit(["sync", "check", "dry-run"]);
  * @category models
  * @since 0.0.0
  */
-export const TsconfigSyncMode = TsconfigSyncModeKit.annotate(
-  $I.annote("TsconfigSyncMode", {
+export const TsconfigSyncMode = TsconfigSyncModeKit.pipe(
+  $I.annoteSchema("TsconfigSyncMode", {
     description: "Command execution mode for tsconfig-sync.",
   })
 );
@@ -246,13 +242,12 @@ export const TsconfigSyncRunOptions = TsconfigSyncMode.mapMembers(
     () => TsconfigSyncRunOptionsCheck,
     () => TsconfigSyncRunOptionsDryRun,
   ])
-)
-  .annotate(
-    $I.annote("TsconfigSyncRunOptions", {
-      description: "Runtime options for executing tsconfig sync at a repo root.",
-    })
-  )
-  .pipe(S.toTaggedUnion("mode"));
+).pipe(
+  $I.annoteSchema("TsconfigSyncRunOptions", {
+    description: "Runtime options for executing tsconfig sync at a repo root.",
+  }),
+  S.toTaggedUnion("mode")
+);
 /**
  * Runtime options for executing tsconfig sync at a repo root.
  *
@@ -275,8 +270,8 @@ export const TsconfigSyncSection = LiteralKit([
   "root-syncpack",
   "package-references",
   "package-docgen",
-]).annotate(
-  $I.annote("TsconfigSyncSection", {
+]).pipe(
+  $I.annoteSchema("TsconfigSyncSection", {
     description: "Sync change section categories for tsconfig-sync.",
   })
 );
@@ -383,13 +378,12 @@ export const TsconfigSyncChange = TsconfigSyncSection.mapMembers(
     () => PackageReferencesChange,
     () => PackageDocgenChange,
   ])
-)
-  .annotate(
-    $I.annote("TsconfigSyncChange", {
-      description: "A single planned file change for tsconfig-sync.",
-    })
-  )
-  .pipe(S.toTaggedUnion("section"));
+).pipe(
+  $I.annoteSchema("TsconfigSyncChange", {
+    description: "A single planned file change for tsconfig-sync.",
+  }),
+  S.toTaggedUnion("section")
+);
 
 /**
  * A single planned file change.
@@ -508,13 +502,12 @@ export const PlannedFileChange = TsconfigSyncSection.mapMembers(
     () => PackageReferencesPlannedFileChange,
     () => PackageDocgenPlannedFileChange,
   ])
-)
-  .annotate(
-    $I.annote("TsconfigSyncChange", {
-      description: "A single planned file change for tsconfig-sync.",
-    })
-  )
-  .pipe(S.toTaggedUnion("section"));
+).pipe(
+  $I.annoteSchema("TsconfigSyncChange", {
+    description: "A single planned file change for tsconfig-sync.",
+  }),
+  S.toTaggedUnion("section")
+);
 
 /**
  * A planned file change with transformed file content.
@@ -566,13 +559,12 @@ class TsconfigSyncResultDryRun extends S.Class<TsconfigSyncResultDryRun>($I`Tsco
  */
 export const TsconfigSyncResult = TsconfigSyncMode.mapMembers(
   Tuple.evolve([() => TsconfigSyncResultSync, () => TsconfigSyncResultCheck, () => TsconfigSyncResultDryRun])
-)
-  .annotate(
-    $I.annote("TsconfigSyncResult", {
-      description: "Result emitted after a sync run.",
-    })
-  )
-  .pipe(S.toTaggedUnion("mode"));
+).pipe(
+  $I.annoteSchema("TsconfigSyncResult", {
+    description: "Result emitted after a sync run.",
+  }),
+  S.toTaggedUnion("mode")
+);
 
 /**
  * Result emitted after a sync run.
@@ -617,8 +609,8 @@ export class WorkspaceDescriptor extends S.Class<WorkspaceDescriptor>($I`Workspa
   })
 ) {}
 
-const JsonObject = S.Record(S.String, S.Unknown).annotate(
-  $I.annote("JsonObject", {
+const JsonObject = S.Record(S.String, S.Unknown).pipe(
+  $I.annoteSchema("JsonObject", {
     description: "Generic JSON object document used for parsed docgen configs.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts
+++ b/packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts
@@ -58,8 +58,8 @@ const VersionCategoryKit = LiteralKit(["bun", "node", "docker", "biome", "effect
  * @category models
  * @since 0.0.0
  */
-export const VersionCategory = VersionCategoryKit.annotate(
-  $I.annote("VersionCategory", {
+export const VersionCategory = VersionCategoryKit.pipe(
+  $I.annoteSchema("VersionCategory", {
     description: "Version category for grouping drift items",
   })
 );
@@ -90,8 +90,8 @@ const VersionCategoryStatusKit = LiteralKit(["ok", "drift", "unpinned", "error"]
  * @category models
  * @since 0.0.0
  */
-export const VersionCategoryStatus = VersionCategoryStatusKit.annotate(
-  $I.annote("VersionCategoryStatus", {
+export const VersionCategoryStatus = VersionCategoryStatusKit.pipe(
+  $I.annoteSchema("VersionCategoryStatus", {
     description: "Status of a version category",
   })
 );
@@ -219,13 +219,12 @@ export const VersionCategoryReport = VersionCategory.mapMembers(
     () => VersionCategoryReportBiome,
     () => VersionCategoryReportEffect,
   ])
-)
-  .annotate(
-    $I.annote("VersionCategoryReport", {
-      description: "Report for a single version category, including its status, items, and error",
-    })
-  )
-  .pipe(S.toTaggedUnion("category"));
+).pipe(
+  $I.annoteSchema("VersionCategoryReport", {
+    description: "Report for a single version category, including its status, items, and error",
+  }),
+  S.toTaggedUnion("category")
+);
 /**
  * Report for a single version category (bun, node, docker, or biome).
  *
@@ -263,8 +262,8 @@ const VersionSyncModeKit = LiteralKit(["check", "write", "dry-run"]);
  * @category models
  * @since 0.0.0
  */
-export const VersionSyncMode = VersionSyncModeKit.annotate(
-  $I.annote("VersionSyncMode", {
+export const VersionSyncMode = VersionSyncModeKit.pipe(
+  $I.annoteSchema("VersionSyncMode", {
     description: "Command execution mode for version sync operations",
   })
 );
@@ -343,13 +342,12 @@ class VersionSyncOptionsDryRun extends S.Class<VersionSyncOptionsDryRun>($I`Vers
  */
 export const VersionSyncOptions = VersionSyncMode.mapMembers(
   Tuple.evolve([() => VersionSyncOptionsCheck, () => VersionSyncOptionsWrite, () => VersionSyncOptionsDryRun])
-)
-  .annotate(
-    $I.annote("VersionSyncOptions", {
-      description: "Resolved command options after flag parsing.",
-    })
-  )
-  .pipe(S.toTaggedUnion("mode"));
+).pipe(
+  $I.annoteSchema("VersionSyncOptions", {
+    description: "Resolved command options after flag parsing.",
+  }),
+  S.toTaggedUnion("mode")
+);
 
 /**
  * Resolved command options after flag parsing.

--- a/packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts
+++ b/packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts
@@ -43,11 +43,9 @@ const BIOME_SCHEMA_URL_PATTERN = /^https:\/\/biomejs\.dev\/schemas\/[^/]+\/schem
 
 const BiomeSchemaUrl = S.String.check(S.isPattern(BIOME_SCHEMA_URL_PATTERN)).pipe(
   S.brand("BiomeSchemaUrl"),
-  S.annotate(
-    $I.annote("BiomeSchemaUrl", {
-      description: "Biome schema URL in canonical https://biomejs.dev/schemas/<version>/schema.json format.",
-    })
-  )
+  $I.annoteSchema("BiomeSchemaUrl", {
+    description: "Biome schema URL in canonical https://biomejs.dev/schemas/<version>/schema.json format.",
+  })
 );
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -68,11 +66,9 @@ const BiomeSchemaUrlToVersion = BiomeSchemaUrl.pipe(
       encode: (version) => BiomeSchemaUrl.make(`${BIOME_SCHEMA_PREFIX}${version}${BIOME_SCHEMA_SUFFIX}`),
     })
   ),
-  S.annotate(
-    $I.annote("BiomeSchemaUrlToVersion", {
-      description: "Schema transformation between canonical Biome schema URL and bare version string.",
-    })
-  )
+  $I.annoteSchema("BiomeSchemaUrlToVersion", {
+    description: "Schema transformation between canonical Biome schema URL and bare version string.",
+  })
 );
 
 /**
@@ -91,11 +87,9 @@ const VersionSpecifierToExactVersion = S.String.pipe(
       encode: identity,
     })
   ),
-  S.annotate(
-    $I.annote("VersionSpecifierToExactVersion", {
-      description: "Schema transformation that strips semver range prefixes from dependency version specifiers.",
-    })
-  )
+  $I.annoteSchema("VersionSpecifierToExactVersion", {
+    description: "Schema transformation that strips semver range prefixes from dependency version specifiers.",
+  })
 );
 
 /**

--- a/packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts
+++ b/packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts
@@ -128,26 +128,22 @@ export class DockerImageState extends S.Class<DockerImageState>($I`DockerImageSt
 
 const StableDockerTag = S.String.check(S.isPattern(STABLE_DOCKER_TAG_PATTERN)).pipe(
   S.brand("StableDockerTag"),
-  S.annotate(
-    $I.annote("StableDockerTag", {
-      description: "Docker tag that is pinned and excludes known unstable/pre-release markers.",
-    })
-  )
+  $I.annoteSchema("StableDockerTag", {
+    description: "Docker tag that is pinned and excludes known unstable/pre-release markers.",
+  })
 );
 const isStableTag = S.is(StableDockerTag);
 
 const MajorOnlyDockerTag = S.String.check(S.isPattern(/^\d+$/)).pipe(
   S.brand("MajorOnlyDockerTag"),
-  S.annotate(
-    $I.annote("MajorOnlyDockerTag", {
-      description: "Pinned Docker tag containing only a major version number.",
-    })
-  )
+  $I.annoteSchema("MajorOnlyDockerTag", {
+    description: "Pinned Docker tag containing only a major version number.",
+  })
 );
 const isMajorOnlyDockerTag = S.is(MajorOnlyDockerTag);
 
-const LatestDockerTag = S.Literal("latest").annotate(
-  $I.annote("LatestDockerTag", {
+const LatestDockerTag = S.Literal("latest").pipe(
+  $I.annoteSchema("LatestDockerTag", {
     description: "Unpinned floating Docker tag.",
   })
 );
@@ -161,11 +157,9 @@ const UnknownDockerImageValueToString = S.Unknown.pipe(
       encode: identity,
     })
   ),
-  S.annotate(
-    $I.annote("UnknownDockerImageValueToString", {
-      description: "Schema transformation that normalizes docker image field values to strings.",
-    })
-  )
+  $I.annoteSchema("UnknownDockerImageValueToString", {
+    description: "Schema transformation that normalizes docker image field values to strings.",
+  })
 );
 const decodeDockerImageValueToString = S.decodeUnknownOption(UnknownDockerImageValueToString);
 const dockerImageValueToString = (value: unknown): string =>

--- a/packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts
+++ b/packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts
@@ -108,11 +108,9 @@ const UnknownNodeVersionValueToString = S.Unknown.pipe(
       encode: identity,
     })
   ),
-  S.annotate(
-    $I.annote("UnknownNodeVersionValueToString", {
-      description: "Schema transformation that normalizes unknown workflow node-version values into strings.",
-    })
-  )
+  $I.annoteSchema("UnknownNodeVersionValueToString", {
+    description: "Schema transformation that normalizes unknown workflow node-version values into strings.",
+  })
 );
 
 const decodeNodeVersionString = S.decodeUnknownOption(UnknownNodeVersionValueToString);

--- a/packages/tooling/tool/cli/src/commands/VersionSync/internal/services/UpdateApplierService.ts
+++ b/packages/tooling/tool/cli/src/commands/VersionSync/internal/services/UpdateApplierService.ts
@@ -19,8 +19,8 @@ import type { FileSystem } from "effect";
 import type { VersionCategoryReport, VersionSyncError, VersionSyncResolution } from "../Models.js";
 
 const $I = $RepoCliId.create("commands/VersionSync/internal/services/UpdateApplierService");
-const VersionCategoryName = LiteralKit(["bun", "node", "docker", "biome", "effect"]).annotate(
-  $I.annote("VersionCategoryName", {
+const VersionCategoryName = LiteralKit(["bun", "node", "docker", "biome", "effect"]).pipe(
+  $I.annoteSchema("VersionCategoryName", {
     description: "Supported update categories for write-mode version-sync application.",
   })
 );

--- a/packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts
+++ b/packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts
@@ -25,11 +25,9 @@ const YamlNodeValueAsString = S.Unknown.pipe(
       encode: (value) => value,
     })
   ),
-  S.annotate(
-    $I.annote("YamlNodeValueAsString", {
-      description: "Schema transformation that normalizes arbitrary YAML node values into comparable strings.",
-    })
-  )
+  $I.annoteSchema("YamlNodeValueAsString", {
+    description: "Schema transformation that normalizes arbitrary YAML node values into comparable strings.",
+  })
 );
 
 const decodeYamlNodeValueAsString = S.decodeUnknownOption(YamlNodeValueAsString);

--- a/packages/wealth-management/domain/src/entities/Account/Account.values.ts
+++ b/packages/wealth-management/domain/src/entities/Account/Account.values.ts
@@ -23,8 +23,8 @@ const $I = $WealthManagementDomainId.create("entities/Account/Account.values");
  * @category schemas
  * @since 0.0.0
  */
-export const AccountType = LiteralKit(["taxable_brokerage"]).annotate(
-  $I.annote("AccountType", {
+export const AccountType = LiteralKit(["taxable_brokerage"]).pipe(
+  $I.annoteSchema("AccountType", {
     description: "Closed fixture type vocabulary for accounts.",
   })
 );

--- a/packages/wealth-management/domain/src/entities/Household/Household.values.ts
+++ b/packages/wealth-management/domain/src/entities/Household/Household.values.ts
@@ -23,8 +23,8 @@ const $I = $WealthManagementDomainId.create("entities/Household/Household.values
  * @category schemas
  * @since 0.0.0
  */
-export const HouseholdStatus = LiteralKit(["active"]).annotate(
-  $I.annote("HouseholdStatus", {
+export const HouseholdStatus = LiteralKit(["active"]).pipe(
+  $I.annoteSchema("HouseholdStatus", {
     description: "Closed fixture status vocabulary for households.",
   })
 );

--- a/packages/wealth-management/domain/src/entities/Party/Party.values.ts
+++ b/packages/wealth-management/domain/src/entities/Party/Party.values.ts
@@ -23,8 +23,8 @@ const $I = $WealthManagementDomainId.create("entities/Party/Party.values");
  * @category schemas
  * @since 0.0.0
  */
-export const PartyType = LiteralKit(["person"]).annotate(
-  $I.annote("PartyType", {
+export const PartyType = LiteralKit(["person"]).pipe(
+  $I.annoteSchema("PartyType", {
     description: "Closed fixture type vocabulary for parties.",
   })
 );

--- a/packages/wealth-management/domain/src/entities/WealthClient/WealthClient.values.ts
+++ b/packages/wealth-management/domain/src/entities/WealthClient/WealthClient.values.ts
@@ -23,8 +23,8 @@ const $I = $WealthManagementDomainId.create("entities/WealthClient/WealthClient.
  * @category schemas
  * @since 0.0.0
  */
-export const WealthClientStatus = LiteralKit(["active_client"]).annotate(
-  $I.annote("WealthClientStatus", {
+export const WealthClientStatus = LiteralKit(["active_client"]).pipe(
+  $I.annoteSchema("WealthClientStatus", {
     description: "Closed fixture status vocabulary for wealth clients.",
   })
 );

--- a/packages/workspace/domain/src/values/ApprovalDecision/ApprovalDecision.model.ts
+++ b/packages/workspace/domain/src/values/ApprovalDecision/ApprovalDecision.model.ts
@@ -22,8 +22,8 @@ const $I = $WorkspaceDomainId.create("values/ApprovalDecision/ApprovalDecision.m
  * @category schemas
  * @since 0.0.0
  */
-export const ApprovalDecision = LiteralKit(["pending"]).annotate(
-  $I.annote("ApprovalDecision", {
+export const ApprovalDecision = LiteralKit(["pending"]).pipe(
+  $I.annoteSchema("ApprovalDecision", {
     description: "Review decision vocabulary for candidate approval gates.",
   })
 );

--- a/packages/workspace/domain/src/values/CandidateLifecycle/CandidateLifecycle.model.ts
+++ b/packages/workspace/domain/src/values/CandidateLifecycle/CandidateLifecycle.model.ts
@@ -22,8 +22,8 @@ const $I = $WorkspaceDomainId.create("values/CandidateLifecycle/CandidateLifecyc
  * @category schemas
  * @since 0.0.0
  */
-export const CandidateLifecycle = LiteralKit(["candidate"]).annotate(
-  $I.annote("CandidateLifecycle", {
+export const CandidateLifecycle = LiteralKit(["candidate"]).pipe(
+  $I.annoteSchema("CandidateLifecycle", {
     description: "Lifecycle state for candidate work produced by the runtime proof.",
   })
 );

--- a/standards/effect-first-development.md
+++ b/standards/effect-first-development.md
@@ -858,9 +858,9 @@ const ContainsScopeSeparator = S.String.check(
   })
 ).pipe(
   S.brand("ContainsScopeSeparator"),
-  S.annotate($I.annote("ContainsScopeSeparator", {
+  $I.annoteSchema("ContainsScopeSeparator", {
     description: "A string that contains the topic scope separator `:`."
-  }))
+  })
 )
 
 const isContainsScopeSeparator = S.is(ContainsScopeSeparator)
@@ -874,9 +874,9 @@ const TopicSegment = S.NonEmptyString.check(
   })
 ).pipe(
   S.brand("TopicSegment"),
-  S.annotate($I.annote("TopicSegment", {
+  $I.annoteSchema("TopicSegment", {
     description: "A non-empty topic segment without the scope separator."
-  }))
+  })
 )
 
 const isTopicSegment = S.is(TopicSegment)
@@ -923,9 +923,9 @@ export const TopicName = S.NonEmptyString.check(
   )
 ).pipe(
   S.brand("TopicName"),
-  S.annotate($I.annote("TopicName", {
+  $I.annoteSchema("TopicName", {
     description: "A topic name composed from valid plain or scoped segments."
-  }))
+  })
 )
 ```
 

--- a/standards/repo-exports.catalog.md
+++ b/standards/repo-exports.catalog.md
@@ -21,7 +21,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | packagesWithoutPublicExports | 1 |
 | missingWorkspaceMetadata | 4 |
 | importSpecifiers | 981 |
-| publicExportEntries | 12900 |
+| publicExportEntries | 12901 |
 | uniquePackageSymbols | 5656 |
 
 ## Seed Discovery Proof
@@ -89,7 +89,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | 50 | `@beep/epistemic-domain` | `packages/epistemic/domain` | has-public-exports | 8 | 18 | 5 |
 | 51 | `@beep/architecture-lab-use-cases` | `packages/architecture-lab/use-cases` | has-public-exports | 7 | 77 | 44 |
 | 52 | `@beep/professional-runtime-proof` | `apps/professional-runtime-proof` | has-public-exports | 1 | 4 | 4 |
-| 53 | `@beep/acp` | `packages/drivers/acp` | has-public-exports | 8 | 404 | 229 |
+| 53 | `@beep/acp` | `packages/drivers/acp` | has-public-exports | 8 | 405 | 229 |
 | 54 | `@beep/nlp` | `packages/foundation/capability/nlp` | has-public-exports | 53 | 589 | 178 |
 | 55 | `@beep/infra` | `infra` | has-public-exports | 1 | 20 | 20 |
 | 56 | `@beep/installer-use-cases` | `packages/installer/use-cases` | has-public-exports | 3 | 51 | 29 |
@@ -796,11 +796,11 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 |---|---|---|---|---|
 | `@beep/repo-cli` | `agentEffectivenessCommand` | const | `packages/tooling/tool/cli/src/commands/AgentEffectiveness/AgentEffectiveness.command.ts:657` | Agent-effectiveness root command. |
 | `@beep/repo-cli` | `ciCommand` | const | `packages/tooling/tool/cli/src/commands/Ci/Ci.command.ts:309` | CI helper command group. |
-| `@beep/repo-cli` | `codegenCommand` | const | `packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts:258` | CLI command that scans a package's `src/` directory and generates (or previews) |
+| `@beep/repo-cli` | `codegenCommand` | const | `packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts:250` | CLI command that scans a package's `src/` directory and generates (or previews) |
 | `@beep/repo-cli` | `codexCommand` | const | `packages/tooling/tool/cli/src/commands/Codex/Codex.command.ts:92` | Codex helper command group. |
 | `@beep/repo-cli` | `createPackageCommand` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/CreatePackage.command.ts:16` | Package creation command. |
 | `@beep/repo-cli` | `docgenCommand` | const | `packages/tooling/tool/cli/src/commands/Docgen/Docgen.command.ts:1088` | Human-first docgen command suite. |
-| `@beep/repo-cli` | `docsCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:245` | Command-first docs discovery entrypoint used by agent config surfaces. |
+| `@beep/repo-cli` | `docsCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:244` | Command-first docs discovery entrypoint used by agent config surfaces. |
 | `@beep/repo-cli` | `filesCommand` | const | `packages/tooling/tool/cli/src/commands/Files/Files.command.ts:437` | File curation command group. |
 | `@beep/repo-cli` | `graphitiCommand` | const | `packages/tooling/tool/cli/src/commands/Graphiti/Graphiti.command.ts:94` | Graphiti command group. |
 | `@beep/repo-cli` | `imageCommand` | const | `packages/tooling/tool/cli/src/commands/Image/Image.command.ts:135` | Image and video curation command group. |
@@ -812,7 +812,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli` | `rootCommand` | const | `packages/tooling/tool/cli/src/commands/Root.ts:45` | Top-level CLI command that registers all subcommands. |
 | `@beep/repo-cli` | `syncDataToTsCommand` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.command.ts:441` | CLI command for syncing official upstream datasets into checked-in TypeScript modules. |
 | `@beep/repo-cli` | `topoSortCommand` | const | `packages/tooling/tool/cli/src/commands/TopoSort/TopoSort.command.ts:33` | CLI command that builds the workspace dependency graph and prints package names |
-| `@beep/repo-cli` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1778` | CLI command for synchronizing root and workspace tsconfig state. |
+| `@beep/repo-cli` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1770` | CLI command for synchronizing root and workspace tsconfig state. |
 | `@beep/repo-cli` | `versionSyncCommand` | const | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.command.ts:49` | CLI command for synchronizing version pins across the monorepo. |
 | `@beep/repo-cli/commands/AgentEffectiveness` | `agentEffectivenessCommand` | const | `packages/tooling/tool/cli/src/commands/AgentEffectiveness/AgentEffectiveness.command.ts:657` | Agent-effectiveness root command. |
 | `@beep/repo-cli/commands/AgentEffectiveness/AgentEffectiveness.command` | `agentEffectivenessCommand` | const | `packages/tooling/tool/cli/src/commands/AgentEffectiveness/AgentEffectiveness.command.ts:657` | Agent-effectiveness root command. |
@@ -959,9 +959,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Ci/index` | `appendTurboSummary` | const | `packages/tooling/tool/cli/src/commands/Ci/Ci.command.ts:257` | Append the latest Turbo run summary to GitHub step summary or stdout. |
 | `@beep/repo-cli/commands/Ci/index` | `ciCommand` | const | `packages/tooling/tool/cli/src/commands/Ci/Ci.command.ts:309` | CI helper command group. |
 | `@beep/repo-cli/commands/Ci/index` | `CiCommandError` | class | `packages/tooling/tool/cli/src/commands/Ci/Ci.errors.ts:26` | Typed failure for CI helper commands. |
-| `@beep/repo-cli/commands/Codegen` | `codegenCommand` | const | `packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts:258` | CLI command that scans a package's `src/` directory and generates (or previews) |
-| `@beep/repo-cli/commands/Codegen/Codegen.command` | `codegenCommand` | const | `packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts:258` | CLI command that scans a package's `src/` directory and generates (or previews) |
-| `@beep/repo-cli/commands/Codegen/index` | `codegenCommand` | const | `packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts:258` | CLI command that scans a package's `src/` directory and generates (or previews) |
+| `@beep/repo-cli/commands/Codegen` | `codegenCommand` | const | `packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts:250` | CLI command that scans a package's `src/` directory and generates (or previews) |
+| `@beep/repo-cli/commands/Codegen/Codegen.command` | `codegenCommand` | const | `packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts:250` | CLI command that scans a package's `src/` directory and generates (or previews) |
+| `@beep/repo-cli/commands/Codegen/index` | `codegenCommand` | const | `packages/tooling/tool/cli/src/commands/Codegen/Codegen.command.ts:250` | CLI command that scans a package's `src/` directory and generates (or previews) |
 | `@beep/repo-cli/commands/Codex` | `codexCommand` | const | `packages/tooling/tool/cli/src/commands/Codex/Codex.command.ts:92` | Codex helper command group. |
 | `@beep/repo-cli/commands/Codex` | `CodexCommandError` | class | `packages/tooling/tool/cli/src/commands/Codex/Codex.errors.ts:35` | Typed failure for Codex helper commands. |
 | `@beep/repo-cli/commands/Codex` | `runCodexQualityReviewFixLoop` | const | `packages/tooling/tool/cli/src/commands/Codex/Codex.command.ts:47` | Launch Codex with the repo-local quality review fix loop prompt. |
@@ -972,26 +972,26 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Codex/index` | `CodexCommandError` | class | `packages/tooling/tool/cli/src/commands/Codex/Codex.errors.ts:35` | Typed failure for Codex helper commands. |
 | `@beep/repo-cli/commands/Codex/index` | `runCodexQualityReviewFixLoop` | const | `packages/tooling/tool/cli/src/commands/Codex/Codex.command.ts:47` | Launch Codex with the repo-local quality review fix loop prompt. |
 | `@beep/repo-cli/commands/CreatePackage` | `createPackageCommand` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/CreatePackage.command.ts:16` | Package creation command. |
-| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `checkConfigNeedsUpdate` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:619` | Check whether config entries already exist (for dry-run output). |
-| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `checkConfigNeedsUpdateForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:549` | Batch read-only drift checker for root config updates. |
+| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `checkConfigNeedsUpdate` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:613` | Check whether config entries already exist (for dry-run output). |
+| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `checkConfigNeedsUpdateForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:543` | Batch read-only drift checker for root config updates. |
 | `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `ConfigUpdateBatchResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:97` | Batch config orchestration result for one or more package targets. |
 | `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `ConfigUpdateResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:39` | Summary of which root configuration files were modified during a config update pass. |
 | `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `ConfigUpdateTarget` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:56` | Config update target for a package that should be registered in root tsconfig files. |
 | `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `ConfigUpdateTargetResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:74` | Per-target config update summary. |
-| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateRootConfigs` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:591` | Orchestrate all root config updates for a newly created package. |
-| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateRootConfigsForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:509` | Batch root config updater for slice flows creating multiple packages. |
-| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateTsconfigPackages` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:304` | Add a project reference to `tsconfig.packages.json`. |
-| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateTsconfigPaths` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:345` | Add path aliases to `tsconfig.json` (JSONC-safe, preserves comments). |
-| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateTstycheConfig` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:399` | Add a test file match entry to `tstyche.json`. |
+| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateRootConfigs` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:585` | Orchestrate all root config updates for a newly created package. |
+| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateRootConfigsForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:503` | Batch root config updater for slice flows creating multiple packages. |
+| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateTsconfigPackages` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:298` | Add a project reference to `tsconfig.packages.json`. |
+| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateTsconfigPaths` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:339` | Add path aliases to `tsconfig.json` (JSONC-safe, preserves comments). |
+| `@beep/repo-cli/commands/CreatePackage/ConfigUpdater` | `updateTstycheConfig` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:393` | Add a test file match entry to `tstyche.json`. |
 | `@beep/repo-cli/commands/CreatePackage/CreatePackage.command` | `createPackageCommand` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/CreatePackage.command.ts:16` | Package creation command. |
-| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `createFileGenerationPlanService` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:465` | Construct the default generation plan service implementation. |
-| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationExecutionResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:232` | Execution report for a plan run. |
-| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationPlan` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:216` | Deterministic generation plan. |
+| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `createFileGenerationPlanService` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:466` | Construct the default generation plan service implementation. |
+| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationExecutionResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:233` | Execution report for a plan run. |
+| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationPlan` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:217` | Deterministic generation plan. |
 | `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationPlanInput` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:114` | Input payload used to create a generation pla. |
-| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationPlanService` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:267` | Service tag for deterministic file-generation planning and execution. |
-| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationPlanServiceShape` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:253` | Service contract for deterministic generation plan orchestration. |
+| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationPlanService` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:268` | Service tag for deterministic file-generation planning and execution. |
+| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `FileGenerationPlanServiceShape` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:254` | Service contract for deterministic generation plan orchestration. |
 | `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `GenerationAction` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:184` | Planned generation action schema. |
-| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `GenerationAction` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:208` | Planned generation action. |
+| `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `GenerationAction` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:209` | Planned generation action. |
 | `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `GenerationActionKind` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:132` | Planned action kinds. |
 | `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `GenerationActionKind` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:143` | Planned generation action. |
 | `@beep/repo-cli/commands/CreatePackage/FileGenerationPlanService` | `PlannedFile` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:82` | A file write operation. |
@@ -1000,7 +1000,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/CreatePackage/Handler` | `resolveCreatePackageTemplateDir` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/Handler.ts:77` | Resolve create-package template directory for both src and dist runtimes. |
 | `@beep/repo-cli/commands/CreatePackage/Handler` | `TemplateContext` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/Handler.ts:278` | Variables passed into every template during package scaffolding. |
 | `@beep/repo-cli/commands/CreatePackage/index` | `createPackageCommand` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/CreatePackage.command.ts:16` | Package creation command. |
-| `@beep/repo-cli/commands/CreatePackage/TemplateService` | `createTemplateService` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/TemplateService.ts:126` | Construct the default template service implementation. |
+| `@beep/repo-cli/commands/CreatePackage/TemplateService` | `createTemplateService` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/TemplateService.ts:124` | Construct the default template service implementation. |
 | `@beep/repo-cli/commands/CreatePackage/TemplateService` | `RenderedTemplate` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/TemplateService.ts:40` | Rendered template output. |
 | `@beep/repo-cli/commands/CreatePackage/TemplateService` | `TemplateRenderRequest` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/TemplateService.ts:56` | Request payload for template rendering. |
 | `@beep/repo-cli/commands/CreatePackage/TemplateService` | `TemplateService` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/TemplateService.ts:88` | Service tag for template rendering. |
@@ -1070,31 +1070,31 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Docgen/internal/Quality` | `generateQualityJson` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:1914` | Renders a quality report as stable JSON. |
 | `@beep/repo-cli/commands/Docgen/internal/Quality` | `generateQualityReport` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:1966` | Renders a quality report as human-readable Markdown. |
 | `@beep/repo-cli/commands/Docgen/internal/Quality` | `resolveDocgenQualityTargets` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:594` | Resolves `docgen quality` targets using the v1 scope policy. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `analyzeDocgenQualityWorkerEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1239` | Build a read-only worker eval report from a quality report. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `AnalyzeDocgenQualityWorkerEvalOptions` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:520` | Options for one worker eval run. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `decodeDocgenQualityReportForWorkerEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1142` | Decode a saved `docgen quality` JSON report for worker eval. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `defaultQualityWorkerEvalPacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1179` | Default packet cap for `docgen quality-worker-eval`. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `defaultQualityWorkerEvalReasoningEffort` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1194` | Default hosted Codex reasoning effort for worker eval. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalPacketStatus` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:194` | Read-only packet execution status for worker eval. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalPacketStatus` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:213` | Read-only packet execution status for worker eval. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalPolicyViolationCode` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:264` | Closed repo-policy issue code emitted by a worker eval. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalPolicyViolationCode` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:295` | Closed repo-policy issue code emitted by a worker eval. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `analyzeDocgenQualityWorkerEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1229` | Build a read-only worker eval report from a quality report. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `AnalyzeDocgenQualityWorkerEvalOptions` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:510` | Options for one worker eval run. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `decodeDocgenQualityReportForWorkerEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1132` | Decode a saved `docgen quality` JSON report for worker eval. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `defaultQualityWorkerEvalPacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1169` | Default packet cap for `docgen quality-worker-eval`. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `defaultQualityWorkerEvalReasoningEffort` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1184` | Default hosted Codex reasoning effort for worker eval. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalPacketStatus` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:188` | Read-only packet execution status for worker eval. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalPacketStatus` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:207` | Read-only packet execution status for worker eval. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalPolicyViolationCode` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:254` | Closed repo-policy issue code emitted by a worker eval. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalPolicyViolationCode` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:285` | Closed repo-policy issue code emitted by a worker eval. |
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalProvider` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:89` | Worker provider supported by `docgen quality-worker-eval`. |
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalProvider` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:108` | Worker provider supported by `docgen quality-worker-eval`. |
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReasoningEffort` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:122` | Codex reasoning effort supported by `docgen quality-worker-eval`. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReasoningEffort` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:147` | Codex reasoning effort supported by `docgen quality-worker-eval`. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReport` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:396` | JSON report emitted by `docgen quality-worker-eval`. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReviewDisposition` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:227` | Advisory disposition assigned to a worker draft. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReviewDisposition` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:250` | Advisory disposition assigned to a worker draft. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalRunner` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:486` | Runner used to execute one Codex eval turn. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalRunnerInput` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:456` | Inputs passed to the Codex runner for one remediation packet. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalRunnerResult` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:432` | Completed worker turn returned by the Codex runner. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalScope` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:161` | Source mode used to build a worker eval queue. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalScope` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:180` | Source mode used to build a worker eval queue. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalWorkerOutput` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:310` | Structured response expected from the Codex worker. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `generateQualityWorkerEvalJson` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1358` | Render a worker eval report as stable JSON. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `qualityWorkerEvalSourcePacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1163` | Compute the source packet limit used for generated quality reports. |
-| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `selectQualityWorkerEvalPackets` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:733` | Select remediation packets for a capped worker eval run. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReasoningEffort` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:141` | Codex reasoning effort supported by `docgen quality-worker-eval`. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReport` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:386` | JSON report emitted by `docgen quality-worker-eval`. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReviewDisposition` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:221` | Advisory disposition assigned to a worker draft. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalReviewDisposition` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:240` | Advisory disposition assigned to a worker draft. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalRunner` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:476` | Runner used to execute one Codex eval turn. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalRunnerInput` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:446` | Inputs passed to the Codex runner for one remediation packet. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalRunnerResult` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:422` | Completed worker turn returned by the Codex runner. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalScope` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:155` | Source mode used to build a worker eval queue. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalScope` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:174` | Source mode used to build a worker eval queue. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `DocgenQualityWorkerEvalWorkerOutput` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:300` | Structured response expected from the Codex worker. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `generateQualityWorkerEvalJson` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1348` | Render a worker eval report as stable JSON. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `qualityWorkerEvalSourcePacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1153` | Compute the source packet limit used for generated quality reports. |
+| `@beep/repo-cli/commands/Docgen/internal/QualityWorkerEval` | `selectQualityWorkerEvalPackets` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:723` | Select remediation packets for a capped worker eval run. |
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerRunpodEval` | `defaultQualityWorkerRunpodEvalOtlpBaseUrl` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:1010` | Default Phoenix-compatible OTLP base URL for remote worker eval traces. |
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerRunpodEval` | `defaultQualityWorkerRunpodEvalOtlpProject` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:1025` | Default Phoenix project for remote worker eval traces. |
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerRunpodEval` | `defaultQualityWorkerRunpodEvalPacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:995` | Default packet cap for Runpod-backed worker eval runs. |
@@ -1106,16 +1106,16 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerRunpodEval` | `runDocgenQualityWorkerRunpodEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:1060` | Run a read-only JSDoc quality worker eval on an ephemeral Runpod pod. |
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerRunpodEval` | `RunDocgenQualityWorkerRunpodEvalOptions` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:262` | Options for a Runpod-backed quality worker eval run. |
 | `@beep/repo-cli/commands/Docgen/internal/QualityWorkerRunpodEval` | `selectQualityWorkerRunpodTemplate` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:394` | Select the first suitable Ollama template from live Runpod templates. |
-| `@beep/repo-cli/commands/Docs` | `docsCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:245` | Command-first docs discovery entrypoint used by agent config surfaces. |
+| `@beep/repo-cli/commands/Docs` | `docsCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:244` | Command-first docs discovery entrypoint used by agent config surfaces. |
 | `@beep/repo-cli/commands/Docs` | `DocsSection` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:78` | Documentation section model. |
-| `@beep/repo-cli/commands/Docs` | `DocsSection` | type | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:97` | Documentation section model. |
+| `@beep/repo-cli/commands/Docs` | `DocsSection` | type | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:96` | Documentation section model. |
 | `@beep/repo-cli/commands/Docs/Docs.aggregate` | `docsAggregateCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.aggregate.ts:75` | Aggregate generated package docs into the root `docs/` layout. |
-| `@beep/repo-cli/commands/Docs/Docs.command` | `docsCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:245` | Command-first docs discovery entrypoint used by agent config surfaces. |
+| `@beep/repo-cli/commands/Docs/Docs.command` | `docsCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:244` | Command-first docs discovery entrypoint used by agent config surfaces. |
 | `@beep/repo-cli/commands/Docs/Docs.command` | `DocsSection` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:78` | Documentation section model. |
-| `@beep/repo-cli/commands/Docs/Docs.command` | `DocsSection` | type | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:97` | Documentation section model. |
-| `@beep/repo-cli/commands/Docs/index` | `docsCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:245` | Command-first docs discovery entrypoint used by agent config surfaces. |
+| `@beep/repo-cli/commands/Docs/Docs.command` | `DocsSection` | type | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:96` | Documentation section model. |
+| `@beep/repo-cli/commands/Docs/index` | `docsCommand` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:244` | Command-first docs discovery entrypoint used by agent config surfaces. |
 | `@beep/repo-cli/commands/Docs/index` | `DocsSection` | const | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:78` | Documentation section model. |
-| `@beep/repo-cli/commands/Docs/index` | `DocsSection` | type | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:97` | Documentation section model. |
+| `@beep/repo-cli/commands/Docs/index` | `DocsSection` | type | `packages/tooling/tool/cli/src/commands/Docs/Docs.command.ts:96` | Documentation section model. |
 | `@beep/repo-cli/commands/Files` | `analyzeSolidBorders` | const | `packages/tooling/tool/cli/src/commands/Files/Files.media.ts:779` | Analyze raw RGB image pixels for near-solid borders on all four sides. |
 | `@beep/repo-cli/commands/Files` | `ArchivedSidecarEntry` | class | `packages/tooling/tool/cli/src/commands/Files/Files.schemas.ts:1301` | Caption or metadata sidecar moved with an archived image. |
 | `@beep/repo-cli/commands/Files` | `archivePoorCandidates` | const | `packages/tooling/tool/cli/src/commands/Files/Files.service.ts:4478` | Archive obvious poor image candidates out of a dataset directory. |
@@ -1669,16 +1669,16 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `ContainerHealthState` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:55` | Container health literal union. |
 | `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `DependencyHealthSnapshot` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:137` | Cached dependency health snapshot payload. |
 | `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `DependencyHealthState` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:71` | Dependency health literal union. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `GraphitiDependencyHealthService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:384` | Service tag for dependency health snapshots. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `GraphitiProxyForwarderService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:399` | Service tag for forwarding requests to upstream graphiti. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `GraphitiProxyQueueService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:414` | Service tag for queueing and draining proxy traffic. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `isFastMcpRequestBody` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:476` | Determine whether an MCP request body is cheap enough to bypass the serialized memory-work queue. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `makeGraphitiDependencyHealthService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:537` | Construct dependency health service implementation. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `makeGraphitiProxyForwarderService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:594` | Construct upstream forwarder service implementation. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `makeGraphitiProxyQueueService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:712` | Construct proxy queue service implementation. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `proxyErrorResponse` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:303` | Build a structured proxy error HTTP response. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `GraphitiDependencyHealthService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:382` | Service tag for dependency health snapshots. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `GraphitiProxyForwarderService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:397` | Service tag for forwarding requests to upstream graphiti. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `GraphitiProxyQueueService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:412` | Service tag for queueing and draining proxy traffic. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `isFastMcpRequestBody` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:474` | Determine whether an MCP request body is cheap enough to bypass the serialized memory-work queue. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `makeGraphitiDependencyHealthService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:535` | Construct dependency health service implementation. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `makeGraphitiProxyForwarderService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:592` | Construct upstream forwarder service implementation. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `makeGraphitiProxyQueueService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:710` | Construct proxy queue service implementation. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `proxyErrorResponse` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:301` | Build a structured proxy error HTTP response. |
 | `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `ProxyHealthPayload` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:184` | Structured JSON payload for health endpoints. |
-| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `proxyHealthResponse` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:345` | Build a structured proxy health HTTP response. |
+| `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `proxyHealthResponse` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:343` | Build a structured proxy health HTTP response. |
 | `@beep/repo-cli/commands/Graphiti/internal/ProxyServices` | `ProxyQueueStats` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:157` | Queue and processing counters for proxy introspection. |
 | `@beep/repo-cli/commands/Image` | `decodeExtractFramesDirOptions` | const | `packages/tooling/tool/cli/src/commands/Image/Image.schemas.ts:258` | Decode unknown directory frame extraction options. |
 | `@beep/repo-cli/commands/Image` | `decodeExtractFramesOptions` | const | `packages/tooling/tool/cli/src/commands/Image/Image.schemas.ts:250` | Decode unknown single-video frame extraction options. |
@@ -1749,10 +1749,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Laws` | `NoNativeRuntimeRulesExecutionError` | class | `packages/tooling/tool/cli/src/commands/Laws/Laws.errors.ts:94` | Failure raised when native runtime enforcement cannot complete. |
 | `@beep/repo-cli/commands/Laws` | `TerseEffectRulesPersistenceError` | class | `packages/tooling/tool/cli/src/commands/Laws/Laws.errors.ts:126` | Failure raised when terse Effect rule updates cannot be written. |
 | `@beep/repo-cli/commands/Laws/AllowlistCheck` | `ALLOWLIST_PATH` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:34` | Relative path to the effect laws allowlist. |
-| `@beep/repo-cli/commands/Laws/AllowlistCheck` | `AllowlistCheckOptions` | class | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:95` | Runtime options for allowlist integrity checks. |
-| `@beep/repo-cli/commands/Laws/AllowlistCheck` | `AllowlistCheckSummary` | class | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:114` | Result of an allowlist integrity check. |
-| `@beep/repo-cli/commands/Laws/AllowlistCheck` | `reportAllowlistCheckSummary` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:315` | Print allowlist integrity diagnostics to the console. |
-| `@beep/repo-cli/commands/Laws/AllowlistCheck` | `runAllowlistCheck` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:253` | Run the effect laws allowlist integrity check. |
+| `@beep/repo-cli/commands/Laws/AllowlistCheck` | `AllowlistCheckOptions` | class | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:93` | Runtime options for allowlist integrity checks. |
+| `@beep/repo-cli/commands/Laws/AllowlistCheck` | `AllowlistCheckSummary` | class | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:112` | Result of an allowlist integrity check. |
+| `@beep/repo-cli/commands/Laws/AllowlistCheck` | `reportAllowlistCheckSummary` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:313` | Print allowlist integrity diagnostics to the console. |
+| `@beep/repo-cli/commands/Laws/AllowlistCheck` | `runAllowlistCheck` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:251` | Run the effect laws allowlist integrity check. |
 | `@beep/repo-cli/commands/Laws/DualArity` | `DualArityInventoryEntry` | namespace | `packages/tooling/tool/cli/src/commands/Laws/DualArity.ts:113` | Namespace for {@link DualArityInventoryEntry} companion types. |
 | `@beep/repo-cli/commands/Laws/DualArity` | `DualArityRulesOptions` | class | `packages/tooling/tool/cli/src/commands/Laws/DualArity.ts:159` | Runtime options for public API dual-arity enforcement. |
 | `@beep/repo-cli/commands/Laws/DualArity` | `DualArityRulesSummary` | class | `packages/tooling/tool/cli/src/commands/Laws/DualArity.ts:189` | Summary of public API dual-arity inventory verification. |
@@ -1805,9 +1805,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Lint/Lint.errors` | `LintCircularAnalysisError` | class | `packages/tooling/tool/cli/src/commands/Lint/Lint.errors.ts:32` | Failure raised when circular dependency analysis cannot complete. |
 | `@beep/repo-cli/commands/Lint/Lint.errors` | `LintFileDiscoveryError` | class | `packages/tooling/tool/cli/src/commands/Lint/Lint.errors.ts:63` | Failure raised when lint file discovery cannot read a source root. |
 | `@beep/repo-cli/commands/Lint/PackageTestImports` | `lintPackageTestImportsCommand` | const | `packages/tooling/tool/cli/src/commands/Lint/PackageTestImports.ts:319` | Lint command for enforcing package aliases from package test and dtslint files. |
-| `@beep/repo-cli/commands/Lint/SchemaFirst` | `lintSchemaFirstCommand` | const | `packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts:633` | Repo-wide schema-first lint command. |
-| `@beep/repo-cli/commands/Lint/SchemaFirst` | `runSchemaFirstLint` | const | `packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts:524` | Run schema-first inventory verification against the committed baseline. |
-| `@beep/repo-cli/commands/Lint/SchemaFirst` | `SchemaFirstInventoryEntry` | namespace | `packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts:78` | Namespace for {@link SchemaFirstInventoryEntry} companion types. |
+| `@beep/repo-cli/commands/Lint/SchemaFirst` | `lintSchemaFirstCommand` | const | `packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts:629` | Repo-wide schema-first lint command. |
+| `@beep/repo-cli/commands/Lint/SchemaFirst` | `runSchemaFirstLint` | const | `packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts:520` | Run schema-first inventory verification against the committed baseline. |
+| `@beep/repo-cli/commands/Lint/SchemaFirst` | `SchemaFirstInventoryEntry` | namespace | `packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts:74` | Namespace for {@link SchemaFirstInventoryEntry} companion types. |
 | `@beep/repo-cli/commands/Lint/SchemaTopology` | `collectSchemaTopologyViolations` | const | `packages/tooling/tool/cli/src/commands/Lint/SchemaTopology.ts:434` | Collect schema topology violations without mutating process state. |
 | `@beep/repo-cli/commands/Lint/SchemaTopology` | `lintSchemaTopologyCommand` | const | `packages/tooling/tool/cli/src/commands/Lint/SchemaTopology.ts:492` | Lint command for enforcing canonical `@beep/schema` topology. |
 | `@beep/repo-cli/commands/Lint/SchemaTopology` | `runSchemaTopologyLint` | const | `packages/tooling/tool/cli/src/commands/Lint/SchemaTopology.ts:466` | Run the schema topology lint command. |
@@ -1883,26 +1883,26 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:803` | Resolve the SQL integration database connection URI from environment variables. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:780` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
-| `@beep/repo-cli/commands/Reuse` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:48` | Structured error emitted when the Codex SDK smoke path fails. |
+| `@beep/repo-cli/commands/Reuse` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:46` | Structured error emitted when the Codex SDK smoke path fails. |
 | `@beep/repo-cli/commands/Reuse` | `CodexRunnerStage` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:26` | Lifecycle stages surfaced by the Codex smoke runner. |
-| `@beep/repo-cli/commands/Reuse` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:40` | Runtime type for `CodexRunnerStage`. |
+| `@beep/repo-cli/commands/Reuse` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:38` | Runtime type for `CodexRunnerStage`. |
 | `@beep/repo-cli/commands/Reuse` | `reuseCommand` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:553` | Reuse-discovery command group. |
 | `@beep/repo-cli/commands/Reuse` | `sanitizeTerminalText` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:145` | Remove terminal control sequences from human-readable reuse output. |
-| `@beep/repo-cli/commands/Reuse/index` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:48` | Structured error emitted when the Codex SDK smoke path fails. |
+| `@beep/repo-cli/commands/Reuse/index` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:46` | Structured error emitted when the Codex SDK smoke path fails. |
 | `@beep/repo-cli/commands/Reuse/index` | `CodexRunnerStage` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:26` | Lifecycle stages surfaced by the Codex smoke runner. |
-| `@beep/repo-cli/commands/Reuse/index` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:40` | Runtime type for `CodexRunnerStage`. |
+| `@beep/repo-cli/commands/Reuse/index` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:38` | Runtime type for `CodexRunnerStage`. |
 | `@beep/repo-cli/commands/Reuse/index` | `reuseCommand` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:553` | Reuse-discovery command group. |
 | `@beep/repo-cli/commands/Reuse/index` | `sanitizeTerminalText` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:145` | Remove terminal control sequences from human-readable reuse output. |
-| `@beep/repo-cli/commands/Reuse/internal/CodexRunner` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:48` | Structured error emitted when the Codex SDK smoke path fails. |
+| `@beep/repo-cli/commands/Reuse/internal/CodexRunner` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:46` | Structured error emitted when the Codex SDK smoke path fails. |
 | `@beep/repo-cli/commands/Reuse/internal/CodexRunner` | `CodexRunnerStage` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:26` | Lifecycle stages surfaced by the Codex smoke runner. |
-| `@beep/repo-cli/commands/Reuse/internal/CodexRunner` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:40` | Runtime type for `CodexRunnerStage`. |
+| `@beep/repo-cli/commands/Reuse/internal/CodexRunner` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:38` | Runtime type for `CodexRunnerStage`. |
 | `@beep/repo-cli/commands/Reuse/internal/CodexRunner` | `CodexSmokeResult` | class | `packages/tooling/tool/cli/src/commands/Reuse/internal/CodexRunner.ts:32` | Structured result for `beep reuse codex-smoke`. |
 | `@beep/repo-cli/commands/Reuse/internal/CodexRunner` | `runCodexSmoke` | const | `packages/tooling/tool/cli/src/commands/Reuse/internal/CodexRunner.ts:53` | Validate the local Codex SDK adapter without running a reuse loop. |
 | `@beep/repo-cli/commands/Reuse/Reuse.command` | `reuseCommand` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:553` | Reuse-discovery command group. |
 | `@beep/repo-cli/commands/Reuse/Reuse.command` | `sanitizeTerminalText` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:145` | Remove terminal control sequences from human-readable reuse output. |
-| `@beep/repo-cli/commands/Reuse/Reuse.errors` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:48` | Structured error emitted when the Codex SDK smoke path fails. |
+| `@beep/repo-cli/commands/Reuse/Reuse.errors` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:46` | Structured error emitted when the Codex SDK smoke path fails. |
 | `@beep/repo-cli/commands/Reuse/Reuse.errors` | `CodexRunnerStage` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:26` | Lifecycle stages surfaced by the Codex smoke runner. |
-| `@beep/repo-cli/commands/Reuse/Reuse.errors` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:40` | Runtime type for `CodexRunnerStage`. |
+| `@beep/repo-cli/commands/Reuse/Reuse.errors` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:38` | Runtime type for `CodexRunnerStage`. |
 | `@beep/repo-cli/commands/Root` | `rootCommand` | const | `packages/tooling/tool/cli/src/commands/Root.ts:45` | Top-level CLI command that registers all subcommands. |
 | `@beep/repo-cli/commands/SyncDataToTs` | `syncDataToTsCommand` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.command.ts:441` | CLI command for syncing official upstream datasets into checked-in TypeScript modules. |
 | `@beep/repo-cli/commands/SyncDataToTs` | `SyncDataToTsDriftError` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.errors.ts:86` | Drift detected in check mode. |
@@ -1915,9 +1915,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataSourceFormat` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:32` | Supported source formats for sync-data-to-ts targets. |
 | `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataSourceFormat` | type | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:44` | Supported source formats for sync-data-to-ts targets. |
 | `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataTarget` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:140` | Checked-in sync target definition. |
-| `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataTarget` | type | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:156` | {@inheritDoc SyncDataTarget} |
+| `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataTarget` | type | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:155` | {@inheritDoc SyncDataTarget} |
 | `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataTargetProjection` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:74` | Rendered target projection ready to compare or write to disk. |
-| `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataTargetResult` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:164` | Per-target command result after diffing or writing. |
+| `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataTargetResult` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:163` | Per-target command result after diffing or writing. |
 | `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataToTsDriftError` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.errors.ts:86` | Drift detected in check mode. |
 | `@beep/repo-cli/commands/SyncDataToTs/internal/Models` | `SyncDataToTsError` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.errors.ts:35` | Operational error during source fetch, parsing, projection, or file writes. |
 | `@beep/repo-cli/commands/SyncDataToTs/SyncDataToTs.command` | `syncDataToTsCommand` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.command.ts:441` | CLI command for syncing official upstream datasets into checked-in TypeScript modules. |
@@ -1925,70 +1925,70 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/SyncDataToTs/SyncDataToTs.errors` | `SyncDataToTsError` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.errors.ts:35` | Operational error during source fetch, parsing, projection, or file writes. |
 | `@beep/repo-cli/commands/SyncDataToTs/targets/index` | `syncDataTargets` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/index.ts:16` | All checked-in sync targets supported by sync-data-to-ts. |
 | `@beep/repo-cli/commands/SyncDataToTs/targets/Iso4217` | `ISO4217_SOURCE_URL` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts:27` | Official SIX XML source for ISO 4217 List One. |
-| `@beep/repo-cli/commands/SyncDataToTs/targets/Iso4217` | `iso4217Target` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts:276` | Checked-in sync target for the official SIX ISO 4217 List One XML feed. |
+| `@beep/repo-cli/commands/SyncDataToTs/targets/Iso4217` | `iso4217Target` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts:274` | Checked-in sync target for the official SIX ISO 4217 List One XML feed. |
 | `@beep/repo-cli/commands/TopoSort` | `topoSortCommand` | const | `packages/tooling/tool/cli/src/commands/TopoSort/TopoSort.command.ts:33` | CLI command that builds the workspace dependency graph and prints package names |
 | `@beep/repo-cli/commands/TopoSort/index` | `topoSortCommand` | const | `packages/tooling/tool/cli/src/commands/TopoSort/TopoSort.command.ts:33` | CLI command that builds the workspace dependency graph and prints package names |
 | `@beep/repo-cli/commands/TopoSort/TopoSort.command` | `topoSortCommand` | const | `packages/tooling/tool/cli/src/commands/TopoSort/TopoSort.command.ts:33` | CLI command that builds the workspace dependency graph and prints package names |
 | `@beep/repo-cli/commands/TsconfigSync` | `buildCanonicalAliasTargets` | const | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:154` | Build root and wildcard alias targets for a package export target. |
-| `@beep/repo-cli/commands/TsconfigSync` | `PlannedFileChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:501` | A planned file change with transformed file content. |
-| `@beep/repo-cli/commands/TsconfigSync` | `PlannedFileChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:525` | A planned file change with transformed file content. |
+| `@beep/repo-cli/commands/TsconfigSync` | `PlannedFileChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:495` | A planned file change with transformed file content. |
+| `@beep/repo-cli/commands/TsconfigSync` | `PlannedFileChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:518` | A planned file change with transformed file content. |
 | `@beep/repo-cli/commands/TsconfigSync` | `resolveRootExportTarget` | const | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:89` | Resolve the canonical root export target from a package `exports` field. |
-| `@beep/repo-cli/commands/TsconfigSync` | `syncTsconfigAtRoot` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1643` | Synchronize tsconfig references and root aliases under a specific repository root. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:376` | A single planned file change. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:400` | A single planned file change. |
-| `@beep/repo-cli/commands/TsconfigSync` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1778` | CLI command for synchronizing root and workspace tsconfig state. |
+| `@beep/repo-cli/commands/TsconfigSync` | `syncTsconfigAtRoot` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1635` | Synchronize tsconfig references and root aliases under a specific repository root. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:371` | A single planned file change. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:394` | A single planned file change. |
+| `@beep/repo-cli/commands/TsconfigSync` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1770` | CLI command for synchronizing root and workspace tsconfig state. |
 | `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncCycleError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:60` | Cycle error raised when workspace dependency cycles are detected. |
 | `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncDriftError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:21` | Drift error raised in check mode when changes are required. |
 | `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncFilterError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:99` | Filter error raised when `--filter` does not match any workspace package. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncMode` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:189` | Command execution mode. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncResult` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:567` | Result emitted after a sync run. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncResult` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:583` | Result emitted after a sync run. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncRunOptions` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:243` | Runtime options for executing tsconfig sync at a repo root. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncRunOptions` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:262` | Runtime options for executing tsconfig sync at a repo root. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncSection` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:270` | Sync change section categories. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncSection` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:290` | Sync change section categories. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigWithPaths` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:665` | Minimal tsconfig shape containing optional `compilerOptions.paths`. |
-| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigWithReferences` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:650` | Minimal tsconfig shape containing optional `references`. |
-| `@beep/repo-cli/commands/TsconfigSync` | `WorkspaceDescriptor` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:599` | Workspace package descriptor with metadata for tsconfig synchronization. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncMode` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:185` | Command execution mode. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncResult` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:560` | Result emitted after a sync run. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncResult` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:575` | Result emitted after a sync run. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncRunOptions` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:239` | Runtime options for executing tsconfig sync at a repo root. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncRunOptions` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:257` | Runtime options for executing tsconfig sync at a repo root. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncSection` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:265` | Sync change section categories. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigSyncSection` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:285` | Sync change section categories. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigWithPaths` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:657` | Minimal tsconfig shape containing optional `compilerOptions.paths`. |
+| `@beep/repo-cli/commands/TsconfigSync` | `TsconfigWithReferences` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:642` | Minimal tsconfig shape containing optional `references`. |
+| `@beep/repo-cli/commands/TsconfigSync` | `WorkspaceDescriptor` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:591` | Workspace package descriptor with metadata for tsconfig synchronization. |
 | `@beep/repo-cli/commands/TsconfigSync/index` | `buildCanonicalAliasTargets` | const | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:154` | Build root and wildcard alias targets for a package export target. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `PlannedFileChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:501` | A planned file change with transformed file content. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `PlannedFileChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:525` | A planned file change with transformed file content. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `PlannedFileChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:495` | A planned file change with transformed file content. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `PlannedFileChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:518` | A planned file change with transformed file content. |
 | `@beep/repo-cli/commands/TsconfigSync/index` | `resolveRootExportTarget` | const | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:89` | Resolve the canonical root export target from a package `exports` field. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `syncTsconfigAtRoot` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1643` | Synchronize tsconfig references and root aliases under a specific repository root. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:376` | A single planned file change. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:400` | A single planned file change. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1778` | CLI command for synchronizing root and workspace tsconfig state. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `syncTsconfigAtRoot` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1635` | Synchronize tsconfig references and root aliases under a specific repository root. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:371` | A single planned file change. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:394` | A single planned file change. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1770` | CLI command for synchronizing root and workspace tsconfig state. |
 | `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncCycleError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:60` | Cycle error raised when workspace dependency cycles are detected. |
 | `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncDriftError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:21` | Drift error raised in check mode when changes are required. |
 | `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncFilterError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:99` | Filter error raised when `--filter` does not match any workspace package. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncMode` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:189` | Command execution mode. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncResult` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:567` | Result emitted after a sync run. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncResult` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:583` | Result emitted after a sync run. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncRunOptions` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:243` | Runtime options for executing tsconfig sync at a repo root. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncRunOptions` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:262` | Runtime options for executing tsconfig sync at a repo root. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncSection` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:270` | Sync change section categories. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncSection` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:290` | Sync change section categories. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigWithPaths` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:665` | Minimal tsconfig shape containing optional `compilerOptions.paths`. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigWithReferences` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:650` | Minimal tsconfig shape containing optional `references`. |
-| `@beep/repo-cli/commands/TsconfigSync/index` | `WorkspaceDescriptor` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:599` | Workspace package descriptor with metadata for tsconfig synchronization. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncMode` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:185` | Command execution mode. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncResult` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:560` | Result emitted after a sync run. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncResult` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:575` | Result emitted after a sync run. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncRunOptions` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:239` | Runtime options for executing tsconfig sync at a repo root. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncRunOptions` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:257` | Runtime options for executing tsconfig sync at a repo root. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncSection` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:265` | Sync change section categories. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigSyncSection` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:285` | Sync change section categories. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigWithPaths` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:657` | Minimal tsconfig shape containing optional `compilerOptions.paths`. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `TsconfigWithReferences` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:642` | Minimal tsconfig shape containing optional `references`. |
+| `@beep/repo-cli/commands/TsconfigSync/index` | `WorkspaceDescriptor` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:591` | Workspace package descriptor with metadata for tsconfig synchronization. |
 | `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `buildCanonicalAliasTargets` | const | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:154` | Build root and wildcard alias targets for a package export target. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `PlannedFileChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:501` | A planned file change with transformed file content. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `PlannedFileChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:525` | A planned file change with transformed file content. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `PlannedFileChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:495` | A planned file change with transformed file content. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `PlannedFileChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:518` | A planned file change with transformed file content. |
 | `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `resolveRootExportTarget` | const | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:89` | Resolve the canonical root export target from a package `exports` field. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `syncTsconfigAtRoot` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1643` | Synchronize tsconfig references and root aliases under a specific repository root. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:376` | A single planned file change. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:400` | A single planned file change. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1778` | CLI command for synchronizing root and workspace tsconfig state. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncMode` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:189` | Command execution mode. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncResult` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:567` | Result emitted after a sync run. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncResult` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:583` | Result emitted after a sync run. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncRunOptions` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:243` | Runtime options for executing tsconfig sync at a repo root. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncRunOptions` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:262` | Runtime options for executing tsconfig sync at a repo root. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncSection` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:270` | Sync change section categories. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncSection` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:290` | Sync change section categories. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigWithPaths` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:665` | Minimal tsconfig shape containing optional `compilerOptions.paths`. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigWithReferences` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:650` | Minimal tsconfig shape containing optional `references`. |
-| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `WorkspaceDescriptor` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:599` | Workspace package descriptor with metadata for tsconfig synchronization. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `syncTsconfigAtRoot` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1635` | Synchronize tsconfig references and root aliases under a specific repository root. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncChange` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:371` | A single planned file change. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncChange` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:394` | A single planned file change. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1770` | CLI command for synchronizing root and workspace tsconfig state. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncMode` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:185` | Command execution mode. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncResult` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:560` | Result emitted after a sync run. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncResult` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:575` | Result emitted after a sync run. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncRunOptions` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:239` | Runtime options for executing tsconfig sync at a repo root. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncRunOptions` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:257` | Runtime options for executing tsconfig sync at a repo root. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncSection` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:265` | Sync change section categories. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigSyncSection` | type | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:285` | Sync change section categories. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigWithPaths` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:657` | Minimal tsconfig shape containing optional `compilerOptions.paths`. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `TsconfigWithReferences` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:642` | Minimal tsconfig shape containing optional `references`. |
+| `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.command` | `WorkspaceDescriptor` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:591` | Workspace package descriptor with metadata for tsconfig synchronization. |
 | `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.errors` | `TsconfigSyncCycleError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:60` | Cycle error raised when workspace dependency cycles are detected. |
 | `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.errors` | `TsconfigSyncDriftError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:21` | Drift error raised in check mode when changes are required. |
 | `@beep/repo-cli/commands/TsconfigSync/TsconfigSync.errors` | `TsconfigSyncFilterError` | class | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.errors.ts:99` | Filter error raised when `--filter` does not match any workspace package. |
@@ -2006,7 +2006,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionCategory` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:79` | Version category for grouping drift items. |
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionCategoryOptions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:72` | Literal option tuple for version categories. |
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionCategoryReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:214` | Report for a single version category (bun, node, docker, biome, or effect). |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionCategoryReport` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:235` | Report for a single version category (bun, node, docker, or biome). |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionCategoryReport` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:234` | Report for a single version category (bun, node, docker, or biome). |
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionCategoryStatus` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:93` | Status of a version category. |
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionCategoryStatus` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:125` | Status of a version category. |
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionCategoryStatusEnum` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:111` | Enum mapping for version category status literals. |
@@ -2015,32 +2015,32 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionDriftItem` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:35` | A single version pin location with its current and expected values. |
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncDriftError` | class | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.errors.ts:100` | Drift detected in check mode (non-zero exit). |
 | `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncError` | class | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.errors.ts:35` | Operational error during version sync (file read/write, parse failures). |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncMode` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:266` | Command execution mode. |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncMode` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:285` | Command execution mode. |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncModeMatch` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:277` | Pattern-matching helper for version-sync mode literals. |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncOptions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:344` | Resolved command options after flag parsing. |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncOptions` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:360` | Resolved command options after flag parsing. |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncReport` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:243` | Full version sync report across all categories. |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncResolution` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:384` | Resolver output consumed by reporting and write-mode services. |
-| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncUpdateLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:368` | YAML location to update in write mode. |
-| `@beep/repo-cli/commands/VersionSync/internal/resolvers/BiomeResolver` | `BiomeSchemaState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:147` | Resolved Biome schema state. |
-| `@beep/repo-cli/commands/VersionSync/internal/resolvers/BiomeResolver` | `buildBiomeReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:218` | Build the Biome schema category report from resolved state. |
-| `@beep/repo-cli/commands/VersionSync/internal/resolvers/BiomeResolver` | `resolveBiomeSchema` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:167` | Resolve current Biome schema version from `biome.jsonc` and installed version from `package.json` catalog. |
-| `@beep/repo-cli/commands/VersionSync/internal/resolvers/BiomeResolver` | `updateBiomeSchema` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:263` | Update the `$schema` field in `biome.jsonc` to match the installed version. |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncMode` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:265` | Command execution mode. |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncMode` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:284` | Command execution mode. |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncModeMatch` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:276` | Pattern-matching helper for version-sync mode literals. |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncOptions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:343` | Resolved command options after flag parsing. |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncOptions` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:358` | Resolved command options after flag parsing. |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncReport` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:242` | Full version sync report across all categories. |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncResolution` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:382` | Resolver output consumed by reporting and write-mode services. |
+| `@beep/repo-cli/commands/VersionSync/internal/Models` | `VersionSyncUpdateLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:366` | YAML location to update in write mode. |
+| `@beep/repo-cli/commands/VersionSync/internal/resolvers/BiomeResolver` | `BiomeSchemaState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:141` | Resolved Biome schema state. |
+| `@beep/repo-cli/commands/VersionSync/internal/resolvers/BiomeResolver` | `buildBiomeReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:212` | Build the Biome schema category report from resolved state. |
+| `@beep/repo-cli/commands/VersionSync/internal/resolvers/BiomeResolver` | `resolveBiomeSchema` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:161` | Resolve current Biome schema version from `biome.jsonc` and installed version from `package.json` catalog. |
+| `@beep/repo-cli/commands/VersionSync/internal/resolvers/BiomeResolver` | `updateBiomeSchema` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:257` | Update the `$schema` field in `biome.jsonc` to match the installed version. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/BunResolver` | `buildBunReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BunResolver.ts:366` | Build the Bun category report from resolved state. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/BunResolver` | `BunSemver` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BunResolver.ts:101` | Parsed Bun semantic version components. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/BunResolver` | `BunVersionState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BunResolver.ts:260` | Resolved Bun version state. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/BunResolver` | `resolveBunVersions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BunResolver.ts:283` | Resolve current Bun versions from local files and optionally fetch latest from GitHub. |
-| `@beep/repo-cli/commands/VersionSync/internal/resolvers/DockerResolver` | `buildDockerReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:429` | Build the Docker category report from resolved state. |
+| `@beep/repo-cli/commands/VersionSync/internal/resolvers/DockerResolver` | `buildDockerReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:423` | Build the Docker category report from resolved state. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/DockerResolver` | `DockerImageState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:117` | Resolved Docker image state. |
-| `@beep/repo-cli/commands/VersionSync/internal/resolvers/DockerResolver` | `resolveDockerImages` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:325` | Resolve Docker image state from docker-compose.yml. |
+| `@beep/repo-cli/commands/VersionSync/internal/resolvers/DockerResolver` | `resolveDockerImages` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:319` | Resolve Docker image state from docker-compose.yml. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/EffectResolver` | `buildEffectReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/EffectResolver.ts:199` | Build the Effect catalog category report from resolved state. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/EffectResolver` | `EffectCatalogState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/EffectResolver.ts:61` | Resolved Effect catalog state derived from the root `package.json` catalog entries. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/EffectResolver` | `resolveEffectCatalog` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/EffectResolver.ts:146` | Resolve the root package.json Effect catalog state. |
-| `@beep/repo-cli/commands/VersionSync/internal/resolvers/NodeResolver` | `buildNodeReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:231` | Build the Node category report from resolved state. |
+| `@beep/repo-cli/commands/VersionSync/internal/resolvers/NodeResolver` | `buildNodeReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:229` | Build the Node category report from resolved state. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/NodeResolver` | `NodeVersionLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:31` | A workflow file location with a `node-version` field. |
 | `@beep/repo-cli/commands/VersionSync/internal/resolvers/NodeResolver` | `NodeVersionState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:50` | Resolved Node version state. |
-| `@beep/repo-cli/commands/VersionSync/internal/resolvers/NodeResolver` | `resolveNodeVersions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:129` | Resolve Node.js version state from `.nvmrc` and workflow files. |
+| `@beep/repo-cli/commands/VersionSync/internal/resolvers/NodeResolver` | `resolveNodeVersions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:127` | Resolve Node.js version state from `.nvmrc` and workflow files. |
 | `@beep/repo-cli/commands/VersionSync/internal/services/CategorySelectionService` | `CategorySelectionService` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/services/CategorySelectionService.ts:33` | Service tag for category-selection logic. |
 | `@beep/repo-cli/commands/VersionSync/internal/services/CategorySelectionService` | `CategorySelectionServiceLive` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/services/CategorySelectionService.ts:63` | Live layer for category-selection logic. |
 | `@beep/repo-cli/commands/VersionSync/internal/services/CategorySelectionService` | `CategorySelectionServiceShape` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/services/CategorySelectionService.ts:22` | Service contract for selecting categories to resolve and update. |
@@ -2056,48 +2056,48 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/VersionSync/internal/updaters/PackageJsonUpdater` | `updateCatalogEntry` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/PackageJsonUpdater.ts:82` | Update a root package.json `catalog` entry using `jsonc-parser`. |
 | `@beep/repo-cli/commands/VersionSync/internal/updaters/PackageJsonUpdater` | `updatePackageManagerField` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/PackageJsonUpdater.ts:38` | Update the `packageManager` field in `package.json` using `jsonc-parser`. |
 | `@beep/repo-cli/commands/VersionSync/internal/updaters/PlainTextUpdater` | `updatePlainTextFile` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/PlainTextUpdater.ts:21` | Update a plain text version file (e.g. `.bun-version`). |
-| `@beep/repo-cli/commands/VersionSync/internal/updaters/YamlFileUpdater` | `replaceNodeVersionWithFile` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts:103` | Replace `node-version: <value>` with `node-version-file: .nvmrc` in a workflow YAML. |
-| `@beep/repo-cli/commands/VersionSync/internal/updaters/YamlFileUpdater` | `updateYamlValue` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts:52` | Update a value at a specific path in a YAML file, preserving comments and formatting. |
+| `@beep/repo-cli/commands/VersionSync/internal/updaters/YamlFileUpdater` | `replaceNodeVersionWithFile` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts:101` | Replace `node-version: <value>` with `node-version-file: .nvmrc` in a workflow YAML. |
+| `@beep/repo-cli/commands/VersionSync/internal/updaters/YamlFileUpdater` | `updateYamlValue` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts:50` | Update a value at a specific path in a YAML file, preserving comments and formatting. |
 | `@beep/repo-cli/commands/VersionSync/VersionSync.command` | `versionSyncCommand` | const | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.command.ts:49` | CLI command for synchronizing version pins across the monorepo. |
 | `@beep/repo-cli/commands/VersionSync/VersionSync.errors` | `NetworkUnavailableError` | class | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.errors.ts:79` | Network unavailable during upstream version resolution. |
 | `@beep/repo-cli/commands/VersionSync/VersionSync.errors` | `VersionSyncDriftError` | class | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.errors.ts:100` | Drift detected in check mode (non-zero exit). |
 | `@beep/repo-cli/commands/VersionSync/VersionSync.errors` | `VersionSyncError` | class | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.errors.ts:35` | Operational error during version sync (file read/write, parse failures). |
-| `@beep/repo-cli/test/CreatePackage` | `checkConfigNeedsUpdate` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:619` | Check whether config entries already exist (for dry-run output). |
-| `@beep/repo-cli/test/CreatePackage` | `checkConfigNeedsUpdateForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:549` | Batch read-only drift checker for root config updates. |
+| `@beep/repo-cli/test/CreatePackage` | `checkConfigNeedsUpdate` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:613` | Check whether config entries already exist (for dry-run output). |
+| `@beep/repo-cli/test/CreatePackage` | `checkConfigNeedsUpdateForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:543` | Batch read-only drift checker for root config updates. |
 | `@beep/repo-cli/test/CreatePackage` | `ConfigUpdateBatchResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:97` | Batch config orchestration result for one or more package targets. |
 | `@beep/repo-cli/test/CreatePackage` | `ConfigUpdateResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:39` | Summary of which root configuration files were modified during a config update pass. |
 | `@beep/repo-cli/test/CreatePackage` | `ConfigUpdateTarget` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:56` | Config update target for a package that should be registered in root tsconfig files. |
 | `@beep/repo-cli/test/CreatePackage` | `ConfigUpdateTargetResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:74` | Per-target config update summary. |
-| `@beep/repo-cli/test/CreatePackage` | `createFileGenerationPlanService` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:465` | Construct the default generation plan service implementation. |
+| `@beep/repo-cli/test/CreatePackage` | `createFileGenerationPlanService` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:466` | Construct the default generation plan service implementation. |
 | `@beep/repo-cli/test/CreatePackage` | `createPackageCommand` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/CreatePackage.command.ts:16` | Package creation command. |
-| `@beep/repo-cli/test/CreatePackage` | `FileGenerationExecutionResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:232` | Execution report for a plan run. |
-| `@beep/repo-cli/test/CreatePackage` | `FileGenerationPlan` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:216` | Deterministic generation plan. |
+| `@beep/repo-cli/test/CreatePackage` | `FileGenerationExecutionResult` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:233` | Execution report for a plan run. |
+| `@beep/repo-cli/test/CreatePackage` | `FileGenerationPlan` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:217` | Deterministic generation plan. |
 | `@beep/repo-cli/test/CreatePackage` | `FileGenerationPlanInput` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:114` | Input payload used to create a generation pla. |
-| `@beep/repo-cli/test/CreatePackage` | `FileGenerationPlanService` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:267` | Service tag for deterministic file-generation planning and execution. |
-| `@beep/repo-cli/test/CreatePackage` | `FileGenerationPlanServiceShape` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:253` | Service contract for deterministic generation plan orchestration. |
+| `@beep/repo-cli/test/CreatePackage` | `FileGenerationPlanService` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:268` | Service tag for deterministic file-generation planning and execution. |
+| `@beep/repo-cli/test/CreatePackage` | `FileGenerationPlanServiceShape` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:254` | Service contract for deterministic generation plan orchestration. |
 | `@beep/repo-cli/test/CreatePackage` | `GenerationAction` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:184` | Planned generation action schema. |
-| `@beep/repo-cli/test/CreatePackage` | `GenerationAction` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:208` | Planned generation action. |
+| `@beep/repo-cli/test/CreatePackage` | `GenerationAction` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:209` | Planned generation action. |
 | `@beep/repo-cli/test/CreatePackage` | `GenerationActionKind` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:132` | Planned action kinds. |
 | `@beep/repo-cli/test/CreatePackage` | `GenerationActionKind` | type | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:143` | Planned generation action. |
 | `@beep/repo-cli/test/CreatePackage` | `PlannedFile` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:82` | A file write operation. |
 | `@beep/repo-cli/test/CreatePackage` | `PlannedSymlink` | class | `packages/tooling/tool/cli/src/commands/CreatePackage/FileGenerationPlanService.ts:98` | A symlink operation. |
-| `@beep/repo-cli/test/CreatePackage` | `updateRootConfigs` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:591` | Orchestrate all root config updates for a newly created package. |
-| `@beep/repo-cli/test/CreatePackage` | `updateRootConfigsForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:509` | Batch root config updater for slice flows creating multiple packages. |
-| `@beep/repo-cli/test/CreatePackage` | `updateTsconfigPackages` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:304` | Add a project reference to `tsconfig.packages.json`. |
-| `@beep/repo-cli/test/CreatePackage` | `updateTsconfigPaths` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:345` | Add path aliases to `tsconfig.json` (JSONC-safe, preserves comments). |
-| `@beep/repo-cli/test/CreatePackage` | `updateTstycheConfig` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:399` | Add a test file match entry to `tstyche.json`. |
+| `@beep/repo-cli/test/CreatePackage` | `updateRootConfigs` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:585` | Orchestrate all root config updates for a newly created package. |
+| `@beep/repo-cli/test/CreatePackage` | `updateRootConfigsForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:503` | Batch root config updater for slice flows creating multiple packages. |
+| `@beep/repo-cli/test/CreatePackage` | `updateTsconfigPackages` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:298` | Add a project reference to `tsconfig.packages.json`. |
+| `@beep/repo-cli/test/CreatePackage` | `updateTsconfigPaths` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:339` | Add path aliases to `tsconfig.json` (JSONC-safe, preserves comments). |
+| `@beep/repo-cli/test/CreatePackage` | `updateTstycheConfig` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:393` | Add a test file match entry to `tstyche.json`. |
 | `@beep/repo-cli/test/Docgen` | `aggregateGeneratedDocs` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:1437` | Aggregate generated package docs into the current root docs layout. |
 | `@beep/repo-cli/test/Docgen` | `analyzeDocgenQuality` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:1834` | Builds the consolidated report emitted by the quality command. |
-| `@beep/repo-cli/test/Docgen` | `analyzeDocgenQualityWorkerEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1239` | Build a read-only worker eval report from a quality report. |
-| `@beep/repo-cli/test/Docgen` | `AnalyzeDocgenQualityWorkerEvalOptions` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:520` | Options for one worker eval run. |
+| `@beep/repo-cli/test/Docgen` | `analyzeDocgenQualityWorkerEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1229` | Build a read-only worker eval report from a quality report. |
+| `@beep/repo-cli/test/Docgen` | `AnalyzeDocgenQualityWorkerEvalOptions` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:510` | Options for one worker eval run. |
 | `@beep/repo-cli/test/Docgen` | `analyzePackageDocumentation` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:1265` | Analyze a package for missing docgen-required JSDoc. |
 | `@beep/repo-cli/test/Docgen` | `analyzePackageQuality` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:1763` | Builds a package-local quality report from ts-morph-enriched subjects. |
 | `@beep/repo-cli/test/Docgen` | `assertNoOrphanDocgenConfigPaths` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:464` | Fail when stale package-local docgen configs exist outside current workspaces. |
 | `@beep/repo-cli/test/Docgen` | `buildDocgenLocalPlan` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Local.ts:850` | Build a local docgen plan from repository state and command options. |
 | `@beep/repo-cli/test/Docgen` | `createDocgenConfigDocument` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:1128` | Build the repo-standard `docgen.json` document for a package. |
-| `@beep/repo-cli/test/Docgen` | `decodeDocgenQualityReportForWorkerEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1142` | Decode a saved `docgen quality` JSON report for worker eval. |
-| `@beep/repo-cli/test/Docgen` | `defaultQualityWorkerEvalPacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1179` | Default packet cap for `docgen quality-worker-eval`. |
-| `@beep/repo-cli/test/Docgen` | `defaultQualityWorkerEvalReasoningEffort` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1194` | Default hosted Codex reasoning effort for worker eval. |
+| `@beep/repo-cli/test/Docgen` | `decodeDocgenQualityReportForWorkerEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1132` | Decode a saved `docgen quality` JSON report for worker eval. |
+| `@beep/repo-cli/test/Docgen` | `defaultQualityWorkerEvalPacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1169` | Default packet cap for `docgen quality-worker-eval`. |
+| `@beep/repo-cli/test/Docgen` | `defaultQualityWorkerEvalReasoningEffort` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1184` | Default hosted Codex reasoning effort for worker eval. |
 | `@beep/repo-cli/test/Docgen` | `defaultQualityWorkerRunpodEvalOtlpBaseUrl` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:1010` | Default Phoenix-compatible OTLP base URL for remote worker eval traces. |
 | `@beep/repo-cli/test/Docgen` | `defaultQualityWorkerRunpodEvalOtlpProject` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:1025` | Default Phoenix project for remote worker eval traces. |
 | `@beep/repo-cli/test/Docgen` | `defaultQualityWorkerRunpodEvalPacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:995` | Default packet cap for Runpod-backed worker eval runs. |
@@ -2135,35 +2135,35 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Docgen` | `DocgenQualitySubject` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:294` | Stable evidence packet for one exported-symbol JSDoc quality review. |
 | `@beep/repo-cli/test/Docgen` | `DocgenQualityTier` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:169` | Quality tier assigned to a JSDoc review subject. |
 | `@beep/repo-cli/test/Docgen` | `DocgenQualityTier` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:188` | Quality tier assigned to a JSDoc review subject. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalPacketStatus` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:194` | Read-only packet execution status for worker eval. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalPacketStatus` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:213` | Read-only packet execution status for worker eval. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalPolicyViolationCode` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:264` | Closed repo-policy issue code emitted by a worker eval. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalPolicyViolationCode` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:295` | Closed repo-policy issue code emitted by a worker eval. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalPacketStatus` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:188` | Read-only packet execution status for worker eval. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalPacketStatus` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:207` | Read-only packet execution status for worker eval. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalPolicyViolationCode` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:254` | Closed repo-policy issue code emitted by a worker eval. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalPolicyViolationCode` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:285` | Closed repo-policy issue code emitted by a worker eval. |
 | `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalProvider` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:89` | Worker provider supported by `docgen quality-worker-eval`. |
 | `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalProvider` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:108` | Worker provider supported by `docgen quality-worker-eval`. |
 | `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReasoningEffort` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:122` | Codex reasoning effort supported by `docgen quality-worker-eval`. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReasoningEffort` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:147` | Codex reasoning effort supported by `docgen quality-worker-eval`. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReport` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:396` | JSON report emitted by `docgen quality-worker-eval`. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReviewDisposition` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:227` | Advisory disposition assigned to a worker draft. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReviewDisposition` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:250` | Advisory disposition assigned to a worker draft. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalRunner` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:486` | Runner used to execute one Codex eval turn. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalRunnerInput` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:456` | Inputs passed to the Codex runner for one remediation packet. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalRunnerResult` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:432` | Completed worker turn returned by the Codex runner. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalScope` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:161` | Source mode used to build a worker eval queue. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalScope` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:180` | Source mode used to build a worker eval queue. |
-| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalWorkerOutput` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:310` | Structured response expected from the Codex worker. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReasoningEffort` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:141` | Codex reasoning effort supported by `docgen quality-worker-eval`. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReport` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:386` | JSON report emitted by `docgen quality-worker-eval`. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReviewDisposition` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:221` | Advisory disposition assigned to a worker draft. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalReviewDisposition` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:240` | Advisory disposition assigned to a worker draft. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalRunner` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:476` | Runner used to execute one Codex eval turn. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalRunnerInput` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:446` | Inputs passed to the Codex runner for one remediation packet. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalRunnerResult` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:422` | Completed worker turn returned by the Codex runner. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalScope` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:155` | Source mode used to build a worker eval queue. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalScope` | type | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:174` | Source mode used to build a worker eval queue. |
+| `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerEvalWorkerOutput` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:300` | Structured response expected from the Codex worker. |
 | `@beep/repo-cli/test/Docgen` | `DocgenQualityWorkerRunpodEvalReport` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:225` | JSON wrapper report emitted by `docgen quality-worker-eval-runpod`. |
 | `@beep/repo-cli/test/Docgen` | `DocgenWorkspacePackage` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:159` | Workspace package metadata used by docgen commands. |
 | `@beep/repo-cli/test/Docgen` | `generateAnalysisJson` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:1427` | Encode a package analysis document as JSON text. |
 | `@beep/repo-cli/test/Docgen` | `generateAnalysisReport` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:1306` | Render a human-first markdown report for a package analysis run. |
 | `@beep/repo-cli/test/Docgen` | `generateQualityJson` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:1914` | Renders a quality report as stable JSON. |
 | `@beep/repo-cli/test/Docgen` | `generateQualityReport` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:1966` | Renders a quality report as human-readable Markdown. |
-| `@beep/repo-cli/test/Docgen` | `generateQualityWorkerEvalJson` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1358` | Render a worker eval report as stable JSON. |
+| `@beep/repo-cli/test/Docgen` | `generateQualityWorkerEvalJson` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1348` | Render a worker eval report as stable JSON. |
 | `@beep/repo-cli/test/Docgen` | `generateQualityWorkerRunpodEvalJson` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:1161` | Render a Runpod worker eval wrapper report as stable JSON. |
 | `@beep/repo-cli/test/Docgen` | `loadDocgenConfigDocument` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:1106` | Load a package-local `docgen.json` document. |
 | `@beep/repo-cli/test/Docgen` | `makeQualityWorkerRunpodEvalPodCreateInput` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:436` | Build the Runpod create-pod body for an Ollama worker eval host. |
 | `@beep/repo-cli/test/Docgen` | `normalizeDocsOutputPath` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:1095` | Normalize a workspace-relative package path to the current root docs output layout. |
-| `@beep/repo-cli/test/Docgen` | `qualityWorkerEvalSourcePacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1163` | Compute the source packet limit used for generated quality reports. |
+| `@beep/repo-cli/test/Docgen` | `qualityWorkerEvalSourcePacketLimit` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:1153` | Compute the source packet limit used for generated quality reports. |
 | `@beep/repo-cli/test/Docgen` | `requiredQualityWorkerRunpodEvalModel` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:980` | Required v1 model id for Runpod-backed Qwen worker evals. |
 | `@beep/repo-cli/test/Docgen` | `resolveDocgenQualityTargets` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts:594` | Resolves `docgen quality` targets using the v1 scope policy. |
 | `@beep/repo-cli/test/Docgen` | `resolveDocgenWorkspacePackage` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts:1213` | Resolve a workspace package by package name, repo-relative path, absolute path, or current docs output path. |
@@ -2172,36 +2172,36 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Docgen` | `runDocgenQualityWorkerRunpodEval` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:1060` | Run a read-only JSDoc quality worker eval on an ephemeral Runpod pod. |
 | `@beep/repo-cli/test/Docgen` | `RunDocgenQualityWorkerRunpodEvalOptions` | class | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:262` | Options for a Runpod-backed quality worker eval run. |
 | `@beep/repo-cli/test/Docgen` | `selectDocgenLocalPackagesForTesting` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/Local.ts:756` | Select package-local docgen targets for changed files. |
-| `@beep/repo-cli/test/Docgen` | `selectQualityWorkerEvalPackets` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:733` | Select remediation packets for a capped worker eval run. |
+| `@beep/repo-cli/test/Docgen` | `selectQualityWorkerEvalPackets` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts:723` | Select remediation packets for a capped worker eval run. |
 | `@beep/repo-cli/test/Docgen` | `selectQualityWorkerRunpodTemplate` | const | `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts:394` | Select the first suitable Ollama template from live Runpod templates. |
 | `@beep/repo-cli/test/Graphiti` | `ContainerHealthState` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:55` | Container health literal union. |
 | `@beep/repo-cli/test/Graphiti` | `DependencyHealthSnapshot` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:137` | Cached dependency health snapshot payload. |
 | `@beep/repo-cli/test/Graphiti` | `DependencyHealthState` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:71` | Dependency health literal union. |
 | `@beep/repo-cli/test/Graphiti` | `ensureGraphitiProxy` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyOps.ts:546` | Ensure the local Graphiti proxy is healthy, starting it in the background when needed. |
 | `@beep/repo-cli/test/Graphiti` | `graphitiCommand` | const | `packages/tooling/tool/cli/src/commands/Graphiti/Graphiti.command.ts:94` | Graphiti command group. |
-| `@beep/repo-cli/test/Graphiti` | `GraphitiDependencyHealthService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:384` | Service tag for dependency health snapshots. |
+| `@beep/repo-cli/test/Graphiti` | `GraphitiDependencyHealthService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:382` | Service tag for dependency health snapshots. |
 | `@beep/repo-cli/test/Graphiti` | `GraphitiProxyConfig` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyConfig.ts:106` | Runtime configuration schema for graphiti proxy. |
 | `@beep/repo-cli/test/Graphiti` | `GraphitiProxyConfigLoadError` | class | `packages/tooling/tool/cli/src/commands/Graphiti/Graphiti.errors.ts:35` | Raised when graphiti proxy configuration cannot be loaded. |
-| `@beep/repo-cli/test/Graphiti` | `GraphitiProxyForwarderService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:399` | Service tag for forwarding requests to upstream graphiti. |
+| `@beep/repo-cli/test/Graphiti` | `GraphitiProxyForwarderService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:397` | Service tag for forwarding requests to upstream graphiti. |
 | `@beep/repo-cli/test/Graphiti` | `GraphitiProxyOpsError` | class | `packages/tooling/tool/cli/src/commands/Graphiti/Graphiti.errors.ts:78` | Typed failure for Graphiti proxy operational helpers. |
-| `@beep/repo-cli/test/Graphiti` | `GraphitiProxyQueueService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:414` | Service tag for queueing and draining proxy traffic. |
+| `@beep/repo-cli/test/Graphiti` | `GraphitiProxyQueueService` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:412` | Service tag for queueing and draining proxy traffic. |
 | `@beep/repo-cli/test/Graphiti` | `installGraphitiProxyService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyOps.ts:717` | Install and start the user-level systemd unit for the Graphiti proxy. |
-| `@beep/repo-cli/test/Graphiti` | `isFastMcpRequestBody` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:476` | Determine whether an MCP request body is cheap enough to bypass the serialized memory-work queue. |
+| `@beep/repo-cli/test/Graphiti` | `isFastMcpRequestBody` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:474` | Determine whether an MCP request body is cheap enough to bypass the serialized memory-work queue. |
 | `@beep/repo-cli/test/Graphiti` | `loadGraphitiProxyConfig` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyConfig.ts:187` | Load graphiti proxy config from Effect Config environment values. |
-| `@beep/repo-cli/test/Graphiti` | `makeGraphitiDependencyHealthService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:537` | Construct dependency health service implementation. |
-| `@beep/repo-cli/test/Graphiti` | `makeGraphitiProxyForwarderService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:594` | Construct upstream forwarder service implementation. |
-| `@beep/repo-cli/test/Graphiti` | `makeGraphitiProxyQueueService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:712` | Construct proxy queue service implementation. |
-| `@beep/repo-cli/test/Graphiti` | `proxyErrorResponse` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:303` | Build a structured proxy error HTTP response. |
+| `@beep/repo-cli/test/Graphiti` | `makeGraphitiDependencyHealthService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:535` | Construct dependency health service implementation. |
+| `@beep/repo-cli/test/Graphiti` | `makeGraphitiProxyForwarderService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:592` | Construct upstream forwarder service implementation. |
+| `@beep/repo-cli/test/Graphiti` | `makeGraphitiProxyQueueService` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:710` | Construct proxy queue service implementation. |
+| `@beep/repo-cli/test/Graphiti` | `proxyErrorResponse` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:301` | Build a structured proxy error HTTP response. |
 | `@beep/repo-cli/test/Graphiti` | `ProxyHealthPayload` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:184` | Structured JSON payload for health endpoints. |
-| `@beep/repo-cli/test/Graphiti` | `proxyHealthResponse` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:345` | Build a structured proxy health HTTP response. |
+| `@beep/repo-cli/test/Graphiti` | `proxyHealthResponse` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:343` | Build a structured proxy health HTTP response. |
 | `@beep/repo-cli/test/Graphiti` | `ProxyQueueStats` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts:157` | Queue and processing counters for proxy introspection. |
 | `@beep/repo-cli/test/Graphiti` | `ProxyServiceConfig` | class | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyOps.ts:64` | Configuration for installing and managing the Graphiti proxy user service. |
 | `@beep/repo-cli/test/Graphiti` | `recoverGraphitiStack` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyOps.ts:639` | Recover the local Graphiti backing stack by restarting unhealthy containers. |
 | `@beep/repo-cli/test/Graphiti` | `runKgWithGraphitiProxy` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyOps.ts:607` | Run a knowledge-graph CLI command with the local Graphiti proxy ensured first. |
 | `@beep/repo-cli/test/Graphiti` | `shouldRecoverGraphitiStackForTesting` | const | `packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyOps.ts:668` | Decide whether Graphiti recovery should restart the backing containers. |
 | `@beep/repo-cli/test/Laws` | `ALLOWLIST_PATH` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:34` | Relative path to the effect laws allowlist. |
-| `@beep/repo-cli/test/Laws` | `AllowlistCheckOptions` | class | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:95` | Runtime options for allowlist integrity checks. |
-| `@beep/repo-cli/test/Laws` | `AllowlistCheckSummary` | class | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:114` | Result of an allowlist integrity check. |
+| `@beep/repo-cli/test/Laws` | `AllowlistCheckOptions` | class | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:93` | Runtime options for allowlist integrity checks. |
+| `@beep/repo-cli/test/Laws` | `AllowlistCheckSummary` | class | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:112` | Result of an allowlist integrity check. |
 | `@beep/repo-cli/test/Laws` | `collectNativeRuntimeViolationKeys` | const | `packages/tooling/tool/cli/src/commands/Laws/NoNativeRuntime.ts:484` | Collect normalized native-runtime violation keys for allowlist integrity checks. |
 | `@beep/repo-cli/test/Laws` | `DualArityInventoryEntry` | namespace | `packages/tooling/tool/cli/src/commands/Laws/DualArity.ts:113` | Namespace for {@link DualArityInventoryEntry} companion types. |
 | `@beep/repo-cli/test/Laws` | `DualArityInventoryReadError` | class | `packages/tooling/tool/cli/src/commands/Laws/Laws.errors.ts:31` | Failure raised when the dual-arity inventory cannot be read or decoded. |
@@ -2220,8 +2220,8 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Laws` | `NoNativeRuntimeRulesExecutionError` | class | `packages/tooling/tool/cli/src/commands/Laws/Laws.errors.ts:94` | Failure raised when native runtime enforcement cannot complete. |
 | `@beep/repo-cli/test/Laws` | `NoNativeRuntimeRulesOptions` | class | `packages/tooling/tool/cli/src/commands/Laws/NoNativeRuntime.ts:91` | Runtime options for repo-local native runtime checks. |
 | `@beep/repo-cli/test/Laws` | `NoNativeRuntimeRulesSummary` | class | `packages/tooling/tool/cli/src/commands/Laws/NoNativeRuntime.ts:167` | Summary of repo-local native runtime checks. |
-| `@beep/repo-cli/test/Laws` | `reportAllowlistCheckSummary` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:315` | Print allowlist integrity diagnostics to the console. |
-| `@beep/repo-cli/test/Laws` | `runAllowlistCheck` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:253` | Run the effect laws allowlist integrity check. |
+| `@beep/repo-cli/test/Laws` | `reportAllowlistCheckSummary` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:313` | Print allowlist integrity diagnostics to the console. |
+| `@beep/repo-cli/test/Laws` | `runAllowlistCheck` | const | `packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts:251` | Run the effect laws allowlist integrity check. |
 | `@beep/repo-cli/test/Laws` | `runDualArityRules` | const | `packages/tooling/tool/cli/src/commands/Laws/DualArity.ts:1425` | Run public API dual-arity inventory verification. |
 | `@beep/repo-cli/test/Laws` | `runEffectFnRules` | const | `packages/tooling/tool/cli/src/commands/Laws/EffectFn.ts:391` | Run the repo-local Effect.fn supplemental law. |
 | `@beep/repo-cli/test/Laws` | `runEffectImportRules` | const | `packages/tooling/tool/cli/src/commands/Laws/EffectImports.ts:110` | Run effect import style migration/check logic. |
@@ -2269,33 +2269,33 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Quality` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:803` | Resolve the SQL integration database connection URI from environment variables. |
 | `@beep/repo-cli/test/Quality` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:780` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
 | `@beep/repo-cli/test/Quality` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
-| `@beep/repo-cli/test/Reuse` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:48` | Structured error emitted when the Codex SDK smoke path fails. |
+| `@beep/repo-cli/test/Reuse` | `CodexRunnerError` | class | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:46` | Structured error emitted when the Codex SDK smoke path fails. |
 | `@beep/repo-cli/test/Reuse` | `CodexRunnerStage` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:26` | Lifecycle stages surfaced by the Codex smoke runner. |
-| `@beep/repo-cli/test/Reuse` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:40` | Runtime type for `CodexRunnerStage`. |
+| `@beep/repo-cli/test/Reuse` | `CodexRunnerStage` | type | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.errors.ts:38` | Runtime type for `CodexRunnerStage`. |
 | `@beep/repo-cli/test/Reuse` | `CodexSmokeResult` | class | `packages/tooling/tool/cli/src/commands/Reuse/internal/CodexRunner.ts:32` | Structured result for `beep reuse codex-smoke`. |
 | `@beep/repo-cli/test/Reuse` | `reuseCommand` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:553` | Reuse-discovery command group. |
 | `@beep/repo-cli/test/Reuse` | `runCodexSmoke` | const | `packages/tooling/tool/cli/src/commands/Reuse/internal/CodexRunner.ts:53` | Validate the local Codex SDK adapter without running a reuse loop. |
 | `@beep/repo-cli/test/Reuse` | `sanitizeTerminalText` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:145` | Remove terminal control sequences from human-readable reuse output. |
 | `@beep/repo-cli/test/SyncDataToTs` | `ISO4217_SOURCE_URL` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts:27` | Official SIX XML source for ISO 4217 List One. |
-| `@beep/repo-cli/test/SyncDataToTs` | `iso4217Target` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts:276` | Checked-in sync target for the official SIX ISO 4217 List One XML feed. |
+| `@beep/repo-cli/test/SyncDataToTs` | `iso4217Target` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts:274` | Checked-in sync target for the official SIX ISO 4217 List One XML feed. |
 | `@beep/repo-cli/test/SyncDataToTs` | `SyncDataRunMode` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:54` | Command execution mode for sync-data-to-ts. |
 | `@beep/repo-cli/test/SyncDataToTs` | `SyncDataRunMode` | type | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:66` | Command execution mode for sync-data-to-ts. |
 | `@beep/repo-cli/test/SyncDataToTs` | `SyncDataSourceFormat` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:32` | Supported source formats for sync-data-to-ts targets. |
 | `@beep/repo-cli/test/SyncDataToTs` | `SyncDataSourceFormat` | type | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:44` | Supported source formats for sync-data-to-ts targets. |
 | `@beep/repo-cli/test/SyncDataToTs` | `SyncDataTarget` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:140` | Checked-in sync target definition. |
-| `@beep/repo-cli/test/SyncDataToTs` | `SyncDataTarget` | type | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:156` | {@inheritDoc SyncDataTarget} |
+| `@beep/repo-cli/test/SyncDataToTs` | `SyncDataTarget` | type | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:155` | {@inheritDoc SyncDataTarget} |
 | `@beep/repo-cli/test/SyncDataToTs` | `SyncDataTargetProjection` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:74` | Rendered target projection ready to compare or write to disk. |
-| `@beep/repo-cli/test/SyncDataToTs` | `SyncDataTargetResult` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:164` | Per-target command result after diffing or writing. |
+| `@beep/repo-cli/test/SyncDataToTs` | `SyncDataTargetResult` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/internal/Models.ts:163` | Per-target command result after diffing or writing. |
 | `@beep/repo-cli/test/SyncDataToTs` | `syncDataTargets` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/index.ts:16` | All checked-in sync targets supported by sync-data-to-ts. |
 | `@beep/repo-cli/test/SyncDataToTs` | `syncDataToTsCommand` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.command.ts:441` | CLI command for syncing official upstream datasets into checked-in TypeScript modules. |
 | `@beep/repo-cli/test/SyncDataToTs` | `SyncDataToTsDriftError` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.errors.ts:86` | Drift detected in check mode. |
 | `@beep/repo-cli/test/SyncDataToTs` | `SyncDataToTsError` | class | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.errors.ts:35` | Operational error during source fetch, parsing, projection, or file writes. |
-| `@beep/repo-cli/test/VersionSync` | `BiomeSchemaState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:147` | Resolved Biome schema state. |
-| `@beep/repo-cli/test/VersionSync` | `buildBiomeReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:218` | Build the Biome schema category report from resolved state. |
+| `@beep/repo-cli/test/VersionSync` | `BiomeSchemaState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:141` | Resolved Biome schema state. |
+| `@beep/repo-cli/test/VersionSync` | `buildBiomeReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:212` | Build the Biome schema category report from resolved state. |
 | `@beep/repo-cli/test/VersionSync` | `buildBunReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BunResolver.ts:366` | Build the Bun category report from resolved state. |
-| `@beep/repo-cli/test/VersionSync` | `buildDockerReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:429` | Build the Docker category report from resolved state. |
+| `@beep/repo-cli/test/VersionSync` | `buildDockerReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:423` | Build the Docker category report from resolved state. |
 | `@beep/repo-cli/test/VersionSync` | `buildEffectReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/EffectResolver.ts:199` | Build the Effect catalog category report from resolved state. |
-| `@beep/repo-cli/test/VersionSync` | `buildNodeReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:231` | Build the Node category report from resolved state. |
+| `@beep/repo-cli/test/VersionSync` | `buildNodeReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:229` | Build the Node category report from resolved state. |
 | `@beep/repo-cli/test/VersionSync` | `BunSemver` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BunResolver.ts:101` | Parsed Bun semantic version components. |
 | `@beep/repo-cli/test/VersionSync` | `BunVersionState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BunResolver.ts:260` | Resolved Bun version state. |
 | `@beep/repo-cli/test/VersionSync` | `DockerImageState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:117` | Resolved Docker image state. |
@@ -2303,22 +2303,22 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/VersionSync` | `NetworkUnavailableError` | class | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.errors.ts:79` | Network unavailable during upstream version resolution. |
 | `@beep/repo-cli/test/VersionSync` | `NodeVersionLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:31` | A workflow file location with a `node-version` field. |
 | `@beep/repo-cli/test/VersionSync` | `NodeVersionState` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:50` | Resolved Node version state. |
-| `@beep/repo-cli/test/VersionSync` | `replaceNodeVersionWithFile` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts:103` | Replace `node-version: <value>` with `node-version-file: .nvmrc` in a workflow YAML. |
-| `@beep/repo-cli/test/VersionSync` | `resolveBiomeSchema` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:167` | Resolve current Biome schema version from `biome.jsonc` and installed version from `package.json` catalog. |
+| `@beep/repo-cli/test/VersionSync` | `replaceNodeVersionWithFile` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts:101` | Replace `node-version: <value>` with `node-version-file: .nvmrc` in a workflow YAML. |
+| `@beep/repo-cli/test/VersionSync` | `resolveBiomeSchema` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:161` | Resolve current Biome schema version from `biome.jsonc` and installed version from `package.json` catalog. |
 | `@beep/repo-cli/test/VersionSync` | `resolveBunVersions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BunResolver.ts:283` | Resolve current Bun versions from local files and optionally fetch latest from GitHub. |
-| `@beep/repo-cli/test/VersionSync` | `resolveDockerImages` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:325` | Resolve Docker image state from docker-compose.yml. |
+| `@beep/repo-cli/test/VersionSync` | `resolveDockerImages` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/DockerResolver.ts:319` | Resolve Docker image state from docker-compose.yml. |
 | `@beep/repo-cli/test/VersionSync` | `resolveEffectCatalog` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/EffectResolver.ts:146` | Resolve the root package.json Effect catalog state. |
-| `@beep/repo-cli/test/VersionSync` | `resolveNodeVersions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:129` | Resolve Node.js version state from `.nvmrc` and workflow files. |
-| `@beep/repo-cli/test/VersionSync` | `updateBiomeSchema` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:263` | Update the `$schema` field in `biome.jsonc` to match the installed version. |
+| `@beep/repo-cli/test/VersionSync` | `resolveNodeVersions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/NodeResolver.ts:127` | Resolve Node.js version state from `.nvmrc` and workflow files. |
+| `@beep/repo-cli/test/VersionSync` | `updateBiomeSchema` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/resolvers/BiomeResolver.ts:257` | Update the `$schema` field in `biome.jsonc` to match the installed version. |
 | `@beep/repo-cli/test/VersionSync` | `updateCatalogEntry` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/PackageJsonUpdater.ts:82` | Update a root package.json `catalog` entry using `jsonc-parser`. |
 | `@beep/repo-cli/test/VersionSync` | `updatePackageManagerField` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/PackageJsonUpdater.ts:38` | Update the `packageManager` field in `package.json` using `jsonc-parser`. |
 | `@beep/repo-cli/test/VersionSync` | `updatePlainTextFile` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/PlainTextUpdater.ts:21` | Update a plain text version file (e.g. `.bun-version`). |
-| `@beep/repo-cli/test/VersionSync` | `updateYamlValue` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts:52` | Update a value at a specific path in a YAML file, preserving comments and formatting. |
+| `@beep/repo-cli/test/VersionSync` | `updateYamlValue` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/updaters/YamlFileUpdater.ts:50` | Update a value at a specific path in a YAML file, preserving comments and formatting. |
 | `@beep/repo-cli/test/VersionSync` | `VersionCategory` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:61` | Version category for grouping drift items. |
 | `@beep/repo-cli/test/VersionSync` | `VersionCategory` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:79` | Version category for grouping drift items. |
 | `@beep/repo-cli/test/VersionSync` | `VersionCategoryOptions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:72` | Literal option tuple for version categories. |
 | `@beep/repo-cli/test/VersionSync` | `VersionCategoryReport` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:214` | Report for a single version category (bun, node, docker, biome, or effect). |
-| `@beep/repo-cli/test/VersionSync` | `VersionCategoryReport` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:235` | Report for a single version category (bun, node, docker, or biome). |
+| `@beep/repo-cli/test/VersionSync` | `VersionCategoryReport` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:234` | Report for a single version category (bun, node, docker, or biome). |
 | `@beep/repo-cli/test/VersionSync` | `VersionCategoryStatus` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:93` | Status of a version category. |
 | `@beep/repo-cli/test/VersionSync` | `VersionCategoryStatus` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:125` | Status of a version category. |
 | `@beep/repo-cli/test/VersionSync` | `VersionCategoryStatusEnum` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:111` | Enum mapping for version category status literals. |
@@ -2328,14 +2328,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/VersionSync` | `versionSyncCommand` | const | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.command.ts:49` | CLI command for synchronizing version pins across the monorepo. |
 | `@beep/repo-cli/test/VersionSync` | `VersionSyncDriftError` | class | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.errors.ts:100` | Drift detected in check mode (non-zero exit). |
 | `@beep/repo-cli/test/VersionSync` | `VersionSyncError` | class | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.errors.ts:35` | Operational error during version sync (file read/write, parse failures). |
-| `@beep/repo-cli/test/VersionSync` | `VersionSyncMode` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:266` | Command execution mode. |
-| `@beep/repo-cli/test/VersionSync` | `VersionSyncMode` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:285` | Command execution mode. |
-| `@beep/repo-cli/test/VersionSync` | `VersionSyncModeMatch` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:277` | Pattern-matching helper for version-sync mode literals. |
-| `@beep/repo-cli/test/VersionSync` | `VersionSyncOptions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:344` | Resolved command options after flag parsing. |
-| `@beep/repo-cli/test/VersionSync` | `VersionSyncOptions` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:360` | Resolved command options after flag parsing. |
-| `@beep/repo-cli/test/VersionSync` | `VersionSyncReport` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:243` | Full version sync report across all categories. |
-| `@beep/repo-cli/test/VersionSync` | `VersionSyncResolution` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:384` | Resolver output consumed by reporting and write-mode services. |
-| `@beep/repo-cli/test/VersionSync` | `VersionSyncUpdateLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:368` | YAML location to update in write mode. |
+| `@beep/repo-cli/test/VersionSync` | `VersionSyncMode` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:265` | Command execution mode. |
+| `@beep/repo-cli/test/VersionSync` | `VersionSyncMode` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:284` | Command execution mode. |
+| `@beep/repo-cli/test/VersionSync` | `VersionSyncModeMatch` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:276` | Pattern-matching helper for version-sync mode literals. |
+| `@beep/repo-cli/test/VersionSync` | `VersionSyncOptions` | const | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:343` | Resolved command options after flag parsing. |
+| `@beep/repo-cli/test/VersionSync` | `VersionSyncOptions` | type | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:358` | Resolved command options after flag parsing. |
+| `@beep/repo-cli/test/VersionSync` | `VersionSyncReport` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:242` | Full version sync report across all categories. |
+| `@beep/repo-cli/test/VersionSync` | `VersionSyncResolution` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:382` | Resolver output consumed by reporting and write-mode services. |
+| `@beep/repo-cli/test/VersionSync` | `VersionSyncUpdateLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:366` | YAML location to update in write mode. |
 
 ### @beep/ai-sync
 
@@ -2795,7 +2795,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 
 | Import | Symbol | Kind | Source | Summary |
 |---|---|---|---|---|
-| `@beep/ai-provider-cli` | `AiProviderCli` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:122` | Effect service for Claude and Codex CLI status checks. |
+| `@beep/ai-provider-cli` | `AiProviderCli` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:128` | Effect service for Claude and Codex CLI status checks. |
 | `@beep/ai-provider-cli` | `AiProviderCliAuthProbe` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:77` | Redacted provider CLI authentication probe. |
 | `@beep/ai-provider-cli` | `AiProviderCliAuthStatus` | const | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:40` | Provider CLI authentication status. |
 | `@beep/ai-provider-cli` | `AiProviderCliAuthStatus` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:52` | Runtime type for {@link AiProviderCliAuthStatus}. |
@@ -2803,7 +2803,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/ai-provider-cli` | `AiProviderCliProcessResult` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:60` | Provider CLI process result. |
 | `@beep/ai-provider-cli` | `AiProviderCliProvider` | const | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:20` | AI provider CLI vocabulary. |
 | `@beep/ai-provider-cli` | `AiProviderCliProvider` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:32` | Runtime type for {@link AiProviderCliProvider}. |
-| `@beep/ai-provider-cli` | `AiProviderCliRunner` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:31` | Product-neutral process runner used by provider CLI probes. |
+| `@beep/ai-provider-cli` | `AiProviderCliRunner` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:32` | Product-neutral process runner used by provider CLI probes. |
 | `@beep/ai-provider-cli/AiProviderCli.errors` | `AiProviderCliError` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.errors.ts:20` | Technical provider CLI failure. |
 | `@beep/ai-provider-cli/AiProviderCli.models` | `AiProviderCliAuthProbe` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:77` | Redacted provider CLI authentication probe. |
 | `@beep/ai-provider-cli/AiProviderCli.models` | `AiProviderCliAuthStatus` | const | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:40` | Provider CLI authentication status. |
@@ -2811,9 +2811,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/ai-provider-cli/AiProviderCli.models` | `AiProviderCliProcessResult` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:60` | Provider CLI process result. |
 | `@beep/ai-provider-cli/AiProviderCli.models` | `AiProviderCliProvider` | const | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:20` | AI provider CLI vocabulary. |
 | `@beep/ai-provider-cli/AiProviderCli.models` | `AiProviderCliProvider` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:32` | Runtime type for {@link AiProviderCliProvider}. |
-| `@beep/ai-provider-cli/AiProviderCli.service` | `AiProviderCli` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:122` | Effect service for Claude and Codex CLI status checks. |
-| `@beep/ai-provider-cli/AiProviderCli.service` | `AiProviderCliRunner` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:31` | Product-neutral process runner used by provider CLI probes. |
-| `@beep/ai-provider-cli/index` | `AiProviderCli` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:122` | Effect service for Claude and Codex CLI status checks. |
+| `@beep/ai-provider-cli/AiProviderCli.service` | `AiProviderCli` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:128` | Effect service for Claude and Codex CLI status checks. |
+| `@beep/ai-provider-cli/AiProviderCli.service` | `AiProviderCliRunner` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:32` | Product-neutral process runner used by provider CLI probes. |
+| `@beep/ai-provider-cli/index` | `AiProviderCli` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:128` | Effect service for Claude and Codex CLI status checks. |
 | `@beep/ai-provider-cli/index` | `AiProviderCliAuthProbe` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:77` | Redacted provider CLI authentication probe. |
 | `@beep/ai-provider-cli/index` | `AiProviderCliAuthStatus` | const | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:40` | Provider CLI authentication status. |
 | `@beep/ai-provider-cli/index` | `AiProviderCliAuthStatus` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:52` | Runtime type for {@link AiProviderCliAuthStatus}. |
@@ -2821,7 +2821,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/ai-provider-cli/index` | `AiProviderCliProcessResult` | class | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:60` | Provider CLI process result. |
 | `@beep/ai-provider-cli/index` | `AiProviderCliProvider` | const | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:20` | AI provider CLI vocabulary. |
 | `@beep/ai-provider-cli/index` | `AiProviderCliProvider` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.models.ts:32` | Runtime type for {@link AiProviderCliProvider}. |
-| `@beep/ai-provider-cli/index` | `AiProviderCliRunner` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:31` | Product-neutral process runner used by provider CLI probes. |
+| `@beep/ai-provider-cli/index` | `AiProviderCliRunner` | type | `packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts:32` | Product-neutral process runner used by provider CLI probes. |
 
 ### @beep/colors
 
@@ -4152,11 +4152,11 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/oip-web/app/sitemap` | `default` | function | `apps/oip-web/src/app/sitemap.ts:24` | Returns the OIP sitemap. |
 | `@beep/oip-web/config/OipRedirects` | `oipRedirects` | const | `apps/oip-web/src/config/OipRedirects.ts:24` | Returns the canonical OIP redirect table for legacy OPIP compatibility. |
 | `@beep/oip-web/contact` | `contactResponseBody` | const | `apps/oip-web/src/contact/ContactSubmission.service.ts:333` | Builds a JSON-safe contact response object. |
-| `@beep/oip-web/contact` | `ContactSubmission` | class | `apps/oip-web/src/contact/ContactSubmission.model.ts:127` | Browser-submitted OIP contact form payload. |
-| `@beep/oip-web/contact` | `ContactSubmissionResponse` | class | `apps/oip-web/src/contact/ContactSubmission.model.ts:162` | Public contact submission response. |
-| `@beep/oip-web/contact` | `ContactSubmissionStatus` | const | `apps/oip-web/src/contact/ContactSubmission.model.ts:82` | Public contact submission status. |
-| `@beep/oip-web/contact` | `ContactSubmissionStatus` | type | `apps/oip-web/src/contact/ContactSubmission.model.ts:102` | Type for {@link ContactSubmissionStatus}. |
-| `@beep/oip-web/contact` | `decodeContactSubmission` | const | `apps/oip-web/src/contact/ContactSubmission.model.ts:193` | Decodes unknown input into a contact submission. |
+| `@beep/oip-web/contact` | `ContactSubmission` | class | `apps/oip-web/src/contact/ContactSubmission.model.ts:119` | Browser-submitted OIP contact form payload. |
+| `@beep/oip-web/contact` | `ContactSubmissionResponse` | class | `apps/oip-web/src/contact/ContactSubmission.model.ts:154` | Public contact submission response. |
+| `@beep/oip-web/contact` | `ContactSubmissionStatus` | const | `apps/oip-web/src/contact/ContactSubmission.model.ts:74` | Public contact submission status. |
+| `@beep/oip-web/contact` | `ContactSubmissionStatus` | type | `apps/oip-web/src/contact/ContactSubmission.model.ts:94` | Type for {@link ContactSubmissionStatus}. |
+| `@beep/oip-web/contact` | `decodeContactSubmission` | const | `apps/oip-web/src/contact/ContactSubmission.model.ts:185` | Decodes unknown input into a contact submission. |
 | `@beep/oip-web/contact` | `submitContact` | const | `apps/oip-web/src/contact/ContactSubmission.service.ts:281` | Submits an OIP contact payload to HubSpot when runtime config is present. |
 | `@beep/oip-web/content` | `AboutPanel` | class | `apps/oip-web/src/content/OipContent.model.ts:341` | Biographical bridge panel. |
 | `@beep/oip-web/content` | `ClientLogo` | class | `apps/oip-web/src/content/OipContent.model.ts:446` | Client logo reference. |
@@ -4561,14 +4561,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 
 | Import | Symbol | Kind | Source | Summary |
 |---|---|---|---|---|
-| `@beep/semantic-web` | `AbsoluteIRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:939` | RFC 3987 `absolute-IRI` schema without a fragment component. |
-| `@beep/semantic-web` | `AbsoluteIRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:962` | RFC 3987 `absolute-IRI` syntax without a fragment component. |
-| `@beep/semantic-web` | `IRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:979` | RFC 3987 `IRI` schema. |
-| `@beep/semantic-web` | `IRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:1002` | RFC 3987 `IRI` syntax. |
+| `@beep/semantic-web` | `AbsoluteIRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:935` | RFC 3987 `absolute-IRI` schema without a fragment component. |
+| `@beep/semantic-web` | `AbsoluteIRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:956` | RFC 3987 `absolute-IRI` syntax without a fragment component. |
+| `@beep/semantic-web` | `IRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:973` | RFC 3987 `IRI` schema. |
+| `@beep/semantic-web` | `IRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:994` | RFC 3987 `IRI` syntax. |
 | `@beep/semantic-web` | `IRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:859` | RFC 3987 `IRI-reference` schema, including absolute and relative forms. |
-| `@beep/semantic-web` | `IRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:882` | RFC 3987 `IRI-reference` syntax, including absolute and relative forms. |
-| `@beep/semantic-web` | `RelativeIRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:899` | RFC 3987 `irelative-ref` schema. |
-| `@beep/semantic-web` | `RelativeIRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:922` | RFC 3987 `irelative-ref` syntax. |
+| `@beep/semantic-web` | `IRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:880` | RFC 3987 `IRI-reference` syntax, including absolute and relative forms. |
+| `@beep/semantic-web` | `RelativeIRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:897` | RFC 3987 `irelative-ref` schema. |
+| `@beep/semantic-web` | `RelativeIRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:918` | RFC 3987 `irelative-ref` syntax. |
 | `@beep/semantic-web` | `VERSION` | const | `packages/foundation/capability/semantic-web/src/index.ts:23` | Package version constant. |
 | `@beep/semantic-web/adapters/canonicalization` | `CanonicalizationServiceLive` | const | `packages/foundation/capability/semantic-web/src/adapters/canonicalization.ts:250` | Canonicalization service live layer. |
 | `@beep/semantic-web/adapters/jsonld-context` | `JsonLdContextServiceLive` | const | `packages/foundation/capability/semantic-web/src/adapters/jsonld-context.ts:132` | JSON-LD context service live layer. |
@@ -4600,103 +4600,103 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/semantic-web/evidence` | `FragmentSelector` | class | `packages/foundation/capability/semantic-web/src/evidence.ts:154` | Fragment selector for evidence anchors. |
 | `@beep/semantic-web/evidence` | `TextPositionSelector` | class | `packages/foundation/capability/semantic-web/src/evidence.ts:114` | Text-position selector for evidence anchors. |
 | `@beep/semantic-web/evidence` | `TextQuoteSelector` | class | `packages/foundation/capability/semantic-web/src/evidence.ts:72` | Text-quote selector for evidence anchors. |
-| `@beep/semantic-web/index` | `AbsoluteIRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:939` | RFC 3987 `absolute-IRI` schema without a fragment component. |
-| `@beep/semantic-web/index` | `AbsoluteIRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:962` | RFC 3987 `absolute-IRI` syntax without a fragment component. |
-| `@beep/semantic-web/index` | `IRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:979` | RFC 3987 `IRI` schema. |
-| `@beep/semantic-web/index` | `IRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:1002` | RFC 3987 `IRI` syntax. |
+| `@beep/semantic-web/index` | `AbsoluteIRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:935` | RFC 3987 `absolute-IRI` schema without a fragment component. |
+| `@beep/semantic-web/index` | `AbsoluteIRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:956` | RFC 3987 `absolute-IRI` syntax without a fragment component. |
+| `@beep/semantic-web/index` | `IRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:973` | RFC 3987 `IRI` schema. |
+| `@beep/semantic-web/index` | `IRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:994` | RFC 3987 `IRI` syntax. |
 | `@beep/semantic-web/index` | `IRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:859` | RFC 3987 `IRI-reference` schema, including absolute and relative forms. |
-| `@beep/semantic-web/index` | `IRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:882` | RFC 3987 `IRI-reference` syntax, including absolute and relative forms. |
-| `@beep/semantic-web/index` | `RelativeIRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:899` | RFC 3987 `irelative-ref` schema. |
-| `@beep/semantic-web/index` | `RelativeIRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:922` | RFC 3987 `irelative-ref` syntax. |
+| `@beep/semantic-web/index` | `IRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:880` | RFC 3987 `IRI-reference` syntax, including absolute and relative forms. |
+| `@beep/semantic-web/index` | `RelativeIRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:897` | RFC 3987 `irelative-ref` schema. |
+| `@beep/semantic-web/index` | `RelativeIRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:918` | RFC 3987 `irelative-ref` syntax. |
 | `@beep/semantic-web/index` | `VERSION` | const | `packages/foundation/capability/semantic-web/src/index.ts:23` | Package version constant. |
-| `@beep/semantic-web/iri` | `AbsoluteIRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:939` | RFC 3987 `absolute-IRI` schema without a fragment component. |
-| `@beep/semantic-web/iri` | `AbsoluteIRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:962` | RFC 3987 `absolute-IRI` syntax without a fragment component. |
-| `@beep/semantic-web/iri` | `IRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:979` | RFC 3987 `IRI` schema. |
-| `@beep/semantic-web/iri` | `IRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:1002` | RFC 3987 `IRI` syntax. |
+| `@beep/semantic-web/iri` | `AbsoluteIRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:935` | RFC 3987 `absolute-IRI` schema without a fragment component. |
+| `@beep/semantic-web/iri` | `AbsoluteIRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:956` | RFC 3987 `absolute-IRI` syntax without a fragment component. |
+| `@beep/semantic-web/iri` | `IRI` | const | `packages/foundation/capability/semantic-web/src/iri.ts:973` | RFC 3987 `IRI` schema. |
+| `@beep/semantic-web/iri` | `IRI` | type | `packages/foundation/capability/semantic-web/src/iri.ts:994` | RFC 3987 `IRI` syntax. |
 | `@beep/semantic-web/iri` | `IRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:859` | RFC 3987 `IRI-reference` schema, including absolute and relative forms. |
-| `@beep/semantic-web/iri` | `IRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:882` | RFC 3987 `IRI-reference` syntax, including absolute and relative forms. |
-| `@beep/semantic-web/iri` | `RelativeIRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:899` | RFC 3987 `irelative-ref` schema. |
-| `@beep/semantic-web/iri` | `RelativeIRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:922` | RFC 3987 `irelative-ref` syntax. |
+| `@beep/semantic-web/iri` | `IRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:880` | RFC 3987 `IRI-reference` syntax, including absolute and relative forms. |
+| `@beep/semantic-web/iri` | `RelativeIRIReference` | const | `packages/foundation/capability/semantic-web/src/iri.ts:897` | RFC 3987 `irelative-ref` schema. |
+| `@beep/semantic-web/iri` | `RelativeIRIReference` | type | `packages/foundation/capability/semantic-web/src/iri.ts:918` | RFC 3987 `irelative-ref` syntax. |
 | `@beep/semantic-web/jsonld` | `JsonLdBlankNodeIdentifier` | const | `packages/foundation/capability/semantic-web/src/jsonld.ts:168` | JSON-LD blank-node identifier used by the bounded document model. |
-| `@beep/semantic-web/jsonld` | `JsonLdBlankNodeIdentifier` | type | `packages/foundation/capability/semantic-web/src/jsonld.ts:201` | Type for {@link JsonLdBlankNodeIdentifier}. |
+| `@beep/semantic-web/jsonld` | `JsonLdBlankNodeIdentifier` | type | `packages/foundation/capability/semantic-web/src/jsonld.ts:199` | Type for {@link JsonLdBlankNodeIdentifier}. |
 | `@beep/semantic-web/jsonld` | `JsonLdContext` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:134` | Normalized JSON-LD context model with bounded base, vocab, and term bindings. |
-| `@beep/semantic-web/jsonld` | `JsonLdDocument` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:397` | Bounded JSON-LD document model with normalized context and graph content. |
-| `@beep/semantic-web/jsonld` | `JsonLdFrame` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:431` | Bounded JSON-LD frame model. |
+| `@beep/semantic-web/jsonld` | `JsonLdDocument` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:395` | Bounded JSON-LD document model with normalized context and graph content. |
+| `@beep/semantic-web/jsonld` | `JsonLdFrame` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:429` | Bounded JSON-LD frame model. |
 | `@beep/semantic-web/jsonld` | `JsonLdKeyword` | const | `packages/foundation/capability/semantic-web/src/jsonld.ts:54` | JSON-LD keyword surface used by the bounded v1 model. |
 | `@beep/semantic-web/jsonld` | `JsonLdKeyword` | type | `packages/foundation/capability/semantic-web/src/jsonld.ts:83` | Type for {@link JsonLdKeyword}. |
-| `@beep/semantic-web/jsonld` | `JsonLdLiteralValue` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:293` | JSON-LD literal value object. |
-| `@beep/semantic-web/jsonld` | `JsonLdNodeIdentifier` | const | `packages/foundation/capability/semantic-web/src/jsonld.ts:216` | JSON-LD node identifier used by the bounded document model. |
-| `@beep/semantic-web/jsonld` | `JsonLdNodeIdentifier` | type | `packages/foundation/capability/semantic-web/src/jsonld.ts:246` | Type for {@link JsonLdNodeIdentifier}. |
-| `@beep/semantic-web/jsonld` | `JsonLdNodeObject` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:361` | JSON-LD node object used by bounded document and framing helpers. |
-| `@beep/semantic-web/jsonld` | `JsonLdPropertyValue` | const | `packages/foundation/capability/semantic-web/src/jsonld.ts:326` | JSON-LD property value union used by bounded node objects. |
-| `@beep/semantic-web/jsonld` | `JsonLdPropertyValue` | type | `packages/foundation/capability/semantic-web/src/jsonld.ts:346` | Type for {@link JsonLdPropertyValue}. |
-| `@beep/semantic-web/jsonld` | `JsonLdReferenceValue` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:261` | JSON-LD node reference value. |
+| `@beep/semantic-web/jsonld` | `JsonLdLiteralValue` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:291` | JSON-LD literal value object. |
+| `@beep/semantic-web/jsonld` | `JsonLdNodeIdentifier` | const | `packages/foundation/capability/semantic-web/src/jsonld.ts:214` | JSON-LD node identifier used by the bounded document model. |
+| `@beep/semantic-web/jsonld` | `JsonLdNodeIdentifier` | type | `packages/foundation/capability/semantic-web/src/jsonld.ts:244` | Type for {@link JsonLdNodeIdentifier}. |
+| `@beep/semantic-web/jsonld` | `JsonLdNodeObject` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:359` | JSON-LD node object used by bounded document and framing helpers. |
+| `@beep/semantic-web/jsonld` | `JsonLdPropertyValue` | const | `packages/foundation/capability/semantic-web/src/jsonld.ts:324` | JSON-LD property value union used by bounded node objects. |
+| `@beep/semantic-web/jsonld` | `JsonLdPropertyValue` | type | `packages/foundation/capability/semantic-web/src/jsonld.ts:344` | Type for {@link JsonLdPropertyValue}. |
+| `@beep/semantic-web/jsonld` | `JsonLdReferenceValue` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:259` | JSON-LD node reference value. |
 | `@beep/semantic-web/jsonld` | `JsonLdTermDefinition` | class | `packages/foundation/capability/semantic-web/src/jsonld.ts:102` | Normalized JSON-LD term definition used by the bounded context model. |
-| `@beep/semantic-web/prov` | `Activity` | class | `packages/foundation/capability/semantic-web/src/prov.ts:308` | PROV activity. |
-| `@beep/semantic-web/prov` | `Agent` | class | `packages/foundation/capability/semantic-web/src/prov.ts:350` | PROV agent. |
-| `@beep/semantic-web/prov` | `Association` | class | `packages/foundation/capability/semantic-web/src/prov.ts:609` | PROV association relation. |
-| `@beep/semantic-web/prov` | `Attribution` | class | `packages/foundation/capability/semantic-web/src/prov.ts:634` | PROV attribution relation. |
-| `@beep/semantic-web/prov` | `Collection` | class | `packages/foundation/capability/semantic-web/src/prov.ts:449` | PROV collection. |
-| `@beep/semantic-web/prov` | `Delegation` | class | `packages/foundation/capability/semantic-web/src/prov.ts:658` | PROV delegation relation. |
-| `@beep/semantic-web/prov` | `Derivation` | class | `packages/foundation/capability/semantic-web/src/prov.ts:683` | PROV derivation relation. |
-| `@beep/semantic-web/prov` | `End` | class | `packages/foundation/capability/semantic-web/src/prov.ts:804` | PROV end relation. |
-| `@beep/semantic-web/prov` | `Entity` | class | `packages/foundation/capability/semantic-web/src/prov.ts:261` | PROV entity. |
-| `@beep/semantic-web/prov` | `Generation` | class | `packages/foundation/capability/semantic-web/src/prov.ts:584` | PROV generation relation. |
-| `@beep/semantic-web/prov` | `LifecycleTimes` | class | `packages/foundation/capability/semantic-web/src/prov.ts:216` | Explicit lifecycle time fields retained outside plain PROV activity timestamps. |
+| `@beep/semantic-web/prov` | `Activity` | class | `packages/foundation/capability/semantic-web/src/prov.ts:302` | PROV activity. |
+| `@beep/semantic-web/prov` | `Agent` | class | `packages/foundation/capability/semantic-web/src/prov.ts:344` | PROV agent. |
+| `@beep/semantic-web/prov` | `Association` | class | `packages/foundation/capability/semantic-web/src/prov.ts:603` | PROV association relation. |
+| `@beep/semantic-web/prov` | `Attribution` | class | `packages/foundation/capability/semantic-web/src/prov.ts:628` | PROV attribution relation. |
+| `@beep/semantic-web/prov` | `Collection` | class | `packages/foundation/capability/semantic-web/src/prov.ts:443` | PROV collection. |
+| `@beep/semantic-web/prov` | `Delegation` | class | `packages/foundation/capability/semantic-web/src/prov.ts:652` | PROV delegation relation. |
+| `@beep/semantic-web/prov` | `Derivation` | class | `packages/foundation/capability/semantic-web/src/prov.ts:677` | PROV derivation relation. |
+| `@beep/semantic-web/prov` | `End` | class | `packages/foundation/capability/semantic-web/src/prov.ts:798` | PROV end relation. |
+| `@beep/semantic-web/prov` | `Entity` | class | `packages/foundation/capability/semantic-web/src/prov.ts:255` | PROV entity. |
+| `@beep/semantic-web/prov` | `Generation` | class | `packages/foundation/capability/semantic-web/src/prov.ts:578` | PROV generation relation. |
+| `@beep/semantic-web/prov` | `LifecycleTimes` | class | `packages/foundation/capability/semantic-web/src/prov.ts:210` | Explicit lifecycle time fields retained outside plain PROV activity timestamps. |
 | `@beep/semantic-web/prov` | `ObjectRef` | const | `packages/foundation/capability/semantic-web/src/prov.ts:75` | PROV object reference encoded as an IRI, CURIE, or local identifier. |
-| `@beep/semantic-web/prov` | `ObjectRef` | type | `packages/foundation/capability/semantic-web/src/prov.ts:107` | Type for {@link ObjectRef}. |
-| `@beep/semantic-web/prov` | `Organization` | class | `packages/foundation/capability/semantic-web/src/prov.ts:515` | PROV organization. |
-| `@beep/semantic-web/prov` | `Person` | class | `packages/foundation/capability/semantic-web/src/prov.ts:482` | PROV person. |
-| `@beep/semantic-web/prov` | `Plan` | class | `packages/foundation/capability/semantic-web/src/prov.ts:416` | PROV plan. |
-| `@beep/semantic-web/prov` | `PrimarySource` | class | `packages/foundation/capability/semantic-web/src/prov.ts:707` | PROV primary-source relation. |
-| `@beep/semantic-web/prov` | `ProvBundle` | class | `packages/foundation/capability/semantic-web/src/prov.ts:900` | Bounded provenance bundle exported by the semantic-web surface. |
-| `@beep/semantic-web/prov` | `ProvDateTime` | const | `packages/foundation/capability/semantic-web/src/prov.ts:169` | PROV timestamp decoded to `DateTime.Utc`. |
-| `@beep/semantic-web/prov` | `ProvDateTime` | type | `packages/foundation/capability/semantic-web/src/prov.ts:201` | Type for {@link ProvDateTime}. |
-| `@beep/semantic-web/prov` | `ProvDateTimeEncoded` | const | `packages/foundation/capability/semantic-web/src/prov.ts:122` | Encoded PROV timestamp string. |
-| `@beep/semantic-web/prov` | `ProvDateTimeEncoded` | type | `packages/foundation/capability/semantic-web/src/prov.ts:154` | Type for {@link ProvDateTimeEncoded}. |
-| `@beep/semantic-web/prov` | `ProvO` | const | `packages/foundation/capability/semantic-web/src/prov.ts:934` | Public provenance entrypoint union. |
-| `@beep/semantic-web/prov` | `ProvO` | type | `packages/foundation/capability/semantic-web/src/prov.ts:963` | Type for {@link ProvO}. |
-| `@beep/semantic-web/prov` | `ProvRecord` | const | `packages/foundation/capability/semantic-web/src/prov.ts:834` | Public PROV record union for the stable semantic-web surface. |
-| `@beep/semantic-web/prov` | `ProvRecord` | type | `packages/foundation/capability/semantic-web/src/prov.ts:883` | Type for {@link ProvRecord}. |
-| `@beep/semantic-web/prov` | `Quotation` | class | `packages/foundation/capability/semantic-web/src/prov.ts:731` | PROV quotation relation. |
-| `@beep/semantic-web/prov` | `Revision` | class | `packages/foundation/capability/semantic-web/src/prov.ts:755` | PROV revision relation. |
-| `@beep/semantic-web/prov` | `SoftwareAgent` | class | `packages/foundation/capability/semantic-web/src/prov.ts:383` | PROV software agent. |
-| `@beep/semantic-web/prov` | `Start` | class | `packages/foundation/capability/semantic-web/src/prov.ts:779` | PROV start relation. |
-| `@beep/semantic-web/prov` | `Usage` | class | `packages/foundation/capability/semantic-web/src/prov.ts:559` | PROV usage relation. |
-| `@beep/semantic-web/rdf` | `areDatasetsEquivalent` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:1049` | Compare datasets by sorted quad serialization. |
-| `@beep/semantic-web/rdf` | `BlankNode` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:380` | RDF blank node value. |
-| `@beep/semantic-web/rdf` | `Curie` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:265` | CURIE-style compact IRI expression. |
-| `@beep/semantic-web/rdf` | `Curie` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:289` | Type for {@link Curie}. |
-| `@beep/semantic-web/rdf` | `Dataset` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:668` | Dataset wrapper for RDF quads. |
-| `@beep/semantic-web/rdf` | `DefaultGraph` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:445` | RDF default graph term. |
-| `@beep/semantic-web/rdf` | `GraphTerm` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:606` | RDF graph term union. |
-| `@beep/semantic-web/rdf` | `GraphTerm` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:627` | Type for {@link GraphTerm}. |
-| `@beep/semantic-web/rdf` | `LanguageTag` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:304` | RDF literal language tag. |
-| `@beep/semantic-web/rdf` | `LanguageTag` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:341` | Type for {@link LanguageTag}. |
-| `@beep/semantic-web/rdf` | `Literal` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:419` | RDF literal value. |
-| `@beep/semantic-web/rdf` | `makeBlankNode` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:797` | Build a blank node from a non-empty label. |
-| `@beep/semantic-web/rdf` | `makeDataset` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:957` | Build a dataset from quads. |
-| `@beep/semantic-web/rdf` | `makeLiteral` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:860` | Build an RDF literal. |
-| `@beep/semantic-web/rdf` | `MakeLiteralOptions` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:817` | Optional language settings for {@link makeLiteral}. |
-| `@beep/semantic-web/rdf` | `makeNamedNode` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:771` | Build a named node from an IRI string. |
-| `@beep/semantic-web/rdf` | `makeQuad` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:921` | Build an RDF quad. |
-| `@beep/semantic-web/rdf` | `MakeQuadOptions` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:881` | Object and optional graph settings for {@link makeQuad}. |
-| `@beep/semantic-web/rdf` | `NamedNode` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:356` | RDF named node value. |
-| `@beep/semantic-web/rdf` | `NamespaceBinding` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:691` | Prefix-to-namespace binding for RDF compaction and expansion. |
-| `@beep/semantic-web/rdf` | `ObjectTerm` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:570` | RDF object term union. |
-| `@beep/semantic-web/rdf` | `ObjectTerm` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:591` | Type for {@link ObjectTerm}. |
+| `@beep/semantic-web/prov` | `ObjectRef` | type | `packages/foundation/capability/semantic-web/src/prov.ts:105` | Type for {@link ObjectRef}. |
+| `@beep/semantic-web/prov` | `Organization` | class | `packages/foundation/capability/semantic-web/src/prov.ts:509` | PROV organization. |
+| `@beep/semantic-web/prov` | `Person` | class | `packages/foundation/capability/semantic-web/src/prov.ts:476` | PROV person. |
+| `@beep/semantic-web/prov` | `Plan` | class | `packages/foundation/capability/semantic-web/src/prov.ts:410` | PROV plan. |
+| `@beep/semantic-web/prov` | `PrimarySource` | class | `packages/foundation/capability/semantic-web/src/prov.ts:701` | PROV primary-source relation. |
+| `@beep/semantic-web/prov` | `ProvBundle` | class | `packages/foundation/capability/semantic-web/src/prov.ts:894` | Bounded provenance bundle exported by the semantic-web surface. |
+| `@beep/semantic-web/prov` | `ProvDateTime` | const | `packages/foundation/capability/semantic-web/src/prov.ts:165` | PROV timestamp decoded to `DateTime.Utc`. |
+| `@beep/semantic-web/prov` | `ProvDateTime` | type | `packages/foundation/capability/semantic-web/src/prov.ts:195` | Type for {@link ProvDateTime}. |
+| `@beep/semantic-web/prov` | `ProvDateTimeEncoded` | const | `packages/foundation/capability/semantic-web/src/prov.ts:120` | Encoded PROV timestamp string. |
+| `@beep/semantic-web/prov` | `ProvDateTimeEncoded` | type | `packages/foundation/capability/semantic-web/src/prov.ts:150` | Type for {@link ProvDateTimeEncoded}. |
+| `@beep/semantic-web/prov` | `ProvO` | const | `packages/foundation/capability/semantic-web/src/prov.ts:928` | Public provenance entrypoint union. |
+| `@beep/semantic-web/prov` | `ProvO` | type | `packages/foundation/capability/semantic-web/src/prov.ts:957` | Type for {@link ProvO}. |
+| `@beep/semantic-web/prov` | `ProvRecord` | const | `packages/foundation/capability/semantic-web/src/prov.ts:828` | Public PROV record union for the stable semantic-web surface. |
+| `@beep/semantic-web/prov` | `ProvRecord` | type | `packages/foundation/capability/semantic-web/src/prov.ts:877` | Type for {@link ProvRecord}. |
+| `@beep/semantic-web/prov` | `Quotation` | class | `packages/foundation/capability/semantic-web/src/prov.ts:725` | PROV quotation relation. |
+| `@beep/semantic-web/prov` | `Revision` | class | `packages/foundation/capability/semantic-web/src/prov.ts:749` | PROV revision relation. |
+| `@beep/semantic-web/prov` | `SoftwareAgent` | class | `packages/foundation/capability/semantic-web/src/prov.ts:377` | PROV software agent. |
+| `@beep/semantic-web/prov` | `Start` | class | `packages/foundation/capability/semantic-web/src/prov.ts:773` | PROV start relation. |
+| `@beep/semantic-web/prov` | `Usage` | class | `packages/foundation/capability/semantic-web/src/prov.ts:553` | PROV usage relation. |
+| `@beep/semantic-web/rdf` | `areDatasetsEquivalent` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:1043` | Compare datasets by sorted quad serialization. |
+| `@beep/semantic-web/rdf` | `BlankNode` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:374` | RDF blank node value. |
+| `@beep/semantic-web/rdf` | `Curie` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:263` | CURIE-style compact IRI expression. |
+| `@beep/semantic-web/rdf` | `Curie` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:285` | Type for {@link Curie}. |
+| `@beep/semantic-web/rdf` | `Dataset` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:662` | Dataset wrapper for RDF quads. |
+| `@beep/semantic-web/rdf` | `DefaultGraph` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:439` | RDF default graph term. |
+| `@beep/semantic-web/rdf` | `GraphTerm` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:600` | RDF graph term union. |
+| `@beep/semantic-web/rdf` | `GraphTerm` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:621` | Type for {@link GraphTerm}. |
+| `@beep/semantic-web/rdf` | `LanguageTag` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:300` | RDF literal language tag. |
+| `@beep/semantic-web/rdf` | `LanguageTag` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:335` | Type for {@link LanguageTag}. |
+| `@beep/semantic-web/rdf` | `Literal` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:413` | RDF literal value. |
+| `@beep/semantic-web/rdf` | `makeBlankNode` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:791` | Build a blank node from a non-empty label. |
+| `@beep/semantic-web/rdf` | `makeDataset` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:951` | Build a dataset from quads. |
+| `@beep/semantic-web/rdf` | `makeLiteral` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:854` | Build an RDF literal. |
+| `@beep/semantic-web/rdf` | `MakeLiteralOptions` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:811` | Optional language settings for {@link makeLiteral}. |
+| `@beep/semantic-web/rdf` | `makeNamedNode` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:765` | Build a named node from an IRI string. |
+| `@beep/semantic-web/rdf` | `makeQuad` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:915` | Build an RDF quad. |
+| `@beep/semantic-web/rdf` | `MakeQuadOptions` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:875` | Object and optional graph settings for {@link makeQuad}. |
+| `@beep/semantic-web/rdf` | `NamedNode` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:350` | RDF named node value. |
+| `@beep/semantic-web/rdf` | `NamespaceBinding` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:685` | Prefix-to-namespace binding for RDF compaction and expansion. |
+| `@beep/semantic-web/rdf` | `ObjectTerm` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:564` | RDF object term union. |
+| `@beep/semantic-web/rdf` | `ObjectTerm` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:585` | Type for {@link ObjectTerm}. |
 | `@beep/semantic-web/rdf` | `PrefixLabel` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:214` | Prefix label used by RDF namespace bindings. |
-| `@beep/semantic-web/rdf` | `PrefixLabel` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:250` | Type for {@link PrefixLabel}. |
-| `@beep/semantic-web/rdf` | `PrefixMap` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:715` | Prefix map keyed by {@link PrefixLabel}. |
-| `@beep/semantic-web/rdf` | `PrefixMap` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:749` | Type for {@link PrefixMap}. |
-| `@beep/semantic-web/rdf` | `Quad` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:642` | RDF quad value aligned with RDF/JS. |
-| `@beep/semantic-web/rdf` | `serializeQuad` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:1006` | Serialize an RDF quad to a deterministic lexical form. |
-| `@beep/semantic-web/rdf` | `serializeTerm` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:975` | Serialize an RDF term to a deterministic lexical form. |
-| `@beep/semantic-web/rdf` | `sortDatasetQuads` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:1028` | Sort dataset quads by deterministic quad serialization. |
-| `@beep/semantic-web/rdf` | `Subject` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:534` | RDF subject term union. |
-| `@beep/semantic-web/rdf` | `Subject` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:555` | Type for {@link Subject}. |
-| `@beep/semantic-web/rdf` | `Term` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:482` | RDF term union. |
-| `@beep/semantic-web/rdf` | `Term` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:519` | Type for {@link Term}. |
+| `@beep/semantic-web/rdf` | `PrefixLabel` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:248` | Type for {@link PrefixLabel}. |
+| `@beep/semantic-web/rdf` | `PrefixMap` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:709` | Prefix map keyed by {@link PrefixLabel}. |
+| `@beep/semantic-web/rdf` | `PrefixMap` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:743` | Type for {@link PrefixMap}. |
+| `@beep/semantic-web/rdf` | `Quad` | class | `packages/foundation/capability/semantic-web/src/rdf.ts:636` | RDF quad value aligned with RDF/JS. |
+| `@beep/semantic-web/rdf` | `serializeQuad` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:1000` | Serialize an RDF quad to a deterministic lexical form. |
+| `@beep/semantic-web/rdf` | `serializeTerm` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:969` | Serialize an RDF term to a deterministic lexical form. |
+| `@beep/semantic-web/rdf` | `sortDatasetQuads` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:1022` | Sort dataset quads by deterministic quad serialization. |
+| `@beep/semantic-web/rdf` | `Subject` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:528` | RDF subject term union. |
+| `@beep/semantic-web/rdf` | `Subject` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:549` | Type for {@link Subject}. |
+| `@beep/semantic-web/rdf` | `Term` | const | `packages/foundation/capability/semantic-web/src/rdf.ts:476` | RDF term union. |
+| `@beep/semantic-web/rdf` | `Term` | type | `packages/foundation/capability/semantic-web/src/rdf.ts:513` | Type for {@link Term}. |
 | `@beep/semantic-web/semantic-schema-metadata` | `annotateSemanticSchema` | const | `packages/foundation/capability/semantic-web/src/semantic-schema-metadata.ts:345` | Attach validated semantic metadata to any Effect schema. |
 | `@beep/semantic-web/semantic-schema-metadata` | `getSemanticSchemaMetadata` | const | `packages/foundation/capability/semantic-web/src/semantic-schema-metadata.ts:426` | Read semantic metadata from any Effect schema, if present. |
 | `@beep/semantic-web/semantic-schema-metadata` | `makeSemanticSchemaMetadata` | const | `packages/foundation/capability/semantic-web/src/semantic-schema-metadata.ts:315` | Validate a metadata payload before attaching it to a public schema. |
@@ -4794,17 +4794,17 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/semantic-web/services/sparql-query` | `SparqlQueryServiceShape` | interface | `packages/foundation/capability/semantic-web/src/services/sparql-query.ts:221` | SPARQL query service contract shape. |
 | `@beep/semantic-web/services/sparql-query` | `SparqlSelectResult` | class | `packages/foundation/capability/semantic-web/src/services/sparql-query.ts:87` | SPARQL select result. |
 | `@beep/semantic-web/services/sparql-query` | `UnsupportedSparqlQueryServiceLive` | const | `packages/foundation/capability/semantic-web/src/services/sparql-query.ts:255` | Unsupported default live layer for the minimal v1 SPARQL contract. |
-| `@beep/semantic-web/uri` | `AbsoluteURI` | const | `packages/foundation/capability/semantic-web/src/uri.ts:286` | RFC 3986 `absolute-URI` schema without a fragment component. |
-| `@beep/semantic-web/uri` | `AbsoluteURI` | type | `packages/foundation/capability/semantic-web/src/uri.ts:310` | Type for {@link AbsoluteURI}. |
-| `@beep/semantic-web/uri` | `areUrisEquivalent` | const | `packages/foundation/capability/semantic-web/src/uri.ts:413` | Compare two URI values using URI-family normalization rules. |
-| `@beep/semantic-web/uri` | `normalizeUriReference` | const | `packages/foundation/capability/semantic-web/src/uri.ts:369` | Normalize a URI or URI reference for transport-oriented comparisons. |
-| `@beep/semantic-web/uri` | `RelativeURIReference` | const | `packages/foundation/capability/semantic-web/src/uri.ts:245` | RFC 3986 `relative-ref` schema. |
-| `@beep/semantic-web/uri` | `RelativeURIReference` | type | `packages/foundation/capability/semantic-web/src/uri.ts:269` | Type for {@link RelativeURIReference}. |
-| `@beep/semantic-web/uri` | `resolveUriReference` | const | `packages/foundation/capability/semantic-web/src/uri.ts:389` | Resolve a URI reference against an absolute base URI. |
-| `@beep/semantic-web/uri` | `URI` | const | `packages/foundation/capability/semantic-web/src/uri.ts:327` | RFC 3986 `URI` schema. |
-| `@beep/semantic-web/uri` | `URI` | type | `packages/foundation/capability/semantic-web/src/uri.ts:351` | Type for {@link URI}. |
+| `@beep/semantic-web/uri` | `AbsoluteURI` | const | `packages/foundation/capability/semantic-web/src/uri.ts:282` | RFC 3986 `absolute-URI` schema without a fragment component. |
+| `@beep/semantic-web/uri` | `AbsoluteURI` | type | `packages/foundation/capability/semantic-web/src/uri.ts:304` | Type for {@link AbsoluteURI}. |
+| `@beep/semantic-web/uri` | `areUrisEquivalent` | const | `packages/foundation/capability/semantic-web/src/uri.ts:405` | Compare two URI values using URI-family normalization rules. |
+| `@beep/semantic-web/uri` | `normalizeUriReference` | const | `packages/foundation/capability/semantic-web/src/uri.ts:361` | Normalize a URI or URI reference for transport-oriented comparisons. |
+| `@beep/semantic-web/uri` | `RelativeURIReference` | const | `packages/foundation/capability/semantic-web/src/uri.ts:243` | RFC 3986 `relative-ref` schema. |
+| `@beep/semantic-web/uri` | `RelativeURIReference` | type | `packages/foundation/capability/semantic-web/src/uri.ts:265` | Type for {@link RelativeURIReference}. |
+| `@beep/semantic-web/uri` | `resolveUriReference` | const | `packages/foundation/capability/semantic-web/src/uri.ts:381` | Resolve a URI reference against an absolute base URI. |
+| `@beep/semantic-web/uri` | `URI` | const | `packages/foundation/capability/semantic-web/src/uri.ts:321` | RFC 3986 `URI` schema. |
+| `@beep/semantic-web/uri` | `URI` | type | `packages/foundation/capability/semantic-web/src/uri.ts:343` | Type for {@link URI}. |
 | `@beep/semantic-web/uri` | `URIReference` | const | `packages/foundation/capability/semantic-web/src/uri.ts:204` | RFC 3986 `URI-reference` schema, including absolute and relative forms. |
-| `@beep/semantic-web/uri` | `URIReference` | type | `packages/foundation/capability/semantic-web/src/uri.ts:228` | Type for {@link URIReference}. |
+| `@beep/semantic-web/uri` | `URIReference` | type | `packages/foundation/capability/semantic-web/src/uri.ts:226` | Type for {@link URIReference}. |
 | `@beep/semantic-web/vocab/oa` | `OA_ANNOTATION` | const | `packages/foundation/capability/semantic-web/src/vocab/oa.ts:39` | `oa:Annotation` |
 | `@beep/semantic-web/vocab/oa` | `OA_HAS_SELECTOR` | const | `packages/foundation/capability/semantic-web/src/vocab/oa.ts:69` | `oa:hasSelector` |
 | `@beep/semantic-web/vocab/oa` | `OA_HAS_TARGET` | const | `packages/foundation/capability/semantic-web/src/vocab/oa.ts:54` | `oa:hasTarget` |
@@ -5662,9 +5662,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics` | `AgentEffectivenessSourceCoverage` | class | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:296` | Source coverage row derived from AI-metrics storage. |
 | `@beep/repo-ai-metrics` | `AgentEffectivenessStatus` | const | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:90` | Status emitted by agent-effectiveness reports. |
 | `@beep/repo-ai-metrics` | `AgentEffectivenessStatus` | type | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:102` | Runtime type for `AgentEffectivenessStatus`. |
-| `@beep/repo-ai-metrics` | `AgentSession` | class | `packages/tooling/library/ai-metrics/src/models.ts:415` | Session-level transcript metadata under an agent task. |
-| `@beep/repo-ai-metrics` | `AgentTask` | class | `packages/tooling/library/ai-metrics/src/models.ts:383` | Canonical unit of analysis for coding-agent metrics. |
-| `@beep/repo-ai-metrics` | `AgentTurn` | class | `packages/tooling/library/ai-metrics/src/models.ts:451` | Turn-level transcript event normalized from local agent logs. |
+| `@beep/repo-ai-metrics` | `AgentSession` | class | `packages/tooling/library/ai-metrics/src/models.ts:411` | Session-level transcript metadata under an agent task. |
+| `@beep/repo-ai-metrics` | `AgentTask` | class | `packages/tooling/library/ai-metrics/src/models.ts:379` | Canonical unit of analysis for coding-agent metrics. |
+| `@beep/repo-ai-metrics` | `AgentTurn` | class | `packages/tooling/library/ai-metrics/src/models.ts:447` | Turn-level transcript event normalized from local agent logs. |
 | `@beep/repo-ai-metrics` | `AI_METRICS_LOCAL_INSECURE_HASH_SALT` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:32` | Local fallback salt used only for smoke-mode private identifier hashes. |
 | `@beep/repo-ai-metrics` | `AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:36` | OTLP attributes approved for redacted AI metrics span export. |
 | `@beep/repo-ai-metrics` | `AiMetricsArchiveError` | class | `packages/tooling/library/ai-metrics/src/archive.ts:35` | Error raised by AI metrics encrypted archive helpers. |
@@ -5732,14 +5732,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics` | `AiMetricsMirrorTableExport` | class | `packages/tooling/library/ai-metrics/src/mirror.ts:434` | One sanitized table exported into a P7 mirror bundle. |
 | `@beep/repo-ai-metrics` | `AiMetricsOtlpAttributeValue` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:72` | Attribute value variants allowed on redacted AI metrics OTLP spans. |
 | `@beep/repo-ai-metrics` | `AiMetricsOtlpAttributeValue` | type | `packages/tooling/library/ai-metrics/src/otlp.ts:90` | Runtime type for {@link AiMetricsOtlpAttributeValue}. |
-| `@beep/repo-ai-metrics` | `AiMetricsOtlpEndpointSpec` | class | `packages/tooling/library/ai-metrics/src/models.ts:305` | Install-owned OTLP endpoint contract consumed by CLI, local smoke, and IaC. |
+| `@beep/repo-ai-metrics` | `AiMetricsOtlpEndpointSpec` | class | `packages/tooling/library/ai-metrics/src/models.ts:301` | Install-owned OTLP endpoint contract consumed by CLI, local smoke, and IaC. |
 | `@beep/repo-ai-metrics` | `AiMetricsOtlpExportError` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:103` | Error raised by AI metrics OTLP projection or export. |
 | `@beep/repo-ai-metrics` | `AiMetricsOtlpExportInput` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:137` | Input for exporting one derived ingest run as OTLP spans. |
 | `@beep/repo-ai-metrics` | `AiMetricsOtlpExportResult` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:206` | Result of a redacted AI metrics OTLP export attempt. |
-| `@beep/repo-ai-metrics` | `AiMetricsOtlpProtocol` | const | `packages/tooling/library/ai-metrics/src/models.ts:212` | OTLP protocol variants supported by the P3 AI metrics backend contract. |
-| `@beep/repo-ai-metrics` | `AiMetricsOtlpProtocol` | type | `packages/tooling/library/ai-metrics/src/models.ts:230` | Runtime type for {@link AiMetricsOtlpProtocol}. |
-| `@beep/repo-ai-metrics` | `AiMetricsOtlpSignalScope` | const | `packages/tooling/library/ai-metrics/src/models.ts:243` | Telemetry signal scope exported to the P3 Phoenix backend. |
-| `@beep/repo-ai-metrics` | `AiMetricsOtlpSignalScope` | type | `packages/tooling/library/ai-metrics/src/models.ts:261` | Runtime type for {@link AiMetricsOtlpSignalScope}. |
+| `@beep/repo-ai-metrics` | `AiMetricsOtlpProtocol` | const | `packages/tooling/library/ai-metrics/src/models.ts:208` | OTLP protocol variants supported by the P3 AI metrics backend contract. |
+| `@beep/repo-ai-metrics` | `AiMetricsOtlpProtocol` | type | `packages/tooling/library/ai-metrics/src/models.ts:226` | Runtime type for {@link AiMetricsOtlpProtocol}. |
+| `@beep/repo-ai-metrics` | `AiMetricsOtlpSignalScope` | const | `packages/tooling/library/ai-metrics/src/models.ts:239` | Telemetry signal scope exported to the P3 Phoenix backend. |
+| `@beep/repo-ai-metrics` | `AiMetricsOtlpSignalScope` | type | `packages/tooling/library/ai-metrics/src/models.ts:257` | Runtime type for {@link AiMetricsOtlpSignalScope}. |
 | `@beep/repo-ai-metrics` | `AiMetricsOtlpSpanProjection` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:160` | One span projection ready to be emitted through Effect tracing. |
 | `@beep/repo-ai-metrics` | `AiMetricsOtlpSpanProjectionBatch` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:181` | Span projection batch resolved for one derived ingest run. |
 | `@beep/repo-ai-metrics` | `AiMetricsOutcomeLabelInput` | class | `packages/tooling/library/ai-metrics/src/scorecard.ts:140` | Input for adding or replacing the current label for one task. |
@@ -5747,9 +5747,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics` | `AiMetricsPrivacyCheckResult` | class | `packages/tooling/library/ai-metrics/src/privacy.ts:182` | Result produced by the P1 privacy proof command. |
 | `@beep/repo-ai-metrics` | `AiMetricsPrivacyError` | class | `packages/tooling/library/ai-metrics/src/privacy.ts:206` | Error raised by AI metrics privacy helpers. |
 | `@beep/repo-ai-metrics` | `AiMetricsPrivacyMode` | const | `packages/tooling/library/ai-metrics/src/models.ts:177` | Raw transcript retention and derived-dashboard privacy posture. |
-| `@beep/repo-ai-metrics` | `AiMetricsPrivacyMode` | type | `packages/tooling/library/ai-metrics/src/models.ts:199` | Runtime type for {@link AiMetricsPrivacyMode}. |
-| `@beep/repo-ai-metrics` | `AiMetricsQualityGateStatus` | const | `packages/tooling/library/ai-metrics/src/models.ts:274` | Quality-gate outcome recorded for a labeled task or benchmark run. |
-| `@beep/repo-ai-metrics` | `AiMetricsQualityGateStatus` | type | `packages/tooling/library/ai-metrics/src/models.ts:292` | Runtime type for {@link AiMetricsQualityGateStatus}. |
+| `@beep/repo-ai-metrics` | `AiMetricsPrivacyMode` | type | `packages/tooling/library/ai-metrics/src/models.ts:195` | Runtime type for {@link AiMetricsPrivacyMode}. |
+| `@beep/repo-ai-metrics` | `AiMetricsQualityGateStatus` | const | `packages/tooling/library/ai-metrics/src/models.ts:270` | Quality-gate outcome recorded for a labeled task or benchmark run. |
+| `@beep/repo-ai-metrics` | `AiMetricsQualityGateStatus` | type | `packages/tooling/library/ai-metrics/src/models.ts:288` | Runtime type for {@link AiMetricsQualityGateStatus}. |
 | `@beep/repo-ai-metrics` | `AiMetricsRawArchiveKey` | const | `packages/tooling/library/ai-metrics/src/archive.ts:115` | Redacted base64 AES-256-GCM key used for raw archive encryption. |
 | `@beep/repo-ai-metrics` | `AiMetricsRawArchiveKey` | type | `packages/tooling/library/ai-metrics/src/archive.ts:135` | Type for {@link AiMetricsRawArchiveKey}. |
 | `@beep/repo-ai-metrics` | `AiMetricsRawArchiveObject` | class | `packages/tooling/library/ai-metrics/src/archive.ts:86` | Safe archive object metadata returned after an encrypted write or lookup. |
@@ -5768,7 +5768,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics` | `AiMetricsRetentionSelector` | class | `packages/tooling/library/ai-metrics/src/retention.ts:189` | Time-window selector for AI metrics retention commands. |
 | `@beep/repo-ai-metrics` | `AiMetricsSanitizedTranscript` | class | `packages/tooling/library/ai-metrics/src/privacy.ts:141` | Redacted transcript summary safe for derived tables, dashboards, and OTLP attributes. |
 | `@beep/repo-ai-metrics` | `AiMetricsScorecardError` | class | `packages/tooling/library/ai-metrics/src/scorecard.ts:42` | Error raised by AI metrics label, benchmark, or scorecard workflows. |
-| `@beep/repo-ai-metrics` | `AiMetricsScoreWeights` | class | `packages/tooling/library/ai-metrics/src/models.ts:329` | Outcome-heavy scorecard weights for coding-agent performance. |
+| `@beep/repo-ai-metrics` | `AiMetricsScoreWeights` | class | `packages/tooling/library/ai-metrics/src/models.ts:325` | Outcome-heavy scorecard weights for coding-agent performance. |
 | `@beep/repo-ai-metrics` | `AiMetricsServiceSpec` | class | `packages/tooling/library/ai-metrics/src/install.ts:209` | One candidate service in the local bakeoff or promoted install target. |
 | `@beep/repo-ai-metrics` | `AiMetricsSourceAttribution` | class | `packages/tooling/library/ai-metrics/src/models.ts:150` | Privacy-preserving source attribution derived from transcript metadata. |
 | `@beep/repo-ai-metrics` | `AiMetricsSourceDiscoveryError` | class | `packages/tooling/library/ai-metrics/src/source-discovery.ts:224` | Error raised by source discovery. |
@@ -5788,12 +5788,12 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics` | `AiMetricsWeeklyReportInput` | class | `packages/tooling/library/ai-metrics/src/scorecard.ts:286` | Input for generating a weekly config-impact report. |
 | `@beep/repo-ai-metrics` | `AiMetricsWeeklyReportResult` | class | `packages/tooling/library/ai-metrics/src/scorecard.ts:309` | Result returned after writing weekly report artifacts. |
 | `@beep/repo-ai-metrics` | `aiMetricsWeeklyReportToJson` | const | `packages/tooling/library/ai-metrics/src/scorecard.ts:1407` | Render a weekly report result as JSON. |
-| `@beep/repo-ai-metrics` | `BenchmarkCase` | class | `packages/tooling/library/ai-metrics/src/models.ts:554` | Repeatable benchmark case for comparing agent configurations. |
-| `@beep/repo-ai-metrics` | `BenchmarkRun` | class | `packages/tooling/library/ai-metrics/src/models.ts:578` | Benchmark run result under one config snapshot. |
+| `@beep/repo-ai-metrics` | `BenchmarkCase` | class | `packages/tooling/library/ai-metrics/src/models.ts:550` | Repeatable benchmark case for comparing agent configurations. |
+| `@beep/repo-ai-metrics` | `BenchmarkRun` | class | `packages/tooling/library/ai-metrics/src/models.ts:574` | Benchmark run result under one config snapshot. |
 | `@beep/repo-ai-metrics` | `buildAiMetricsMirrorBundle` | const | `packages/tooling/library/ai-metrics/src/mirror.ts:643` | Build a sanitized deploy-safe P7 mirror bundle from local derived DuckDB data. |
-| `@beep/repo-ai-metrics` | `ClaudeTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:692` | Minimal external Claude JSONL shape. |
-| `@beep/repo-ai-metrics` | `CodexTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:669` | Minimal external Codex JSONL shape. |
-| `@beep/repo-ai-metrics` | `ConfigSnapshot` | class | `packages/tooling/library/ai-metrics/src/models.ts:354` | Versioned snapshot of agent-facing repository configuration. |
+| `@beep/repo-ai-metrics` | `ClaudeTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:688` | Minimal external Claude JSONL shape. |
+| `@beep/repo-ai-metrics` | `CodexTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:665` | Minimal external Codex JSONL shape. |
+| `@beep/repo-ai-metrics` | `ConfigSnapshot` | class | `packages/tooling/library/ai-metrics/src/models.ts:350` | Versioned snapshot of agent-facing repository configuration. |
 | `@beep/repo-ai-metrics` | `configSnapshotToJson` | const | `packages/tooling/library/ai-metrics/src/config-snapshot.ts:543` | Render a config snapshot result as JSON. |
 | `@beep/repo-ai-metrics` | `decryptEncryptedRawArchiveEnvelope` | const | `packages/tooling/library/ai-metrics/src/archive.ts:362` | Decrypt an archive envelope for package-level verification. |
 | `@beep/repo-ai-metrics` | `DEFAULT_AGENT_EFFECTIVENESS_WORKER_EVAL_REPORT_PATH` | const | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:53` | Stable default pointer used to locate the latest checked-in JSDoc worker-eval evidence. |
@@ -5821,10 +5821,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics` | `makeAiMetricsPrivacyCheckResult` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:653` | Build the P1 privacy proof payload for one transcript. |
 | `@beep/repo-ai-metrics` | `makeAiMetricsSourceAttribution` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:426` | Derive privacy-safe source attribution from local transcript metadata. |
 | `@beep/repo-ai-metrics` | `makeSanitizedTranscript` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:593` | Build a sanitized transcript projection from an ingest summary and raw JSONL text. |
-| `@beep/repo-ai-metrics` | `ModelCall` | class | `packages/tooling/library/ai-metrics/src/models.ts:479` | Model or provider call measured under an agent task. |
-| `@beep/repo-ai-metrics` | `OpenClawTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:717` | Minimal external OpenClaw JSONL shape. |
+| `@beep/repo-ai-metrics` | `ModelCall` | class | `packages/tooling/library/ai-metrics/src/models.ts:475` | Model or provider call measured under an agent task. |
+| `@beep/repo-ai-metrics` | `OpenClawTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:713` | Minimal external OpenClaw JSONL shape. |
 | `@beep/repo-ai-metrics` | `otlpExportResultToJson` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:515` | Render an OTLP export result as JSON. |
-| `@beep/repo-ai-metrics` | `OutcomeLabel` | class | `packages/tooling/library/ai-metrics/src/models.ts:526` | Human label used by the weekly outcome-heavy scorecard. |
+| `@beep/repo-ai-metrics` | `OutcomeLabel` | class | `packages/tooling/library/ai-metrics/src/models.ts:522` | Human label used by the weekly outcome-heavy scorecard. |
 | `@beep/repo-ai-metrics` | `privacyCheckToJson` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:692` | Render a privacy check result as JSON. |
 | `@beep/repo-ai-metrics` | `queueAiMetricsLabels` | const | `packages/tooling/library/ai-metrics/src/scorecard.ts:527` | Read unlabeled tasks for human review. |
 | `@beep/repo-ai-metrics` | `readAiMetricsOtlpSpanProjections` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:444` | Read derived DuckDB rows and build redacted OTLP span projections. |
@@ -5840,14 +5840,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics` | `runAiMetricsRetentionCompact` | const | `packages/tooling/library/ai-metrics/src/retention.ts:773` | Compact selected AI metrics derived Parquet and report outputs. |
 | `@beep/repo-ai-metrics` | `runAiMetricsRetentionDelete` | const | `packages/tooling/library/ai-metrics/src/retention.ts:748` | Delete selected AI metrics raw, derived, and report data. |
 | `@beep/repo-ai-metrics` | `runAiMetricsRetentionRestoreDrill` | const | `packages/tooling/library/ai-metrics/src/retention.ts:798` | Restore selected encrypted raw archive objects into disposable derived storage. |
-| `@beep/repo-ai-metrics` | `Scorecard` | class | `packages/tooling/library/ai-metrics/src/models.ts:605` | Derived scorecard for weekly or config-impact review. |
+| `@beep/repo-ai-metrics` | `Scorecard` | class | `packages/tooling/library/ai-metrics/src/models.ts:601` | Derived scorecard for weekly or config-impact review. |
 | `@beep/repo-ai-metrics` | `shellQuote` | const | `packages/tooling/library/ai-metrics/src/shell.ts:24` | Quote a value as one POSIX shell token. |
 | `@beep/repo-ai-metrics` | `sourceDiscoveryToJson` | const | `packages/tooling/library/ai-metrics/src/source-discovery.ts:631` | Render a source discovery result as JSON. |
 | `@beep/repo-ai-metrics` | `summarizeTranscriptText` | const | `packages/tooling/library/ai-metrics/src/ingest.ts:177` | Summarize JSONL transcript text into a stable ingest summary. |
 | `@beep/repo-ai-metrics` | `summaryToJson` | const | `packages/tooling/library/ai-metrics/src/ingest.ts:220` | Render a transcript ingest summary as JSON. |
 | `@beep/repo-ai-metrics` | `syncAgentEffectivenessPhoenix` | const | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:2642` | Sync agent-effectiveness datasets, prompts, experiments, and resolved annotations to Phoenix. |
-| `@beep/repo-ai-metrics` | `ToolInvocation` | class | `packages/tooling/library/ai-metrics/src/models.ts:503` | Tool or shell command invocation measured under an agent task. |
-| `@beep/repo-ai-metrics` | `TranscriptIngestSummary` | class | `packages/tooling/library/ai-metrics/src/models.ts:641` | Summary produced by transcript ingestion. |
+| `@beep/repo-ai-metrics` | `ToolInvocation` | class | `packages/tooling/library/ai-metrics/src/models.ts:499` | Tool or shell command invocation measured under an agent task. |
+| `@beep/repo-ai-metrics` | `TranscriptIngestSummary` | class | `packages/tooling/library/ai-metrics/src/models.ts:637` | Summary produced by transcript ingestion. |
 | `@beep/repo-ai-metrics` | `upsertAiMetricsBenchmarkCase` | const | `packages/tooling/library/ai-metrics/src/scorecard.ts:681` | Add or replace a deploy-safe benchmark case. |
 | `@beep/repo-ai-metrics` | `writeAiMetricsConfigSnapshotArtifacts` | const | `packages/tooling/library/ai-metrics/src/config-snapshot.ts:477` | Persist a config snapshot manifest and latest pointer for future diff attribution. |
 | `@beep/repo-ai-metrics` | `writeAiMetricsDerivedStorage` | const | `packages/tooling/library/ai-metrics/src/derived-storage.ts:1072` | Project sanitized AI metrics records into DuckDB and export Parquet snapshots. |
@@ -5984,9 +5984,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/index` | `AgentEffectivenessSourceCoverage` | class | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:296` | Source coverage row derived from AI-metrics storage. |
 | `@beep/repo-ai-metrics/index` | `AgentEffectivenessStatus` | const | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:90` | Status emitted by agent-effectiveness reports. |
 | `@beep/repo-ai-metrics/index` | `AgentEffectivenessStatus` | type | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:102` | Runtime type for `AgentEffectivenessStatus`. |
-| `@beep/repo-ai-metrics/index` | `AgentSession` | class | `packages/tooling/library/ai-metrics/src/models.ts:415` | Session-level transcript metadata under an agent task. |
-| `@beep/repo-ai-metrics/index` | `AgentTask` | class | `packages/tooling/library/ai-metrics/src/models.ts:383` | Canonical unit of analysis for coding-agent metrics. |
-| `@beep/repo-ai-metrics/index` | `AgentTurn` | class | `packages/tooling/library/ai-metrics/src/models.ts:451` | Turn-level transcript event normalized from local agent logs. |
+| `@beep/repo-ai-metrics/index` | `AgentSession` | class | `packages/tooling/library/ai-metrics/src/models.ts:411` | Session-level transcript metadata under an agent task. |
+| `@beep/repo-ai-metrics/index` | `AgentTask` | class | `packages/tooling/library/ai-metrics/src/models.ts:379` | Canonical unit of analysis for coding-agent metrics. |
+| `@beep/repo-ai-metrics/index` | `AgentTurn` | class | `packages/tooling/library/ai-metrics/src/models.ts:447` | Turn-level transcript event normalized from local agent logs. |
 | `@beep/repo-ai-metrics/index` | `AI_METRICS_LOCAL_INSECURE_HASH_SALT` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:32` | Local fallback salt used only for smoke-mode private identifier hashes. |
 | `@beep/repo-ai-metrics/index` | `AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:36` | OTLP attributes approved for redacted AI metrics span export. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsArchiveError` | class | `packages/tooling/library/ai-metrics/src/archive.ts:35` | Error raised by AI metrics encrypted archive helpers. |
@@ -6054,14 +6054,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/index` | `AiMetricsMirrorTableExport` | class | `packages/tooling/library/ai-metrics/src/mirror.ts:434` | One sanitized table exported into a P7 mirror bundle. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsOtlpAttributeValue` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:72` | Attribute value variants allowed on redacted AI metrics OTLP spans. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsOtlpAttributeValue` | type | `packages/tooling/library/ai-metrics/src/otlp.ts:90` | Runtime type for {@link AiMetricsOtlpAttributeValue}. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpEndpointSpec` | class | `packages/tooling/library/ai-metrics/src/models.ts:305` | Install-owned OTLP endpoint contract consumed by CLI, local smoke, and IaC. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpEndpointSpec` | class | `packages/tooling/library/ai-metrics/src/models.ts:301` | Install-owned OTLP endpoint contract consumed by CLI, local smoke, and IaC. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsOtlpExportError` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:103` | Error raised by AI metrics OTLP projection or export. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsOtlpExportInput` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:137` | Input for exporting one derived ingest run as OTLP spans. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsOtlpExportResult` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:206` | Result of a redacted AI metrics OTLP export attempt. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpProtocol` | const | `packages/tooling/library/ai-metrics/src/models.ts:212` | OTLP protocol variants supported by the P3 AI metrics backend contract. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpProtocol` | type | `packages/tooling/library/ai-metrics/src/models.ts:230` | Runtime type for {@link AiMetricsOtlpProtocol}. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpSignalScope` | const | `packages/tooling/library/ai-metrics/src/models.ts:243` | Telemetry signal scope exported to the P3 Phoenix backend. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpSignalScope` | type | `packages/tooling/library/ai-metrics/src/models.ts:261` | Runtime type for {@link AiMetricsOtlpSignalScope}. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpProtocol` | const | `packages/tooling/library/ai-metrics/src/models.ts:208` | OTLP protocol variants supported by the P3 AI metrics backend contract. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpProtocol` | type | `packages/tooling/library/ai-metrics/src/models.ts:226` | Runtime type for {@link AiMetricsOtlpProtocol}. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpSignalScope` | const | `packages/tooling/library/ai-metrics/src/models.ts:239` | Telemetry signal scope exported to the P3 Phoenix backend. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsOtlpSignalScope` | type | `packages/tooling/library/ai-metrics/src/models.ts:257` | Runtime type for {@link AiMetricsOtlpSignalScope}. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsOtlpSpanProjection` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:160` | One span projection ready to be emitted through Effect tracing. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsOtlpSpanProjectionBatch` | class | `packages/tooling/library/ai-metrics/src/otlp.ts:181` | Span projection batch resolved for one derived ingest run. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsOutcomeLabelInput` | class | `packages/tooling/library/ai-metrics/src/scorecard.ts:140` | Input for adding or replacing the current label for one task. |
@@ -6069,9 +6069,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/index` | `AiMetricsPrivacyCheckResult` | class | `packages/tooling/library/ai-metrics/src/privacy.ts:182` | Result produced by the P1 privacy proof command. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsPrivacyError` | class | `packages/tooling/library/ai-metrics/src/privacy.ts:206` | Error raised by AI metrics privacy helpers. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsPrivacyMode` | const | `packages/tooling/library/ai-metrics/src/models.ts:177` | Raw transcript retention and derived-dashboard privacy posture. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsPrivacyMode` | type | `packages/tooling/library/ai-metrics/src/models.ts:199` | Runtime type for {@link AiMetricsPrivacyMode}. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsQualityGateStatus` | const | `packages/tooling/library/ai-metrics/src/models.ts:274` | Quality-gate outcome recorded for a labeled task or benchmark run. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsQualityGateStatus` | type | `packages/tooling/library/ai-metrics/src/models.ts:292` | Runtime type for {@link AiMetricsQualityGateStatus}. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsPrivacyMode` | type | `packages/tooling/library/ai-metrics/src/models.ts:195` | Runtime type for {@link AiMetricsPrivacyMode}. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsQualityGateStatus` | const | `packages/tooling/library/ai-metrics/src/models.ts:270` | Quality-gate outcome recorded for a labeled task or benchmark run. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsQualityGateStatus` | type | `packages/tooling/library/ai-metrics/src/models.ts:288` | Runtime type for {@link AiMetricsQualityGateStatus}. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsRawArchiveKey` | const | `packages/tooling/library/ai-metrics/src/archive.ts:115` | Redacted base64 AES-256-GCM key used for raw archive encryption. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsRawArchiveKey` | type | `packages/tooling/library/ai-metrics/src/archive.ts:135` | Type for {@link AiMetricsRawArchiveKey}. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsRawArchiveObject` | class | `packages/tooling/library/ai-metrics/src/archive.ts:86` | Safe archive object metadata returned after an encrypted write or lookup. |
@@ -6090,7 +6090,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/index` | `AiMetricsRetentionSelector` | class | `packages/tooling/library/ai-metrics/src/retention.ts:189` | Time-window selector for AI metrics retention commands. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsSanitizedTranscript` | class | `packages/tooling/library/ai-metrics/src/privacy.ts:141` | Redacted transcript summary safe for derived tables, dashboards, and OTLP attributes. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsScorecardError` | class | `packages/tooling/library/ai-metrics/src/scorecard.ts:42` | Error raised by AI metrics label, benchmark, or scorecard workflows. |
-| `@beep/repo-ai-metrics/index` | `AiMetricsScoreWeights` | class | `packages/tooling/library/ai-metrics/src/models.ts:329` | Outcome-heavy scorecard weights for coding-agent performance. |
+| `@beep/repo-ai-metrics/index` | `AiMetricsScoreWeights` | class | `packages/tooling/library/ai-metrics/src/models.ts:325` | Outcome-heavy scorecard weights for coding-agent performance. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsServiceSpec` | class | `packages/tooling/library/ai-metrics/src/install.ts:209` | One candidate service in the local bakeoff or promoted install target. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsSourceAttribution` | class | `packages/tooling/library/ai-metrics/src/models.ts:150` | Privacy-preserving source attribution derived from transcript metadata. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsSourceDiscoveryError` | class | `packages/tooling/library/ai-metrics/src/source-discovery.ts:224` | Error raised by source discovery. |
@@ -6110,12 +6110,12 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/index` | `AiMetricsWeeklyReportInput` | class | `packages/tooling/library/ai-metrics/src/scorecard.ts:286` | Input for generating a weekly config-impact report. |
 | `@beep/repo-ai-metrics/index` | `AiMetricsWeeklyReportResult` | class | `packages/tooling/library/ai-metrics/src/scorecard.ts:309` | Result returned after writing weekly report artifacts. |
 | `@beep/repo-ai-metrics/index` | `aiMetricsWeeklyReportToJson` | const | `packages/tooling/library/ai-metrics/src/scorecard.ts:1407` | Render a weekly report result as JSON. |
-| `@beep/repo-ai-metrics/index` | `BenchmarkCase` | class | `packages/tooling/library/ai-metrics/src/models.ts:554` | Repeatable benchmark case for comparing agent configurations. |
-| `@beep/repo-ai-metrics/index` | `BenchmarkRun` | class | `packages/tooling/library/ai-metrics/src/models.ts:578` | Benchmark run result under one config snapshot. |
+| `@beep/repo-ai-metrics/index` | `BenchmarkCase` | class | `packages/tooling/library/ai-metrics/src/models.ts:550` | Repeatable benchmark case for comparing agent configurations. |
+| `@beep/repo-ai-metrics/index` | `BenchmarkRun` | class | `packages/tooling/library/ai-metrics/src/models.ts:574` | Benchmark run result under one config snapshot. |
 | `@beep/repo-ai-metrics/index` | `buildAiMetricsMirrorBundle` | const | `packages/tooling/library/ai-metrics/src/mirror.ts:643` | Build a sanitized deploy-safe P7 mirror bundle from local derived DuckDB data. |
-| `@beep/repo-ai-metrics/index` | `ClaudeTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:692` | Minimal external Claude JSONL shape. |
-| `@beep/repo-ai-metrics/index` | `CodexTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:669` | Minimal external Codex JSONL shape. |
-| `@beep/repo-ai-metrics/index` | `ConfigSnapshot` | class | `packages/tooling/library/ai-metrics/src/models.ts:354` | Versioned snapshot of agent-facing repository configuration. |
+| `@beep/repo-ai-metrics/index` | `ClaudeTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:688` | Minimal external Claude JSONL shape. |
+| `@beep/repo-ai-metrics/index` | `CodexTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:665` | Minimal external Codex JSONL shape. |
+| `@beep/repo-ai-metrics/index` | `ConfigSnapshot` | class | `packages/tooling/library/ai-metrics/src/models.ts:350` | Versioned snapshot of agent-facing repository configuration. |
 | `@beep/repo-ai-metrics/index` | `configSnapshotToJson` | const | `packages/tooling/library/ai-metrics/src/config-snapshot.ts:543` | Render a config snapshot result as JSON. |
 | `@beep/repo-ai-metrics/index` | `decryptEncryptedRawArchiveEnvelope` | const | `packages/tooling/library/ai-metrics/src/archive.ts:362` | Decrypt an archive envelope for package-level verification. |
 | `@beep/repo-ai-metrics/index` | `DEFAULT_AGENT_EFFECTIVENESS_WORKER_EVAL_REPORT_PATH` | const | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:53` | Stable default pointer used to locate the latest checked-in JSDoc worker-eval evidence. |
@@ -6143,10 +6143,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/index` | `makeAiMetricsPrivacyCheckResult` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:653` | Build the P1 privacy proof payload for one transcript. |
 | `@beep/repo-ai-metrics/index` | `makeAiMetricsSourceAttribution` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:426` | Derive privacy-safe source attribution from local transcript metadata. |
 | `@beep/repo-ai-metrics/index` | `makeSanitizedTranscript` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:593` | Build a sanitized transcript projection from an ingest summary and raw JSONL text. |
-| `@beep/repo-ai-metrics/index` | `ModelCall` | class | `packages/tooling/library/ai-metrics/src/models.ts:479` | Model or provider call measured under an agent task. |
-| `@beep/repo-ai-metrics/index` | `OpenClawTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:717` | Minimal external OpenClaw JSONL shape. |
+| `@beep/repo-ai-metrics/index` | `ModelCall` | class | `packages/tooling/library/ai-metrics/src/models.ts:475` | Model or provider call measured under an agent task. |
+| `@beep/repo-ai-metrics/index` | `OpenClawTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:713` | Minimal external OpenClaw JSONL shape. |
 | `@beep/repo-ai-metrics/index` | `otlpExportResultToJson` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:515` | Render an OTLP export result as JSON. |
-| `@beep/repo-ai-metrics/index` | `OutcomeLabel` | class | `packages/tooling/library/ai-metrics/src/models.ts:526` | Human label used by the weekly outcome-heavy scorecard. |
+| `@beep/repo-ai-metrics/index` | `OutcomeLabel` | class | `packages/tooling/library/ai-metrics/src/models.ts:522` | Human label used by the weekly outcome-heavy scorecard. |
 | `@beep/repo-ai-metrics/index` | `privacyCheckToJson` | const | `packages/tooling/library/ai-metrics/src/privacy.ts:692` | Render a privacy check result as JSON. |
 | `@beep/repo-ai-metrics/index` | `queueAiMetricsLabels` | const | `packages/tooling/library/ai-metrics/src/scorecard.ts:527` | Read unlabeled tasks for human review. |
 | `@beep/repo-ai-metrics/index` | `readAiMetricsOtlpSpanProjections` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:444` | Read derived DuckDB rows and build redacted OTLP span projections. |
@@ -6162,14 +6162,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/index` | `runAiMetricsRetentionCompact` | const | `packages/tooling/library/ai-metrics/src/retention.ts:773` | Compact selected AI metrics derived Parquet and report outputs. |
 | `@beep/repo-ai-metrics/index` | `runAiMetricsRetentionDelete` | const | `packages/tooling/library/ai-metrics/src/retention.ts:748` | Delete selected AI metrics raw, derived, and report data. |
 | `@beep/repo-ai-metrics/index` | `runAiMetricsRetentionRestoreDrill` | const | `packages/tooling/library/ai-metrics/src/retention.ts:798` | Restore selected encrypted raw archive objects into disposable derived storage. |
-| `@beep/repo-ai-metrics/index` | `Scorecard` | class | `packages/tooling/library/ai-metrics/src/models.ts:605` | Derived scorecard for weekly or config-impact review. |
+| `@beep/repo-ai-metrics/index` | `Scorecard` | class | `packages/tooling/library/ai-metrics/src/models.ts:601` | Derived scorecard for weekly or config-impact review. |
 | `@beep/repo-ai-metrics/index` | `shellQuote` | const | `packages/tooling/library/ai-metrics/src/shell.ts:24` | Quote a value as one POSIX shell token. |
 | `@beep/repo-ai-metrics/index` | `sourceDiscoveryToJson` | const | `packages/tooling/library/ai-metrics/src/source-discovery.ts:631` | Render a source discovery result as JSON. |
 | `@beep/repo-ai-metrics/index` | `summarizeTranscriptText` | const | `packages/tooling/library/ai-metrics/src/ingest.ts:177` | Summarize JSONL transcript text into a stable ingest summary. |
 | `@beep/repo-ai-metrics/index` | `summaryToJson` | const | `packages/tooling/library/ai-metrics/src/ingest.ts:220` | Render a transcript ingest summary as JSON. |
 | `@beep/repo-ai-metrics/index` | `syncAgentEffectivenessPhoenix` | const | `packages/tooling/library/ai-metrics/src/agent-effectiveness.ts:2642` | Sync agent-effectiveness datasets, prompts, experiments, and resolved annotations to Phoenix. |
-| `@beep/repo-ai-metrics/index` | `ToolInvocation` | class | `packages/tooling/library/ai-metrics/src/models.ts:503` | Tool or shell command invocation measured under an agent task. |
-| `@beep/repo-ai-metrics/index` | `TranscriptIngestSummary` | class | `packages/tooling/library/ai-metrics/src/models.ts:641` | Summary produced by transcript ingestion. |
+| `@beep/repo-ai-metrics/index` | `ToolInvocation` | class | `packages/tooling/library/ai-metrics/src/models.ts:499` | Tool or shell command invocation measured under an agent task. |
+| `@beep/repo-ai-metrics/index` | `TranscriptIngestSummary` | class | `packages/tooling/library/ai-metrics/src/models.ts:637` | Summary produced by transcript ingestion. |
 | `@beep/repo-ai-metrics/index` | `upsertAiMetricsBenchmarkCase` | const | `packages/tooling/library/ai-metrics/src/scorecard.ts:681` | Add or replace a deploy-safe benchmark case. |
 | `@beep/repo-ai-metrics/index` | `writeAiMetricsConfigSnapshotArtifacts` | const | `packages/tooling/library/ai-metrics/src/config-snapshot.ts:477` | Persist a config snapshot manifest and latest pointer for future diff attribution. |
 | `@beep/repo-ai-metrics/index` | `writeAiMetricsDerivedStorage` | const | `packages/tooling/library/ai-metrics/src/derived-storage.ts:1072` | Project sanitized AI metrics records into DuckDB and export Parquet snapshots. |
@@ -6210,21 +6210,21 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/mirror` | `AiMetricsMirrorTableExport` | class | `packages/tooling/library/ai-metrics/src/mirror.ts:434` | One sanitized table exported into a P7 mirror bundle. |
 | `@beep/repo-ai-metrics/mirror` | `buildAiMetricsMirrorBundle` | const | `packages/tooling/library/ai-metrics/src/mirror.ts:643` | Build a sanitized deploy-safe P7 mirror bundle from local derived DuckDB data. |
 | `@beep/repo-ai-metrics/mirror` | `locateLatestAiMetricsMirrorBundle` | const | `packages/tooling/library/ai-metrics/src/mirror.ts:540` | Locate the latest local mirror bundle pointer for a data root. |
-| `@beep/repo-ai-metrics/models` | `AgentSession` | class | `packages/tooling/library/ai-metrics/src/models.ts:415` | Session-level transcript metadata under an agent task. |
-| `@beep/repo-ai-metrics/models` | `AgentTask` | class | `packages/tooling/library/ai-metrics/src/models.ts:383` | Canonical unit of analysis for coding-agent metrics. |
-| `@beep/repo-ai-metrics/models` | `AgentTurn` | class | `packages/tooling/library/ai-metrics/src/models.ts:451` | Turn-level transcript event normalized from local agent logs. |
+| `@beep/repo-ai-metrics/models` | `AgentSession` | class | `packages/tooling/library/ai-metrics/src/models.ts:411` | Session-level transcript metadata under an agent task. |
+| `@beep/repo-ai-metrics/models` | `AgentTask` | class | `packages/tooling/library/ai-metrics/src/models.ts:379` | Canonical unit of analysis for coding-agent metrics. |
+| `@beep/repo-ai-metrics/models` | `AgentTurn` | class | `packages/tooling/library/ai-metrics/src/models.ts:447` | Turn-level transcript event normalized from local agent logs. |
 | `@beep/repo-ai-metrics/models` | `AiMetricsDeployTarget` | const | `packages/tooling/library/ai-metrics/src/models.ts:26` | Supported deployment targets for the AI metrics stack. |
 | `@beep/repo-ai-metrics/models` | `AiMetricsDeployTarget` | type | `packages/tooling/library/ai-metrics/src/models.ts:44` | Runtime type for {@link AiMetricsDeployTarget}. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpEndpointSpec` | class | `packages/tooling/library/ai-metrics/src/models.ts:305` | Install-owned OTLP endpoint contract consumed by CLI, local smoke, and IaC. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpProtocol` | const | `packages/tooling/library/ai-metrics/src/models.ts:212` | OTLP protocol variants supported by the P3 AI metrics backend contract. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpProtocol` | type | `packages/tooling/library/ai-metrics/src/models.ts:230` | Runtime type for {@link AiMetricsOtlpProtocol}. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpSignalScope` | const | `packages/tooling/library/ai-metrics/src/models.ts:243` | Telemetry signal scope exported to the P3 Phoenix backend. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpSignalScope` | type | `packages/tooling/library/ai-metrics/src/models.ts:261` | Runtime type for {@link AiMetricsOtlpSignalScope}. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpEndpointSpec` | class | `packages/tooling/library/ai-metrics/src/models.ts:301` | Install-owned OTLP endpoint contract consumed by CLI, local smoke, and IaC. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpProtocol` | const | `packages/tooling/library/ai-metrics/src/models.ts:208` | OTLP protocol variants supported by the P3 AI metrics backend contract. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpProtocol` | type | `packages/tooling/library/ai-metrics/src/models.ts:226` | Runtime type for {@link AiMetricsOtlpProtocol}. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpSignalScope` | const | `packages/tooling/library/ai-metrics/src/models.ts:239` | Telemetry signal scope exported to the P3 Phoenix backend. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsOtlpSignalScope` | type | `packages/tooling/library/ai-metrics/src/models.ts:257` | Runtime type for {@link AiMetricsOtlpSignalScope}. |
 | `@beep/repo-ai-metrics/models` | `AiMetricsPrivacyMode` | const | `packages/tooling/library/ai-metrics/src/models.ts:177` | Raw transcript retention and derived-dashboard privacy posture. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsPrivacyMode` | type | `packages/tooling/library/ai-metrics/src/models.ts:199` | Runtime type for {@link AiMetricsPrivacyMode}. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsQualityGateStatus` | const | `packages/tooling/library/ai-metrics/src/models.ts:274` | Quality-gate outcome recorded for a labeled task or benchmark run. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsQualityGateStatus` | type | `packages/tooling/library/ai-metrics/src/models.ts:292` | Runtime type for {@link AiMetricsQualityGateStatus}. |
-| `@beep/repo-ai-metrics/models` | `AiMetricsScoreWeights` | class | `packages/tooling/library/ai-metrics/src/models.ts:329` | Outcome-heavy scorecard weights for coding-agent performance. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsPrivacyMode` | type | `packages/tooling/library/ai-metrics/src/models.ts:195` | Runtime type for {@link AiMetricsPrivacyMode}. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsQualityGateStatus` | const | `packages/tooling/library/ai-metrics/src/models.ts:270` | Quality-gate outcome recorded for a labeled task or benchmark run. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsQualityGateStatus` | type | `packages/tooling/library/ai-metrics/src/models.ts:288` | Runtime type for {@link AiMetricsQualityGateStatus}. |
+| `@beep/repo-ai-metrics/models` | `AiMetricsScoreWeights` | class | `packages/tooling/library/ai-metrics/src/models.ts:325` | Outcome-heavy scorecard weights for coding-agent performance. |
 | `@beep/repo-ai-metrics/models` | `AiMetricsSourceAttribution` | class | `packages/tooling/library/ai-metrics/src/models.ts:150` | Privacy-preserving source attribution derived from transcript metadata. |
 | `@beep/repo-ai-metrics/models` | `AiMetricsSourceRole` | const | `packages/tooling/library/ai-metrics/src/models.ts:119` | Role of a discovered source file within the source's local storage. |
 | `@beep/repo-ai-metrics/models` | `AiMetricsSourceRole` | type | `packages/tooling/library/ai-metrics/src/models.ts:137` | Runtime type for {@link AiMetricsSourceRole}. |
@@ -6232,17 +6232,17 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-ai-metrics/models` | `AiMetricsTool` | type | `packages/tooling/library/ai-metrics/src/models.ts:75` | Runtime type for {@link AiMetricsTool}. |
 | `@beep/repo-ai-metrics/models` | `AiMetricsTranscriptSource` | const | `packages/tooling/library/ai-metrics/src/models.ts:88` | Transcript source kind normalized by the ingest layer. |
 | `@beep/repo-ai-metrics/models` | `AiMetricsTranscriptSource` | type | `packages/tooling/library/ai-metrics/src/models.ts:106` | Runtime type for {@link AiMetricsTranscriptSource}. |
-| `@beep/repo-ai-metrics/models` | `BenchmarkCase` | class | `packages/tooling/library/ai-metrics/src/models.ts:554` | Repeatable benchmark case for comparing agent configurations. |
-| `@beep/repo-ai-metrics/models` | `BenchmarkRun` | class | `packages/tooling/library/ai-metrics/src/models.ts:578` | Benchmark run result under one config snapshot. |
-| `@beep/repo-ai-metrics/models` | `ClaudeTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:692` | Minimal external Claude JSONL shape. |
-| `@beep/repo-ai-metrics/models` | `CodexTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:669` | Minimal external Codex JSONL shape. |
-| `@beep/repo-ai-metrics/models` | `ConfigSnapshot` | class | `packages/tooling/library/ai-metrics/src/models.ts:354` | Versioned snapshot of agent-facing repository configuration. |
-| `@beep/repo-ai-metrics/models` | `ModelCall` | class | `packages/tooling/library/ai-metrics/src/models.ts:479` | Model or provider call measured under an agent task. |
-| `@beep/repo-ai-metrics/models` | `OpenClawTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:717` | Minimal external OpenClaw JSONL shape. |
-| `@beep/repo-ai-metrics/models` | `OutcomeLabel` | class | `packages/tooling/library/ai-metrics/src/models.ts:526` | Human label used by the weekly outcome-heavy scorecard. |
-| `@beep/repo-ai-metrics/models` | `Scorecard` | class | `packages/tooling/library/ai-metrics/src/models.ts:605` | Derived scorecard for weekly or config-impact review. |
-| `@beep/repo-ai-metrics/models` | `ToolInvocation` | class | `packages/tooling/library/ai-metrics/src/models.ts:503` | Tool or shell command invocation measured under an agent task. |
-| `@beep/repo-ai-metrics/models` | `TranscriptIngestSummary` | class | `packages/tooling/library/ai-metrics/src/models.ts:641` | Summary produced by transcript ingestion. |
+| `@beep/repo-ai-metrics/models` | `BenchmarkCase` | class | `packages/tooling/library/ai-metrics/src/models.ts:550` | Repeatable benchmark case for comparing agent configurations. |
+| `@beep/repo-ai-metrics/models` | `BenchmarkRun` | class | `packages/tooling/library/ai-metrics/src/models.ts:574` | Benchmark run result under one config snapshot. |
+| `@beep/repo-ai-metrics/models` | `ClaudeTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:688` | Minimal external Claude JSONL shape. |
+| `@beep/repo-ai-metrics/models` | `CodexTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:665` | Minimal external Codex JSONL shape. |
+| `@beep/repo-ai-metrics/models` | `ConfigSnapshot` | class | `packages/tooling/library/ai-metrics/src/models.ts:350` | Versioned snapshot of agent-facing repository configuration. |
+| `@beep/repo-ai-metrics/models` | `ModelCall` | class | `packages/tooling/library/ai-metrics/src/models.ts:475` | Model or provider call measured under an agent task. |
+| `@beep/repo-ai-metrics/models` | `OpenClawTranscriptLine` | class | `packages/tooling/library/ai-metrics/src/models.ts:713` | Minimal external OpenClaw JSONL shape. |
+| `@beep/repo-ai-metrics/models` | `OutcomeLabel` | class | `packages/tooling/library/ai-metrics/src/models.ts:522` | Human label used by the weekly outcome-heavy scorecard. |
+| `@beep/repo-ai-metrics/models` | `Scorecard` | class | `packages/tooling/library/ai-metrics/src/models.ts:601` | Derived scorecard for weekly or config-impact review. |
+| `@beep/repo-ai-metrics/models` | `ToolInvocation` | class | `packages/tooling/library/ai-metrics/src/models.ts:499` | Tool or shell command invocation measured under an agent task. |
+| `@beep/repo-ai-metrics/models` | `TranscriptIngestSummary` | class | `packages/tooling/library/ai-metrics/src/models.ts:637` | Summary produced by transcript ingestion. |
 | `@beep/repo-ai-metrics/otlp` | `AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:36` | OTLP attributes approved for redacted AI metrics span export. |
 | `@beep/repo-ai-metrics/otlp` | `AiMetricsOtlpAttributeValue` | const | `packages/tooling/library/ai-metrics/src/otlp.ts:72` | Attribute value variants allowed on redacted AI metrics OTLP spans. |
 | `@beep/repo-ai-metrics/otlp` | `AiMetricsOtlpAttributeValue` | type | `packages/tooling/library/ai-metrics/src/otlp.ts:90` | Runtime type for {@link AiMetricsOtlpAttributeValue}. |
@@ -7023,11 +7023,11 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/acp/agent` | `layer` | const | `packages/drivers/acp/src/AcpAgent.service.ts:609` | Constructs a layer for an ACP agent over the provided transport. |
 | `@beep/acp/agent` | `layerStdio` | const | `packages/drivers/acp/src/AcpAgent.service.ts:625` | Constructs a layer that reads its transport from the `Stdio` service. |
 | `@beep/acp/agent` | `make` | const | `packages/drivers/acp/src/AcpAgent.service.ts:286` | Constructs an ACP agent from an Effect `Stdio` transport. |
-| `@beep/acp/client` | `AcpClient` | class | `packages/drivers/acp/src/AcpClient.service.ts:302` | Context service tag for an ACP client. |
-| `@beep/acp/client` | `AcpClientOptions` | interface | `packages/drivers/acp/src/AcpClient.service.ts:48` | Options for constructing an ACP client service. |
-| `@beep/acp/client` | `AcpClientShape` | interface | `packages/drivers/acp/src/AcpClient.service.ts:72` | Service shape implemented by the ACP client driver. |
-| `@beep/acp/client` | `layerChildProcess` | const | `packages/drivers/acp/src/AcpClient.service.ts:690` | Constructs an ACP client layer backed by a spawned child process. |
-| `@beep/acp/client` | `make` | const | `packages/drivers/acp/src/AcpClient.service.ts:359` | Constructs an ACP client from an Effect `Stdio` transport. |
+| `@beep/acp/client` | `AcpClient` | class | `packages/drivers/acp/src/AcpClient.service.ts:303` | Context service tag for an ACP client. |
+| `@beep/acp/client` | `AcpClientOptions` | interface | `packages/drivers/acp/src/AcpClient.service.ts:49` | Options for constructing an ACP client service. |
+| `@beep/acp/client` | `AcpClientShape` | interface | `packages/drivers/acp/src/AcpClient.service.ts:73` | Service shape implemented by the ACP client driver. |
+| `@beep/acp/client` | `layerChildProcess` | const | `packages/drivers/acp/src/AcpClient.service.ts:691` | Constructs an ACP client layer backed by a spawned child process. |
+| `@beep/acp/client` | `make` | const | `packages/drivers/acp/src/AcpClient.service.ts:360` | Constructs an ACP client from an Effect `Stdio` transport. |
 | `@beep/acp/errors` | `AcpError` | const | `packages/drivers/acp/src/Acp.errors.ts:392` | Union of typed technical failures emitted by the ACP driver. |
 | `@beep/acp/errors` | `AcpError` | type | `packages/drivers/acp/src/Acp.errors.ts:414` | Type for {@link AcpError}. |
 | `@beep/acp/errors` | `AcpProcessExitedError` | class | `packages/drivers/acp/src/Acp.errors.ts:62` | Failure raised when an ACP process exits before the protocol completes. |
@@ -7035,13 +7035,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/acp/errors` | `AcpRequestError` | class | `packages/drivers/acp/src/Acp.errors.ts:145` | JSON-RPC request failure returned by an ACP peer. |
 | `@beep/acp/errors` | `AcpSpawnError` | class | `packages/drivers/acp/src/Acp.errors.ts:31` | Failure raised when an ACP child process cannot be spawned. |
 | `@beep/acp/errors` | `AcpTransportError` | class | `packages/drivers/acp/src/Acp.errors.ts:120` | Failure raised by the ACP transport boundary. |
-| `@beep/acp/protocol` | `AcpIncomingNotification` | const | `packages/drivers/acp/src/AcpProtocol.service.ts:140` | Schema for notifications decoded from the ACP peer stream. |
-| `@beep/acp/protocol` | `AcpIncomingNotification` | type | `packages/drivers/acp/src/AcpProtocol.service.ts:173` | Type for {@link AcpIncomingNotification}. |
-| `@beep/acp/protocol` | `AcpPatchedProtocol` | interface | `packages/drivers/acp/src/AcpProtocol.service.ts:216` | Runtime protocol handles used by ACP clients and agents. |
-| `@beep/acp/protocol` | `AcpPatchedProtocolOptions` | interface | `packages/drivers/acp/src/AcpProtocol.service.ts:192` | Options used to create the patched ACP protocol. |
-| `@beep/acp/protocol` | `AcpProtocolLogEvent` | class | `packages/drivers/acp/src/AcpProtocol.service.ts:92` | Structured log event emitted by the ACP protocol adapter. |
-| `@beep/acp/protocol` | `AcpProtocolLoggingOptions` | class | `packages/drivers/acp/src/AcpProtocol.service.ts:117` | Schema-backed ACP protocol logging flags. |
-| `@beep/acp/protocol` | `makeAcpPatchedProtocol` | const | `packages/drivers/acp/src/AcpProtocol.service.ts:252` | Builds the patched ACP protocol over an Effect `Stdio` transport. |
+| `@beep/acp/protocol` | `AcpIncomingNotification` | const | `packages/drivers/acp/src/AcpProtocol.service.ts:186` | Schema for notifications decoded from the ACP peer stream. |
+| `@beep/acp/protocol` | `AcpIncomingNotification` | type | `packages/drivers/acp/src/AcpProtocol.service.ts:219` | Type for {@link AcpIncomingNotification}. |
+| `@beep/acp/protocol` | `AcpPatchedProtocol` | interface | `packages/drivers/acp/src/AcpProtocol.service.ts:262` | Runtime protocol handles used by ACP clients and agents. |
+| `@beep/acp/protocol` | `AcpPatchedProtocolOptions` | interface | `packages/drivers/acp/src/AcpProtocol.service.ts:238` | Options used to create the patched ACP protocol. |
+| `@beep/acp/protocol` | `AcpProtocolLogEvent` | const | `packages/drivers/acp/src/AcpProtocol.service.ts:97` | Structured log event emitted by the ACP protocol adapter. |
+| `@beep/acp/protocol` | `AcpProtocolLogEvent` | type | `packages/drivers/acp/src/AcpProtocol.service.ts:147` | Structured log event emitted by the ACP protocol adapter. |
+| `@beep/acp/protocol` | `AcpProtocolLoggingOptions` | class | `packages/drivers/acp/src/AcpProtocol.service.ts:163` | Schema-backed ACP protocol logging flags. |
+| `@beep/acp/protocol` | `makeAcpPatchedProtocol` | const | `packages/drivers/acp/src/AcpProtocol.service.ts:304` | Builds the patched ACP protocol over an Effect `Stdio` transport. |
 | `@beep/acp/rpc` | `AgentRpcs` | const | `packages/drivers/acp/src/AcpRpc.models.ts:425` | RPC group served by ACP agents. |
 | `@beep/acp/rpc` | `AuthenticateRpc` | const | `packages/drivers/acp/src/AcpRpc.models.ts:45` | RPC definition for `AuthenticateRpc`. |
 | `@beep/acp/rpc` | `ClientRpcs` | const | `packages/drivers/acp/src/AcpRpc.models.ts:453` | RPC group served by ACP clients. |
@@ -7429,31 +7430,31 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp` | `Wink` | SourceFile | `packages/foundation/capability/nlp/src/Wink/index.ts:7` |  |
 | `@beep/nlp/Core` | `addElements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:302` | Append elements to a pattern. |
 | `@beep/nlp/Core` | `applyPatch` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:613` | Apply a patch to a pattern. |
-| `@beep/nlp/Core` | `BracketStringToEntityPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:134` | Decode an entity bracket string into a pattern element. |
-| `@beep/nlp/Core` | `BracketStringToLiteralPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:167` | Decode a literal bracket string into a pattern element. |
-| `@beep/nlp/Core` | `BracketStringToPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:200` | Decode any supported bracket string element. |
-| `@beep/nlp/Core` | `BracketStringToPatternElement` | type | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:225` | Runtime type for {@link BracketStringToPatternElement}. |
+| `@beep/nlp/Core` | `BracketStringToEntityPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:132` | Decode an entity bracket string into a pattern element. |
+| `@beep/nlp/Core` | `BracketStringToLiteralPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:163` | Decode a literal bracket string into a pattern element. |
+| `@beep/nlp/Core` | `BracketStringToPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:194` | Decode any supported bracket string element. |
+| `@beep/nlp/Core` | `BracketStringToPatternElement` | type | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:217` | Runtime type for {@link BracketStringToPatternElement}. |
 | `@beep/nlp/Core` | `BracketStringToPOSPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:103` | Decode a POS bracket string into a pattern element. |
 | `@beep/nlp/Core` | `charPosition` | const | `packages/foundation/capability/nlp/src/Core/Token.ts:120` | Constructor for {@link CharPosition}. |
 | `@beep/nlp/Core` | `CharPosition` | const | `packages/foundation/capability/nlp/src/Core/Token.ts:137` | Schema for {@link CharPosition}. |
 | `@beep/nlp/Core` | `CharPosition` | type | `packages/foundation/capability/nlp/src/Core/Token.ts:90` | Branded number type for character positions. |
 | `@beep/nlp/Core` | `combine` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:576` | Combine two patterns into a new one. |
 | `@beep/nlp/Core` | `composePatches` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:631` | Compose multiple patches from left to right. |
-| `@beep/nlp/Core` | `Document` | class | `packages/foundation/capability/nlp/src/Core/Document.ts:169` | Immutable NLP document model. |
+| `@beep/nlp/Core` | `Document` | class | `packages/foundation/capability/nlp/src/Core/Document.ts:167` | Immutable NLP document model. |
 | `@beep/nlp/Core` | `DocumentId` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:43` | Branded identifier for NLP documents. |
-| `@beep/nlp/Core` | `DocumentId` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:65` | Runtime type for {@link DocumentId}. |
-| `@beep/nlp/Core` | `documentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:95` | Constructor for {@link DocumentIndex}. |
-| `@beep/nlp/Core` | `DocumentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:112` | Schema for {@link DocumentIndex}. |
-| `@beep/nlp/Core` | `DocumentIndex` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:80` | Branded index for documents in ordered collections. |
+| `@beep/nlp/Core` | `DocumentId` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:63` | Runtime type for {@link DocumentId}. |
+| `@beep/nlp/Core` | `documentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:93` | Constructor for {@link DocumentIndex}. |
+| `@beep/nlp/Core` | `DocumentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:110` | Schema for {@link DocumentIndex}. |
+| `@beep/nlp/Core` | `DocumentIndex` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:78` | Branded index for documents in ordered collections. |
 | `@beep/nlp/Core` | `drop` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:555` | Drop the first `count` elements. |
 | `@beep/nlp/Core` | `elementAt` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:423` | Get an element by index. |
 | `@beep/nlp/Core` | `elements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:408` | Materialize pattern elements as a readonly array. |
 | `@beep/nlp/Core` | `entity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:116` | Create an entity pattern element. |
 | `@beep/nlp/Core` | `entity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:117` |  |
 | `@beep/nlp/Core` | `entity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:118` |  |
-| `@beep/nlp/Core` | `EntityPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:296` | Pattern element matching one or more entity types. |
-| `@beep/nlp/Core` | `EntityPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:196` | Entity alternatives for a single pattern position. |
-| `@beep/nlp/Core` | `EntityPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:219` | Runtime type for {@link EntityPatternOption}. |
+| `@beep/nlp/Core` | `EntityPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:290` | Pattern element matching one or more entity types. |
+| `@beep/nlp/Core` | `EntityPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:194` | Entity alternatives for a single pattern position. |
+| `@beep/nlp/Core` | `EntityPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:215` | Runtime type for {@link EntityPatternOption}. |
 | `@beep/nlp/Core` | `extractBracketContent` | const | `packages/foundation/capability/nlp/src/Core/PatternOperations.ts:89` | Create a bracket-string content slice if the input is bracketed. |
 | `@beep/nlp/Core` | `extractElementValues` | const | `packages/foundation/capability/nlp/src/Core/PatternOperations.ts:74` | Extract element values as a readonly array. |
 | `@beep/nlp/Core` | `filterElements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:513` | Filter pattern elements. |
@@ -7473,13 +7474,13 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Core` | `literal` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:141` | Create a literal pattern element. |
 | `@beep/nlp/Core` | `literal` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:142` |  |
 | `@beep/nlp/Core` | `literal` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:143` |  |
-| `@beep/nlp/Core` | `LiteralPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:319` | Pattern element matching one or more literal strings. |
-| `@beep/nlp/Core` | `LiteralPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:234` | Literal alternatives for a single pattern position. |
-| `@beep/nlp/Core` | `LiteralPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:258` | Runtime type for {@link LiteralPatternOption}. |
+| `@beep/nlp/Core` | `LiteralPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:313` | Pattern element matching one or more literal strings. |
+| `@beep/nlp/Core` | `LiteralPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:230` | Literal alternatives for a single pattern position. |
+| `@beep/nlp/Core` | `LiteralPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:252` | Runtime type for {@link LiteralPatternOption}. |
 | `@beep/nlp/Core` | `make` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:241` | Construct a pattern from an id and ordered elements. |
 | `@beep/nlp/Core` | `mapElements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:492` | Map pattern elements. |
-| `@beep/nlp/Core` | `MarkRange` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:415` | Inclusive mark range over pattern element positions. |
-| `@beep/nlp/Core` | `MarkRange` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:436` | Runtime type for {@link MarkRange}. |
+| `@beep/nlp/Core` | `MarkRange` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:405` | Inclusive mark range over pattern element positions. |
+| `@beep/nlp/Core` | `MarkRange` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:424` | Runtime type for {@link MarkRange}. |
 | `@beep/nlp/Core` | `optionalEntity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:188` | Create an optional entity pattern element. |
 | `@beep/nlp/Core` | `optionalEntity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:189` |  |
 | `@beep/nlp/Core` | `optionalEntity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:190` |  |
@@ -7491,19 +7492,19 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Core` | `optionalPos` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:165` |  |
 | `@beep/nlp/Core` | `patchReplaceAllLiterals` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:675` | Replace all literal elements. |
 | `@beep/nlp/Core` | `patchReplaceLiteralAt` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:647` | Replace a literal element at a given index. |
-| `@beep/nlp/Core` | `Pattern` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:451` | Immutable NLP pattern. |
-| `@beep/nlp/Core` | `PatternElement` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:342` | Union of supported pattern elements. |
-| `@beep/nlp/Core` | `PatternElement` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:363` | Runtime type for {@link PatternElement}. |
-| `@beep/nlp/Core` | `PatternFromString` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:240` | Decode a string array into ordered pattern elements. |
-| `@beep/nlp/Core` | `PatternId` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:378` | Branded pattern identifier. |
-| `@beep/nlp/Core` | `PatternId` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:400` | Runtime type for {@link PatternId}. |
+| `@beep/nlp/Core` | `Pattern` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:439` | Immutable NLP pattern. |
+| `@beep/nlp/Core` | `PatternElement` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:336` | Union of supported pattern elements. |
+| `@beep/nlp/Core` | `PatternElement` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:355` | Runtime type for {@link PatternElement}. |
+| `@beep/nlp/Core` | `PatternFromString` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:232` | Decode a string array into ordered pattern elements. |
+| `@beep/nlp/Core` | `PatternId` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:370` | Branded pattern identifier. |
+| `@beep/nlp/Core` | `PatternId` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:390` | Runtime type for {@link PatternId}. |
 | `@beep/nlp/Core` | `PatternPatch` | type | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:598` | Functional patch over a pattern. |
 | `@beep/nlp/Core` | `pos` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:91` | Create a POS pattern element. |
 | `@beep/nlp/Core` | `pos` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:92` |  |
 | `@beep/nlp/Core` | `pos` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:93` |  |
-| `@beep/nlp/Core` | `POSPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:273` | Pattern element matching one or more POS tags. |
+| `@beep/nlp/Core` | `POSPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:267` | Pattern element matching one or more POS tags. |
 | `@beep/nlp/Core` | `POSPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:158` | POS alternatives for a single pattern position. |
-| `@beep/nlp/Core` | `POSPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:181` | Runtime type for {@link POSPatternOption}. |
+| `@beep/nlp/Core` | `POSPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:179` | Runtime type for {@link POSPatternOption}. |
 | `@beep/nlp/Core` | `prependElements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:323` | Prepend elements to a pattern. |
 | `@beep/nlp/Core` | `Sentence` | class | `packages/foundation/capability/nlp/src/Core/Sentence.ts:82` | Immutable NLP sentence model. |
 | `@beep/nlp/Core` | `sentenceIndex` | const | `packages/foundation/capability/nlp/src/Core/Sentence.ts:50` | Constructor for {@link SentenceIndex}. |
@@ -7528,39 +7529,39 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Core` | `withId` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:344` | Replace the pattern id. |
 | `@beep/nlp/Core` | `withMark` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:263` | Add a mark range to a pattern. |
 | `@beep/nlp/Core` | `withoutMark` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:281` | Remove a mark range from a pattern. |
-| `@beep/nlp/Core/Document` | `Document` | class | `packages/foundation/capability/nlp/src/Core/Document.ts:169` | Immutable NLP document model. |
+| `@beep/nlp/Core/Document` | `Document` | class | `packages/foundation/capability/nlp/src/Core/Document.ts:167` | Immutable NLP document model. |
 | `@beep/nlp/Core/Document` | `DocumentId` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:43` | Branded identifier for NLP documents. |
-| `@beep/nlp/Core/Document` | `DocumentId` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:65` | Runtime type for {@link DocumentId}. |
-| `@beep/nlp/Core/Document` | `documentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:95` | Constructor for {@link DocumentIndex}. |
-| `@beep/nlp/Core/Document` | `DocumentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:112` | Schema for {@link DocumentIndex}. |
-| `@beep/nlp/Core/Document` | `DocumentIndex` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:80` | Branded index for documents in ordered collections. |
+| `@beep/nlp/Core/Document` | `DocumentId` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:63` | Runtime type for {@link DocumentId}. |
+| `@beep/nlp/Core/Document` | `documentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:93` | Constructor for {@link DocumentIndex}. |
+| `@beep/nlp/Core/Document` | `DocumentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:110` | Schema for {@link DocumentIndex}. |
+| `@beep/nlp/Core/Document` | `DocumentIndex` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:78` | Branded index for documents in ordered collections. |
 | `@beep/nlp/Core/index` | `addElements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:302` | Append elements to a pattern. |
 | `@beep/nlp/Core/index` | `applyPatch` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:613` | Apply a patch to a pattern. |
-| `@beep/nlp/Core/index` | `BracketStringToEntityPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:134` | Decode an entity bracket string into a pattern element. |
-| `@beep/nlp/Core/index` | `BracketStringToLiteralPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:167` | Decode a literal bracket string into a pattern element. |
-| `@beep/nlp/Core/index` | `BracketStringToPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:200` | Decode any supported bracket string element. |
-| `@beep/nlp/Core/index` | `BracketStringToPatternElement` | type | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:225` | Runtime type for {@link BracketStringToPatternElement}. |
+| `@beep/nlp/Core/index` | `BracketStringToEntityPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:132` | Decode an entity bracket string into a pattern element. |
+| `@beep/nlp/Core/index` | `BracketStringToLiteralPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:163` | Decode a literal bracket string into a pattern element. |
+| `@beep/nlp/Core/index` | `BracketStringToPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:194` | Decode any supported bracket string element. |
+| `@beep/nlp/Core/index` | `BracketStringToPatternElement` | type | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:217` | Runtime type for {@link BracketStringToPatternElement}. |
 | `@beep/nlp/Core/index` | `BracketStringToPOSPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:103` | Decode a POS bracket string into a pattern element. |
 | `@beep/nlp/Core/index` | `charPosition` | const | `packages/foundation/capability/nlp/src/Core/Token.ts:120` | Constructor for {@link CharPosition}. |
 | `@beep/nlp/Core/index` | `CharPosition` | const | `packages/foundation/capability/nlp/src/Core/Token.ts:137` | Schema for {@link CharPosition}. |
 | `@beep/nlp/Core/index` | `CharPosition` | type | `packages/foundation/capability/nlp/src/Core/Token.ts:90` | Branded number type for character positions. |
 | `@beep/nlp/Core/index` | `combine` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:576` | Combine two patterns into a new one. |
 | `@beep/nlp/Core/index` | `composePatches` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:631` | Compose multiple patches from left to right. |
-| `@beep/nlp/Core/index` | `Document` | class | `packages/foundation/capability/nlp/src/Core/Document.ts:169` | Immutable NLP document model. |
+| `@beep/nlp/Core/index` | `Document` | class | `packages/foundation/capability/nlp/src/Core/Document.ts:167` | Immutable NLP document model. |
 | `@beep/nlp/Core/index` | `DocumentId` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:43` | Branded identifier for NLP documents. |
-| `@beep/nlp/Core/index` | `DocumentId` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:65` | Runtime type for {@link DocumentId}. |
-| `@beep/nlp/Core/index` | `documentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:95` | Constructor for {@link DocumentIndex}. |
-| `@beep/nlp/Core/index` | `DocumentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:112` | Schema for {@link DocumentIndex}. |
-| `@beep/nlp/Core/index` | `DocumentIndex` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:80` | Branded index for documents in ordered collections. |
+| `@beep/nlp/Core/index` | `DocumentId` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:63` | Runtime type for {@link DocumentId}. |
+| `@beep/nlp/Core/index` | `documentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:93` | Constructor for {@link DocumentIndex}. |
+| `@beep/nlp/Core/index` | `DocumentIndex` | const | `packages/foundation/capability/nlp/src/Core/Document.ts:110` | Schema for {@link DocumentIndex}. |
+| `@beep/nlp/Core/index` | `DocumentIndex` | type | `packages/foundation/capability/nlp/src/Core/Document.ts:78` | Branded index for documents in ordered collections. |
 | `@beep/nlp/Core/index` | `drop` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:555` | Drop the first `count` elements. |
 | `@beep/nlp/Core/index` | `elementAt` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:423` | Get an element by index. |
 | `@beep/nlp/Core/index` | `elements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:408` | Materialize pattern elements as a readonly array. |
 | `@beep/nlp/Core/index` | `entity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:116` | Create an entity pattern element. |
 | `@beep/nlp/Core/index` | `entity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:117` |  |
 | `@beep/nlp/Core/index` | `entity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:118` |  |
-| `@beep/nlp/Core/index` | `EntityPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:296` | Pattern element matching one or more entity types. |
-| `@beep/nlp/Core/index` | `EntityPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:196` | Entity alternatives for a single pattern position. |
-| `@beep/nlp/Core/index` | `EntityPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:219` | Runtime type for {@link EntityPatternOption}. |
+| `@beep/nlp/Core/index` | `EntityPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:290` | Pattern element matching one or more entity types. |
+| `@beep/nlp/Core/index` | `EntityPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:194` | Entity alternatives for a single pattern position. |
+| `@beep/nlp/Core/index` | `EntityPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:215` | Runtime type for {@link EntityPatternOption}. |
 | `@beep/nlp/Core/index` | `extractBracketContent` | const | `packages/foundation/capability/nlp/src/Core/PatternOperations.ts:89` | Create a bracket-string content slice if the input is bracketed. |
 | `@beep/nlp/Core/index` | `extractElementValues` | const | `packages/foundation/capability/nlp/src/Core/PatternOperations.ts:74` | Extract element values as a readonly array. |
 | `@beep/nlp/Core/index` | `filterElements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:513` | Filter pattern elements. |
@@ -7580,13 +7581,13 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Core/index` | `literal` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:141` | Create a literal pattern element. |
 | `@beep/nlp/Core/index` | `literal` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:142` |  |
 | `@beep/nlp/Core/index` | `literal` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:143` |  |
-| `@beep/nlp/Core/index` | `LiteralPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:319` | Pattern element matching one or more literal strings. |
-| `@beep/nlp/Core/index` | `LiteralPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:234` | Literal alternatives for a single pattern position. |
-| `@beep/nlp/Core/index` | `LiteralPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:258` | Runtime type for {@link LiteralPatternOption}. |
+| `@beep/nlp/Core/index` | `LiteralPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:313` | Pattern element matching one or more literal strings. |
+| `@beep/nlp/Core/index` | `LiteralPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:230` | Literal alternatives for a single pattern position. |
+| `@beep/nlp/Core/index` | `LiteralPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:252` | Runtime type for {@link LiteralPatternOption}. |
 | `@beep/nlp/Core/index` | `make` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:241` | Construct a pattern from an id and ordered elements. |
 | `@beep/nlp/Core/index` | `mapElements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:492` | Map pattern elements. |
-| `@beep/nlp/Core/index` | `MarkRange` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:415` | Inclusive mark range over pattern element positions. |
-| `@beep/nlp/Core/index` | `MarkRange` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:436` | Runtime type for {@link MarkRange}. |
+| `@beep/nlp/Core/index` | `MarkRange` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:405` | Inclusive mark range over pattern element positions. |
+| `@beep/nlp/Core/index` | `MarkRange` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:424` | Runtime type for {@link MarkRange}. |
 | `@beep/nlp/Core/index` | `optionalEntity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:188` | Create an optional entity pattern element. |
 | `@beep/nlp/Core/index` | `optionalEntity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:189` |  |
 | `@beep/nlp/Core/index` | `optionalEntity` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:190` |  |
@@ -7598,19 +7599,19 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Core/index` | `optionalPos` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:165` |  |
 | `@beep/nlp/Core/index` | `patchReplaceAllLiterals` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:675` | Replace all literal elements. |
 | `@beep/nlp/Core/index` | `patchReplaceLiteralAt` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:647` | Replace a literal element at a given index. |
-| `@beep/nlp/Core/index` | `Pattern` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:451` | Immutable NLP pattern. |
-| `@beep/nlp/Core/index` | `PatternElement` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:342` | Union of supported pattern elements. |
-| `@beep/nlp/Core/index` | `PatternElement` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:363` | Runtime type for {@link PatternElement}. |
-| `@beep/nlp/Core/index` | `PatternFromString` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:240` | Decode a string array into ordered pattern elements. |
-| `@beep/nlp/Core/index` | `PatternId` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:378` | Branded pattern identifier. |
-| `@beep/nlp/Core/index` | `PatternId` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:400` | Runtime type for {@link PatternId}. |
+| `@beep/nlp/Core/index` | `Pattern` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:439` | Immutable NLP pattern. |
+| `@beep/nlp/Core/index` | `PatternElement` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:336` | Union of supported pattern elements. |
+| `@beep/nlp/Core/index` | `PatternElement` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:355` | Runtime type for {@link PatternElement}. |
+| `@beep/nlp/Core/index` | `PatternFromString` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:232` | Decode a string array into ordered pattern elements. |
+| `@beep/nlp/Core/index` | `PatternId` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:370` | Branded pattern identifier. |
+| `@beep/nlp/Core/index` | `PatternId` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:390` | Runtime type for {@link PatternId}. |
 | `@beep/nlp/Core/index` | `PatternPatch` | type | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:598` | Functional patch over a pattern. |
 | `@beep/nlp/Core/index` | `pos` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:91` | Create a POS pattern element. |
 | `@beep/nlp/Core/index` | `pos` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:92` |  |
 | `@beep/nlp/Core/index` | `pos` | function | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:93` |  |
-| `@beep/nlp/Core/index` | `POSPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:273` | Pattern element matching one or more POS tags. |
+| `@beep/nlp/Core/index` | `POSPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:267` | Pattern element matching one or more POS tags. |
 | `@beep/nlp/Core/index` | `POSPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:158` | POS alternatives for a single pattern position. |
-| `@beep/nlp/Core/index` | `POSPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:181` | Runtime type for {@link POSPatternOption}. |
+| `@beep/nlp/Core/index` | `POSPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:179` | Runtime type for {@link POSPatternOption}. |
 | `@beep/nlp/Core/index` | `prependElements` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:323` | Prepend elements to a pattern. |
 | `@beep/nlp/Core/index` | `Sentence` | class | `packages/foundation/capability/nlp/src/Core/Sentence.ts:82` | Immutable NLP sentence model. |
 | `@beep/nlp/Core/index` | `sentenceIndex` | const | `packages/foundation/capability/nlp/src/Core/Sentence.ts:50` | Constructor for {@link SentenceIndex}. |
@@ -7635,22 +7636,22 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Core/index` | `withId` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:344` | Replace the pattern id. |
 | `@beep/nlp/Core/index` | `withMark` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:263` | Add a mark range to a pattern. |
 | `@beep/nlp/Core/index` | `withoutMark` | const | `packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:281` | Remove a mark range from a pattern. |
-| `@beep/nlp/Core/Pattern` | `EntityPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:296` | Pattern element matching one or more entity types. |
-| `@beep/nlp/Core/Pattern` | `EntityPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:196` | Entity alternatives for a single pattern position. |
-| `@beep/nlp/Core/Pattern` | `EntityPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:219` | Runtime type for {@link EntityPatternOption}. |
-| `@beep/nlp/Core/Pattern` | `LiteralPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:319` | Pattern element matching one or more literal strings. |
-| `@beep/nlp/Core/Pattern` | `LiteralPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:234` | Literal alternatives for a single pattern position. |
-| `@beep/nlp/Core/Pattern` | `LiteralPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:258` | Runtime type for {@link LiteralPatternOption}. |
-| `@beep/nlp/Core/Pattern` | `MarkRange` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:415` | Inclusive mark range over pattern element positions. |
-| `@beep/nlp/Core/Pattern` | `MarkRange` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:436` | Runtime type for {@link MarkRange}. |
-| `@beep/nlp/Core/Pattern` | `Pattern` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:451` | Immutable NLP pattern. |
-| `@beep/nlp/Core/Pattern` | `PatternElement` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:342` | Union of supported pattern elements. |
-| `@beep/nlp/Core/Pattern` | `PatternElement` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:363` | Runtime type for {@link PatternElement}. |
-| `@beep/nlp/Core/Pattern` | `PatternId` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:378` | Branded pattern identifier. |
-| `@beep/nlp/Core/Pattern` | `PatternId` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:400` | Runtime type for {@link PatternId}. |
-| `@beep/nlp/Core/Pattern` | `POSPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:273` | Pattern element matching one or more POS tags. |
+| `@beep/nlp/Core/Pattern` | `EntityPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:290` | Pattern element matching one or more entity types. |
+| `@beep/nlp/Core/Pattern` | `EntityPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:194` | Entity alternatives for a single pattern position. |
+| `@beep/nlp/Core/Pattern` | `EntityPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:215` | Runtime type for {@link EntityPatternOption}. |
+| `@beep/nlp/Core/Pattern` | `LiteralPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:313` | Pattern element matching one or more literal strings. |
+| `@beep/nlp/Core/Pattern` | `LiteralPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:230` | Literal alternatives for a single pattern position. |
+| `@beep/nlp/Core/Pattern` | `LiteralPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:252` | Runtime type for {@link LiteralPatternOption}. |
+| `@beep/nlp/Core/Pattern` | `MarkRange` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:405` | Inclusive mark range over pattern element positions. |
+| `@beep/nlp/Core/Pattern` | `MarkRange` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:424` | Runtime type for {@link MarkRange}. |
+| `@beep/nlp/Core/Pattern` | `Pattern` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:439` | Immutable NLP pattern. |
+| `@beep/nlp/Core/Pattern` | `PatternElement` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:336` | Union of supported pattern elements. |
+| `@beep/nlp/Core/Pattern` | `PatternElement` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:355` | Runtime type for {@link PatternElement}. |
+| `@beep/nlp/Core/Pattern` | `PatternId` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:370` | Branded pattern identifier. |
+| `@beep/nlp/Core/Pattern` | `PatternId` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:390` | Runtime type for {@link PatternId}. |
+| `@beep/nlp/Core/Pattern` | `POSPatternElement` | class | `packages/foundation/capability/nlp/src/Core/Pattern.ts:267` | Pattern element matching one or more POS tags. |
 | `@beep/nlp/Core/Pattern` | `POSPatternOption` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:158` | POS alternatives for a single pattern position. |
-| `@beep/nlp/Core/Pattern` | `POSPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:181` | Runtime type for {@link POSPatternOption}. |
+| `@beep/nlp/Core/Pattern` | `POSPatternOption` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:179` | Runtime type for {@link POSPatternOption}. |
 | `@beep/nlp/Core/Pattern` | `WinkEntityType` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:112` | Supported wink entity types. |
 | `@beep/nlp/Core/Pattern` | `WinkEntityType` | type | `packages/foundation/capability/nlp/src/Core/Pattern.ts:132` | Runtime type for {@link WinkEntityType}. |
 | `@beep/nlp/Core/Pattern` | `WinkPOSTag` | const | `packages/foundation/capability/nlp/src/Core/Pattern.ts:77` | Supported wink part-of-speech tags. |
@@ -7705,12 +7706,12 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Core/PatternOperations` | `isPOSElement` | const | `packages/foundation/capability/nlp/src/Core/PatternOperations.ts:26` | Check whether an element is a POS element. |
 | `@beep/nlp/Core/PatternOperations` | `joinBracketValues` | const | `packages/foundation/capability/nlp/src/Core/PatternOperations.ts:120` | Join values into bracket-string form. |
 | `@beep/nlp/Core/PatternOperations` | `splitBracketValues` | const | `packages/foundation/capability/nlp/src/Core/PatternOperations.ts:105` | Split bracket content into trimmed segments. |
-| `@beep/nlp/Core/PatternParsers` | `BracketStringToEntityPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:134` | Decode an entity bracket string into a pattern element. |
-| `@beep/nlp/Core/PatternParsers` | `BracketStringToLiteralPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:167` | Decode a literal bracket string into a pattern element. |
-| `@beep/nlp/Core/PatternParsers` | `BracketStringToPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:200` | Decode any supported bracket string element. |
-| `@beep/nlp/Core/PatternParsers` | `BracketStringToPatternElement` | type | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:225` | Runtime type for {@link BracketStringToPatternElement}. |
+| `@beep/nlp/Core/PatternParsers` | `BracketStringToEntityPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:132` | Decode an entity bracket string into a pattern element. |
+| `@beep/nlp/Core/PatternParsers` | `BracketStringToLiteralPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:163` | Decode a literal bracket string into a pattern element. |
+| `@beep/nlp/Core/PatternParsers` | `BracketStringToPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:194` | Decode any supported bracket string element. |
+| `@beep/nlp/Core/PatternParsers` | `BracketStringToPatternElement` | type | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:217` | Runtime type for {@link BracketStringToPatternElement}. |
 | `@beep/nlp/Core/PatternParsers` | `BracketStringToPOSPatternElement` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:103` | Decode a POS bracket string into a pattern element. |
-| `@beep/nlp/Core/PatternParsers` | `PatternFromString` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:240` | Decode a string array into ordered pattern elements. |
+| `@beep/nlp/Core/PatternParsers` | `PatternFromString` | const | `packages/foundation/capability/nlp/src/Core/PatternParsers.ts:232` | Decode a string array into ordered pattern elements. |
 | `@beep/nlp/Core/Sentence` | `Sentence` | class | `packages/foundation/capability/nlp/src/Core/Sentence.ts:82` | Immutable NLP sentence model. |
 | `@beep/nlp/Core/Sentence` | `sentenceIndex` | const | `packages/foundation/capability/nlp/src/Core/Sentence.ts:50` | Constructor for {@link SentenceIndex}. |
 | `@beep/nlp/Core/Sentence` | `SentenceIndex` | const | `packages/foundation/capability/nlp/src/Core/Sentence.ts:67` | Schema for {@link SentenceIndex}. |
@@ -7870,14 +7871,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Wink` | `BM25Config` | class | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:192` | BM25 configuration used by wink vectorization and corpus management. |
 | `@beep/nlp/Wink` | `BM25Norm` | const | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:117` | BM25 normalization mode used by the vectorizer and corpus services. |
 | `@beep/nlp/Wink` | `CorpusManagerError` | class | `packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts:262` | Error raised while managing a live corpus session. |
-| `@beep/nlp/Wink` | `CustomEntityExample` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:101` | One custom-entity example expressed as ordered bracket-pattern elements. |
+| `@beep/nlp/Wink` | `CustomEntityExample` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:99` | One custom-entity example expressed as ordered bracket-pattern elements. |
 | `@beep/nlp/Wink` | `DefaultBM25Config` | const | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:221` | Default BM25 configuration used by the live wink vectorizer. |
 | `@beep/nlp/Wink` | `DocumentTermSet` | class | `packages/foundation/capability/nlp/src/Wink/WinkSimilarity.ts:100` | Set of normalized document terms used for set-based similarity. |
 | `@beep/nlp/Wink` | `DocumentVector` | class | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:241` | Dense vector representation for a document or query. |
 | `@beep/nlp/Wink` | `EntityGroupName` | const | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:64` | Branded identifier for a wink custom-entity group. |
-| `@beep/nlp/Wink` | `EntityGroupName` | type | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:86` | Runtime type for {@link EntityGroupName}. |
+| `@beep/nlp/Wink` | `EntityGroupName` | type | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:84` | Runtime type for {@link EntityGroupName}. |
 | `@beep/nlp/Wink` | `InstanceId` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:51` | Branded runtime identifier for one live wink engine instance. |
-| `@beep/nlp/Wink` | `InstanceId` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:73` | Runtime type for {@link InstanceId}. |
+| `@beep/nlp/Wink` | `InstanceId` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:71` | Runtime type for {@link InstanceId}. |
 | `@beep/nlp/Wink` | `ScopedVectorizer` | interface | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:80` | Minimal isolated vectorizer surface used by ranking and keyword extraction. |
 | `@beep/nlp/Wink` | `SentenceSpanFailure` | class | `packages/foundation/capability/nlp/src/Wink/WinkTokenizer.ts:44` | Failure raised when wink sentence spans cannot be derived from the token stream. |
 | `@beep/nlp/Wink` | `SimilarityError` | class | `packages/foundation/capability/nlp/src/Wink/WinkSimilarity.ts:157` | Error raised while computing wink-backed similarity. |
@@ -7887,14 +7888,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Wink` | `VectorizerError` | class | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:323` | Error raised while learning or querying wink BM25 vectors. |
 | `@beep/nlp/Wink` | `WinkCorpusManager` | class | `packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts:727` | Wink corpus manager service. |
 | `@beep/nlp/Wink` | `WinkCorpusManagerLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts:744` | Live wink corpus manager layer. |
-| `@beep/nlp/Wink` | `WinkEngine` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:240` | Wink engine service tag. |
-| `@beep/nlp/Wink` | `WinkEngineCustomEntities` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:145` | Collection of learned custom-entity examples tracked as one logical group. |
+| `@beep/nlp/Wink` | `WinkEngine` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:238` | Wink engine service tag. |
+| `@beep/nlp/Wink` | `WinkEngineCustomEntities` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:143` | Collection of learned custom-entity examples tracked as one logical group. |
 | `@beep/nlp/Wink` | `WinkEngineError` | class | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:37` | Failure raised while creating or accessing the wink runtime. |
-| `@beep/nlp/Wink` | `WinkEngineLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:255` | Live wink engine layer. |
+| `@beep/nlp/Wink` | `WinkEngineLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:253` | Live wink engine layer. |
 | `@beep/nlp/Wink` | `WinkEngineRef` | const | `packages/foundation/capability/nlp/src/Wink/index.ts:55` | import { WinkEngineRef } from "@beep/nlp/Wink" |
 | `@beep/nlp/Wink` | `WinkEngineRefLive` | const | `packages/foundation/capability/nlp/src/Wink/index.ts:67` | import { WinkEngineRefLive } from "@beep/nlp/Wink" |
-| `@beep/nlp/Wink` | `WinkEngineRuntimeState` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:111` | In-memory wink engine runtime state including the live wink runtime. |
-| `@beep/nlp/Wink` | `WinkEngineState` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:88` | Serializable wink engine state metadata. |
+| `@beep/nlp/Wink` | `WinkEngineRuntimeState` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:109` | In-memory wink engine runtime state including the live wink runtime. |
+| `@beep/nlp/Wink` | `WinkEngineState` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:86` | Serializable wink engine state metadata. |
 | `@beep/nlp/Wink` | `WinkEntityError` | class | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:131` | Failure raised while learning or managing custom entity patterns. |
 | `@beep/nlp/Wink` | `WinkError` | type | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:180` | Union of wink runtime errors. |
 | `@beep/nlp/Wink` | `WinkLayerAllLive` | const | `packages/foundation/capability/nlp/src/Wink/index.ts:21` | import { WinkLayerAllLive } from "@beep/nlp/Wink" |
@@ -7913,14 +7914,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Wink/index` | `BM25Config` | class | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:192` | BM25 configuration used by wink vectorization and corpus management. |
 | `@beep/nlp/Wink/index` | `BM25Norm` | const | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:117` | BM25 normalization mode used by the vectorizer and corpus services. |
 | `@beep/nlp/Wink/index` | `CorpusManagerError` | class | `packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts:262` | Error raised while managing a live corpus session. |
-| `@beep/nlp/Wink/index` | `CustomEntityExample` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:101` | One custom-entity example expressed as ordered bracket-pattern elements. |
+| `@beep/nlp/Wink/index` | `CustomEntityExample` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:99` | One custom-entity example expressed as ordered bracket-pattern elements. |
 | `@beep/nlp/Wink/index` | `DefaultBM25Config` | const | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:221` | Default BM25 configuration used by the live wink vectorizer. |
 | `@beep/nlp/Wink/index` | `DocumentTermSet` | class | `packages/foundation/capability/nlp/src/Wink/WinkSimilarity.ts:100` | Set of normalized document terms used for set-based similarity. |
 | `@beep/nlp/Wink/index` | `DocumentVector` | class | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:241` | Dense vector representation for a document or query. |
 | `@beep/nlp/Wink/index` | `EntityGroupName` | const | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:64` | Branded identifier for a wink custom-entity group. |
-| `@beep/nlp/Wink/index` | `EntityGroupName` | type | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:86` | Runtime type for {@link EntityGroupName}. |
+| `@beep/nlp/Wink/index` | `EntityGroupName` | type | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:84` | Runtime type for {@link EntityGroupName}. |
 | `@beep/nlp/Wink/index` | `InstanceId` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:51` | Branded runtime identifier for one live wink engine instance. |
-| `@beep/nlp/Wink/index` | `InstanceId` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:73` | Runtime type for {@link InstanceId}. |
+| `@beep/nlp/Wink/index` | `InstanceId` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:71` | Runtime type for {@link InstanceId}. |
 | `@beep/nlp/Wink/index` | `ScopedVectorizer` | interface | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:80` | Minimal isolated vectorizer surface used by ranking and keyword extraction. |
 | `@beep/nlp/Wink/index` | `SentenceSpanFailure` | class | `packages/foundation/capability/nlp/src/Wink/WinkTokenizer.ts:44` | Failure raised when wink sentence spans cannot be derived from the token stream. |
 | `@beep/nlp/Wink/index` | `SimilarityError` | class | `packages/foundation/capability/nlp/src/Wink/WinkSimilarity.ts:157` | Error raised while computing wink-backed similarity. |
@@ -7930,14 +7931,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Wink/index` | `VectorizerError` | class | `packages/foundation/capability/nlp/src/Wink/WinkVectorizer.ts:323` | Error raised while learning or querying wink BM25 vectors. |
 | `@beep/nlp/Wink/index` | `WinkCorpusManager` | class | `packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts:727` | Wink corpus manager service. |
 | `@beep/nlp/Wink/index` | `WinkCorpusManagerLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts:744` | Live wink corpus manager layer. |
-| `@beep/nlp/Wink/index` | `WinkEngine` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:240` | Wink engine service tag. |
-| `@beep/nlp/Wink/index` | `WinkEngineCustomEntities` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:145` | Collection of learned custom-entity examples tracked as one logical group. |
+| `@beep/nlp/Wink/index` | `WinkEngine` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:238` | Wink engine service tag. |
+| `@beep/nlp/Wink/index` | `WinkEngineCustomEntities` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:143` | Collection of learned custom-entity examples tracked as one logical group. |
 | `@beep/nlp/Wink/index` | `WinkEngineError` | class | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:37` | Failure raised while creating or accessing the wink runtime. |
-| `@beep/nlp/Wink/index` | `WinkEngineLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:255` | Live wink engine layer. |
+| `@beep/nlp/Wink/index` | `WinkEngineLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:253` | Live wink engine layer. |
 | `@beep/nlp/Wink/index` | `WinkEngineRef` | const | `packages/foundation/capability/nlp/src/Wink/index.ts:55` | import { WinkEngineRef } from "@beep/nlp/Wink" |
 | `@beep/nlp/Wink/index` | `WinkEngineRefLive` | const | `packages/foundation/capability/nlp/src/Wink/index.ts:67` | import { WinkEngineRefLive } from "@beep/nlp/Wink" |
-| `@beep/nlp/Wink/index` | `WinkEngineRuntimeState` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:111` | In-memory wink engine runtime state including the live wink runtime. |
-| `@beep/nlp/Wink/index` | `WinkEngineState` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:88` | Serializable wink engine state metadata. |
+| `@beep/nlp/Wink/index` | `WinkEngineRuntimeState` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:109` | In-memory wink engine runtime state including the live wink runtime. |
+| `@beep/nlp/Wink/index` | `WinkEngineState` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:86` | Serializable wink engine state metadata. |
 | `@beep/nlp/Wink/index` | `WinkEntityError` | class | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:131` | Failure raised while learning or managing custom entity patterns. |
 | `@beep/nlp/Wink/index` | `WinkError` | type | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:180` | Union of wink runtime errors. |
 | `@beep/nlp/Wink/index` | `WinkLayerAllLive` | const | `packages/foundation/capability/nlp/src/Wink/index.ts:21` | import { WinkLayerAllLive } from "@beep/nlp/Wink" |
@@ -7967,11 +7968,11 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Wink/WinkCorpusManager` | `WinkCorpusManager` | class | `packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts:727` | Wink corpus manager service. |
 | `@beep/nlp/Wink/WinkCorpusManager` | `WinkCorpusManagerLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts:744` | Live wink corpus manager layer. |
 | `@beep/nlp/Wink/WinkEngine` | `InstanceId` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:51` | Branded runtime identifier for one live wink engine instance. |
-| `@beep/nlp/Wink/WinkEngine` | `InstanceId` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:73` | Runtime type for {@link InstanceId}. |
-| `@beep/nlp/Wink/WinkEngine` | `WinkEngine` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:240` | Wink engine service tag. |
-| `@beep/nlp/Wink/WinkEngine` | `WinkEngineLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:255` | Live wink engine layer. |
-| `@beep/nlp/Wink/WinkEngine` | `WinkEngineRuntimeState` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:111` | In-memory wink engine runtime state including the live wink runtime. |
-| `@beep/nlp/Wink/WinkEngine` | `WinkEngineState` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:88` | Serializable wink engine state metadata. |
+| `@beep/nlp/Wink/WinkEngine` | `InstanceId` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:71` | Runtime type for {@link InstanceId}. |
+| `@beep/nlp/Wink/WinkEngine` | `WinkEngine` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:238` | Wink engine service tag. |
+| `@beep/nlp/Wink/WinkEngine` | `WinkEngineLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:253` | Live wink engine layer. |
+| `@beep/nlp/Wink/WinkEngine` | `WinkEngineRuntimeState` | type | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:109` | In-memory wink engine runtime state including the live wink runtime. |
+| `@beep/nlp/Wink/WinkEngine` | `WinkEngineState` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngine.ts:86` | Serializable wink engine state metadata. |
 | `@beep/nlp/Wink/WinkEngineRef` | `InstanceId` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngineRef.ts:96` | import { InstanceId } from "@beep/nlp/Wink/WinkEngineRef" |
 | `@beep/nlp/Wink/WinkEngineRef` | `WinkEngineRef` | class | `packages/foundation/capability/nlp/src/Wink/WinkEngineRef.ts:56` | Compatibility service for inspecting and updating the shared wink runtime state ref. |
 | `@beep/nlp/Wink/WinkEngineRef` | `WinkEngineRefLive` | const | `packages/foundation/capability/nlp/src/Wink/WinkEngineRef.ts:71` | Live layer for {@link WinkEngineRef}. |
@@ -7981,10 +7982,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/nlp/Wink/WinkErrors` | `WinkEntityError` | class | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:131` | Failure raised while learning or managing custom entity patterns. |
 | `@beep/nlp/Wink/WinkErrors` | `WinkError` | type | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:180` | Union of wink runtime errors. |
 | `@beep/nlp/Wink/WinkErrors` | `WinkTokenizationError` | class | `packages/foundation/capability/nlp/src/Wink/WinkErrors.ts:82` | Failure raised while reading or tokenizing text through wink. |
-| `@beep/nlp/Wink/WinkPattern` | `CustomEntityExample` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:101` | One custom-entity example expressed as ordered bracket-pattern elements. |
+| `@beep/nlp/Wink/WinkPattern` | `CustomEntityExample` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:99` | One custom-entity example expressed as ordered bracket-pattern elements. |
 | `@beep/nlp/Wink/WinkPattern` | `EntityGroupName` | const | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:64` | Branded identifier for a wink custom-entity group. |
-| `@beep/nlp/Wink/WinkPattern` | `EntityGroupName` | type | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:86` | Runtime type for {@link EntityGroupName}. |
-| `@beep/nlp/Wink/WinkPattern` | `WinkEngineCustomEntities` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:145` | Collection of learned custom-entity examples tracked as one logical group. |
+| `@beep/nlp/Wink/WinkPattern` | `EntityGroupName` | type | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:84` | Runtime type for {@link EntityGroupName}. |
+| `@beep/nlp/Wink/WinkPattern` | `WinkEngineCustomEntities` | class | `packages/foundation/capability/nlp/src/Wink/WinkPattern.ts:143` | Collection of learned custom-entity examples tracked as one logical group. |
 | `@beep/nlp/Wink/WinkSimilarity` | `DocumentTermSet` | class | `packages/foundation/capability/nlp/src/Wink/WinkSimilarity.ts:100` | Set of normalized document terms used for set-based similarity. |
 | `@beep/nlp/Wink/WinkSimilarity` | `SimilarityError` | class | `packages/foundation/capability/nlp/src/Wink/WinkSimilarity.ts:157` | Error raised while computing wink-backed similarity. |
 | `@beep/nlp/Wink/WinkSimilarity` | `SimilarityScore` | class | `packages/foundation/capability/nlp/src/Wink/WinkSimilarity.ts:127` | Similarity score returned from a wink-backed comparison. |
@@ -8269,28 +8270,28 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 |---|---|---|---|---|
 | `@beep/repo-utils` | `applyPackageJsonPatchEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:378` | Apply a typed JSON Patch document to a package.json value. |
 | `@beep/repo-utils` | `buildRepoDependencyIndex` | const | `packages/tooling/library/repo-utils/src/DependencyIndex.ts:56` | Build a complete dependency index for the entire monorepo. |
-| `@beep/repo-utils` | `ByteLength` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:662` | Non-negative byte length schema. |
-| `@beep/repo-utils` | `ByteLength` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:682` | Branded non-negative byte length. |
-| `@beep/repo-utils` | `ByteOffset` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:629` | Non-negative byte offset schema. |
-| `@beep/repo-utils` | `ByteOffset` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:649` | Branded non-negative byte offset. |
+| `@beep/repo-utils` | `ByteLength` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:634` | Non-negative byte length schema. |
+| `@beep/repo-utils` | `ByteLength` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:652` | Branded non-negative byte length. |
+| `@beep/repo-utils` | `ByteOffset` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:603` | Non-negative byte offset schema. |
+| `@beep/repo-utils` | `ByteOffset` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:621` | Branded non-negative byte offset. |
 | `@beep/repo-utils` | `collectTsConfigPaths` | const | `packages/tooling/library/repo-utils/src/TsConfig.ts:49` | Collect all `tsconfig*.json` file paths for each workspace and the root. |
 | `@beep/repo-utils` | `collectUniqueNpmDependencies` | const | `packages/tooling/library/repo-utils/src/UniqueDeps.ts:69` | Collect all unique external NPM dependency names from every package |
-| `@beep/repo-utils` | `ColumnNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:596` | Positive 1-based column number schema. |
-| `@beep/repo-utils` | `ColumnNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:616` | Branded positive 1-based column number. |
+| `@beep/repo-utils` | `ColumnNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:572` | Positive 1-based column number schema. |
+| `@beep/repo-utils` | `ColumnNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:590` | Branded positive 1-based column number. |
 | `@beep/repo-utils` | `computeTransitiveClosure` | const | `packages/tooling/library/repo-utils/src/Graph.ts:324` | Compute the transitive closure of dependencies for a single package. |
-| `@beep/repo-utils` | `ContentHash` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:695` | SHA-256 content hash schema. |
-| `@beep/repo-utils` | `ContentHash` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:715` | Branded SHA-256 content hash. |
-| `@beep/repo-utils` | `ContentHashFromBytes` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1053` | Effectful one-way schema transformation from source bytes to a canonical content hash. |
-| `@beep/repo-utils` | `ContentHashFromSourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1086` | Effectful one-way schema transformation from source text to a canonical content hash. |
+| `@beep/repo-utils` | `ContentHash` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:665` | SHA-256 content hash schema. |
+| `@beep/repo-utils` | `ContentHash` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:683` | Branded SHA-256 content hash. |
+| `@beep/repo-utils` | `ContentHashFromBytes` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:999` | Effectful one-way schema transformation from source bytes to a canonical content hash. |
+| `@beep/repo-utils` | `ContentHashFromSourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1030` | Effectful one-way schema transformation from source text to a canonical content hash. |
 | `@beep/repo-utils` | `createTSMorphService` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:667` | Construct the current live implementation for the v1 TSMorphService contract. |
 | `@beep/repo-utils` | `CyclicDependencyError` | class | `packages/tooling/library/repo-utils/src/errors/CyclicDependencyError.ts:33` | Raised when topological sorting or cycle detection finds circular |
-| `@beep/repo-utils` | `decodePackageJson` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1349` | Synchronously decode an unknown value into a strict `PackageJson`. |
-| `@beep/repo-utils` | `decodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1384` | Decode an unknown value into a strict `PackageJson` as an Effect. |
-| `@beep/repo-utils` | `decodePackageJsonExit` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1367` | Synchronously decode an unknown value into a strict `PackageJson`, |
-| `@beep/repo-utils` | `decodeTSConfig` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1674` | Synchronously decode an unknown value into a strict `TSConfig`. |
-| `@beep/repo-utils` | `decodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1712` | Decode an unknown value into a strict `TSConfig` as an Effect. |
-| `@beep/repo-utils` | `decodeTSConfigExit` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1692` | Synchronously decode an unknown value into a strict `TSConfig`, |
-| `@beep/repo-utils` | `decodeTSConfigFromJsoncTextEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1735` | Decode JSONC text into a strict `TSConfig`. |
+| `@beep/repo-utils` | `decodePackageJson` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1348` | Synchronously decode an unknown value into a strict `PackageJson`. |
+| `@beep/repo-utils` | `decodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1383` | Decode an unknown value into a strict `PackageJson` as an Effect. |
+| `@beep/repo-utils` | `decodePackageJsonExit` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1366` | Synchronously decode an unknown value into a strict `PackageJson`, |
+| `@beep/repo-utils` | `decodeTSConfig` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1668` | Synchronously decode an unknown value into a strict `TSConfig`. |
+| `@beep/repo-utils` | `decodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1706` | Decode an unknown value into a strict `TSConfig` as an Effect. |
+| `@beep/repo-utils` | `decodeTSConfigExit` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1686` | Synchronously decode an unknown value into a strict `TSConfig`, |
+| `@beep/repo-utils` | `decodeTSConfigFromJsoncTextEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1729` | Decode JSONC text into a strict `TSConfig`. |
 | `@beep/repo-utils` | `DependencyRecord` | const | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:27` | A record mapping package names to version specifiers. |
 | `@beep/repo-utils` | `DependencyRecord` | type | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:47` | A record mapping package names to version specifiers. |
 | `@beep/repo-utils` | `detectCycles` | const | `packages/tooling/library/repo-utils/src/Graph.ts:168` | Detect all cycles in a directed dependency graph. |
@@ -8298,17 +8299,17 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils` | `DomainError` | class | `packages/tooling/library/repo-utils/src/errors/DomainError.ts:32` | A generic domain-level error with an optional underlying cause. |
 | `@beep/repo-utils` | `emptyWorkspaceDeps` | const | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:103` | Create an empty WorkspaceDeps for a given package name. |
 | `@beep/repo-utils` | `encodePackageJsonCanonicalPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:327` | Encode an unknown package.json value to a canonical pretty JSON string. |
-| `@beep/repo-utils` | `encodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1404` | Encode a strict `PackageJson` value back to its encoded form as an Effect. |
-| `@beep/repo-utils` | `encodePackageJsonPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1446` | Encode a strict `PackageJson` value to a pretty-printed JSON string. |
-| `@beep/repo-utils` | `encodePackageJsonToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1425` | Encode a strict `PackageJson` value to a compact JSON string as an Effect. |
-| `@beep/repo-utils` | `encodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1759` | Encode a strict `TSConfig` value back to its encoded form as an Effect. |
-| `@beep/repo-utils` | `encodeTSConfigPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1801` | Encode a strict `TSConfig` value to a pretty-printed JSON string. |
-| `@beep/repo-utils` | `encodeTSConfigToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1780` | Encode a strict `TSConfig` value to a compact JSON string as an Effect. |
+| `@beep/repo-utils` | `encodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1403` | Encode a strict `PackageJson` value back to its encoded form as an Effect. |
+| `@beep/repo-utils` | `encodePackageJsonPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1445` | Encode a strict `PackageJson` value to a pretty-printed JSON string. |
+| `@beep/repo-utils` | `encodePackageJsonToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1424` | Encode a strict `PackageJson` value to a compact JSON string as an Effect. |
+| `@beep/repo-utils` | `encodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1753` | Encode a strict `TSConfig` value back to its encoded form as an Effect. |
+| `@beep/repo-utils` | `encodeTSConfigPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1795` | Encode a strict `TSConfig` value to a pretty-printed JSON string. |
+| `@beep/repo-utils` | `encodeTSConfigToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1774` | Encode a strict `TSConfig` value to a compact JSON string as an Effect. |
 | `@beep/repo-utils` | `extractWorkspaceDependencies` | const | `packages/tooling/library/repo-utils/src/Dependencies.ts:75` | Extract and classify dependencies from a decoded `PackageJson`. |
-| `@beep/repo-utils` | `FilePathToTsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:933` | Schema transformation from a generic file path to a `TsConfigFilePath`. |
-| `@beep/repo-utils` | `FilePathToTypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:979` | Schema transformation from a generic file path to a TypeScript declaration file path. |
-| `@beep/repo-utils` | `FilePathToTypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1002` | Schema transformation from a generic file path to a TypeScript source file path. |
-| `@beep/repo-utils` | `FilePathToTypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:956` | Schema transformation from a generic file path to a TypeScript implementation file path. |
+| `@beep/repo-utils` | `FilePathToTsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:889` | Schema transformation from a generic file path to a `TsConfigFilePath`. |
+| `@beep/repo-utils` | `FilePathToTypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:931` | Schema transformation from a generic file path to a TypeScript declaration file path. |
+| `@beep/repo-utils` | `FilePathToTypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:952` | Schema transformation from a generic file path to a TypeScript source file path. |
+| `@beep/repo-utils` | `FilePathToTypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:910` | Schema transformation from a generic file path to a TypeScript implementation file path. |
 | `@beep/repo-utils` | `findRepoRoot` | const | `packages/tooling/library/repo-utils/src/Root.ts:45` | Find the repository root by walking upward from the given directory |
 | `@beep/repo-utils` | `FsUtils` | class | `packages/tooling/library/repo-utils/src/FsUtils.ts:160` | Service tag for `FsUtils`. |
 | `@beep/repo-utils` | `FsUtilsLive` | const | `packages/tooling/library/repo-utils/src/FsUtils.ts:176` | Live layer for `FsUtils` that uses the platform `FileSystem` and `Path` |
@@ -8316,112 +8317,112 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils` | `getPackageJsonSchemaIssues` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:410` | Format a SchemaError into package.json validation issues with JSON Pointers. |
 | `@beep/repo-utils` | `getWorkspaceDir` | const | `packages/tooling/library/repo-utils/src/Workspaces.ts:196` | Look up the absolute directory for a single workspace by package name. |
 | `@beep/repo-utils` | `GlobOptions` | class | `packages/tooling/library/repo-utils/src/FsUtils.ts:36` | Options for glob matching operations. |
-| `@beep/repo-utils` | `InternalTsMorphNode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1154` | Internal runtime schema for a live ts-morph Node instance. |
-| `@beep/repo-utils` | `InternalTsMorphProject` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1114` | Internal runtime schemas. |
-| `@beep/repo-utils` | `InternalTsMorphSourceFile` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1133` | Internal runtime schema for a live ts-morph SourceFile instance. |
+| `@beep/repo-utils` | `InternalTsMorphNode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1092` | Internal runtime schema for a live ts-morph Node instance. |
+| `@beep/repo-utils` | `InternalTsMorphProject` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1056` | Internal runtime schemas. |
+| `@beep/repo-utils` | `InternalTsMorphSourceFile` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1073` | Internal runtime schema for a live ts-morph SourceFile instance. |
 | `@beep/repo-utils` | `jsonParse` | const | `packages/tooling/library/repo-utils/src/JsonUtils.ts:82` | Parse a JSON string into an unknown value using `SchemaGetter.parseJson`. |
 | `@beep/repo-utils` | `jsonStringifyCompact` | const | `packages/tooling/library/repo-utils/src/JsonUtils.ts:59` | Serialize a value to a compact JSON string |
 | `@beep/repo-utils` | `jsonStringifyPretty` | const | `packages/tooling/library/repo-utils/src/JsonUtils.ts:35` | Serialize a value to a pretty-printed JSON string (2-space indent) |
-| `@beep/repo-utils` | `LineNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:563` | Positive 1-based line number schema. |
-| `@beep/repo-utils` | `LineNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:583` | Branded positive 1-based line number. |
-| `@beep/repo-utils` | `makeProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1342` | Builds a stable `ProjectCacheKey` from validated scope identity parts. |
-| `@beep/repo-utils` | `makeProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1320` | Builds a stable `ProjectScopeId` from validated scope identity parts. |
-| `@beep/repo-utils` | `makeSymbol` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1362` | Normalizes symbol input by deriving missing identity and category fields. |
-| `@beep/repo-utils` | `makeSymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1301` | Builds a stable `SymbolId` from validated symbol identity parts. |
+| `@beep/repo-utils` | `LineNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:541` | Positive 1-based line number schema. |
+| `@beep/repo-utils` | `LineNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:559` | Branded positive 1-based line number. |
+| `@beep/repo-utils` | `makeProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1278` | Builds a stable `ProjectCacheKey` from validated scope identity parts. |
+| `@beep/repo-utils` | `makeProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1256` | Builds a stable `ProjectScopeId` from validated scope identity parts. |
+| `@beep/repo-utils` | `makeSymbol` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1298` | Normalizes symbol input by deriving missing identity and category fields. |
+| `@beep/repo-utils` | `makeSymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1237` | Builds a stable `SymbolId` from validated symbol identity parts. |
 | `@beep/repo-utils` | `normalizePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:306` | Normalize an unknown package.json value into a canonical encoded object. |
 | `@beep/repo-utils` | `NoSuchFileError` | class | `packages/tooling/library/repo-utils/src/errors/NoSuchFileError.ts:32` | Raised when a required file or directory cannot be located. |
-| `@beep/repo-utils` | `NpmPackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:966` | Type-safe schema for npm package.json files. |
-| `@beep/repo-utils` | `NpmPackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1008` | Namespace helpers for the strict npm package-json schema. |
+| `@beep/repo-utils` | `NpmPackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:965` | Type-safe schema for npm package.json files. |
+| `@beep/repo-utils` | `NpmPackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1007` | Namespace helpers for the strict npm package-json schema. |
 | `@beep/repo-utils` | `npmPackageJsonJsonSchema` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:289` | Draft 2020-12 JSON Schema document for the npm-only package.json schema. |
-| `@beep/repo-utils` | `PackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:988` | Type-safe schema for this repo's package.json files. |
-| `@beep/repo-utils` | `PackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1037` | Namespace helpers for the repo-aware package-json schema. |
+| `@beep/repo-utils` | `PackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:987` | Type-safe schema for this repo's package.json files. |
+| `@beep/repo-utils` | `PackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1036` | Namespace helpers for the repo-aware package-json schema. |
 | `@beep/repo-utils` | `packageJsonJsonSchema` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:275` | Draft 2020-12 JSON Schema document for the repo-aware package.json schema. |
 | `@beep/repo-utils` | `PackageJsonValidationIssue` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:252` | Structured package.json validation issue. |
-| `@beep/repo-utils` | `ProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:844` | Cache key schema for memoized ts-morph projects. |
-| `@beep/repo-utils` | `ProjectCacheKey` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:864` | Branded cache key for memoized ts-morph projects. |
-| `@beep/repo-utils` | `ProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:788` | Stable identity schema for a resolved ts-morph project scope. |
-| `@beep/repo-utils` | `ProjectScopeId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:808` | Branded stable identity for a resolved ts-morph project scope. |
-| `@beep/repo-utils` | `ProjectScopeIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:821` | Parsed components of a `ProjectScopeId`. |
+| `@beep/repo-utils` | `ProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:810` | Cache key schema for memoized ts-morph projects. |
+| `@beep/repo-utils` | `ProjectCacheKey` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:828` | Branded cache key for memoized ts-morph projects. |
+| `@beep/repo-utils` | `ProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:756` | Stable identity schema for a resolved ts-morph project scope. |
+| `@beep/repo-utils` | `ProjectScopeId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:774` | Branded stable identity for a resolved ts-morph project scope. |
+| `@beep/repo-utils` | `ProjectScopeIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:787` | Parsed components of a `ProjectScopeId`. |
 | `@beep/repo-utils` | `RepoRootPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:121` | Repository root directory path schema. |
-| `@beep/repo-utils` | `RepoRootPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:141` | Branded repository root directory path. |
+| `@beep/repo-utils` | `RepoRootPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:139` | Branded repository root directory path. |
 | `@beep/repo-utils` | `resolveWorkspaceDirs` | const | `packages/tooling/library/repo-utils/src/Workspaces.ts:88` | Resolve all workspace directories declared in the root `package.json`. |
 | `@beep/repo-utils` | `ReuseAnalysisError` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:116` | Typed error returned when reuse analysis cannot complete a repository scan or lookup. |
-| `@beep/repo-utils` | `ReuseCandidate` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:292` | Ranked reuse candidate inventory item. |
-| `@beep/repo-utils` | `ReuseCandidateKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:99` | Candidate kind domain for inventory items. |
-| `@beep/repo-utils` | `ReuseCandidateKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:124` | Runtime type for `ReuseCandidateKind`. |
+| `@beep/repo-utils` | `ReuseCandidate` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:286` | Ranked reuse candidate inventory item. |
+| `@beep/repo-utils` | `ReuseCandidateKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:95` | Candidate kind domain for inventory items. |
+| `@beep/repo-utils` | `ReuseCandidateKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:118` | Runtime type for `ReuseCandidateKind`. |
 | `@beep/repo-utils` | `ReuseCandidateNotFoundError` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:142` | Typed error returned when a requested candidate id is absent from the current reuse inventory. |
-| `@beep/repo-utils` | `ReuseCatalogEntry` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:179` | Catalog entry describing an existing reusable symbol or curated pattern. |
+| `@beep/repo-utils` | `ReuseCatalogEntry` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:173` | Catalog entry describing an existing reusable symbol or curated pattern. |
 | `@beep/repo-utils` | `ReuseCatalogOrigin` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:27` | Catalog entry origin domain. |
-| `@beep/repo-utils` | `ReuseCatalogOrigin` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:51` | Runtime type for `ReuseCatalogOrigin`. |
+| `@beep/repo-utils` | `ReuseCatalogOrigin` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:49` | Runtime type for `ReuseCatalogOrigin`. |
 | `@beep/repo-utils` | `ReuseCatalogService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:971` | Service tag for the reuse catalog contract. |
 | `@beep/repo-utils` | `ReuseCatalogServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1107` | Default live layer for building the shared reuse catalog. |
 | `@beep/repo-utils` | `ReuseDiscoveryService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1039` | Service tag for reuse candidate discovery. |
 | `@beep/repo-utils` | `ReuseDiscoveryServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1255` | Default live layer for reuse candidate discovery and local option lookup. |
-| `@beep/repo-utils` | `ReuseFindResult` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:409` | Results for local-file reuse lookups. |
-| `@beep/repo-utils` | `ReuseInventory` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:335` | Inventory payload produced for a requested scope. |
+| `@beep/repo-utils` | `ReuseFindResult` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:403` | Results for local-file reuse lookups. |
+| `@beep/repo-utils` | `ReuseInventory` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:329` | Inventory payload produced for a requested scope. |
 | `@beep/repo-utils` | `ReuseInventoryService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1073` | Service tag for reuse inventory materialization. |
 | `@beep/repo-utils` | `ReuseInventoryServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1433` | Default live layer for ranked reuse inventories and implementation packets. |
-| `@beep/repo-utils` | `ReusePacket` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:379` | Materialized implementation packet for one reuse candidate. |
-| `@beep/repo-utils` | `ReusePartitionPlan` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:247` | Partition plan covering scout and specialist work units for a selected scope. |
+| `@beep/repo-utils` | `ReusePacket` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:373` | Materialized implementation packet for one reuse candidate. |
+| `@beep/repo-utils` | `ReusePartitionPlan` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:241` | Partition plan covering scout and specialist work units for a selected scope. |
 | `@beep/repo-utils` | `ReusePartitionPlannerService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1001` | Service tag for reuse partition planning. |
 | `@beep/repo-utils` | `ReusePartitionPlannerServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1152` | Default live layer for reuse partition planning. |
 | `@beep/repo-utils` | `ReuseServiceSuiteLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1518` | Fully wired reuse-discovery layer suite for CLI and tests. |
-| `@beep/repo-utils` | `ReuseSourceSymbolRef` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:143` | File-local source symbol reference tied to a reuse opportunity. |
-| `@beep/repo-utils` | `ReuseWorkUnit` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:215` | Partition work unit emitted for package scouts or hotspot specialists. |
-| `@beep/repo-utils` | `ReuseWorkUnitKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:65` | Partition work-unit kind. |
-| `@beep/repo-utils` | `ReuseWorkUnitKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:85` | Runtime type for `ReuseWorkUnitKind`. |
-| `@beep/repo-utils` | `SourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:530` | Non-empty source text schema. |
-| `@beep/repo-utils` | `SourceText` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:550` | Branded non-empty source text. |
-| `@beep/repo-utils` | `Symbol` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1175` | TS-native symbol record with strict identity, kind, and source-location metadata. |
-| `@beep/repo-utils` | `Symbol` | namespace | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1245` | Namespace helpers for normalized TSMorph symbols. |
-| `@beep/repo-utils` | `SymbolCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:443` | Coarse symbol categories used by the TSMorph models. |
-| `@beep/repo-utils` | `SymbolCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:456` | Literal union of coarse TSMorph symbol categories. |
-| `@beep/repo-utils` | `symbolCategoryFromKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:469` | Maps a declaration kind to its coarse symbol category. |
-| `@beep/repo-utils` | `SymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:318` | Symbol-safe implementation file path schema. |
-| `@beep/repo-utils` | `SymbolFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:338` | Branded symbol-safe implementation file path. |
-| `@beep/repo-utils` | `SymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:877` | Stable symbol identity schema. |
-| `@beep/repo-utils` | `SymbolId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:897` | Branded stable symbol identity. |
-| `@beep/repo-utils` | `SymbolIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:910` | Parsed components of a `SymbolId`. |
-| `@beep/repo-utils` | `SymbolInit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1283` | Input shape for constructing a normalized `Symbol`. |
-| `@beep/repo-utils` | `SymbolKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:417` | Supported TypeScript declaration kinds for normalized symbols. |
-| `@beep/repo-utils` | `SymbolKind` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:430` | Literal union of supported TypeScript declaration kinds. |
-| `@beep/repo-utils` | `SymbolKindToCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:492` | Schema transformation from declaration kind to coarse symbol category. |
-| `@beep/repo-utils` | `SymbolKindToCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:517` | Output type produced by `SymbolKindToCategory`. |
-| `@beep/repo-utils` | `SymbolNameSegment` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:351` | Single segment schema for a symbol name. |
-| `@beep/repo-utils` | `SymbolNameSegment` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:371` | Branded single symbol name segment. |
-| `@beep/repo-utils` | `SymbolQualifiedName` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:384` | Qualified symbol name schema. |
-| `@beep/repo-utils` | `SymbolQualifiedName` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:404` | Branded qualified symbol name. |
+| `@beep/repo-utils` | `ReuseSourceSymbolRef` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:137` | File-local source symbol reference tied to a reuse opportunity. |
+| `@beep/repo-utils` | `ReuseWorkUnit` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:209` | Partition work unit emitted for package scouts or hotspot specialists. |
+| `@beep/repo-utils` | `ReuseWorkUnitKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:63` | Partition work-unit kind. |
+| `@beep/repo-utils` | `ReuseWorkUnitKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:81` | Runtime type for `ReuseWorkUnitKind`. |
+| `@beep/repo-utils` | `SourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:510` | Non-empty source text schema. |
+| `@beep/repo-utils` | `SourceText` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:528` | Branded non-empty source text. |
+| `@beep/repo-utils` | `Symbol` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1111` | TS-native symbol record with strict identity, kind, and source-location metadata. |
+| `@beep/repo-utils` | `Symbol` | namespace | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1181` | Namespace helpers for normalized TSMorph symbols. |
+| `@beep/repo-utils` | `SymbolCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:425` | Coarse symbol categories used by the TSMorph models. |
+| `@beep/repo-utils` | `SymbolCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:438` | Literal union of coarse TSMorph symbol categories. |
+| `@beep/repo-utils` | `symbolCategoryFromKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:451` | Maps a declaration kind to its coarse symbol category. |
+| `@beep/repo-utils` | `SymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:306` | Symbol-safe implementation file path schema. |
+| `@beep/repo-utils` | `SymbolFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:324` | Branded symbol-safe implementation file path. |
+| `@beep/repo-utils` | `SymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:841` | Stable symbol identity schema. |
+| `@beep/repo-utils` | `SymbolId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:859` | Branded stable symbol identity. |
+| `@beep/repo-utils` | `SymbolIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:872` | Parsed components of a `SymbolId`. |
+| `@beep/repo-utils` | `SymbolInit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1219` | Input shape for constructing a normalized `Symbol`. |
+| `@beep/repo-utils` | `SymbolKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:399` | Supported TypeScript declaration kinds for normalized symbols. |
+| `@beep/repo-utils` | `SymbolKind` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:412` | Literal union of supported TypeScript declaration kinds. |
+| `@beep/repo-utils` | `SymbolKindToCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:474` | Schema transformation from declaration kind to coarse symbol category. |
+| `@beep/repo-utils` | `SymbolKindToCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:497` | Output type produced by `SymbolKindToCategory`. |
+| `@beep/repo-utils` | `SymbolNameSegment` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:337` | Single segment schema for a symbol name. |
+| `@beep/repo-utils` | `SymbolNameSegment` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:355` | Branded single symbol name segment. |
+| `@beep/repo-utils` | `SymbolQualifiedName` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:368` | Qualified symbol name schema. |
+| `@beep/repo-utils` | `SymbolQualifiedName` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:386` | Branded qualified symbol name. |
 | `@beep/repo-utils` | `topologicalSort` | const | `packages/tooling/library/repo-utils/src/Graph.ts:109` | Compute a topological ordering (dependency-first build order) of packages |
-| `@beep/repo-utils` | `TSConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1603` | Strict TypeScript tsconfig document schema. |
-| `@beep/repo-utils` | `TSConfig` | namespace | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1624` | Namespace helpers for the strict tsconfig schema. |
-| `@beep/repo-utils` | `TSConfigBuildOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1349` | Strict TypeScript buildOptions section. |
-| `@beep/repo-utils` | `TSConfigCompilerOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1242` | Strict TypeScript compilerOptions section. |
-| `@beep/repo-utils` | `TsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:187` | `tsconfig*.json` file path schema. |
-| `@beep/repo-utils` | `TsConfigFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:207` | Branded `tsconfig*.json` file path. |
-| `@beep/repo-utils` | `TSConfigReference` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:494` | Project reference entry for tsconfig `references`. |
-| `@beep/repo-utils` | `TSConfigTypeAcquisition` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1385` | Strict TypeScript typeAcquisition section. |
-| `@beep/repo-utils` | `TSConfigWatchOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1302` | Strict TypeScript watchOptions section. |
-| `@beep/repo-utils` | `TsMorphDiagnostic` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1872` | Tagged union schema for normalized TypeScript diagnostics. |
-| `@beep/repo-utils` | `TsMorphDiagnostic` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1898` | Decoded normalized TypeScript diagnostic union. |
-| `@beep/repo-utils` | `TsMorphDiagnosticCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1788` | Supported normalized diagnostic categories. |
-| `@beep/repo-utils` | `TsMorphDiagnosticCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1801` | Literal union of normalized diagnostic categories. |
-| `@beep/repo-utils` | `TsMorphDiagnosticsRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1911` | Request schema for TypeScript diagnostics in a resolved scope. |
-| `@beep/repo-utils` | `TsMorphDiagnosticsResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1932` | Diagnostics payload for a TypeScript file. |
-| `@beep/repo-utils` | `TsMorphFileOutline` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1557` | File outline payload for a TypeScript source file. |
-| `@beep/repo-utils` | `TsMorphFileOutlineRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1536` | Request schema for extracting a file outline. |
-| `@beep/repo-utils` | `TsMorphProjectInspectionRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1482` | Request schema for read-only ts-morph project inspection. |
+| `@beep/repo-utils` | `TSConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1597` | Strict TypeScript tsconfig document schema. |
+| `@beep/repo-utils` | `TSConfig` | namespace | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1618` | Namespace helpers for the strict tsconfig schema. |
+| `@beep/repo-utils` | `TSConfigBuildOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1343` | Strict TypeScript buildOptions section. |
+| `@beep/repo-utils` | `TSConfigCompilerOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1236` | Strict TypeScript compilerOptions section. |
+| `@beep/repo-utils` | `TsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:183` | `tsconfig*.json` file path schema. |
+| `@beep/repo-utils` | `TsConfigFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:201` | Branded `tsconfig*.json` file path. |
+| `@beep/repo-utils` | `TSConfigReference` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:488` | Project reference entry for tsconfig `references`. |
+| `@beep/repo-utils` | `TSConfigTypeAcquisition` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1379` | Strict TypeScript typeAcquisition section. |
+| `@beep/repo-utils` | `TSConfigWatchOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1296` | Strict TypeScript watchOptions section. |
+| `@beep/repo-utils` | `TsMorphDiagnostic` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1803` | Tagged union schema for normalized TypeScript diagnostics. |
+| `@beep/repo-utils` | `TsMorphDiagnostic` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1828` | Decoded normalized TypeScript diagnostic union. |
+| `@beep/repo-utils` | `TsMorphDiagnosticCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1719` | Supported normalized diagnostic categories. |
+| `@beep/repo-utils` | `TsMorphDiagnosticCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1732` | Literal union of normalized diagnostic categories. |
+| `@beep/repo-utils` | `TsMorphDiagnosticsRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1841` | Request schema for TypeScript diagnostics in a resolved scope. |
+| `@beep/repo-utils` | `TsMorphDiagnosticsResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1862` | Diagnostics payload for a TypeScript file. |
+| `@beep/repo-utils` | `TsMorphFileOutline` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1490` | File outline payload for a TypeScript source file. |
+| `@beep/repo-utils` | `TsMorphFileOutlineRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1469` | Request schema for extracting a file outline. |
+| `@beep/repo-utils` | `TsMorphProjectInspectionRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1415` | Request schema for read-only ts-morph project inspection. |
 | `@beep/repo-utils` | `TsMorphProjectLoadError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:171` | Typed error returned when a scoped ts-morph project cannot be constructed. |
-| `@beep/repo-utils` | `TsMorphProjectScope` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1510` | Resolved ts-morph project scope payload. |
-| `@beep/repo-utils` | `TsMorphProjectScopeRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1459` | Request schema for resolving a ts-morph project scope. |
-| `@beep/repo-utils` | `TsMorphReferencePolicy` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:754` | Reference traversal policies for ts-morph scope resolution. |
-| `@beep/repo-utils` | `TsMorphReferencePolicy` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:767` | Literal union of ts-morph reference traversal policies. |
-| `@beep/repo-utils` | `TsMorphScopeEntrypoint` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1414` | Tagged union schema for ts-morph scope resolution entrypoints. |
-| `@beep/repo-utils` | `TsMorphScopeEntrypoint` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1446` | Decoded ts-morph scope entrypoint union. |
-| `@beep/repo-utils` | `TsMorphScopeMode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:728` | Supported ts-morph project scope modes. |
-| `@beep/repo-utils` | `TsMorphScopeMode` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:741` | Literal union of ts-morph project scope modes. |
+| `@beep/repo-utils` | `TsMorphProjectScope` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1443` | Resolved ts-morph project scope payload. |
+| `@beep/repo-utils` | `TsMorphProjectScopeRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1392` | Request schema for resolving a ts-morph project scope. |
+| `@beep/repo-utils` | `TsMorphReferencePolicy` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:722` | Reference traversal policies for ts-morph scope resolution. |
+| `@beep/repo-utils` | `TsMorphReferencePolicy` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:735` | Literal union of ts-morph reference traversal policies. |
+| `@beep/repo-utils` | `TsMorphScopeEntrypoint` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1350` | Tagged union schema for ts-morph scope resolution entrypoints. |
+| `@beep/repo-utils` | `TsMorphScopeEntrypoint` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1379` | Decoded ts-morph scope entrypoint union. |
+| `@beep/repo-utils` | `TsMorphScopeMode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:696` | Supported ts-morph project scope modes. |
+| `@beep/repo-utils` | `TsMorphScopeMode` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:709` | Literal union of ts-morph project scope modes. |
 | `@beep/repo-utils` | `TsMorphScopeResolutionError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:146` | Typed error returned when a scope or repository path cannot be resolved. |
-| `@beep/repo-utils` | `TsMorphSearchLimit` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1663` | Positive result-limit schema for ts-morph search. |
-| `@beep/repo-utils` | `TsMorphSearchLimit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1683` | Branded positive result limit for ts-morph search. |
+| `@beep/repo-utils` | `TsMorphSearchLimit` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1596` | Positive result-limit schema for ts-morph search. |
+| `@beep/repo-utils` | `TsMorphSearchLimit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1614` | Branded positive result limit for ts-morph search. |
 | `@beep/repo-utils` | `TSMorphService` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:351` | Service tag for the read-only v1 ts-morph contract. |
 | `@beep/repo-utils` | `TSMorphServiceError` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:271` | Tagged union of all recoverable service errors emitted by `TSMorphService`. |
 | `@beep/repo-utils` | `TSMorphServiceError` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:291` | Tagged union type for all ts-morph service errors. |
@@ -8429,33 +8430,33 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils` | `TSMorphServiceShape` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:304` | Read-only v1 service contract for ts-morph-backed scope, symbol, source, and diagnostic operations. |
 | `@beep/repo-utils` | `TsMorphServiceUnavailableError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:121` | Typed error retained for compatibility with older placeholder service wiring. |
 | `@beep/repo-utils` | `TsMorphSourceFileError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:194` | Typed error returned when a TypeScript file cannot be loaded from a resolved scope. |
-| `@beep/repo-utils` | `TsMorphSourceTextRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1579` | Request schema for reading file source text. |
-| `@beep/repo-utils` | `TsMorphSourceTextResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1599` | Source text payload for a TypeScript file. |
-| `@beep/repo-utils` | `TsMorphSymbolLookupRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1621` | Request schema for symbol lookup by stable identifier. |
-| `@beep/repo-utils` | `TsMorphSymbolLookupResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1642` | Symbol lookup result payload. |
+| `@beep/repo-utils` | `TsMorphSourceTextRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1512` | Request schema for reading file source text. |
+| `@beep/repo-utils` | `TsMorphSourceTextResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1532` | Source text payload for a TypeScript file. |
+| `@beep/repo-utils` | `TsMorphSymbolLookupRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1554` | Request schema for symbol lookup by stable identifier. |
+| `@beep/repo-utils` | `TsMorphSymbolLookupResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1575` | Symbol lookup result payload. |
 | `@beep/repo-utils` | `TsMorphSymbolNotFoundError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:218` | Typed error returned when a symbol id cannot be resolved within a scope. |
-| `@beep/repo-utils` | `TsMorphSymbolSearchRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1696` | Request schema for symbol search within a resolved scope. |
-| `@beep/repo-utils` | `TsMorphSymbolSearchResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1720` | Symbol search result payload. |
-| `@beep/repo-utils` | `TsMorphSymbolSourceRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1744` | Request schema for reading symbol source text. |
-| `@beep/repo-utils` | `TsMorphSymbolSourceResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1765` | Symbol source payload including extracted text. |
+| `@beep/repo-utils` | `TsMorphSymbolSearchRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1627` | Request schema for symbol search within a resolved scope. |
+| `@beep/repo-utils` | `TsMorphSymbolSearchResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1651` | Symbol search result payload. |
+| `@beep/repo-utils` | `TsMorphSymbolSourceRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1675` | Request schema for reading symbol source text. |
+| `@beep/repo-utils` | `TsMorphSymbolSourceResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1696` | Symbol source payload including extracted text. |
 | `@beep/repo-utils` | `TsMorphUnsupportedFileError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:246` | Typed error returned when a request targets a currently unsupported TypeScript source boundary. |
-| `@beep/repo-utils` | `TSNodeConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1489` | Strict ts-node config section stored under `ts-node`. |
+| `@beep/repo-utils` | `TSNodeConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1483` | Strict ts-node config section stored under `ts-node`. |
 | `@beep/repo-utils` | `TSSyntaxKind` | const | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:462` | Literal schema kit for canonical TypeScript SyntaxKind names. |
 | `@beep/repo-utils` | `TSSyntaxKind` | namespace | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:481` | Companion namespace for {@link TSSyntaxKind}. |
 | `@beep/repo-utils` | `TSSyntaxKindCode` | const | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:441` | Lookup table from canonical SyntaxKind names to their numeric codes. |
 | `@beep/repo-utils` | `TSSyntaxKindLiteral` | const | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:510` | Literal union of all canonical TypeScript SyntaxKind string names. |
 | `@beep/repo-utils` | `TSSyntaxKindLiteral` | type | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:524` | Inferred type for {@link TSSyntaxKindLiteral}. |
-| `@beep/repo-utils` | `TypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:253` | TypeScript declaration file path schema. |
-| `@beep/repo-utils` | `TypeScriptDeclarationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:273` | Branded TypeScript declaration file path. |
-| `@beep/repo-utils` | `TypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:286` | TypeScript source file path schema. |
-| `@beep/repo-utils` | `TypeScriptFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:305` | Branded TypeScript source file path. |
-| `@beep/repo-utils` | `TypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:220` | TypeScript implementation file path schema. |
-| `@beep/repo-utils` | `TypeScriptImplementationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:240` | Branded TypeScript implementation file path. |
-| `@beep/repo-utils` | `TypeScriptImplementationFilePathToSymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1025` | Schema transformation from a TypeScript implementation file path to a symbol-safe file path. |
+| `@beep/repo-utils` | `TypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:245` | TypeScript declaration file path schema. |
+| `@beep/repo-utils` | `TypeScriptDeclarationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:263` | Branded TypeScript declaration file path. |
+| `@beep/repo-utils` | `TypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:276` | TypeScript source file path schema. |
+| `@beep/repo-utils` | `TypeScriptFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:293` | Branded TypeScript source file path. |
+| `@beep/repo-utils` | `TypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:214` | TypeScript implementation file path schema. |
+| `@beep/repo-utils` | `TypeScriptImplementationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:232` | Branded TypeScript implementation file path. |
+| `@beep/repo-utils` | `TypeScriptImplementationFilePathToSymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:973` | Schema transformation from a TypeScript implementation file path to a symbol-safe file path. |
 | `@beep/repo-utils` | `UniqueNpmDeps` | class | `packages/tooling/library/repo-utils/src/UniqueDeps.ts:36` | Result of collecting unique NPM dependencies across the monorepo. |
 | `@beep/repo-utils` | `WorkspaceDeps` | class | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:77` | Classified dependencies for a single workspace package. |
-| `@beep/repo-utils` | `WorkspaceDirectoryPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:154` | Workspace directory path schema. |
-| `@beep/repo-utils` | `WorkspaceDirectoryPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:174` | Branded workspace directory path. |
+| `@beep/repo-utils` | `WorkspaceDirectoryPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:152` | Workspace directory path schema. |
+| `@beep/repo-utils` | `WorkspaceDirectoryPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:170` | Branded workspace directory path. |
 | `@beep/repo-utils/Dependencies` | `extractWorkspaceDependencies` | const | `packages/tooling/library/repo-utils/src/Dependencies.ts:75` | Extract and classify dependencies from a decoded `PackageJson`. |
 | `@beep/repo-utils/DependencyIndex` | `buildRepoDependencyIndex` | const | `packages/tooling/library/repo-utils/src/DependencyIndex.ts:56` | Build a complete dependency index for the entire monorepo. |
 | `@beep/repo-utils/errors/CyclicDependencyError` | `CyclicDependencyError` | class | `packages/tooling/library/repo-utils/src/errors/CyclicDependencyError.ts:33` | Raised when topological sorting or cycle detection finds circular |
@@ -8473,28 +8474,28 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/Graph` | `topologicalSort` | const | `packages/tooling/library/repo-utils/src/Graph.ts:109` | Compute a topological ordering (dependency-first build order) of packages |
 | `@beep/repo-utils/index` | `applyPackageJsonPatchEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:378` | Apply a typed JSON Patch document to a package.json value. |
 | `@beep/repo-utils/index` | `buildRepoDependencyIndex` | const | `packages/tooling/library/repo-utils/src/DependencyIndex.ts:56` | Build a complete dependency index for the entire monorepo. |
-| `@beep/repo-utils/index` | `ByteLength` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:662` | Non-negative byte length schema. |
-| `@beep/repo-utils/index` | `ByteLength` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:682` | Branded non-negative byte length. |
-| `@beep/repo-utils/index` | `ByteOffset` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:629` | Non-negative byte offset schema. |
-| `@beep/repo-utils/index` | `ByteOffset` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:649` | Branded non-negative byte offset. |
+| `@beep/repo-utils/index` | `ByteLength` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:634` | Non-negative byte length schema. |
+| `@beep/repo-utils/index` | `ByteLength` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:652` | Branded non-negative byte length. |
+| `@beep/repo-utils/index` | `ByteOffset` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:603` | Non-negative byte offset schema. |
+| `@beep/repo-utils/index` | `ByteOffset` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:621` | Branded non-negative byte offset. |
 | `@beep/repo-utils/index` | `collectTsConfigPaths` | const | `packages/tooling/library/repo-utils/src/TsConfig.ts:49` | Collect all `tsconfig*.json` file paths for each workspace and the root. |
 | `@beep/repo-utils/index` | `collectUniqueNpmDependencies` | const | `packages/tooling/library/repo-utils/src/UniqueDeps.ts:69` | Collect all unique external NPM dependency names from every package |
-| `@beep/repo-utils/index` | `ColumnNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:596` | Positive 1-based column number schema. |
-| `@beep/repo-utils/index` | `ColumnNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:616` | Branded positive 1-based column number. |
+| `@beep/repo-utils/index` | `ColumnNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:572` | Positive 1-based column number schema. |
+| `@beep/repo-utils/index` | `ColumnNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:590` | Branded positive 1-based column number. |
 | `@beep/repo-utils/index` | `computeTransitiveClosure` | const | `packages/tooling/library/repo-utils/src/Graph.ts:324` | Compute the transitive closure of dependencies for a single package. |
-| `@beep/repo-utils/index` | `ContentHash` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:695` | SHA-256 content hash schema. |
-| `@beep/repo-utils/index` | `ContentHash` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:715` | Branded SHA-256 content hash. |
-| `@beep/repo-utils/index` | `ContentHashFromBytes` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1053` | Effectful one-way schema transformation from source bytes to a canonical content hash. |
-| `@beep/repo-utils/index` | `ContentHashFromSourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1086` | Effectful one-way schema transformation from source text to a canonical content hash. |
+| `@beep/repo-utils/index` | `ContentHash` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:665` | SHA-256 content hash schema. |
+| `@beep/repo-utils/index` | `ContentHash` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:683` | Branded SHA-256 content hash. |
+| `@beep/repo-utils/index` | `ContentHashFromBytes` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:999` | Effectful one-way schema transformation from source bytes to a canonical content hash. |
+| `@beep/repo-utils/index` | `ContentHashFromSourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1030` | Effectful one-way schema transformation from source text to a canonical content hash. |
 | `@beep/repo-utils/index` | `createTSMorphService` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:667` | Construct the current live implementation for the v1 TSMorphService contract. |
 | `@beep/repo-utils/index` | `CyclicDependencyError` | class | `packages/tooling/library/repo-utils/src/errors/CyclicDependencyError.ts:33` | Raised when topological sorting or cycle detection finds circular |
-| `@beep/repo-utils/index` | `decodePackageJson` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1349` | Synchronously decode an unknown value into a strict `PackageJson`. |
-| `@beep/repo-utils/index` | `decodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1384` | Decode an unknown value into a strict `PackageJson` as an Effect. |
-| `@beep/repo-utils/index` | `decodePackageJsonExit` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1367` | Synchronously decode an unknown value into a strict `PackageJson`, |
-| `@beep/repo-utils/index` | `decodeTSConfig` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1674` | Synchronously decode an unknown value into a strict `TSConfig`. |
-| `@beep/repo-utils/index` | `decodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1712` | Decode an unknown value into a strict `TSConfig` as an Effect. |
-| `@beep/repo-utils/index` | `decodeTSConfigExit` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1692` | Synchronously decode an unknown value into a strict `TSConfig`, |
-| `@beep/repo-utils/index` | `decodeTSConfigFromJsoncTextEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1735` | Decode JSONC text into a strict `TSConfig`. |
+| `@beep/repo-utils/index` | `decodePackageJson` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1348` | Synchronously decode an unknown value into a strict `PackageJson`. |
+| `@beep/repo-utils/index` | `decodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1383` | Decode an unknown value into a strict `PackageJson` as an Effect. |
+| `@beep/repo-utils/index` | `decodePackageJsonExit` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1366` | Synchronously decode an unknown value into a strict `PackageJson`, |
+| `@beep/repo-utils/index` | `decodeTSConfig` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1668` | Synchronously decode an unknown value into a strict `TSConfig`. |
+| `@beep/repo-utils/index` | `decodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1706` | Decode an unknown value into a strict `TSConfig` as an Effect. |
+| `@beep/repo-utils/index` | `decodeTSConfigExit` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1686` | Synchronously decode an unknown value into a strict `TSConfig`, |
+| `@beep/repo-utils/index` | `decodeTSConfigFromJsoncTextEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1729` | Decode JSONC text into a strict `TSConfig`. |
 | `@beep/repo-utils/index` | `DependencyRecord` | const | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:27` | A record mapping package names to version specifiers. |
 | `@beep/repo-utils/index` | `DependencyRecord` | type | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:47` | A record mapping package names to version specifiers. |
 | `@beep/repo-utils/index` | `detectCycles` | const | `packages/tooling/library/repo-utils/src/Graph.ts:168` | Detect all cycles in a directed dependency graph. |
@@ -8502,17 +8503,17 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/index` | `DomainError` | class | `packages/tooling/library/repo-utils/src/errors/DomainError.ts:32` | A generic domain-level error with an optional underlying cause. |
 | `@beep/repo-utils/index` | `emptyWorkspaceDeps` | const | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:103` | Create an empty WorkspaceDeps for a given package name. |
 | `@beep/repo-utils/index` | `encodePackageJsonCanonicalPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:327` | Encode an unknown package.json value to a canonical pretty JSON string. |
-| `@beep/repo-utils/index` | `encodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1404` | Encode a strict `PackageJson` value back to its encoded form as an Effect. |
-| `@beep/repo-utils/index` | `encodePackageJsonPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1446` | Encode a strict `PackageJson` value to a pretty-printed JSON string. |
-| `@beep/repo-utils/index` | `encodePackageJsonToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1425` | Encode a strict `PackageJson` value to a compact JSON string as an Effect. |
-| `@beep/repo-utils/index` | `encodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1759` | Encode a strict `TSConfig` value back to its encoded form as an Effect. |
-| `@beep/repo-utils/index` | `encodeTSConfigPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1801` | Encode a strict `TSConfig` value to a pretty-printed JSON string. |
-| `@beep/repo-utils/index` | `encodeTSConfigToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1780` | Encode a strict `TSConfig` value to a compact JSON string as an Effect. |
+| `@beep/repo-utils/index` | `encodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1403` | Encode a strict `PackageJson` value back to its encoded form as an Effect. |
+| `@beep/repo-utils/index` | `encodePackageJsonPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1445` | Encode a strict `PackageJson` value to a pretty-printed JSON string. |
+| `@beep/repo-utils/index` | `encodePackageJsonToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1424` | Encode a strict `PackageJson` value to a compact JSON string as an Effect. |
+| `@beep/repo-utils/index` | `encodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1753` | Encode a strict `TSConfig` value back to its encoded form as an Effect. |
+| `@beep/repo-utils/index` | `encodeTSConfigPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1795` | Encode a strict `TSConfig` value to a pretty-printed JSON string. |
+| `@beep/repo-utils/index` | `encodeTSConfigToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1774` | Encode a strict `TSConfig` value to a compact JSON string as an Effect. |
 | `@beep/repo-utils/index` | `extractWorkspaceDependencies` | const | `packages/tooling/library/repo-utils/src/Dependencies.ts:75` | Extract and classify dependencies from a decoded `PackageJson`. |
-| `@beep/repo-utils/index` | `FilePathToTsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:933` | Schema transformation from a generic file path to a `TsConfigFilePath`. |
-| `@beep/repo-utils/index` | `FilePathToTypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:979` | Schema transformation from a generic file path to a TypeScript declaration file path. |
-| `@beep/repo-utils/index` | `FilePathToTypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1002` | Schema transformation from a generic file path to a TypeScript source file path. |
-| `@beep/repo-utils/index` | `FilePathToTypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:956` | Schema transformation from a generic file path to a TypeScript implementation file path. |
+| `@beep/repo-utils/index` | `FilePathToTsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:889` | Schema transformation from a generic file path to a `TsConfigFilePath`. |
+| `@beep/repo-utils/index` | `FilePathToTypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:931` | Schema transformation from a generic file path to a TypeScript declaration file path. |
+| `@beep/repo-utils/index` | `FilePathToTypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:952` | Schema transformation from a generic file path to a TypeScript source file path. |
+| `@beep/repo-utils/index` | `FilePathToTypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:910` | Schema transformation from a generic file path to a TypeScript implementation file path. |
 | `@beep/repo-utils/index` | `findRepoRoot` | const | `packages/tooling/library/repo-utils/src/Root.ts:45` | Find the repository root by walking upward from the given directory |
 | `@beep/repo-utils/index` | `FsUtils` | class | `packages/tooling/library/repo-utils/src/FsUtils.ts:160` | Service tag for `FsUtils`. |
 | `@beep/repo-utils/index` | `FsUtilsLive` | const | `packages/tooling/library/repo-utils/src/FsUtils.ts:176` | Live layer for `FsUtils` that uses the platform `FileSystem` and `Path` |
@@ -8520,112 +8521,112 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/index` | `getPackageJsonSchemaIssues` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:410` | Format a SchemaError into package.json validation issues with JSON Pointers. |
 | `@beep/repo-utils/index` | `getWorkspaceDir` | const | `packages/tooling/library/repo-utils/src/Workspaces.ts:196` | Look up the absolute directory for a single workspace by package name. |
 | `@beep/repo-utils/index` | `GlobOptions` | class | `packages/tooling/library/repo-utils/src/FsUtils.ts:36` | Options for glob matching operations. |
-| `@beep/repo-utils/index` | `InternalTsMorphNode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1154` | Internal runtime schema for a live ts-morph Node instance. |
-| `@beep/repo-utils/index` | `InternalTsMorphProject` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1114` | Internal runtime schemas. |
-| `@beep/repo-utils/index` | `InternalTsMorphSourceFile` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1133` | Internal runtime schema for a live ts-morph SourceFile instance. |
+| `@beep/repo-utils/index` | `InternalTsMorphNode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1092` | Internal runtime schema for a live ts-morph Node instance. |
+| `@beep/repo-utils/index` | `InternalTsMorphProject` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1056` | Internal runtime schemas. |
+| `@beep/repo-utils/index` | `InternalTsMorphSourceFile` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1073` | Internal runtime schema for a live ts-morph SourceFile instance. |
 | `@beep/repo-utils/index` | `jsonParse` | const | `packages/tooling/library/repo-utils/src/JsonUtils.ts:82` | Parse a JSON string into an unknown value using `SchemaGetter.parseJson`. |
 | `@beep/repo-utils/index` | `jsonStringifyCompact` | const | `packages/tooling/library/repo-utils/src/JsonUtils.ts:59` | Serialize a value to a compact JSON string |
 | `@beep/repo-utils/index` | `jsonStringifyPretty` | const | `packages/tooling/library/repo-utils/src/JsonUtils.ts:35` | Serialize a value to a pretty-printed JSON string (2-space indent) |
-| `@beep/repo-utils/index` | `LineNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:563` | Positive 1-based line number schema. |
-| `@beep/repo-utils/index` | `LineNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:583` | Branded positive 1-based line number. |
-| `@beep/repo-utils/index` | `makeProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1342` | Builds a stable `ProjectCacheKey` from validated scope identity parts. |
-| `@beep/repo-utils/index` | `makeProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1320` | Builds a stable `ProjectScopeId` from validated scope identity parts. |
-| `@beep/repo-utils/index` | `makeSymbol` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1362` | Normalizes symbol input by deriving missing identity and category fields. |
-| `@beep/repo-utils/index` | `makeSymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1301` | Builds a stable `SymbolId` from validated symbol identity parts. |
+| `@beep/repo-utils/index` | `LineNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:541` | Positive 1-based line number schema. |
+| `@beep/repo-utils/index` | `LineNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:559` | Branded positive 1-based line number. |
+| `@beep/repo-utils/index` | `makeProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1278` | Builds a stable `ProjectCacheKey` from validated scope identity parts. |
+| `@beep/repo-utils/index` | `makeProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1256` | Builds a stable `ProjectScopeId` from validated scope identity parts. |
+| `@beep/repo-utils/index` | `makeSymbol` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1298` | Normalizes symbol input by deriving missing identity and category fields. |
+| `@beep/repo-utils/index` | `makeSymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1237` | Builds a stable `SymbolId` from validated symbol identity parts. |
 | `@beep/repo-utils/index` | `normalizePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:306` | Normalize an unknown package.json value into a canonical encoded object. |
 | `@beep/repo-utils/index` | `NoSuchFileError` | class | `packages/tooling/library/repo-utils/src/errors/NoSuchFileError.ts:32` | Raised when a required file or directory cannot be located. |
-| `@beep/repo-utils/index` | `NpmPackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:966` | Type-safe schema for npm package.json files. |
-| `@beep/repo-utils/index` | `NpmPackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1008` | Namespace helpers for the strict npm package-json schema. |
+| `@beep/repo-utils/index` | `NpmPackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:965` | Type-safe schema for npm package.json files. |
+| `@beep/repo-utils/index` | `NpmPackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1007` | Namespace helpers for the strict npm package-json schema. |
 | `@beep/repo-utils/index` | `npmPackageJsonJsonSchema` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:289` | Draft 2020-12 JSON Schema document for the npm-only package.json schema. |
-| `@beep/repo-utils/index` | `PackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:988` | Type-safe schema for this repo's package.json files. |
-| `@beep/repo-utils/index` | `PackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1037` | Namespace helpers for the repo-aware package-json schema. |
+| `@beep/repo-utils/index` | `PackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:987` | Type-safe schema for this repo's package.json files. |
+| `@beep/repo-utils/index` | `PackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1036` | Namespace helpers for the repo-aware package-json schema. |
 | `@beep/repo-utils/index` | `packageJsonJsonSchema` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:275` | Draft 2020-12 JSON Schema document for the repo-aware package.json schema. |
 | `@beep/repo-utils/index` | `PackageJsonValidationIssue` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:252` | Structured package.json validation issue. |
-| `@beep/repo-utils/index` | `ProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:844` | Cache key schema for memoized ts-morph projects. |
-| `@beep/repo-utils/index` | `ProjectCacheKey` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:864` | Branded cache key for memoized ts-morph projects. |
-| `@beep/repo-utils/index` | `ProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:788` | Stable identity schema for a resolved ts-morph project scope. |
-| `@beep/repo-utils/index` | `ProjectScopeId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:808` | Branded stable identity for a resolved ts-morph project scope. |
-| `@beep/repo-utils/index` | `ProjectScopeIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:821` | Parsed components of a `ProjectScopeId`. |
+| `@beep/repo-utils/index` | `ProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:810` | Cache key schema for memoized ts-morph projects. |
+| `@beep/repo-utils/index` | `ProjectCacheKey` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:828` | Branded cache key for memoized ts-morph projects. |
+| `@beep/repo-utils/index` | `ProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:756` | Stable identity schema for a resolved ts-morph project scope. |
+| `@beep/repo-utils/index` | `ProjectScopeId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:774` | Branded stable identity for a resolved ts-morph project scope. |
+| `@beep/repo-utils/index` | `ProjectScopeIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:787` | Parsed components of a `ProjectScopeId`. |
 | `@beep/repo-utils/index` | `RepoRootPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:121` | Repository root directory path schema. |
-| `@beep/repo-utils/index` | `RepoRootPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:141` | Branded repository root directory path. |
+| `@beep/repo-utils/index` | `RepoRootPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:139` | Branded repository root directory path. |
 | `@beep/repo-utils/index` | `resolveWorkspaceDirs` | const | `packages/tooling/library/repo-utils/src/Workspaces.ts:88` | Resolve all workspace directories declared in the root `package.json`. |
 | `@beep/repo-utils/index` | `ReuseAnalysisError` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:116` | Typed error returned when reuse analysis cannot complete a repository scan or lookup. |
-| `@beep/repo-utils/index` | `ReuseCandidate` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:292` | Ranked reuse candidate inventory item. |
-| `@beep/repo-utils/index` | `ReuseCandidateKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:99` | Candidate kind domain for inventory items. |
-| `@beep/repo-utils/index` | `ReuseCandidateKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:124` | Runtime type for `ReuseCandidateKind`. |
+| `@beep/repo-utils/index` | `ReuseCandidate` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:286` | Ranked reuse candidate inventory item. |
+| `@beep/repo-utils/index` | `ReuseCandidateKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:95` | Candidate kind domain for inventory items. |
+| `@beep/repo-utils/index` | `ReuseCandidateKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:118` | Runtime type for `ReuseCandidateKind`. |
 | `@beep/repo-utils/index` | `ReuseCandidateNotFoundError` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:142` | Typed error returned when a requested candidate id is absent from the current reuse inventory. |
-| `@beep/repo-utils/index` | `ReuseCatalogEntry` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:179` | Catalog entry describing an existing reusable symbol or curated pattern. |
+| `@beep/repo-utils/index` | `ReuseCatalogEntry` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:173` | Catalog entry describing an existing reusable symbol or curated pattern. |
 | `@beep/repo-utils/index` | `ReuseCatalogOrigin` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:27` | Catalog entry origin domain. |
-| `@beep/repo-utils/index` | `ReuseCatalogOrigin` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:51` | Runtime type for `ReuseCatalogOrigin`. |
+| `@beep/repo-utils/index` | `ReuseCatalogOrigin` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:49` | Runtime type for `ReuseCatalogOrigin`. |
 | `@beep/repo-utils/index` | `ReuseCatalogService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:971` | Service tag for the reuse catalog contract. |
 | `@beep/repo-utils/index` | `ReuseCatalogServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1107` | Default live layer for building the shared reuse catalog. |
 | `@beep/repo-utils/index` | `ReuseDiscoveryService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1039` | Service tag for reuse candidate discovery. |
 | `@beep/repo-utils/index` | `ReuseDiscoveryServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1255` | Default live layer for reuse candidate discovery and local option lookup. |
-| `@beep/repo-utils/index` | `ReuseFindResult` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:409` | Results for local-file reuse lookups. |
-| `@beep/repo-utils/index` | `ReuseInventory` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:335` | Inventory payload produced for a requested scope. |
+| `@beep/repo-utils/index` | `ReuseFindResult` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:403` | Results for local-file reuse lookups. |
+| `@beep/repo-utils/index` | `ReuseInventory` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:329` | Inventory payload produced for a requested scope. |
 | `@beep/repo-utils/index` | `ReuseInventoryService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1073` | Service tag for reuse inventory materialization. |
 | `@beep/repo-utils/index` | `ReuseInventoryServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1433` | Default live layer for ranked reuse inventories and implementation packets. |
-| `@beep/repo-utils/index` | `ReusePacket` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:379` | Materialized implementation packet for one reuse candidate. |
-| `@beep/repo-utils/index` | `ReusePartitionPlan` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:247` | Partition plan covering scout and specialist work units for a selected scope. |
+| `@beep/repo-utils/index` | `ReusePacket` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:373` | Materialized implementation packet for one reuse candidate. |
+| `@beep/repo-utils/index` | `ReusePartitionPlan` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:241` | Partition plan covering scout and specialist work units for a selected scope. |
 | `@beep/repo-utils/index` | `ReusePartitionPlannerService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1001` | Service tag for reuse partition planning. |
 | `@beep/repo-utils/index` | `ReusePartitionPlannerServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1152` | Default live layer for reuse partition planning. |
 | `@beep/repo-utils/index` | `ReuseServiceSuiteLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1518` | Fully wired reuse-discovery layer suite for CLI and tests. |
-| `@beep/repo-utils/index` | `ReuseSourceSymbolRef` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:143` | File-local source symbol reference tied to a reuse opportunity. |
-| `@beep/repo-utils/index` | `ReuseWorkUnit` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:215` | Partition work unit emitted for package scouts or hotspot specialists. |
-| `@beep/repo-utils/index` | `ReuseWorkUnitKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:65` | Partition work-unit kind. |
-| `@beep/repo-utils/index` | `ReuseWorkUnitKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:85` | Runtime type for `ReuseWorkUnitKind`. |
-| `@beep/repo-utils/index` | `SourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:530` | Non-empty source text schema. |
-| `@beep/repo-utils/index` | `SourceText` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:550` | Branded non-empty source text. |
-| `@beep/repo-utils/index` | `Symbol` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1175` | TS-native symbol record with strict identity, kind, and source-location metadata. |
-| `@beep/repo-utils/index` | `Symbol` | namespace | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1245` | Namespace helpers for normalized TSMorph symbols. |
-| `@beep/repo-utils/index` | `SymbolCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:443` | Coarse symbol categories used by the TSMorph models. |
-| `@beep/repo-utils/index` | `SymbolCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:456` | Literal union of coarse TSMorph symbol categories. |
-| `@beep/repo-utils/index` | `symbolCategoryFromKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:469` | Maps a declaration kind to its coarse symbol category. |
-| `@beep/repo-utils/index` | `SymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:318` | Symbol-safe implementation file path schema. |
-| `@beep/repo-utils/index` | `SymbolFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:338` | Branded symbol-safe implementation file path. |
-| `@beep/repo-utils/index` | `SymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:877` | Stable symbol identity schema. |
-| `@beep/repo-utils/index` | `SymbolId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:897` | Branded stable symbol identity. |
-| `@beep/repo-utils/index` | `SymbolIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:910` | Parsed components of a `SymbolId`. |
-| `@beep/repo-utils/index` | `SymbolInit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1283` | Input shape for constructing a normalized `Symbol`. |
-| `@beep/repo-utils/index` | `SymbolKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:417` | Supported TypeScript declaration kinds for normalized symbols. |
-| `@beep/repo-utils/index` | `SymbolKind` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:430` | Literal union of supported TypeScript declaration kinds. |
-| `@beep/repo-utils/index` | `SymbolKindToCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:492` | Schema transformation from declaration kind to coarse symbol category. |
-| `@beep/repo-utils/index` | `SymbolKindToCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:517` | Output type produced by `SymbolKindToCategory`. |
-| `@beep/repo-utils/index` | `SymbolNameSegment` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:351` | Single segment schema for a symbol name. |
-| `@beep/repo-utils/index` | `SymbolNameSegment` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:371` | Branded single symbol name segment. |
-| `@beep/repo-utils/index` | `SymbolQualifiedName` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:384` | Qualified symbol name schema. |
-| `@beep/repo-utils/index` | `SymbolQualifiedName` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:404` | Branded qualified symbol name. |
+| `@beep/repo-utils/index` | `ReuseSourceSymbolRef` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:137` | File-local source symbol reference tied to a reuse opportunity. |
+| `@beep/repo-utils/index` | `ReuseWorkUnit` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:209` | Partition work unit emitted for package scouts or hotspot specialists. |
+| `@beep/repo-utils/index` | `ReuseWorkUnitKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:63` | Partition work-unit kind. |
+| `@beep/repo-utils/index` | `ReuseWorkUnitKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:81` | Runtime type for `ReuseWorkUnitKind`. |
+| `@beep/repo-utils/index` | `SourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:510` | Non-empty source text schema. |
+| `@beep/repo-utils/index` | `SourceText` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:528` | Branded non-empty source text. |
+| `@beep/repo-utils/index` | `Symbol` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1111` | TS-native symbol record with strict identity, kind, and source-location metadata. |
+| `@beep/repo-utils/index` | `Symbol` | namespace | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1181` | Namespace helpers for normalized TSMorph symbols. |
+| `@beep/repo-utils/index` | `SymbolCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:425` | Coarse symbol categories used by the TSMorph models. |
+| `@beep/repo-utils/index` | `SymbolCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:438` | Literal union of coarse TSMorph symbol categories. |
+| `@beep/repo-utils/index` | `symbolCategoryFromKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:451` | Maps a declaration kind to its coarse symbol category. |
+| `@beep/repo-utils/index` | `SymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:306` | Symbol-safe implementation file path schema. |
+| `@beep/repo-utils/index` | `SymbolFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:324` | Branded symbol-safe implementation file path. |
+| `@beep/repo-utils/index` | `SymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:841` | Stable symbol identity schema. |
+| `@beep/repo-utils/index` | `SymbolId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:859` | Branded stable symbol identity. |
+| `@beep/repo-utils/index` | `SymbolIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:872` | Parsed components of a `SymbolId`. |
+| `@beep/repo-utils/index` | `SymbolInit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1219` | Input shape for constructing a normalized `Symbol`. |
+| `@beep/repo-utils/index` | `SymbolKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:399` | Supported TypeScript declaration kinds for normalized symbols. |
+| `@beep/repo-utils/index` | `SymbolKind` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:412` | Literal union of supported TypeScript declaration kinds. |
+| `@beep/repo-utils/index` | `SymbolKindToCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:474` | Schema transformation from declaration kind to coarse symbol category. |
+| `@beep/repo-utils/index` | `SymbolKindToCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:497` | Output type produced by `SymbolKindToCategory`. |
+| `@beep/repo-utils/index` | `SymbolNameSegment` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:337` | Single segment schema for a symbol name. |
+| `@beep/repo-utils/index` | `SymbolNameSegment` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:355` | Branded single symbol name segment. |
+| `@beep/repo-utils/index` | `SymbolQualifiedName` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:368` | Qualified symbol name schema. |
+| `@beep/repo-utils/index` | `SymbolQualifiedName` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:386` | Branded qualified symbol name. |
 | `@beep/repo-utils/index` | `topologicalSort` | const | `packages/tooling/library/repo-utils/src/Graph.ts:109` | Compute a topological ordering (dependency-first build order) of packages |
-| `@beep/repo-utils/index` | `TSConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1603` | Strict TypeScript tsconfig document schema. |
-| `@beep/repo-utils/index` | `TSConfig` | namespace | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1624` | Namespace helpers for the strict tsconfig schema. |
-| `@beep/repo-utils/index` | `TSConfigBuildOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1349` | Strict TypeScript buildOptions section. |
-| `@beep/repo-utils/index` | `TSConfigCompilerOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1242` | Strict TypeScript compilerOptions section. |
-| `@beep/repo-utils/index` | `TsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:187` | `tsconfig*.json` file path schema. |
-| `@beep/repo-utils/index` | `TsConfigFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:207` | Branded `tsconfig*.json` file path. |
-| `@beep/repo-utils/index` | `TSConfigReference` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:494` | Project reference entry for tsconfig `references`. |
-| `@beep/repo-utils/index` | `TSConfigTypeAcquisition` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1385` | Strict TypeScript typeAcquisition section. |
-| `@beep/repo-utils/index` | `TSConfigWatchOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1302` | Strict TypeScript watchOptions section. |
-| `@beep/repo-utils/index` | `TsMorphDiagnostic` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1872` | Tagged union schema for normalized TypeScript diagnostics. |
-| `@beep/repo-utils/index` | `TsMorphDiagnostic` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1898` | Decoded normalized TypeScript diagnostic union. |
-| `@beep/repo-utils/index` | `TsMorphDiagnosticCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1788` | Supported normalized diagnostic categories. |
-| `@beep/repo-utils/index` | `TsMorphDiagnosticCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1801` | Literal union of normalized diagnostic categories. |
-| `@beep/repo-utils/index` | `TsMorphDiagnosticsRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1911` | Request schema for TypeScript diagnostics in a resolved scope. |
-| `@beep/repo-utils/index` | `TsMorphDiagnosticsResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1932` | Diagnostics payload for a TypeScript file. |
-| `@beep/repo-utils/index` | `TsMorphFileOutline` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1557` | File outline payload for a TypeScript source file. |
-| `@beep/repo-utils/index` | `TsMorphFileOutlineRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1536` | Request schema for extracting a file outline. |
-| `@beep/repo-utils/index` | `TsMorphProjectInspectionRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1482` | Request schema for read-only ts-morph project inspection. |
+| `@beep/repo-utils/index` | `TSConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1597` | Strict TypeScript tsconfig document schema. |
+| `@beep/repo-utils/index` | `TSConfig` | namespace | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1618` | Namespace helpers for the strict tsconfig schema. |
+| `@beep/repo-utils/index` | `TSConfigBuildOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1343` | Strict TypeScript buildOptions section. |
+| `@beep/repo-utils/index` | `TSConfigCompilerOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1236` | Strict TypeScript compilerOptions section. |
+| `@beep/repo-utils/index` | `TsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:183` | `tsconfig*.json` file path schema. |
+| `@beep/repo-utils/index` | `TsConfigFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:201` | Branded `tsconfig*.json` file path. |
+| `@beep/repo-utils/index` | `TSConfigReference` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:488` | Project reference entry for tsconfig `references`. |
+| `@beep/repo-utils/index` | `TSConfigTypeAcquisition` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1379` | Strict TypeScript typeAcquisition section. |
+| `@beep/repo-utils/index` | `TSConfigWatchOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1296` | Strict TypeScript watchOptions section. |
+| `@beep/repo-utils/index` | `TsMorphDiagnostic` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1803` | Tagged union schema for normalized TypeScript diagnostics. |
+| `@beep/repo-utils/index` | `TsMorphDiagnostic` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1828` | Decoded normalized TypeScript diagnostic union. |
+| `@beep/repo-utils/index` | `TsMorphDiagnosticCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1719` | Supported normalized diagnostic categories. |
+| `@beep/repo-utils/index` | `TsMorphDiagnosticCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1732` | Literal union of normalized diagnostic categories. |
+| `@beep/repo-utils/index` | `TsMorphDiagnosticsRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1841` | Request schema for TypeScript diagnostics in a resolved scope. |
+| `@beep/repo-utils/index` | `TsMorphDiagnosticsResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1862` | Diagnostics payload for a TypeScript file. |
+| `@beep/repo-utils/index` | `TsMorphFileOutline` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1490` | File outline payload for a TypeScript source file. |
+| `@beep/repo-utils/index` | `TsMorphFileOutlineRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1469` | Request schema for extracting a file outline. |
+| `@beep/repo-utils/index` | `TsMorphProjectInspectionRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1415` | Request schema for read-only ts-morph project inspection. |
 | `@beep/repo-utils/index` | `TsMorphProjectLoadError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:171` | Typed error returned when a scoped ts-morph project cannot be constructed. |
-| `@beep/repo-utils/index` | `TsMorphProjectScope` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1510` | Resolved ts-morph project scope payload. |
-| `@beep/repo-utils/index` | `TsMorphProjectScopeRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1459` | Request schema for resolving a ts-morph project scope. |
-| `@beep/repo-utils/index` | `TsMorphReferencePolicy` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:754` | Reference traversal policies for ts-morph scope resolution. |
-| `@beep/repo-utils/index` | `TsMorphReferencePolicy` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:767` | Literal union of ts-morph reference traversal policies. |
-| `@beep/repo-utils/index` | `TsMorphScopeEntrypoint` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1414` | Tagged union schema for ts-morph scope resolution entrypoints. |
-| `@beep/repo-utils/index` | `TsMorphScopeEntrypoint` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1446` | Decoded ts-morph scope entrypoint union. |
-| `@beep/repo-utils/index` | `TsMorphScopeMode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:728` | Supported ts-morph project scope modes. |
-| `@beep/repo-utils/index` | `TsMorphScopeMode` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:741` | Literal union of ts-morph project scope modes. |
+| `@beep/repo-utils/index` | `TsMorphProjectScope` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1443` | Resolved ts-morph project scope payload. |
+| `@beep/repo-utils/index` | `TsMorphProjectScopeRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1392` | Request schema for resolving a ts-morph project scope. |
+| `@beep/repo-utils/index` | `TsMorphReferencePolicy` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:722` | Reference traversal policies for ts-morph scope resolution. |
+| `@beep/repo-utils/index` | `TsMorphReferencePolicy` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:735` | Literal union of ts-morph reference traversal policies. |
+| `@beep/repo-utils/index` | `TsMorphScopeEntrypoint` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1350` | Tagged union schema for ts-morph scope resolution entrypoints. |
+| `@beep/repo-utils/index` | `TsMorphScopeEntrypoint` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1379` | Decoded ts-morph scope entrypoint union. |
+| `@beep/repo-utils/index` | `TsMorphScopeMode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:696` | Supported ts-morph project scope modes. |
+| `@beep/repo-utils/index` | `TsMorphScopeMode` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:709` | Literal union of ts-morph project scope modes. |
 | `@beep/repo-utils/index` | `TsMorphScopeResolutionError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:146` | Typed error returned when a scope or repository path cannot be resolved. |
-| `@beep/repo-utils/index` | `TsMorphSearchLimit` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1663` | Positive result-limit schema for ts-morph search. |
-| `@beep/repo-utils/index` | `TsMorphSearchLimit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1683` | Branded positive result limit for ts-morph search. |
+| `@beep/repo-utils/index` | `TsMorphSearchLimit` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1596` | Positive result-limit schema for ts-morph search. |
+| `@beep/repo-utils/index` | `TsMorphSearchLimit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1614` | Branded positive result limit for ts-morph search. |
 | `@beep/repo-utils/index` | `TSMorphService` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:351` | Service tag for the read-only v1 ts-morph contract. |
 | `@beep/repo-utils/index` | `TSMorphServiceError` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:271` | Tagged union of all recoverable service errors emitted by `TSMorphService`. |
 | `@beep/repo-utils/index` | `TSMorphServiceError` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:291` | Tagged union type for all ts-morph service errors. |
@@ -8633,172 +8634,172 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/index` | `TSMorphServiceShape` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:304` | Read-only v1 service contract for ts-morph-backed scope, symbol, source, and diagnostic operations. |
 | `@beep/repo-utils/index` | `TsMorphServiceUnavailableError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:121` | Typed error retained for compatibility with older placeholder service wiring. |
 | `@beep/repo-utils/index` | `TsMorphSourceFileError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:194` | Typed error returned when a TypeScript file cannot be loaded from a resolved scope. |
-| `@beep/repo-utils/index` | `TsMorphSourceTextRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1579` | Request schema for reading file source text. |
-| `@beep/repo-utils/index` | `TsMorphSourceTextResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1599` | Source text payload for a TypeScript file. |
-| `@beep/repo-utils/index` | `TsMorphSymbolLookupRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1621` | Request schema for symbol lookup by stable identifier. |
-| `@beep/repo-utils/index` | `TsMorphSymbolLookupResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1642` | Symbol lookup result payload. |
+| `@beep/repo-utils/index` | `TsMorphSourceTextRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1512` | Request schema for reading file source text. |
+| `@beep/repo-utils/index` | `TsMorphSourceTextResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1532` | Source text payload for a TypeScript file. |
+| `@beep/repo-utils/index` | `TsMorphSymbolLookupRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1554` | Request schema for symbol lookup by stable identifier. |
+| `@beep/repo-utils/index` | `TsMorphSymbolLookupResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1575` | Symbol lookup result payload. |
 | `@beep/repo-utils/index` | `TsMorphSymbolNotFoundError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:218` | Typed error returned when a symbol id cannot be resolved within a scope. |
-| `@beep/repo-utils/index` | `TsMorphSymbolSearchRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1696` | Request schema for symbol search within a resolved scope. |
-| `@beep/repo-utils/index` | `TsMorphSymbolSearchResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1720` | Symbol search result payload. |
-| `@beep/repo-utils/index` | `TsMorphSymbolSourceRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1744` | Request schema for reading symbol source text. |
-| `@beep/repo-utils/index` | `TsMorphSymbolSourceResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1765` | Symbol source payload including extracted text. |
+| `@beep/repo-utils/index` | `TsMorphSymbolSearchRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1627` | Request schema for symbol search within a resolved scope. |
+| `@beep/repo-utils/index` | `TsMorphSymbolSearchResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1651` | Symbol search result payload. |
+| `@beep/repo-utils/index` | `TsMorphSymbolSourceRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1675` | Request schema for reading symbol source text. |
+| `@beep/repo-utils/index` | `TsMorphSymbolSourceResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1696` | Symbol source payload including extracted text. |
 | `@beep/repo-utils/index` | `TsMorphUnsupportedFileError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:246` | Typed error returned when a request targets a currently unsupported TypeScript source boundary. |
-| `@beep/repo-utils/index` | `TSNodeConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1489` | Strict ts-node config section stored under `ts-node`. |
+| `@beep/repo-utils/index` | `TSNodeConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1483` | Strict ts-node config section stored under `ts-node`. |
 | `@beep/repo-utils/index` | `TSSyntaxKind` | const | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:462` | Literal schema kit for canonical TypeScript SyntaxKind names. |
 | `@beep/repo-utils/index` | `TSSyntaxKind` | namespace | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:481` | Companion namespace for {@link TSSyntaxKind}. |
 | `@beep/repo-utils/index` | `TSSyntaxKindCode` | const | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:441` | Lookup table from canonical SyntaxKind names to their numeric codes. |
 | `@beep/repo-utils/index` | `TSSyntaxKindLiteral` | const | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:510` | Literal union of all canonical TypeScript SyntaxKind string names. |
 | `@beep/repo-utils/index` | `TSSyntaxKindLiteral` | type | `packages/tooling/library/repo-utils/src/TypeScript/models/TSSyntaxKind.model.ts:524` | Inferred type for {@link TSSyntaxKindLiteral}. |
-| `@beep/repo-utils/index` | `TypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:253` | TypeScript declaration file path schema. |
-| `@beep/repo-utils/index` | `TypeScriptDeclarationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:273` | Branded TypeScript declaration file path. |
-| `@beep/repo-utils/index` | `TypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:286` | TypeScript source file path schema. |
-| `@beep/repo-utils/index` | `TypeScriptFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:305` | Branded TypeScript source file path. |
-| `@beep/repo-utils/index` | `TypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:220` | TypeScript implementation file path schema. |
-| `@beep/repo-utils/index` | `TypeScriptImplementationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:240` | Branded TypeScript implementation file path. |
-| `@beep/repo-utils/index` | `TypeScriptImplementationFilePathToSymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1025` | Schema transformation from a TypeScript implementation file path to a symbol-safe file path. |
+| `@beep/repo-utils/index` | `TypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:245` | TypeScript declaration file path schema. |
+| `@beep/repo-utils/index` | `TypeScriptDeclarationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:263` | Branded TypeScript declaration file path. |
+| `@beep/repo-utils/index` | `TypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:276` | TypeScript source file path schema. |
+| `@beep/repo-utils/index` | `TypeScriptFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:293` | Branded TypeScript source file path. |
+| `@beep/repo-utils/index` | `TypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:214` | TypeScript implementation file path schema. |
+| `@beep/repo-utils/index` | `TypeScriptImplementationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:232` | Branded TypeScript implementation file path. |
+| `@beep/repo-utils/index` | `TypeScriptImplementationFilePathToSymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:973` | Schema transformation from a TypeScript implementation file path to a symbol-safe file path. |
 | `@beep/repo-utils/index` | `UniqueNpmDeps` | class | `packages/tooling/library/repo-utils/src/UniqueDeps.ts:36` | Result of collecting unique NPM dependencies across the monorepo. |
 | `@beep/repo-utils/index` | `WorkspaceDeps` | class | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:77` | Classified dependencies for a single workspace package. |
-| `@beep/repo-utils/index` | `WorkspaceDirectoryPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:154` | Workspace directory path schema. |
-| `@beep/repo-utils/index` | `WorkspaceDirectoryPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:174` | Branded workspace directory path. |
+| `@beep/repo-utils/index` | `WorkspaceDirectoryPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:152` | Workspace directory path schema. |
+| `@beep/repo-utils/index` | `WorkspaceDirectoryPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:170` | Branded workspace directory path. |
 | `@beep/repo-utils/JSDoc/index` | `Models` | SourceFile | `packages/tooling/library/repo-utils/src/JSDoc/models/index.ts:14` |  |
-| `@beep/repo-utils/JSDoc/JSDoc` | `AccessModifierJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1138` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `AccessModifierJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1171` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `ClosureSpecificJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3840` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `ClosureSpecificJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3870` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `DocumentationContentJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1535` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `DocumentationContentJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1560` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `EventDependencyJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2555` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `EventDependencyJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2572` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `InlineJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2084` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `InlineJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2101` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAbstract` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:792` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAccess` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:616` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAlias` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2603` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAlpha` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1591` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `AccessModifierJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1136` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `AccessModifierJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1169` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `ClosureSpecificJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3838` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `ClosureSpecificJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3868` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `DocumentationContentJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1533` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `DocumentationContentJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1558` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `EventDependencyJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2553` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `EventDependencyJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2570` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `InlineJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2082` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `InlineJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2099` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAbstract` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:790` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAccess` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:614` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAlias` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2601` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAlpha` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1589` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAsync` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:420` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAugments` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:300` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAuthor` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1469` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocBeta` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1624` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocBorrows` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2636` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocAuthor` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1467` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocBeta` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1622` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocBorrows` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2634` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocCallback` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:271` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocCategory` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3901` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocCategory` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3899` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocClass` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:362` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocClassDesc` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2669` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocConstant` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:905` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocConstructs` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2702` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocCopyright` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2735` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDecorator` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1892` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDefault` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:934` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDefaultValue` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:962` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDefine` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3345` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDeprecated` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1335` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDescription` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1201` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDict` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3378` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDocument` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3934` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocClassDesc` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2667` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocConstant` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:903` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocConstructs` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2700` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocCopyright` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2733` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDecorator` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1890` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDefault` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:932` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDefaultValue` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:960` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDefine` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3343` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDeprecated` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1333` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDescription` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1199` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDict` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3376` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocDocument` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3932` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocEnum` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:392` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocEvent` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2487` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocEventProperty` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1926` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExample` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1301` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExpand` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4033` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExperimental` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1657` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExport` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1020` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExports` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:991` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExternal` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2801` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExterns` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3543` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocFile` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2834` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocFinal` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:820` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocFires` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2421` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocFunction` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2334` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocEvent` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2485` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocEventProperty` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1924` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExample` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1299` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExpand` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4031` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExperimental` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1655` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExport` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1018` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExports` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:989` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExternal` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2799` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocExterns` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3541` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocFile` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2832` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocFinal` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:818` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocFires` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2419` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocFunction` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2332` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocGenerator` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:448` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocGlobal` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2867` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocGroup` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3967` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocHidden` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4000` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocHideConstructor` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2900` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocIgnore` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2933` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocGlobal` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2865` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocGroup` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3965` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocHidden` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3998` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocHideConstructor` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2898` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocIgnore` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2931` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocImplements` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:329` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocImplicitCast` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3411` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocImport` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1076` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInheritDoc` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2050` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInline` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4066` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInner` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2966` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInstance` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3000` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInterface` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2301` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInternal` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1690` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocKind` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3033` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocLabel` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1859` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocLends` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3080` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocLicense` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2768` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocLink` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2016` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocListens` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2454` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMember` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2234` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMemberOf` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2200` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMergeModuleWith` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4099` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMixes` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3147` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMixin` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3113` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocModule` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2132` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocName` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3180` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNamespace` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2166` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoAlias` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3576` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoCollapse` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3774` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoCompile` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3609` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoInline` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3807` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoSideEffects` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3642` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocOverload` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4287` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocOverride` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:848` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPackage` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:735` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPackageDocumentation` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1824` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocImplicitCast` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3409` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocImport` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1074` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInheritDoc` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2048` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInline` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4064` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInner` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2964` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInstance` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2998` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInterface` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2299` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocInternal` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1688` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocKind` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3031` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocLabel` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1857` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocLends` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3078` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocLicense` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2766` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocLink` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2014` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocListens` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2452` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMember` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2232` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMemberOf` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2198` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMergeModuleWith` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4097` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMixes` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3145` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocMixin` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3111` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocModule` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2130` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocName` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3178` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNamespace` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2164` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoAlias` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3574` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoCollapse` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3772` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoCompile` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3607` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoInline` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3805` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocNoSideEffects` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3640` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocOverload` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4285` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocOverride` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:846` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPackage` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:733` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPackageDocumentation` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1822` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocParam` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:32` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPolymer` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3675` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPolymerBehavior` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3708` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPrimaryExport` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4132` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPrivate` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:679` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPrivateRemarks` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1791` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocProperty` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2267` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocProtected` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:707` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPublic` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:650` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocReadonly` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:763` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocRecord` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3741` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocRemarks` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1268` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocRequires` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2521` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPolymer` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3673` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPolymerBehavior` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3706` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPrimaryExport` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4130` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPrivate` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:677` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPrivateRemarks` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1789` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocProperty` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2265` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocProtected` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:705` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocPublic` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:648` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocReadonly` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:761` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocRecord` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3739` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocRemarks` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1266` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocRequires` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2519` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocReturns` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:72` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSatisfies` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1048` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSealed` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1724` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSee` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1369` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSince` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1402` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSortStrategy` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4165` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocStatic` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:877` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocStruct` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3444` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSummary` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1235` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSuppress` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3510` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTag` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4367` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTag` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4393` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSatisfies` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1046` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSealed` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1722` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSee` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1367` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSince` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1400` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSortStrategy` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4163` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocStatic` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:875` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocStruct` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3442` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSummary` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1233` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocSuppress` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3508` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTag` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4365` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTag` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4391` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTemplate` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:145` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocThis` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1109` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocThis` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1107` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocThrows` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:110` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTodo` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1502` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTutorial` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3246` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTodo` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1500` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTutorial` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3244` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocType` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:213` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTypeDef` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:242` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocTypeParam` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:180` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocUnrestricted` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3477` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocUseDeclaredType` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4198` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocVariation` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3213` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocVersion` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1436` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocVirtual` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1758` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocUnrestricted` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3475` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocUseDeclaredType` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4196` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocVariation` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3211` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocVersion` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1434` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `JSDocVirtual` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1756` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `JSDocYields` | class | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:476` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `matchStructuralJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:581` | Matches over structural JSDoc tag variants. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `OrganizationalJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2368` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `OrganizationalJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2390` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `RemainingJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3279` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `RemainingJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3314` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `matchStructuralJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:579` | Matches over structural JSDoc tag variants. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `OrganizationalJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2366` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `OrganizationalJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:2388` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `RemainingJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3277` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `RemainingJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:3312` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/JSDoc` | `StructuralJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:510` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `StructuralJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:550` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `TSDocSpecificJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1959` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `TSDocSpecificJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1985` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `TypeDocSpecificJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4231` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `TypeDocSpecificJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4256` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `TypeScriptSpecificJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4321` | JSDoc tag metadata export. |
-| `@beep/repo-utils/JSDoc/JSDoc` | `TypeScriptSpecificJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4338` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `StructuralJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:548` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `TSDocSpecificJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1957` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `TSDocSpecificJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:1983` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `TypeDocSpecificJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4229` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `TypeDocSpecificJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4254` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `TypeScriptSpecificJSDoc` | const | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4319` | JSDoc tag metadata export. |
+| `@beep/repo-utils/JSDoc/JSDoc` | `TypeScriptSpecificJSDoc` | namespace | `packages/tooling/library/repo-utils/src/JSDoc/JSDoc.ts:4336` | JSDoc tag metadata export. |
 | `@beep/repo-utils/JSDoc/models/ApplicableTo.model` | `ApplicableTo` | const | `packages/tooling/library/repo-utils/src/JSDoc/models/ApplicableTo.model.ts:24` | AST-level attachment surface for a documentation tag. |
 | `@beep/repo-utils/JSDoc/models/ApplicableTo.model` | `ApplicableTo` | type | `packages/tooling/library/repo-utils/src/JSDoc/models/ApplicableTo.model.ts:73` | JSDoc model export. |
 | `@beep/repo-utils/JSDoc/models/ArchitecturalLayer.model` | `ArchitecturalLayer` | const | `packages/tooling/library/repo-utils/src/JSDoc/models/ArchitecturalLayer.model.ts:27` | Architectural layer mappings across established patterns. |
@@ -9487,44 +9488,44 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/JsonUtils` | `jsonStringifyCompact` | const | `packages/tooling/library/repo-utils/src/JsonUtils.ts:59` | Serialize a value to a compact JSON string |
 | `@beep/repo-utils/JsonUtils` | `jsonStringifyPretty` | const | `packages/tooling/library/repo-utils/src/JsonUtils.ts:35` | Serialize a value to a pretty-printed JSON string (2-space indent) |
 | `@beep/repo-utils/Reuse/index` | `ReuseAnalysisError` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:116` | Typed error returned when reuse analysis cannot complete a repository scan or lookup. |
-| `@beep/repo-utils/Reuse/index` | `ReuseCandidate` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:292` | Ranked reuse candidate inventory item. |
-| `@beep/repo-utils/Reuse/index` | `ReuseCandidateKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:99` | Candidate kind domain for inventory items. |
-| `@beep/repo-utils/Reuse/index` | `ReuseCandidateKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:124` | Runtime type for `ReuseCandidateKind`. |
+| `@beep/repo-utils/Reuse/index` | `ReuseCandidate` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:286` | Ranked reuse candidate inventory item. |
+| `@beep/repo-utils/Reuse/index` | `ReuseCandidateKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:95` | Candidate kind domain for inventory items. |
+| `@beep/repo-utils/Reuse/index` | `ReuseCandidateKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:118` | Runtime type for `ReuseCandidateKind`. |
 | `@beep/repo-utils/Reuse/index` | `ReuseCandidateNotFoundError` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:142` | Typed error returned when a requested candidate id is absent from the current reuse inventory. |
-| `@beep/repo-utils/Reuse/index` | `ReuseCatalogEntry` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:179` | Catalog entry describing an existing reusable symbol or curated pattern. |
+| `@beep/repo-utils/Reuse/index` | `ReuseCatalogEntry` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:173` | Catalog entry describing an existing reusable symbol or curated pattern. |
 | `@beep/repo-utils/Reuse/index` | `ReuseCatalogOrigin` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:27` | Catalog entry origin domain. |
-| `@beep/repo-utils/Reuse/index` | `ReuseCatalogOrigin` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:51` | Runtime type for `ReuseCatalogOrigin`. |
+| `@beep/repo-utils/Reuse/index` | `ReuseCatalogOrigin` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:49` | Runtime type for `ReuseCatalogOrigin`. |
 | `@beep/repo-utils/Reuse/index` | `ReuseCatalogService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:971` | Service tag for the reuse catalog contract. |
 | `@beep/repo-utils/Reuse/index` | `ReuseCatalogServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1107` | Default live layer for building the shared reuse catalog. |
 | `@beep/repo-utils/Reuse/index` | `ReuseDiscoveryService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1039` | Service tag for reuse candidate discovery. |
 | `@beep/repo-utils/Reuse/index` | `ReuseDiscoveryServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1255` | Default live layer for reuse candidate discovery and local option lookup. |
-| `@beep/repo-utils/Reuse/index` | `ReuseFindResult` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:409` | Results for local-file reuse lookups. |
-| `@beep/repo-utils/Reuse/index` | `ReuseInventory` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:335` | Inventory payload produced for a requested scope. |
+| `@beep/repo-utils/Reuse/index` | `ReuseFindResult` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:403` | Results for local-file reuse lookups. |
+| `@beep/repo-utils/Reuse/index` | `ReuseInventory` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:329` | Inventory payload produced for a requested scope. |
 | `@beep/repo-utils/Reuse/index` | `ReuseInventoryService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1073` | Service tag for reuse inventory materialization. |
 | `@beep/repo-utils/Reuse/index` | `ReuseInventoryServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1433` | Default live layer for ranked reuse inventories and implementation packets. |
-| `@beep/repo-utils/Reuse/index` | `ReusePacket` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:379` | Materialized implementation packet for one reuse candidate. |
-| `@beep/repo-utils/Reuse/index` | `ReusePartitionPlan` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:247` | Partition plan covering scout and specialist work units for a selected scope. |
+| `@beep/repo-utils/Reuse/index` | `ReusePacket` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:373` | Materialized implementation packet for one reuse candidate. |
+| `@beep/repo-utils/Reuse/index` | `ReusePartitionPlan` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:241` | Partition plan covering scout and specialist work units for a selected scope. |
 | `@beep/repo-utils/Reuse/index` | `ReusePartitionPlannerService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1001` | Service tag for reuse partition planning. |
 | `@beep/repo-utils/Reuse/index` | `ReusePartitionPlannerServiceLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1152` | Default live layer for reuse partition planning. |
 | `@beep/repo-utils/Reuse/index` | `ReuseServiceSuiteLive` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:1518` | Fully wired reuse-discovery layer suite for CLI and tests. |
-| `@beep/repo-utils/Reuse/index` | `ReuseSourceSymbolRef` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:143` | File-local source symbol reference tied to a reuse opportunity. |
-| `@beep/repo-utils/Reuse/index` | `ReuseWorkUnit` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:215` | Partition work unit emitted for package scouts or hotspot specialists. |
-| `@beep/repo-utils/Reuse/index` | `ReuseWorkUnitKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:65` | Partition work-unit kind. |
-| `@beep/repo-utils/Reuse/index` | `ReuseWorkUnitKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:85` | Runtime type for `ReuseWorkUnitKind`. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCandidate` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:292` | Ranked reuse candidate inventory item. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCandidateKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:99` | Candidate kind domain for inventory items. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCandidateKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:124` | Runtime type for `ReuseCandidateKind`. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCatalogEntry` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:179` | Catalog entry describing an existing reusable symbol or curated pattern. |
+| `@beep/repo-utils/Reuse/index` | `ReuseSourceSymbolRef` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:137` | File-local source symbol reference tied to a reuse opportunity. |
+| `@beep/repo-utils/Reuse/index` | `ReuseWorkUnit` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:209` | Partition work unit emitted for package scouts or hotspot specialists. |
+| `@beep/repo-utils/Reuse/index` | `ReuseWorkUnitKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:63` | Partition work-unit kind. |
+| `@beep/repo-utils/Reuse/index` | `ReuseWorkUnitKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:81` | Runtime type for `ReuseWorkUnitKind`. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCandidate` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:286` | Ranked reuse candidate inventory item. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCandidateKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:95` | Candidate kind domain for inventory items. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCandidateKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:118` | Runtime type for `ReuseCandidateKind`. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCatalogEntry` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:173` | Catalog entry describing an existing reusable symbol or curated pattern. |
 | `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCatalogOrigin` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:27` | Catalog entry origin domain. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCatalogOrigin` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:51` | Runtime type for `ReuseCatalogOrigin`. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseFindResult` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:409` | Results for local-file reuse lookups. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseInventory` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:335` | Inventory payload produced for a requested scope. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReusePacket` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:379` | Materialized implementation packet for one reuse candidate. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReusePartitionPlan` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:247` | Partition plan covering scout and specialist work units for a selected scope. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseSourceSymbolRef` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:143` | File-local source symbol reference tied to a reuse opportunity. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseWorkUnit` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:215` | Partition work unit emitted for package scouts or hotspot specialists. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseWorkUnitKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:65` | Partition work-unit kind. |
-| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseWorkUnitKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:85` | Runtime type for `ReuseWorkUnitKind`. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseCatalogOrigin` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:49` | Runtime type for `ReuseCatalogOrigin`. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseFindResult` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:403` | Results for local-file reuse lookups. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseInventory` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:329` | Inventory payload produced for a requested scope. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReusePacket` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:373` | Materialized implementation packet for one reuse candidate. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReusePartitionPlan` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:241` | Partition plan covering scout and specialist work units for a selected scope. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseSourceSymbolRef` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:137` | File-local source symbol reference tied to a reuse opportunity. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseWorkUnit` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:209` | Partition work unit emitted for package scouts or hotspot specialists. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseWorkUnitKind` | const | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:63` | Partition work-unit kind. |
+| `@beep/repo-utils/Reuse/Reuse.model` | `ReuseWorkUnitKind` | type | `packages/tooling/library/repo-utils/src/Reuse/Reuse.model.ts:81` | Runtime type for `ReuseWorkUnitKind`. |
 | `@beep/repo-utils/Reuse/Reuse.service` | `ReuseAnalysisError` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:116` | Typed error returned when reuse analysis cannot complete a repository scan or lookup. |
 | `@beep/repo-utils/Reuse/Reuse.service` | `ReuseCandidateNotFoundError` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:142` | Typed error returned when a requested candidate id is absent from the current reuse inventory. |
 | `@beep/repo-utils/Reuse/Reuse.service` | `ReuseCatalogService` | class | `packages/tooling/library/repo-utils/src/Reuse/Reuse.service.ts:971` | Service tag for the reuse catalog contract. |
@@ -9558,58 +9559,58 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/schemas/JSDocCategories` | `JSDocCategoryNormalizationStatus` | type | `packages/tooling/library/repo-utils/src/schemas/JSDocCategories.ts:157` | Normalization status for an observed `@category` value. |
 | `@beep/repo-utils/schemas/JSDocCategories` | `normalizeJSDocCategory` | const | `packages/tooling/library/repo-utils/src/schemas/JSDocCategories.ts:365` | Normalize and classify a single observed `@category` value. |
 | `@beep/repo-utils/schemas/JSDocCategories` | `normalizeJSDocCategoryKey` | const | `packages/tooling/library/repo-utils/src/schemas/JSDocCategories.ts:295` | Normalize free-form category text to the repo slug key format. |
-| `@beep/repo-utils/schemas/PackageJson` | `Author` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:297` | The package author field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Author` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1079` | Runtime type for {@link Author}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Bin` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:414` | Schema for the `bin` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Bin` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1157` | Runtime type for {@link Bin}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Browser` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:433` | Schema for the `browser` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Browser` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1170` | Runtime type for {@link Browser}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Bugs` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:374` | Schema for the `bugs` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Bugs` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1131` | Runtime type for {@link Bugs}. |
-| `@beep/repo-utils/schemas/PackageJson` | `BundleDependencies` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:537` | Schema for the `bundleDependencies` / `bundledDependencies` fields. |
-| `@beep/repo-utils/schemas/PackageJson` | `BundleDependencies` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1222` | Runtime type for {@link BundleDependencies}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Contributors` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:316` | The package contributors field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Contributors` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1092` | Runtime type for {@link Contributors}. |
-| `@beep/repo-utils/schemas/PackageJson` | `decodePackageJson` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1349` | Synchronously decode an unknown value into a strict `PackageJson`. |
-| `@beep/repo-utils/schemas/PackageJson` | `decodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1384` | Decode an unknown value into a strict `PackageJson` as an Effect. |
-| `@beep/repo-utils/schemas/PackageJson` | `decodePackageJsonExit` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1367` | Synchronously decode an unknown value into a strict `PackageJson`, |
-| `@beep/repo-utils/schemas/PackageJson` | `DevEngineDependency` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:616` | Schema for a development environment requirement entry. |
-| `@beep/repo-utils/schemas/PackageJson` | `DevEngineDependency` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1261` | Runtime type for {@link DevEngineDependency}. |
-| `@beep/repo-utils/schemas/PackageJson` | `DevEngines` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:658` | Schema for the `devEngines` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `DevEngines` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1274` | Runtime type for {@link DevEngines}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Directories` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:474` | Schema for the `directories` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Directories` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1183` | Runtime type for {@link Directories}. |
-| `@beep/repo-utils/schemas/PackageJson` | `encodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1404` | Encode a strict `PackageJson` value back to its encoded form as an Effect. |
-| `@beep/repo-utils/schemas/PackageJson` | `encodePackageJsonPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1446` | Encode a strict `PackageJson` value to a pretty-printed JSON string. |
-| `@beep/repo-utils/schemas/PackageJson` | `encodePackageJsonToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1425` | Encode a strict `PackageJson` value to a compact JSON string as an Effect. |
-| `@beep/repo-utils/schemas/PackageJson` | `Funding` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:394` | Schema for the `funding` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Funding` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1144` | Runtime type for {@link Funding}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Maintainers` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:335` | The package maintainers field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Maintainers` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1105` | Runtime type for {@link Maintainers}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Man` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:499` | Schema for the `man` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Man` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1196` | Runtime type for {@link Man}. |
-| `@beep/repo-utils/schemas/PackageJson` | `NpmPackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:966` | Type-safe schema for npm package.json files. |
-| `@beep/repo-utils/schemas/PackageJson` | `NpmPackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1008` | Namespace helpers for the strict npm package-json schema. |
-| `@beep/repo-utils/schemas/PackageJson` | `PackageExports` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:726` | Schema for the `exports` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `PackageExports` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1287` | Runtime type for {@link PackageExports}. |
-| `@beep/repo-utils/schemas/PackageJson` | `PackageImports` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:798` | Schema for the `imports` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `PackageImports` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1300` | Runtime type for {@link PackageImports}. |
-| `@beep/repo-utils/schemas/PackageJson` | `PackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:988` | Type-safe schema for this repo's package.json files. |
-| `@beep/repo-utils/schemas/PackageJson` | `PackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1037` | Namespace helpers for the repo-aware package-json schema. |
-| `@beep/repo-utils/schemas/PackageJson` | `PeerDependenciesMeta` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:556` | Schema for the `peerDependenciesMeta` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `PeerDependenciesMeta` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1235` | Runtime type for {@link PeerDependenciesMeta}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Person` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:277` | A person involved with the package, represented as a string or structured object. |
-| `@beep/repo-utils/schemas/PackageJson` | `Person` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1066` | Runtime type for {@link Person}. |
-| `@beep/repo-utils/schemas/PackageJson` | `PublishConfig` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:876` | Schema for the `publishConfig` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `PublishConfig` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1326` | Runtime type for {@link PublishConfig}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Repository` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:354` | Schema for the `repository` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Repository` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1118` | Runtime type for {@link Repository}. |
-| `@beep/repo-utils/schemas/PackageJson` | `SideEffects` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:518` | Schema for the `sideEffects` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `SideEffects` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1209` | Runtime type for {@link SideEffects}. |
-| `@beep/repo-utils/schemas/PackageJson` | `TypesVersions` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:578` | Schema for the `typesVersions` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `TypesVersions` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1248` | Runtime type for {@link TypesVersions}. |
-| `@beep/repo-utils/schemas/PackageJson` | `Workspaces` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:856` | Schema for the `workspaces` field. |
-| `@beep/repo-utils/schemas/PackageJson` | `Workspaces` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1313` | Runtime type for {@link Workspaces}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Author` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:296` | The package author field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Author` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1078` | Runtime type for {@link Author}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Bin` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:413` | Schema for the `bin` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Bin` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1156` | Runtime type for {@link Bin}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Browser` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:432` | Schema for the `browser` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Browser` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1169` | Runtime type for {@link Browser}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Bugs` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:373` | Schema for the `bugs` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Bugs` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1130` | Runtime type for {@link Bugs}. |
+| `@beep/repo-utils/schemas/PackageJson` | `BundleDependencies` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:536` | Schema for the `bundleDependencies` / `bundledDependencies` fields. |
+| `@beep/repo-utils/schemas/PackageJson` | `BundleDependencies` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1221` | Runtime type for {@link BundleDependencies}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Contributors` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:315` | The package contributors field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Contributors` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1091` | Runtime type for {@link Contributors}. |
+| `@beep/repo-utils/schemas/PackageJson` | `decodePackageJson` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1348` | Synchronously decode an unknown value into a strict `PackageJson`. |
+| `@beep/repo-utils/schemas/PackageJson` | `decodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1383` | Decode an unknown value into a strict `PackageJson` as an Effect. |
+| `@beep/repo-utils/schemas/PackageJson` | `decodePackageJsonExit` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1366` | Synchronously decode an unknown value into a strict `PackageJson`, |
+| `@beep/repo-utils/schemas/PackageJson` | `DevEngineDependency` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:615` | Schema for a development environment requirement entry. |
+| `@beep/repo-utils/schemas/PackageJson` | `DevEngineDependency` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1260` | Runtime type for {@link DevEngineDependency}. |
+| `@beep/repo-utils/schemas/PackageJson` | `DevEngines` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:657` | Schema for the `devEngines` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `DevEngines` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1273` | Runtime type for {@link DevEngines}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Directories` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:473` | Schema for the `directories` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Directories` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1182` | Runtime type for {@link Directories}. |
+| `@beep/repo-utils/schemas/PackageJson` | `encodePackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1403` | Encode a strict `PackageJson` value back to its encoded form as an Effect. |
+| `@beep/repo-utils/schemas/PackageJson` | `encodePackageJsonPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1445` | Encode a strict `PackageJson` value to a pretty-printed JSON string. |
+| `@beep/repo-utils/schemas/PackageJson` | `encodePackageJsonToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1424` | Encode a strict `PackageJson` value to a compact JSON string as an Effect. |
+| `@beep/repo-utils/schemas/PackageJson` | `Funding` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:393` | Schema for the `funding` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Funding` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1143` | Runtime type for {@link Funding}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Maintainers` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:334` | The package maintainers field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Maintainers` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1104` | Runtime type for {@link Maintainers}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Man` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:498` | Schema for the `man` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Man` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1195` | Runtime type for {@link Man}. |
+| `@beep/repo-utils/schemas/PackageJson` | `NpmPackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:965` | Type-safe schema for npm package.json files. |
+| `@beep/repo-utils/schemas/PackageJson` | `NpmPackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1007` | Namespace helpers for the strict npm package-json schema. |
+| `@beep/repo-utils/schemas/PackageJson` | `PackageExports` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:725` | Schema for the `exports` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `PackageExports` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1286` | Runtime type for {@link PackageExports}. |
+| `@beep/repo-utils/schemas/PackageJson` | `PackageImports` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:797` | Schema for the `imports` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `PackageImports` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1299` | Runtime type for {@link PackageImports}. |
+| `@beep/repo-utils/schemas/PackageJson` | `PackageJson` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:987` | Type-safe schema for this repo's package.json files. |
+| `@beep/repo-utils/schemas/PackageJson` | `PackageJson` | namespace | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1036` | Namespace helpers for the repo-aware package-json schema. |
+| `@beep/repo-utils/schemas/PackageJson` | `PeerDependenciesMeta` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:555` | Schema for the `peerDependenciesMeta` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `PeerDependenciesMeta` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1234` | Runtime type for {@link PeerDependenciesMeta}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Person` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:276` | A person involved with the package, represented as a string or structured object. |
+| `@beep/repo-utils/schemas/PackageJson` | `Person` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1065` | Runtime type for {@link Person}. |
+| `@beep/repo-utils/schemas/PackageJson` | `PublishConfig` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:875` | Schema for the `publishConfig` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `PublishConfig` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1325` | Runtime type for {@link PublishConfig}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Repository` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:353` | Schema for the `repository` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Repository` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1117` | Runtime type for {@link Repository}. |
+| `@beep/repo-utils/schemas/PackageJson` | `SideEffects` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:517` | Schema for the `sideEffects` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `SideEffects` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1208` | Runtime type for {@link SideEffects}. |
+| `@beep/repo-utils/schemas/PackageJson` | `TypesVersions` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:577` | Schema for the `typesVersions` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `TypesVersions` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1247` | Runtime type for {@link TypesVersions}. |
+| `@beep/repo-utils/schemas/PackageJson` | `Workspaces` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:855` | Schema for the `workspaces` field. |
+| `@beep/repo-utils/schemas/PackageJson` | `Workspaces` | type | `packages/tooling/library/repo-utils/src/schemas/PackageJson.ts:1312` | Runtime type for {@link Workspaces}. |
 | `@beep/repo-utils/schemas/PackageJsonTools` | `applyPackageJsonPatchEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:378` | Apply a typed JSON Patch document to a package.json value. |
 | `@beep/repo-utils/schemas/PackageJsonTools` | `diffPackageJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:351` | Compute a typed JSON Patch diff between two package.json values. |
 | `@beep/repo-utils/schemas/PackageJsonTools` | `encodePackageJsonCanonicalPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:327` | Encode an unknown package.json value to a canonical pretty JSON string. |
@@ -9618,21 +9619,21 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/schemas/PackageJsonTools` | `npmPackageJsonJsonSchema` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:289` | Draft 2020-12 JSON Schema document for the npm-only package.json schema. |
 | `@beep/repo-utils/schemas/PackageJsonTools` | `packageJsonJsonSchema` | const | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:275` | Draft 2020-12 JSON Schema document for the repo-aware package.json schema. |
 | `@beep/repo-utils/schemas/PackageJsonTools` | `PackageJsonValidationIssue` | class | `packages/tooling/library/repo-utils/src/schemas/PackageJsonTools.ts:252` | Structured package.json validation issue. |
-| `@beep/repo-utils/schemas/TSConfig` | `decodeTSConfig` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1674` | Synchronously decode an unknown value into a strict `TSConfig`. |
-| `@beep/repo-utils/schemas/TSConfig` | `decodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1712` | Decode an unknown value into a strict `TSConfig` as an Effect. |
-| `@beep/repo-utils/schemas/TSConfig` | `decodeTSConfigExit` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1692` | Synchronously decode an unknown value into a strict `TSConfig`, |
-| `@beep/repo-utils/schemas/TSConfig` | `decodeTSConfigFromJsoncTextEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1735` | Decode JSONC text into a strict `TSConfig`. |
-| `@beep/repo-utils/schemas/TSConfig` | `encodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1759` | Encode a strict `TSConfig` value back to its encoded form as an Effect. |
-| `@beep/repo-utils/schemas/TSConfig` | `encodeTSConfigPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1801` | Encode a strict `TSConfig` value to a pretty-printed JSON string. |
-| `@beep/repo-utils/schemas/TSConfig` | `encodeTSConfigToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1780` | Encode a strict `TSConfig` value to a compact JSON string as an Effect. |
-| `@beep/repo-utils/schemas/TSConfig` | `TSConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1603` | Strict TypeScript tsconfig document schema. |
-| `@beep/repo-utils/schemas/TSConfig` | `TSConfig` | namespace | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1624` | Namespace helpers for the strict tsconfig schema. |
-| `@beep/repo-utils/schemas/TSConfig` | `TSConfigBuildOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1349` | Strict TypeScript buildOptions section. |
-| `@beep/repo-utils/schemas/TSConfig` | `TSConfigCompilerOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1242` | Strict TypeScript compilerOptions section. |
-| `@beep/repo-utils/schemas/TSConfig` | `TSConfigReference` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:494` | Project reference entry for tsconfig `references`. |
-| `@beep/repo-utils/schemas/TSConfig` | `TSConfigTypeAcquisition` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1385` | Strict TypeScript typeAcquisition section. |
-| `@beep/repo-utils/schemas/TSConfig` | `TSConfigWatchOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1302` | Strict TypeScript watchOptions section. |
-| `@beep/repo-utils/schemas/TSConfig` | `TSNodeConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1489` | Strict ts-node config section stored under `ts-node`. |
+| `@beep/repo-utils/schemas/TSConfig` | `decodeTSConfig` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1668` | Synchronously decode an unknown value into a strict `TSConfig`. |
+| `@beep/repo-utils/schemas/TSConfig` | `decodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1706` | Decode an unknown value into a strict `TSConfig` as an Effect. |
+| `@beep/repo-utils/schemas/TSConfig` | `decodeTSConfigExit` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1686` | Synchronously decode an unknown value into a strict `TSConfig`, |
+| `@beep/repo-utils/schemas/TSConfig` | `decodeTSConfigFromJsoncTextEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1729` | Decode JSONC text into a strict `TSConfig`. |
+| `@beep/repo-utils/schemas/TSConfig` | `encodeTSConfigEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1753` | Encode a strict `TSConfig` value back to its encoded form as an Effect. |
+| `@beep/repo-utils/schemas/TSConfig` | `encodeTSConfigPrettyEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1795` | Encode a strict `TSConfig` value to a pretty-printed JSON string. |
+| `@beep/repo-utils/schemas/TSConfig` | `encodeTSConfigToJsonEffect` | const | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1774` | Encode a strict `TSConfig` value to a compact JSON string as an Effect. |
+| `@beep/repo-utils/schemas/TSConfig` | `TSConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1597` | Strict TypeScript tsconfig document schema. |
+| `@beep/repo-utils/schemas/TSConfig` | `TSConfig` | namespace | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1618` | Namespace helpers for the strict tsconfig schema. |
+| `@beep/repo-utils/schemas/TSConfig` | `TSConfigBuildOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1343` | Strict TypeScript buildOptions section. |
+| `@beep/repo-utils/schemas/TSConfig` | `TSConfigCompilerOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1236` | Strict TypeScript compilerOptions section. |
+| `@beep/repo-utils/schemas/TSConfig` | `TSConfigReference` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:488` | Project reference entry for tsconfig `references`. |
+| `@beep/repo-utils/schemas/TSConfig` | `TSConfigTypeAcquisition` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1379` | Strict TypeScript typeAcquisition section. |
+| `@beep/repo-utils/schemas/TSConfig` | `TSConfigWatchOptions` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1296` | Strict TypeScript watchOptions section. |
+| `@beep/repo-utils/schemas/TSConfig` | `TSNodeConfig` | class | `packages/tooling/library/repo-utils/src/schemas/TSConfig.ts:1483` | Strict ts-node config section stored under `ts-node`. |
 | `@beep/repo-utils/schemas/TsconfigAliasTargets` | `buildCanonicalAliasTargets` | const | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:154` | Build root and wildcard alias targets for a package export target. |
 | `@beep/repo-utils/schemas/TsconfigAliasTargets` | `buildDocgenAliasTargets` | const | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:204` | Build source-root and source-wildcard alias targets for docgen example resolution. |
 | `@beep/repo-utils/schemas/TsconfigAliasTargets` | `CanonicalAliasTargets` | class | `packages/tooling/library/repo-utils/src/schemas/TsconfigAliasTargets.ts:35` | Canonical alias targets derived for a package root export. |
@@ -9648,81 +9649,81 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/schemas/WorkspaceDeps` | `emptyWorkspaceDeps` | const | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:103` | Create an empty WorkspaceDeps for a given package name. |
 | `@beep/repo-utils/schemas/WorkspaceDeps` | `WorkspaceDeps` | class | `packages/tooling/library/repo-utils/src/schemas/WorkspaceDeps.ts:77` | Classified dependencies for a single workspace package. |
 | `@beep/repo-utils/TsConfig` | `collectTsConfigPaths` | const | `packages/tooling/library/repo-utils/src/TsConfig.ts:49` | Collect all `tsconfig*.json` file paths for each workspace and the root. |
-| `@beep/repo-utils/TSMorph/index` | `ByteLength` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:662` | Non-negative byte length schema. |
-| `@beep/repo-utils/TSMorph/index` | `ByteLength` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:682` | Branded non-negative byte length. |
-| `@beep/repo-utils/TSMorph/index` | `ByteOffset` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:629` | Non-negative byte offset schema. |
-| `@beep/repo-utils/TSMorph/index` | `ByteOffset` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:649` | Branded non-negative byte offset. |
-| `@beep/repo-utils/TSMorph/index` | `ColumnNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:596` | Positive 1-based column number schema. |
-| `@beep/repo-utils/TSMorph/index` | `ColumnNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:616` | Branded positive 1-based column number. |
-| `@beep/repo-utils/TSMorph/index` | `ContentHash` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:695` | SHA-256 content hash schema. |
-| `@beep/repo-utils/TSMorph/index` | `ContentHash` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:715` | Branded SHA-256 content hash. |
-| `@beep/repo-utils/TSMorph/index` | `ContentHashFromBytes` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1053` | Effectful one-way schema transformation from source bytes to a canonical content hash. |
-| `@beep/repo-utils/TSMorph/index` | `ContentHashFromSourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1086` | Effectful one-way schema transformation from source text to a canonical content hash. |
+| `@beep/repo-utils/TSMorph/index` | `ByteLength` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:634` | Non-negative byte length schema. |
+| `@beep/repo-utils/TSMorph/index` | `ByteLength` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:652` | Branded non-negative byte length. |
+| `@beep/repo-utils/TSMorph/index` | `ByteOffset` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:603` | Non-negative byte offset schema. |
+| `@beep/repo-utils/TSMorph/index` | `ByteOffset` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:621` | Branded non-negative byte offset. |
+| `@beep/repo-utils/TSMorph/index` | `ColumnNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:572` | Positive 1-based column number schema. |
+| `@beep/repo-utils/TSMorph/index` | `ColumnNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:590` | Branded positive 1-based column number. |
+| `@beep/repo-utils/TSMorph/index` | `ContentHash` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:665` | SHA-256 content hash schema. |
+| `@beep/repo-utils/TSMorph/index` | `ContentHash` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:683` | Branded SHA-256 content hash. |
+| `@beep/repo-utils/TSMorph/index` | `ContentHashFromBytes` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:999` | Effectful one-way schema transformation from source bytes to a canonical content hash. |
+| `@beep/repo-utils/TSMorph/index` | `ContentHashFromSourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1030` | Effectful one-way schema transformation from source text to a canonical content hash. |
 | `@beep/repo-utils/TSMorph/index` | `createTSMorphService` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:667` | Construct the current live implementation for the v1 TSMorphService contract. |
-| `@beep/repo-utils/TSMorph/index` | `FilePathToTsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:933` | Schema transformation from a generic file path to a `TsConfigFilePath`. |
-| `@beep/repo-utils/TSMorph/index` | `FilePathToTypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:979` | Schema transformation from a generic file path to a TypeScript declaration file path. |
-| `@beep/repo-utils/TSMorph/index` | `FilePathToTypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1002` | Schema transformation from a generic file path to a TypeScript source file path. |
-| `@beep/repo-utils/TSMorph/index` | `FilePathToTypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:956` | Schema transformation from a generic file path to a TypeScript implementation file path. |
-| `@beep/repo-utils/TSMorph/index` | `InternalTsMorphNode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1154` | Internal runtime schema for a live ts-morph Node instance. |
-| `@beep/repo-utils/TSMorph/index` | `InternalTsMorphProject` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1114` | Internal runtime schemas. |
-| `@beep/repo-utils/TSMorph/index` | `InternalTsMorphSourceFile` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1133` | Internal runtime schema for a live ts-morph SourceFile instance. |
-| `@beep/repo-utils/TSMorph/index` | `LineNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:563` | Positive 1-based line number schema. |
-| `@beep/repo-utils/TSMorph/index` | `LineNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:583` | Branded positive 1-based line number. |
-| `@beep/repo-utils/TSMorph/index` | `makeProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1342` | Builds a stable `ProjectCacheKey` from validated scope identity parts. |
-| `@beep/repo-utils/TSMorph/index` | `makeProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1320` | Builds a stable `ProjectScopeId` from validated scope identity parts. |
-| `@beep/repo-utils/TSMorph/index` | `makeSymbol` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1362` | Normalizes symbol input by deriving missing identity and category fields. |
-| `@beep/repo-utils/TSMorph/index` | `makeSymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1301` | Builds a stable `SymbolId` from validated symbol identity parts. |
-| `@beep/repo-utils/TSMorph/index` | `ProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:844` | Cache key schema for memoized ts-morph projects. |
-| `@beep/repo-utils/TSMorph/index` | `ProjectCacheKey` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:864` | Branded cache key for memoized ts-morph projects. |
-| `@beep/repo-utils/TSMorph/index` | `ProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:788` | Stable identity schema for a resolved ts-morph project scope. |
-| `@beep/repo-utils/TSMorph/index` | `ProjectScopeId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:808` | Branded stable identity for a resolved ts-morph project scope. |
-| `@beep/repo-utils/TSMorph/index` | `ProjectScopeIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:821` | Parsed components of a `ProjectScopeId`. |
+| `@beep/repo-utils/TSMorph/index` | `FilePathToTsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:889` | Schema transformation from a generic file path to a `TsConfigFilePath`. |
+| `@beep/repo-utils/TSMorph/index` | `FilePathToTypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:931` | Schema transformation from a generic file path to a TypeScript declaration file path. |
+| `@beep/repo-utils/TSMorph/index` | `FilePathToTypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:952` | Schema transformation from a generic file path to a TypeScript source file path. |
+| `@beep/repo-utils/TSMorph/index` | `FilePathToTypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:910` | Schema transformation from a generic file path to a TypeScript implementation file path. |
+| `@beep/repo-utils/TSMorph/index` | `InternalTsMorphNode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1092` | Internal runtime schema for a live ts-morph Node instance. |
+| `@beep/repo-utils/TSMorph/index` | `InternalTsMorphProject` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1056` | Internal runtime schemas. |
+| `@beep/repo-utils/TSMorph/index` | `InternalTsMorphSourceFile` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1073` | Internal runtime schema for a live ts-morph SourceFile instance. |
+| `@beep/repo-utils/TSMorph/index` | `LineNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:541` | Positive 1-based line number schema. |
+| `@beep/repo-utils/TSMorph/index` | `LineNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:559` | Branded positive 1-based line number. |
+| `@beep/repo-utils/TSMorph/index` | `makeProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1278` | Builds a stable `ProjectCacheKey` from validated scope identity parts. |
+| `@beep/repo-utils/TSMorph/index` | `makeProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1256` | Builds a stable `ProjectScopeId` from validated scope identity parts. |
+| `@beep/repo-utils/TSMorph/index` | `makeSymbol` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1298` | Normalizes symbol input by deriving missing identity and category fields. |
+| `@beep/repo-utils/TSMorph/index` | `makeSymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1237` | Builds a stable `SymbolId` from validated symbol identity parts. |
+| `@beep/repo-utils/TSMorph/index` | `ProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:810` | Cache key schema for memoized ts-morph projects. |
+| `@beep/repo-utils/TSMorph/index` | `ProjectCacheKey` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:828` | Branded cache key for memoized ts-morph projects. |
+| `@beep/repo-utils/TSMorph/index` | `ProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:756` | Stable identity schema for a resolved ts-morph project scope. |
+| `@beep/repo-utils/TSMorph/index` | `ProjectScopeId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:774` | Branded stable identity for a resolved ts-morph project scope. |
+| `@beep/repo-utils/TSMorph/index` | `ProjectScopeIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:787` | Parsed components of a `ProjectScopeId`. |
 | `@beep/repo-utils/TSMorph/index` | `RepoRootPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:121` | Repository root directory path schema. |
-| `@beep/repo-utils/TSMorph/index` | `RepoRootPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:141` | Branded repository root directory path. |
-| `@beep/repo-utils/TSMorph/index` | `SourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:530` | Non-empty source text schema. |
-| `@beep/repo-utils/TSMorph/index` | `SourceText` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:550` | Branded non-empty source text. |
-| `@beep/repo-utils/TSMorph/index` | `Symbol` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1175` | TS-native symbol record with strict identity, kind, and source-location metadata. |
-| `@beep/repo-utils/TSMorph/index` | `Symbol` | namespace | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1245` | Namespace helpers for normalized TSMorph symbols. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:443` | Coarse symbol categories used by the TSMorph models. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:456` | Literal union of coarse TSMorph symbol categories. |
-| `@beep/repo-utils/TSMorph/index` | `symbolCategoryFromKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:469` | Maps a declaration kind to its coarse symbol category. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:318` | Symbol-safe implementation file path schema. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:338` | Branded symbol-safe implementation file path. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:877` | Stable symbol identity schema. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:897` | Branded stable symbol identity. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:910` | Parsed components of a `SymbolId`. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolInit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1283` | Input shape for constructing a normalized `Symbol`. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:417` | Supported TypeScript declaration kinds for normalized symbols. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolKind` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:430` | Literal union of supported TypeScript declaration kinds. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolKindToCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:492` | Schema transformation from declaration kind to coarse symbol category. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolKindToCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:517` | Output type produced by `SymbolKindToCategory`. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolNameSegment` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:351` | Single segment schema for a symbol name. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolNameSegment` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:371` | Branded single symbol name segment. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolQualifiedName` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:384` | Qualified symbol name schema. |
-| `@beep/repo-utils/TSMorph/index` | `SymbolQualifiedName` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:404` | Branded qualified symbol name. |
-| `@beep/repo-utils/TSMorph/index` | `TsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:187` | `tsconfig*.json` file path schema. |
-| `@beep/repo-utils/TSMorph/index` | `TsConfigFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:207` | Branded `tsconfig*.json` file path. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnostic` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1872` | Tagged union schema for normalized TypeScript diagnostics. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnostic` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1898` | Decoded normalized TypeScript diagnostic union. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnosticCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1788` | Supported normalized diagnostic categories. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnosticCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1801` | Literal union of normalized diagnostic categories. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnosticsRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1911` | Request schema for TypeScript diagnostics in a resolved scope. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnosticsResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1932` | Diagnostics payload for a TypeScript file. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphFileOutline` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1557` | File outline payload for a TypeScript source file. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphFileOutlineRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1536` | Request schema for extracting a file outline. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphProjectInspectionRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1482` | Request schema for read-only ts-morph project inspection. |
+| `@beep/repo-utils/TSMorph/index` | `RepoRootPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:139` | Branded repository root directory path. |
+| `@beep/repo-utils/TSMorph/index` | `SourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:510` | Non-empty source text schema. |
+| `@beep/repo-utils/TSMorph/index` | `SourceText` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:528` | Branded non-empty source text. |
+| `@beep/repo-utils/TSMorph/index` | `Symbol` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1111` | TS-native symbol record with strict identity, kind, and source-location metadata. |
+| `@beep/repo-utils/TSMorph/index` | `Symbol` | namespace | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1181` | Namespace helpers for normalized TSMorph symbols. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:425` | Coarse symbol categories used by the TSMorph models. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:438` | Literal union of coarse TSMorph symbol categories. |
+| `@beep/repo-utils/TSMorph/index` | `symbolCategoryFromKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:451` | Maps a declaration kind to its coarse symbol category. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:306` | Symbol-safe implementation file path schema. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:324` | Branded symbol-safe implementation file path. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:841` | Stable symbol identity schema. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:859` | Branded stable symbol identity. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:872` | Parsed components of a `SymbolId`. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolInit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1219` | Input shape for constructing a normalized `Symbol`. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:399` | Supported TypeScript declaration kinds for normalized symbols. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolKind` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:412` | Literal union of supported TypeScript declaration kinds. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolKindToCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:474` | Schema transformation from declaration kind to coarse symbol category. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolKindToCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:497` | Output type produced by `SymbolKindToCategory`. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolNameSegment` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:337` | Single segment schema for a symbol name. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolNameSegment` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:355` | Branded single symbol name segment. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolQualifiedName` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:368` | Qualified symbol name schema. |
+| `@beep/repo-utils/TSMorph/index` | `SymbolQualifiedName` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:386` | Branded qualified symbol name. |
+| `@beep/repo-utils/TSMorph/index` | `TsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:183` | `tsconfig*.json` file path schema. |
+| `@beep/repo-utils/TSMorph/index` | `TsConfigFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:201` | Branded `tsconfig*.json` file path. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnostic` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1803` | Tagged union schema for normalized TypeScript diagnostics. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnostic` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1828` | Decoded normalized TypeScript diagnostic union. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnosticCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1719` | Supported normalized diagnostic categories. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnosticCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1732` | Literal union of normalized diagnostic categories. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnosticsRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1841` | Request schema for TypeScript diagnostics in a resolved scope. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphDiagnosticsResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1862` | Diagnostics payload for a TypeScript file. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphFileOutline` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1490` | File outline payload for a TypeScript source file. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphFileOutlineRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1469` | Request schema for extracting a file outline. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphProjectInspectionRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1415` | Request schema for read-only ts-morph project inspection. |
 | `@beep/repo-utils/TSMorph/index` | `TsMorphProjectLoadError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:171` | Typed error returned when a scoped ts-morph project cannot be constructed. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphProjectScope` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1510` | Resolved ts-morph project scope payload. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphProjectScopeRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1459` | Request schema for resolving a ts-morph project scope. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphReferencePolicy` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:754` | Reference traversal policies for ts-morph scope resolution. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphReferencePolicy` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:767` | Literal union of ts-morph reference traversal policies. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphScopeEntrypoint` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1414` | Tagged union schema for ts-morph scope resolution entrypoints. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphScopeEntrypoint` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1446` | Decoded ts-morph scope entrypoint union. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphScopeMode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:728` | Supported ts-morph project scope modes. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphScopeMode` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:741` | Literal union of ts-morph project scope modes. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphProjectScope` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1443` | Resolved ts-morph project scope payload. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphProjectScopeRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1392` | Request schema for resolving a ts-morph project scope. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphReferencePolicy` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:722` | Reference traversal policies for ts-morph scope resolution. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphReferencePolicy` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:735` | Literal union of ts-morph reference traversal policies. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphScopeEntrypoint` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1350` | Tagged union schema for ts-morph scope resolution entrypoints. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphScopeEntrypoint` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1379` | Decoded ts-morph scope entrypoint union. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphScopeMode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:696` | Supported ts-morph project scope modes. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphScopeMode` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:709` | Literal union of ts-morph project scope modes. |
 | `@beep/repo-utils/TSMorph/index` | `TsMorphScopeResolutionError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:146` | Typed error returned when a scope or repository path cannot be resolved. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSearchLimit` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1663` | Positive result-limit schema for ts-morph search. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSearchLimit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1683` | Branded positive result limit for ts-morph search. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSearchLimit` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1596` | Positive result-limit schema for ts-morph search. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSearchLimit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1614` | Branded positive result limit for ts-morph search. |
 | `@beep/repo-utils/TSMorph/index` | `TSMorphService` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:351` | Service tag for the read-only v1 ts-morph contract. |
 | `@beep/repo-utils/TSMorph/index` | `TSMorphServiceError` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:271` | Tagged union of all recoverable service errors emitted by `TSMorphService`. |
 | `@beep/repo-utils/TSMorph/index` | `TSMorphServiceError` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:291` | Tagged union type for all ts-morph service errors. |
@@ -9730,114 +9731,114 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-utils/TSMorph/index` | `TSMorphServiceShape` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:304` | Read-only v1 service contract for ts-morph-backed scope, symbol, source, and diagnostic operations. |
 | `@beep/repo-utils/TSMorph/index` | `TsMorphServiceUnavailableError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:121` | Typed error retained for compatibility with older placeholder service wiring. |
 | `@beep/repo-utils/TSMorph/index` | `TsMorphSourceFileError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:194` | Typed error returned when a TypeScript file cannot be loaded from a resolved scope. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSourceTextRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1579` | Request schema for reading file source text. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSourceTextResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1599` | Source text payload for a TypeScript file. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolLookupRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1621` | Request schema for symbol lookup by stable identifier. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolLookupResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1642` | Symbol lookup result payload. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSourceTextRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1512` | Request schema for reading file source text. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSourceTextResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1532` | Source text payload for a TypeScript file. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolLookupRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1554` | Request schema for symbol lookup by stable identifier. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolLookupResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1575` | Symbol lookup result payload. |
 | `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolNotFoundError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:218` | Typed error returned when a symbol id cannot be resolved within a scope. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolSearchRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1696` | Request schema for symbol search within a resolved scope. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolSearchResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1720` | Symbol search result payload. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolSourceRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1744` | Request schema for reading symbol source text. |
-| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolSourceResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1765` | Symbol source payload including extracted text. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolSearchRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1627` | Request schema for symbol search within a resolved scope. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolSearchResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1651` | Symbol search result payload. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolSourceRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1675` | Request schema for reading symbol source text. |
+| `@beep/repo-utils/TSMorph/index` | `TsMorphSymbolSourceResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1696` | Symbol source payload including extracted text. |
 | `@beep/repo-utils/TSMorph/index` | `TsMorphUnsupportedFileError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:246` | Typed error returned when a request targets a currently unsupported TypeScript source boundary. |
-| `@beep/repo-utils/TSMorph/index` | `TypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:253` | TypeScript declaration file path schema. |
-| `@beep/repo-utils/TSMorph/index` | `TypeScriptDeclarationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:273` | Branded TypeScript declaration file path. |
-| `@beep/repo-utils/TSMorph/index` | `TypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:286` | TypeScript source file path schema. |
-| `@beep/repo-utils/TSMorph/index` | `TypeScriptFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:305` | Branded TypeScript source file path. |
-| `@beep/repo-utils/TSMorph/index` | `TypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:220` | TypeScript implementation file path schema. |
-| `@beep/repo-utils/TSMorph/index` | `TypeScriptImplementationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:240` | Branded TypeScript implementation file path. |
-| `@beep/repo-utils/TSMorph/index` | `TypeScriptImplementationFilePathToSymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1025` | Schema transformation from a TypeScript implementation file path to a symbol-safe file path. |
-| `@beep/repo-utils/TSMorph/index` | `WorkspaceDirectoryPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:154` | Workspace directory path schema. |
-| `@beep/repo-utils/TSMorph/index` | `WorkspaceDirectoryPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:174` | Branded workspace directory path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ByteLength` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:662` | Non-negative byte length schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ByteLength` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:682` | Branded non-negative byte length. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ByteOffset` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:629` | Non-negative byte offset schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ByteOffset` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:649` | Branded non-negative byte offset. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ColumnNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:596` | Positive 1-based column number schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ColumnNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:616` | Branded positive 1-based column number. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ContentHash` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:695` | SHA-256 content hash schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ContentHash` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:715` | Branded SHA-256 content hash. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ContentHashFromBytes` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1053` | Effectful one-way schema transformation from source bytes to a canonical content hash. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ContentHashFromSourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1086` | Effectful one-way schema transformation from source text to a canonical content hash. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `FilePathToTsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:933` | Schema transformation from a generic file path to a `TsConfigFilePath`. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `FilePathToTypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:979` | Schema transformation from a generic file path to a TypeScript declaration file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `FilePathToTypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1002` | Schema transformation from a generic file path to a TypeScript source file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `FilePathToTypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:956` | Schema transformation from a generic file path to a TypeScript implementation file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `InternalTsMorphNode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1154` | Internal runtime schema for a live ts-morph Node instance. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `InternalTsMorphProject` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1114` | Internal runtime schemas. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `InternalTsMorphSourceFile` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1133` | Internal runtime schema for a live ts-morph SourceFile instance. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `LineNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:563` | Positive 1-based line number schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `LineNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:583` | Branded positive 1-based line number. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `makeProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1342` | Builds a stable `ProjectCacheKey` from validated scope identity parts. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `makeProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1320` | Builds a stable `ProjectScopeId` from validated scope identity parts. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `makeSymbol` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1362` | Normalizes symbol input by deriving missing identity and category fields. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `makeSymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1301` | Builds a stable `SymbolId` from validated symbol identity parts. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:844` | Cache key schema for memoized ts-morph projects. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectCacheKey` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:864` | Branded cache key for memoized ts-morph projects. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:788` | Stable identity schema for a resolved ts-morph project scope. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectScopeId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:808` | Branded stable identity for a resolved ts-morph project scope. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectScopeIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:821` | Parsed components of a `ProjectScopeId`. |
+| `@beep/repo-utils/TSMorph/index` | `TypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:245` | TypeScript declaration file path schema. |
+| `@beep/repo-utils/TSMorph/index` | `TypeScriptDeclarationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:263` | Branded TypeScript declaration file path. |
+| `@beep/repo-utils/TSMorph/index` | `TypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:276` | TypeScript source file path schema. |
+| `@beep/repo-utils/TSMorph/index` | `TypeScriptFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:293` | Branded TypeScript source file path. |
+| `@beep/repo-utils/TSMorph/index` | `TypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:214` | TypeScript implementation file path schema. |
+| `@beep/repo-utils/TSMorph/index` | `TypeScriptImplementationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:232` | Branded TypeScript implementation file path. |
+| `@beep/repo-utils/TSMorph/index` | `TypeScriptImplementationFilePathToSymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:973` | Schema transformation from a TypeScript implementation file path to a symbol-safe file path. |
+| `@beep/repo-utils/TSMorph/index` | `WorkspaceDirectoryPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:152` | Workspace directory path schema. |
+| `@beep/repo-utils/TSMorph/index` | `WorkspaceDirectoryPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:170` | Branded workspace directory path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ByteLength` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:634` | Non-negative byte length schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ByteLength` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:652` | Branded non-negative byte length. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ByteOffset` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:603` | Non-negative byte offset schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ByteOffset` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:621` | Branded non-negative byte offset. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ColumnNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:572` | Positive 1-based column number schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ColumnNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:590` | Branded positive 1-based column number. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ContentHash` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:665` | SHA-256 content hash schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ContentHash` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:683` | Branded SHA-256 content hash. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ContentHashFromBytes` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:999` | Effectful one-way schema transformation from source bytes to a canonical content hash. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ContentHashFromSourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1030` | Effectful one-way schema transformation from source text to a canonical content hash. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `FilePathToTsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:889` | Schema transformation from a generic file path to a `TsConfigFilePath`. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `FilePathToTypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:931` | Schema transformation from a generic file path to a TypeScript declaration file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `FilePathToTypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:952` | Schema transformation from a generic file path to a TypeScript source file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `FilePathToTypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:910` | Schema transformation from a generic file path to a TypeScript implementation file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `InternalTsMorphNode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1092` | Internal runtime schema for a live ts-morph Node instance. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `InternalTsMorphProject` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1056` | Internal runtime schemas. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `InternalTsMorphSourceFile` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1073` | Internal runtime schema for a live ts-morph SourceFile instance. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `LineNumber` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:541` | Positive 1-based line number schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `LineNumber` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:559` | Branded positive 1-based line number. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `makeProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1278` | Builds a stable `ProjectCacheKey` from validated scope identity parts. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `makeProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1256` | Builds a stable `ProjectScopeId` from validated scope identity parts. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `makeSymbol` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1298` | Normalizes symbol input by deriving missing identity and category fields. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `makeSymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1237` | Builds a stable `SymbolId` from validated symbol identity parts. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectCacheKey` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:810` | Cache key schema for memoized ts-morph projects. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectCacheKey` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:828` | Branded cache key for memoized ts-morph projects. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectScopeId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:756` | Stable identity schema for a resolved ts-morph project scope. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectScopeId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:774` | Branded stable identity for a resolved ts-morph project scope. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `ProjectScopeIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:787` | Parsed components of a `ProjectScopeId`. |
 | `@beep/repo-utils/TSMorph/TSMorph.model` | `RepoRootPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:121` | Repository root directory path schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `RepoRootPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:141` | Branded repository root directory path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:530` | Non-empty source text schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SourceText` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:550` | Branded non-empty source text. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `Symbol` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1175` | TS-native symbol record with strict identity, kind, and source-location metadata. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `Symbol` | namespace | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1245` | Namespace helpers for normalized TSMorph symbols. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:443` | Coarse symbol categories used by the TSMorph models. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:456` | Literal union of coarse TSMorph symbol categories. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `symbolCategoryFromKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:469` | Maps a declaration kind to its coarse symbol category. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:318` | Symbol-safe implementation file path schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:338` | Branded symbol-safe implementation file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:877` | Stable symbol identity schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:897` | Branded stable symbol identity. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:910` | Parsed components of a `SymbolId`. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolInit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1283` | Input shape for constructing a normalized `Symbol`. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:417` | Supported TypeScript declaration kinds for normalized symbols. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolKind` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:430` | Literal union of supported TypeScript declaration kinds. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolKindToCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:492` | Schema transformation from declaration kind to coarse symbol category. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolKindToCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:517` | Output type produced by `SymbolKindToCategory`. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolNameSegment` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:351` | Single segment schema for a symbol name. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolNameSegment` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:371` | Branded single symbol name segment. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolQualifiedName` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:384` | Qualified symbol name schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolQualifiedName` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:404` | Branded qualified symbol name. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:187` | `tsconfig*.json` file path schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsConfigFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:207` | Branded `tsconfig*.json` file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnostic` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1872` | Tagged union schema for normalized TypeScript diagnostics. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnostic` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1898` | Decoded normalized TypeScript diagnostic union. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnosticCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1788` | Supported normalized diagnostic categories. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnosticCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1801` | Literal union of normalized diagnostic categories. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnosticsRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1911` | Request schema for TypeScript diagnostics in a resolved scope. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnosticsResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1932` | Diagnostics payload for a TypeScript file. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphFileOutline` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1557` | File outline payload for a TypeScript source file. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphFileOutlineRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1536` | Request schema for extracting a file outline. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphProjectInspectionRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1482` | Request schema for read-only ts-morph project inspection. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphProjectScope` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1510` | Resolved ts-morph project scope payload. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphProjectScopeRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1459` | Request schema for resolving a ts-morph project scope. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphReferencePolicy` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:754` | Reference traversal policies for ts-morph scope resolution. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphReferencePolicy` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:767` | Literal union of ts-morph reference traversal policies. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphScopeEntrypoint` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1414` | Tagged union schema for ts-morph scope resolution entrypoints. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphScopeEntrypoint` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1446` | Decoded ts-morph scope entrypoint union. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphScopeMode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:728` | Supported ts-morph project scope modes. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphScopeMode` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:741` | Literal union of ts-morph project scope modes. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSearchLimit` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1663` | Positive result-limit schema for ts-morph search. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSearchLimit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1683` | Branded positive result limit for ts-morph search. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSourceTextRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1579` | Request schema for reading file source text. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSourceTextResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1599` | Source text payload for a TypeScript file. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolLookupRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1621` | Request schema for symbol lookup by stable identifier. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolLookupResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1642` | Symbol lookup result payload. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolSearchRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1696` | Request schema for symbol search within a resolved scope. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolSearchResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1720` | Symbol search result payload. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolSourceRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1744` | Request schema for reading symbol source text. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolSourceResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1765` | Symbol source payload including extracted text. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:253` | TypeScript declaration file path schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptDeclarationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:273` | Branded TypeScript declaration file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:286` | TypeScript source file path schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:305` | Branded TypeScript source file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:220` | TypeScript implementation file path schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptImplementationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:240` | Branded TypeScript implementation file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptImplementationFilePathToSymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1025` | Schema transformation from a TypeScript implementation file path to a symbol-safe file path. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `WorkspaceDirectoryPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:154` | Workspace directory path schema. |
-| `@beep/repo-utils/TSMorph/TSMorph.model` | `WorkspaceDirectoryPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:174` | Branded workspace directory path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `RepoRootPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:139` | Branded repository root directory path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SourceText` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:510` | Non-empty source text schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SourceText` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:528` | Branded non-empty source text. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `Symbol` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1111` | TS-native symbol record with strict identity, kind, and source-location metadata. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `Symbol` | namespace | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1181` | Namespace helpers for normalized TSMorph symbols. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:425` | Coarse symbol categories used by the TSMorph models. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:438` | Literal union of coarse TSMorph symbol categories. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `symbolCategoryFromKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:451` | Maps a declaration kind to its coarse symbol category. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:306` | Symbol-safe implementation file path schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:324` | Branded symbol-safe implementation file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolId` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:841` | Stable symbol identity schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolId` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:859` | Branded stable symbol identity. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolIdParts` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:872` | Parsed components of a `SymbolId`. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolInit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1219` | Input shape for constructing a normalized `Symbol`. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolKind` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:399` | Supported TypeScript declaration kinds for normalized symbols. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolKind` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:412` | Literal union of supported TypeScript declaration kinds. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolKindToCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:474` | Schema transformation from declaration kind to coarse symbol category. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolKindToCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:497` | Output type produced by `SymbolKindToCategory`. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolNameSegment` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:337` | Single segment schema for a symbol name. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolNameSegment` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:355` | Branded single symbol name segment. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolQualifiedName` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:368` | Qualified symbol name schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `SymbolQualifiedName` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:386` | Branded qualified symbol name. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsConfigFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:183` | `tsconfig*.json` file path schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsConfigFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:201` | Branded `tsconfig*.json` file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnostic` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1803` | Tagged union schema for normalized TypeScript diagnostics. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnostic` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1828` | Decoded normalized TypeScript diagnostic union. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnosticCategory` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1719` | Supported normalized diagnostic categories. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnosticCategory` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1732` | Literal union of normalized diagnostic categories. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnosticsRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1841` | Request schema for TypeScript diagnostics in a resolved scope. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphDiagnosticsResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1862` | Diagnostics payload for a TypeScript file. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphFileOutline` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1490` | File outline payload for a TypeScript source file. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphFileOutlineRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1469` | Request schema for extracting a file outline. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphProjectInspectionRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1415` | Request schema for read-only ts-morph project inspection. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphProjectScope` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1443` | Resolved ts-morph project scope payload. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphProjectScopeRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1392` | Request schema for resolving a ts-morph project scope. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphReferencePolicy` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:722` | Reference traversal policies for ts-morph scope resolution. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphReferencePolicy` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:735` | Literal union of ts-morph reference traversal policies. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphScopeEntrypoint` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1350` | Tagged union schema for ts-morph scope resolution entrypoints. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphScopeEntrypoint` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1379` | Decoded ts-morph scope entrypoint union. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphScopeMode` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:696` | Supported ts-morph project scope modes. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphScopeMode` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:709` | Literal union of ts-morph project scope modes. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSearchLimit` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1596` | Positive result-limit schema for ts-morph search. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSearchLimit` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1614` | Branded positive result limit for ts-morph search. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSourceTextRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1512` | Request schema for reading file source text. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSourceTextResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1532` | Source text payload for a TypeScript file. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolLookupRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1554` | Request schema for symbol lookup by stable identifier. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolLookupResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1575` | Symbol lookup result payload. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolSearchRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1627` | Request schema for symbol search within a resolved scope. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolSearchResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1651` | Symbol search result payload. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolSourceRequest` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1675` | Request schema for reading symbol source text. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TsMorphSymbolSourceResult` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:1696` | Symbol source payload including extracted text. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptDeclarationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:245` | TypeScript declaration file path schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptDeclarationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:263` | Branded TypeScript declaration file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:276` | TypeScript source file path schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:293` | Branded TypeScript source file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptImplementationFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:214` | TypeScript implementation file path schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptImplementationFilePath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:232` | Branded TypeScript implementation file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `TypeScriptImplementationFilePathToSymbolFilePath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:973` | Schema transformation from a TypeScript implementation file path to a symbol-safe file path. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `WorkspaceDirectoryPath` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:152` | Workspace directory path schema. |
+| `@beep/repo-utils/TSMorph/TSMorph.model` | `WorkspaceDirectoryPath` | type | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts:170` | Branded workspace directory path. |
 | `@beep/repo-utils/TSMorph/TSMorph.service` | `createTSMorphService` | const | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:667` | Construct the current live implementation for the v1 TSMorphService contract. |
 | `@beep/repo-utils/TSMorph/TSMorph.service` | `TsMorphProjectLoadError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:171` | Typed error returned when a scoped ts-morph project cannot be constructed. |
 | `@beep/repo-utils/TSMorph/TSMorph.service` | `TsMorphScopeResolutionError` | class | `packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts:146` | Typed error returned when a scope or repository path cannot be resolved. |
@@ -9918,43 +9919,43 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `CauseTaggedErrorConstructor` | type | `packages/foundation/modeling/schema/src/CauseTaggedError/CauseTaggedError.errors.ts:249` | Callable constructor for creating cause-tagged error class factories. |
 | `@beep/schema` | `CauseTaggedErrorFactory` | interface | `packages/foundation/modeling/schema/src/CauseTaggedError/CauseTaggedError.errors.ts:210` | Factory returned by {@link CauseTaggedError} after an identity namespace has been selected. |
 | `@beep/schema` | `CauseTaggedErrorWithStatics` | type | `packages/foundation/modeling/schema/src/CauseTaggedError/CauseTaggedError.errors.ts:164` | Tagged error class returned by {@link CauseTaggedError}, including dual construction helpers. |
-| `@beep/schema` | `ColorAmount` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:106` | Shared finite amount used by color helper request schemas. |
-| `@beep/schema` | `ColorAmount` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:121` | Type for {@link ColorAmount}. |
-| `@beep/schema` | `CommaSeparatedList` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:81` | Schema that decodes a comma-separated string into a trimmed non-empty string array. |
-| `@beep/schema` | `CommaSeparatedList` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:109` | Type for {@link CommaSeparatedList}. |
-| `@beep/schema` | `Csv` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:293` | Schema factory for CSV documents whose rows are validated by the provided |
-| `@beep/schema` | `CSV` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:293` | Schema factory for CSV documents whose rows are validated by the provided |
-| `@beep/schema` | `CSV` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:336` | Runtime type extracted from the {@link CSV} alias. |
-| `@beep/schema` | `CsvDocument` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:50` | Schema transformation returned by the CSV schema factory for a row schema. |
-| `@beep/schema` | `CsvText` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:320` | Branded runtime type for CSV document text produced by encoding a `CSV` |
-| `@beep/schema` | `Darken` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:230` | One-way schema for darkening a color. |
-| `@beep/schema` | `Darken` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:248` | Type for {@link Darken}. |
-| `@beep/schema` | `DarkenInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:214` | Request schema for darkening a color. |
-| `@beep/schema` | `DateTimeInput` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:418` | Union of raw and tagged values accepted by {@link DateTimeUtcFromValid}. |
-| `@beep/schema` | `DateTimeInput` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:449` | {@inheritDoc DateTimeInput} |
-| `@beep/schema` | `DateTimeInputDate` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:244` | Valid JavaScript `Date` input accepted by Effect `DateTime.make`. |
-| `@beep/schema` | `DateTimeInputDate` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:265` | {@inheritDoc DateTimeInputDate} |
-| `@beep/schema` | `DateTimeInputDateTime` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:286` | Existing Effect `DateTime` values accepted by {@link DateTimeUtcFromValid}. |
-| `@beep/schema` | `DateTimeInputDateTime` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:307` | {@inheritDoc DateTimeInputDateTime} |
-| `@beep/schema` | `DateTimeInputInstant` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:323` | Tagged Effect `DateTime.Instant` transport value. |
-| `@beep/schema` | `DateTimeInputInstantWithZone` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:350` | Tagged Effect `DateTime.InstantWithZone` transport value. |
+| `@beep/schema` | `ColorAmount` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:104` | Shared finite amount used by color helper request schemas. |
+| `@beep/schema` | `ColorAmount` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:117` | Type for {@link ColorAmount}. |
+| `@beep/schema` | `CommaSeparatedList` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:79` | Schema that decodes a comma-separated string into a trimmed non-empty string array. |
+| `@beep/schema` | `CommaSeparatedList` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:105` | Type for {@link CommaSeparatedList}. |
+| `@beep/schema` | `Csv` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:289` | Schema factory for CSV documents whose rows are validated by the provided |
+| `@beep/schema` | `CSV` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:289` | Schema factory for CSV documents whose rows are validated by the provided |
+| `@beep/schema` | `CSV` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:332` | Runtime type extracted from the {@link CSV} alias. |
+| `@beep/schema` | `CsvDocument` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:48` | Schema transformation returned by the CSV schema factory for a row schema. |
+| `@beep/schema` | `CsvText` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:316` | Branded runtime type for CSV document text produced by encoding a `CSV` |
+| `@beep/schema` | `Darken` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:222` | One-way schema for darkening a color. |
+| `@beep/schema` | `Darken` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:238` | Type for {@link Darken}. |
+| `@beep/schema` | `DarkenInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:206` | Request schema for darkening a color. |
+| `@beep/schema` | `DateTimeInput` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:416` | Union of raw and tagged values accepted by {@link DateTimeUtcFromValid}. |
+| `@beep/schema` | `DateTimeInput` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:447` | {@inheritDoc DateTimeInput} |
+| `@beep/schema` | `DateTimeInputDate` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:242` | Valid JavaScript `Date` input accepted by Effect `DateTime.make`. |
+| `@beep/schema` | `DateTimeInputDate` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:263` | {@inheritDoc DateTimeInputDate} |
+| `@beep/schema` | `DateTimeInputDateTime` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:284` | Existing Effect `DateTime` values accepted by {@link DateTimeUtcFromValid}. |
+| `@beep/schema` | `DateTimeInputDateTime` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:305` | {@inheritDoc DateTimeInputDateTime} |
+| `@beep/schema` | `DateTimeInputInstant` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:321` | Tagged Effect `DateTime.Instant` transport value. |
+| `@beep/schema` | `DateTimeInputInstantWithZone` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:348` | Tagged Effect `DateTime.InstantWithZone` transport value. |
 | `@beep/schema` | `DateTimeInputKind` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:34` | Literal discriminator values used by tagged date-time input representations. |
-| `@beep/schema` | `DateTimeInputKind` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:64` | {@inheritDoc DateTimeInputKind} |
-| `@beep/schema` | `DateTimeInputNumber` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:202` | Valid numeric epoch-millisecond input accepted by Effect `DateTime.make`. |
-| `@beep/schema` | `DateTimeInputNumber` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:223` | {@inheritDoc DateTimeInputNumber} |
-| `@beep/schema` | `DateTimeInputParts` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:383` | Tagged `Partial<DateTime.Parts>` transport value. |
-| `@beep/schema` | `DateTimeInputString` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:159` | Valid string input accepted by Effect `DateTime.make`. |
-| `@beep/schema` | `DateTimeInputString` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:180` | {@inheritDoc DateTimeInputString} |
-| `@beep/schema` | `DateTimeUtcFromValid` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:512` | Bidirectional schema transformation from valid DateTime input to `DateTime.Utc`. |
-| `@beep/schema` | `DateTimeUtcFromValid` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:540` | {@inheritDoc DateTimeUtcFromValid} |
+| `@beep/schema` | `DateTimeInputKind` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:62` | {@inheritDoc DateTimeInputKind} |
+| `@beep/schema` | `DateTimeInputNumber` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:200` | Valid numeric epoch-millisecond input accepted by Effect `DateTime.make`. |
+| `@beep/schema` | `DateTimeInputNumber` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:221` | {@inheritDoc DateTimeInputNumber} |
+| `@beep/schema` | `DateTimeInputParts` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:381` | Tagged `Partial<DateTime.Parts>` transport value. |
+| `@beep/schema` | `DateTimeInputString` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:157` | Valid string input accepted by Effect `DateTime.make`. |
+| `@beep/schema` | `DateTimeInputString` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:178` | {@inheritDoc DateTimeInputString} |
+| `@beep/schema` | `DateTimeUtcFromValid` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:510` | Bidirectional schema transformation from valid DateTime input to `DateTime.Utc`. |
+| `@beep/schema` | `DateTimeUtcFromValid` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:538` | {@inheritDoc DateTimeUtcFromValid} |
 | `@beep/schema` | `daysInMonth` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:456` | Get the number of days in a given month, accounting for leap years. |
-| `@beep/schema` | `decodeJsoncTextAs` | const | `packages/foundation/modeling/schema/src/Jsonc.ts:127` | Builds a decoder that parses JSONC text and then decodes the result through a |
-| `@beep/schema` | `decodeJsonlTextAs` | const | `packages/foundation/modeling/schema/src/Jsonl.ts:136` | Builds a decoder that parses JSONL text and then decodes the resulting value |
+| `@beep/schema` | `decodeJsoncTextAs` | const | `packages/foundation/modeling/schema/src/Jsonc.ts:125` | Builds a decoder that parses JSONC text and then decodes the result through a |
+| `@beep/schema` | `decodeJsonlTextAs` | const | `packages/foundation/modeling/schema/src/Jsonl.ts:134` | Builds a decoder that parses JSONL text and then decodes the resulting value |
 | `@beep/schema` | `decodeJsonString` | const | `packages/foundation/modeling/schema/src/Json.ts:86` | Decodes a JSON string into an unknown JSON-compatible value. |
-| `@beep/schema` | `decodeMarkdownTextAs` | const | `packages/foundation/modeling/schema/src/Markdown.ts:210` | Builds a decoder that renders Markdown text to HTML and then decodes the |
-| `@beep/schema` | `decodeTomlTextAs` | const | `packages/foundation/modeling/schema/src/Toml.ts:128` | Builds a decoder that parses TOML text and then decodes the result through a |
-| `@beep/schema` | `decodeXmlTextAs` | const | `packages/foundation/modeling/schema/src/Xml.ts:119` | Builds a decoder that parses XML text and then decodes the result through a |
-| `@beep/schema` | `decodeYamlTextAs` | const | `packages/foundation/modeling/schema/src/Yaml.ts:133` | Builds a decoder that parses YAML text and then decodes the result through a |
+| `@beep/schema` | `decodeMarkdownTextAs` | const | `packages/foundation/modeling/schema/src/Markdown.ts:206` | Builds a decoder that renders Markdown text to HTML and then decodes the |
+| `@beep/schema` | `decodeTomlTextAs` | const | `packages/foundation/modeling/schema/src/Toml.ts:126` | Builds a decoder that parses TOML text and then decodes the result through a |
+| `@beep/schema` | `decodeXmlTextAs` | const | `packages/foundation/modeling/schema/src/Xml.ts:117` | Builds a decoder that parses XML text and then decodes the result through a |
+| `@beep/schema` | `decodeYamlTextAs` | const | `packages/foundation/modeling/schema/src/Yaml.ts:131` | Builds a decoder that parses YAML text and then decodes the result through a |
 | `@beep/schema` | `destructiveTransform` | const | `packages/foundation/modeling/schema/src/Transformations.ts:47` | Applies a lossy transform by inferring the target type from a callback result. |
 | `@beep/schema` | `diffInDays` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:380` | Get the difference in whole days between two `LocalDate` values. |
 | `@beep/schema` | `DirectedGraph` | const | `packages/foundation/modeling/schema/src/Graph/Graph.transforms.ts:160` | Schema for immutable directed graphs. |
@@ -9964,20 +9965,20 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `DomainModel` | SourceFile | `packages/foundation/modeling/schema/src/DomainModel.ts:8` |  |
 | `@beep/schema` | `Duration` | const | `packages/foundation/modeling/schema/src/Duration/Duration.schema.ts:41` | Compatibility alias for the primary Effect Duration schema. |
 | `@beep/schema` | `Duration` | type | `packages/foundation/modeling/schema/src/Duration/Duration.schema.ts:49` | Runtime type extracted from {@link Duration}. |
-| `@beep/schema` | `DurationFromInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:226` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
-| `@beep/schema` | `DurationFromInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:246` | Decoded duration type extracted from {@link DurationFromInput}. |
-| `@beep/schema` | `DurationFromInputValue` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:226` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
-| `@beep/schema` | `DurationFromInputValue` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:246` | Decoded duration type extracted from {@link DurationFromInput}. |
-| `@beep/schema` | `DurationInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:167` | Union schema for all duration input shapes accepted by {@link DurationFromInput}. |
-| `@beep/schema` | `DurationInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:189` | Duration input type extracted from {@link DurationInput}. |
-| `@beep/schema` | `DurationInputValue` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:167` | Union schema for all duration input shapes accepted by {@link DurationFromInput}. |
-| `@beep/schema` | `DurationInputValue` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:189` | Duration input type extracted from {@link DurationInput}. |
-| `@beep/schema` | `DurationObject` | class | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:127` | Structured duration input with additive unit fields. |
+| `@beep/schema` | `DurationFromInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:222` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
+| `@beep/schema` | `DurationFromInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:240` | Decoded duration type extracted from {@link DurationFromInput}. |
+| `@beep/schema` | `DurationFromInputValue` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:222` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
+| `@beep/schema` | `DurationFromInputValue` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:240` | Decoded duration type extracted from {@link DurationFromInput}. |
+| `@beep/schema` | `DurationInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:165` | Union schema for all duration input shapes accepted by {@link DurationFromInput}. |
+| `@beep/schema` | `DurationInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:185` | Duration input type extracted from {@link DurationInput}. |
+| `@beep/schema` | `DurationInputValue` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:165` | Union schema for all duration input shapes accepted by {@link DurationFromInput}. |
+| `@beep/schema` | `DurationInputValue` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:185` | Duration input type extracted from {@link DurationInput}. |
+| `@beep/schema` | `DurationObject` | class | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:125` | Structured duration input with additive unit fields. |
 | `@beep/schema` | `DurationUnit` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:65` | Literal union of duration unit labels accepted by {@link DurationInput}. |
-| `@beep/schema` | `DurationUnit` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:96` | Duration unit string type extracted from {@link DurationUnit}. |
-| `@beep/schema` | `DurationUnitAlias` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:104` | Backwards-compatible alias for {@link DurationUnit}. |
+| `@beep/schema` | `DurationUnit` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:94` | Duration unit string type extracted from {@link DurationUnit}. |
+| `@beep/schema` | `DurationUnitAlias` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:102` | Backwards-compatible alias for {@link DurationUnit}. |
 | `@beep/schema` | `DurationUnitValue` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:65` | Literal union of duration unit labels accepted by {@link DurationInput}. |
-| `@beep/schema` | `DurationUnitValue` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:96` | Duration unit string type extracted from {@link DurationUnit}. |
+| `@beep/schema` | `DurationUnitValue` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:94` | Duration unit string type extracted from {@link DurationUnit}. |
 | `@beep/schema` | `DurationValue` | const | `packages/foundation/modeling/schema/src/Duration/Duration.schema.ts:41` | Compatibility alias for the primary Effect Duration schema. |
 | `@beep/schema` | `DurationValue` | type | `packages/foundation/modeling/schema/src/Duration/Duration.schema.ts:49` | Runtime type extracted from {@link Duration}. |
 | `@beep/schema` | `Edge` | const | `packages/foundation/modeling/schema/src/Graph/Graph.edge.ts:181` | Schema for graph edges. This is an alias of {@link EdgeTransform}. |
@@ -10000,8 +10001,8 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `encodeJsonString` | const | `packages/foundation/modeling/schema/src/Json.ts:104` | Encodes an unknown JSON-compatible value into a compact JSON string. |
 | `@beep/schema` | `endOfMonth` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:409` | Return the last day of the month for the given `LocalDate`. |
 | `@beep/schema` | `endOfYear` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:435` | Return December 31st for the year of the given `LocalDate`. |
-| `@beep/schema` | `EndsWithSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:150` | Branded schema for strings that end with a POSIX or Windows path separator. |
-| `@beep/schema` | `EndsWithSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:172` | Type for {@link EndsWithSeparator}. |
+| `@beep/schema` | `EndsWithSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:142` | Branded schema for strings that end with a POSIX or Windows path separator. |
+| `@beep/schema` | `EndsWithSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:162` | Type for {@link EndsWithSeparator}. |
 | `@beep/schema` | `EntitySchema` | SourceFile | `packages/foundation/modeling/schema/src/EntitySchema/index.ts:14` |  |
 | `@beep/schema` | `equals` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:320` | Dual predicate returning `true` when two `LocalDate` values represent the same calendar date. |
 | `@beep/schema` | `extractMimeExtensions` | const | `packages/foundation/modeling/schema/src/FileExtension.ts:72` | Extracts the distinct file extensions from a mime-type dictionary. |
@@ -10011,7 +10012,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `FileName` | const | `packages/foundation/modeling/schema/src/FileName.ts:100` |  |
 | `@beep/schema` | `FileName` | type | `packages/foundation/modeling/schema/src/FileName.ts:118` | Type for {@link FileName}. |
 | `@beep/schema` | `FilePath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:139` | Branded schema for file path strings that are valid on at least one major OS. |
-| `@beep/schema` | `FilePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:154` | Branded file path string type extracted from {@link FilePath}. |
+| `@beep/schema` | `FilePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:152` | Branded file path string type extracted from {@link FilePath}. |
 | `@beep/schema` | `Float16Arr` | const | `packages/foundation/modeling/schema/src/Float16Array.ts:74` | Schema that accepts native `Float16Array` instances. |
 | `@beep/schema` | `Float16Arr` | type | `packages/foundation/modeling/schema/src/Float16Array.ts:86` | Type for {@link Float16Arr}. |
 | `@beep/schema` | `Float16ArrayField` | const | `packages/foundation/modeling/schema/src/Float16Array.ts:179` | Model field helper for storing `Float16Array` values in variant-based model |
@@ -10042,20 +10043,20 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `FnType` | type | `packages/foundation/modeling/schema/src/Fn/Fn.schema.ts:130` | Function type helper used by {@link Fn}. Inputs modeled with `never`, |
 | `@beep/schema` | `fromDate` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:231` | Create a `LocalDate` from a JavaScript `Date` using its UTC components. |
 | `@beep/schema` | `fromDateTime` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:264` | Create a `LocalDate` from a `DateTime` by extracting its UTC date components. |
-| `@beep/schema` | `FromInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:226` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
-| `@beep/schema` | `FromInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:246` | Decoded duration type extracted from {@link DurationFromInput}. |
+| `@beep/schema` | `FromInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:222` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
+| `@beep/schema` | `FromInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:240` | Decoded duration type extracted from {@link DurationFromInput}. |
 | `@beep/schema` | `fromString` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:208` | Parse a `YYYY-MM-DD` string into a `LocalDate`, returning an `Effect` that fails for invalid input. |
-| `@beep/schema` | `GenerateAlphaScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:263` | One-way schema for generating an alpha-blended 12-step scale. |
-| `@beep/schema` | `GenerateAlphaScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:283` | Type for {@link GenerateAlphaScale}. |
-| `@beep/schema` | `GenerateAlphaScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:247` | Request schema for generating an alpha-blended 12-step scale. |
-| `@beep/schema` | `GenerateNeutralScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:219` | One-way schema for generating a neutral 12-step scale. |
-| `@beep/schema` | `GenerateNeutralScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:239` | Type for {@link GenerateNeutralScale}. |
-| `@beep/schema` | `GenerateNeutralScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:203` | Request schema for generating a neutral 12-step scale. |
-| `@beep/schema` | `GenerateScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:175` | One-way schema for generating a chromatic 12-step scale. |
-| `@beep/schema` | `GenerateScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:195` | Type for {@link GenerateScale}. |
-| `@beep/schema` | `GenerateScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:159` | Request schema for generating a chromatic 12-step scale. |
+| `@beep/schema` | `GenerateAlphaScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:255` | One-way schema for generating an alpha-blended 12-step scale. |
+| `@beep/schema` | `GenerateAlphaScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:273` | Type for {@link GenerateAlphaScale}. |
+| `@beep/schema` | `GenerateAlphaScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:239` | Request schema for generating an alpha-blended 12-step scale. |
+| `@beep/schema` | `GenerateNeutralScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:213` | One-way schema for generating a neutral 12-step scale. |
+| `@beep/schema` | `GenerateNeutralScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:231` | Type for {@link GenerateNeutralScale}. |
+| `@beep/schema` | `GenerateNeutralScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:197` | Request schema for generating a neutral 12-step scale. |
+| `@beep/schema` | `GenerateScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:171` | One-way schema for generating a chromatic 12-step scale. |
+| `@beep/schema` | `GenerateScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:189` | Type for {@link GenerateScale}. |
+| `@beep/schema` | `GenerateScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:155` | Request schema for generating a chromatic 12-step scale. |
 | `@beep/schema` | `Glob` | const | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:105` | Branded schema for portable non-empty glob pattern strings. |
-| `@beep/schema` | `Glob` | type | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:120` | Type for {@link Glob}. |
+| `@beep/schema` | `Glob` | type | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:118` | Type for {@link Glob}. |
 | `@beep/schema` | `GraphEncoded` | const | `packages/foundation/modeling/schema/src/Graph/Graph.encoded.ts:141` | Schema for encoded graphs. |
 | `@beep/schema` | `GraphEncoded` | type | `packages/foundation/modeling/schema/src/Graph/Graph.encoded.ts:31` | Encoded graph representation used by graph codecs. |
 | `@beep/schema` | `GraphEncodedSchema` | interface | `packages/foundation/modeling/schema/src/Graph/Graph.encoded.ts:98` | Schema type for encoded graphs. |
@@ -10064,20 +10065,20 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `GraphIso` | type | `packages/foundation/modeling/schema/src/Graph/Graph.encoded.ts:63` | Public schema module export. |
 | `@beep/schema` | `GraphKind` | const | `packages/foundation/modeling/schema/src/Graph/Graph.primitives.ts:109` | Schema for graph kind discriminators. |
 | `@beep/schema` | `GraphKind` | type | `packages/foundation/modeling/schema/src/Graph/Graph.primitives.ts:121` | Graph kind discriminator type extracted from {@link GraphKind}. |
-| `@beep/schema` | `HasLeafSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:83` | Branded schema for path strings that include a non-root leaf segment. |
-| `@beep/schema` | `HasLeafSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:132` | Type for {@link HasLeafSegment}. |
+| `@beep/schema` | `HasLeafSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:79` | Branded schema for path strings that include a non-root leaf segment. |
+| `@beep/schema` | `HasLeafSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:126` | Type for {@link HasLeafSegment}. |
 | `@beep/schema` | `HasNullByte` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:29` | Branded schema for strings that contain an embedded NUL byte. |
-| `@beep/schema` | `HasNullByte` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:51` | Branded string type containing an embedded NUL byte. |
-| `@beep/schema` | `HexColor` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:127` | Canonical lowercase six-digit hex color schema. |
-| `@beep/schema` | `HexColor` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:142` | Type for {@link HexColor}. |
+| `@beep/schema` | `HasNullByte` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:49` | Branded string type containing an embedded NUL byte. |
+| `@beep/schema` | `HexColor` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:125` | Canonical lowercase six-digit hex color schema. |
+| `@beep/schema` | `HexColor` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:138` | Type for {@link HexColor}. |
 | `@beep/schema` | `HexColorInput` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:105` | Boundary schema for hex color input strings. |
-| `@beep/schema` | `HexColorInput` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:119` | Type for {@link HexColorInput}. |
+| `@beep/schema` | `HexColorInput` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:117` | Type for {@link HexColorInput}. |
 | `@beep/schema` | `HexColorScale12` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:124` | Fixed-size 12-step canonical hex color scale. |
-| `@beep/schema` | `HexColorScale12` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:141` | Type for {@link HexColorScale12}. |
-| `@beep/schema` | `HexToOklch` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:145` | Transformation schema for decoding boundary hex input into canonical OKLCH. |
-| `@beep/schema` | `HexToOklch` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:166` | Type for {@link HexToOklch}. |
+| `@beep/schema` | `HexColorScale12` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:139` | Type for {@link HexColorScale12}. |
+| `@beep/schema` | `HexToOklch` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:137` | Transformation schema for decoding boundary hex input into canonical OKLCH. |
+| `@beep/schema` | `HexToOklch` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:156` | Type for {@link HexToOklch}. |
 | `@beep/schema` | `HexToRgb` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:38` | Transformation schema for decoding boundary hex input into normalized RGB. |
-| `@beep/schema` | `HexToRgb` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:59` | Type for {@link HexToRgb}. |
+| `@beep/schema` | `HexToRgb` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:57` | Type for {@link HexToRgb}. |
 | `@beep/schema` | `HtmlFragment` | const | `packages/foundation/modeling/schema/src/Html.ts:33` | Branded schema for trusted HTML fragment strings. |
 | `@beep/schema` | `HtmlFragment` | type | `packages/foundation/modeling/schema/src/Html.ts:55` | Type for {@link HtmlFragment}. |
 | `@beep/schema` | `ImageFileExtension` | const | `packages/foundation/modeling/schema/src/FileExtension.ts:216` | Schema for file extensions associated with `image/*` mime types. |
@@ -10112,9 +10113,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `JsonObject` | type | `packages/foundation/modeling/schema/src/Json.ts:39` | Runtime type extracted from the {@link JsonObject} schema. |
 | `@beep/schema` | `KebabCaseStr` | const | `packages/foundation/modeling/schema/src/KebabStr.ts:28` | Branded kebab-case string schema with a lowercase leading letter. |
 | `@beep/schema` | `KebabCaseStr` | type | `packages/foundation/modeling/schema/src/KebabStr.ts:54` | Type for {@link KebabCaseStr}. |
-| `@beep/schema` | `Lighten` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:188` | One-way schema for lightening a color. |
-| `@beep/schema` | `Lighten` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:206` | Type for {@link Lighten}. |
-| `@beep/schema` | `LightenInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:172` | Request schema for lightening a color. |
+| `@beep/schema` | `Lighten` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:182` | One-way schema for lightening a color. |
+| `@beep/schema` | `Lighten` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:198` | Type for {@link Lighten}. |
+| `@beep/schema` | `LightenInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:166` | Request schema for lightening a color. |
 | `@beep/schema` | `LiteralKit` | function | `packages/foundation/modeling/schema/src/LiteralKit/LiteralKit.schema.ts:705` | Builds a literal schema kit from a non-empty tuple of mixed literals. |
 | `@beep/schema` | `LiteralKit` | function | `packages/foundation/modeling/schema/src/LiteralKit/LiteralKit.schema.ts:706` |  |
 | `@beep/schema` | `LiteralKit` | function | `packages/foundation/modeling/schema/src/LiteralKit/LiteralKit.schema.ts:710` |  |
@@ -10138,8 +10139,8 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `MappedLiteralKit` | function | `packages/foundation/modeling/schema/src/MappedLiteralKit/MappedLiteralKit.schema.ts:334` | Builds a mapped literal schema kit from a non-empty tuple of literal pairs. |
 | `@beep/schema` | `MappedLiteralKit` | interface | `packages/foundation/modeling/schema/src/MappedLiteralKit/MappedLiteralKit.schema.ts:303` | Public schema module export. |
 | `@beep/schema` | `Markdown` | const | `packages/foundation/modeling/schema/src/Markdown.ts:122` | Branded schema for Markdown document strings accepted by the active parser. |
-| `@beep/schema` | `Markdown` | type | `packages/foundation/modeling/schema/src/Markdown.ts:141` | Branded Markdown document string type extracted from {@link Markdown}. |
-| `@beep/schema` | `MarkdownTextToHtml` | const | `packages/foundation/modeling/schema/src/Markdown.ts:169` | Schema factory that renders Markdown text into HTML using `Bun.markdown.html`. |
+| `@beep/schema` | `Markdown` | type | `packages/foundation/modeling/schema/src/Markdown.ts:139` | Branded Markdown document string type extracted from {@link Markdown}. |
+| `@beep/schema` | `MarkdownTextToHtml` | const | `packages/foundation/modeling/schema/src/Markdown.ts:167` | Schema factory that renders Markdown text into HTML using `Bun.markdown.html`. |
 | `@beep/schema` | `matchLiteral` | const | `packages/foundation/modeling/schema/src/LiteralKit/LiteralKit.schema.ts:217` | Converts a literal value to its string key at runtime using the |
 | `@beep/schema` | `MimeType` | const | `packages/foundation/modeling/schema/src/MimeType.ts:100` | Schema kit that covers all supported mime types with per-category sub-schemas. |
 | `@beep/schema` | `MimeType` | type | `packages/foundation/modeling/schema/src/MimeType.ts:149` | Union of supported mime-type literals. |
@@ -10147,9 +10148,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `MiscFileExtension` | type | `packages/foundation/modeling/schema/src/FileExtension.ts:315` | Union of literals accepted by {@link MiscFileExtension}. |
 | `@beep/schema` | `MiscMimeType` | const | `packages/foundation/modeling/schema/src/MimeType.ts:379` | Schema for miscellaneous mime-type literals that do not fit standard categories. |
 | `@beep/schema` | `MiscMimeType` | type | `packages/foundation/modeling/schema/src/MimeType.ts:402` | Union of miscellaneous mime-type literals. |
-| `@beep/schema` | `MixColors` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:146` | One-way schema for mixing two colors. |
-| `@beep/schema` | `MixColors` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:164` | Type for {@link MixColors}. |
-| `@beep/schema` | `MixColorsInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:129` | Request schema for mixing two colors. |
+| `@beep/schema` | `MixColors` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:142` | One-way schema for mixing two colors. |
+| `@beep/schema` | `MixColors` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:158` | Type for {@link MixColors}. |
+| `@beep/schema` | `MixColorsInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:125` | Request schema for mixing two colors. |
 | `@beep/schema` | `Model` | SourceFile | `packages/foundation/modeling/schema/src/Model/index.ts:14` |  |
 | `@beep/schema` | `MutableDirectedGraph` | const | `packages/foundation/modeling/schema/src/Graph/Graph.transforms.ts:208` | Schema for mutable directed graphs. |
 | `@beep/schema` | `MutableDirectedGraph` | interface | `packages/foundation/modeling/schema/src/Graph/Graph.transforms.ts:53` | Schema for decoding encoded graph payloads into mutable directed graphs. |
@@ -10171,7 +10172,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `MutableUndirectedGraph` | interface | `packages/foundation/modeling/schema/src/Graph/Graph.transforms.ts:66` | Schema for decoding encoded graph payloads into mutable undirected graphs. |
 | `@beep/schema` | `MutableUndirectedGraphFromSelf` | const | `packages/foundation/modeling/schema/src/Graph/Graph.from-self.ts:346` | Schema for validating existing mutable undirected Effect graphs. |
 | `@beep/schema` | `MutableUndirectedGraphFromSelf` | interface | `packages/foundation/modeling/schema/src/Graph/Graph.from-self.ts:121` | Schema for validating existing mutable undirected Effect graphs. |
-| `@beep/schema` | `NativePathToPosixPath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:70` | Schema transformation that converts native file-system paths (with backslashes) to POSIX separators. |
+| `@beep/schema` | `NativePathToPosixPath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:68` | Schema transformation that converts native file-system paths (with backslashes) to POSIX separators. |
 | `@beep/schema` | `NegInt` | const | `packages/foundation/modeling/schema/src/Int.ts:154` | Branded schema for negative integers (less than zero). |
 | `@beep/schema` | `NegInt` | type | `packages/foundation/modeling/schema/src/Int.ts:180` | Type for {@link NegInt}. |
 | `@beep/schema` | `NodeIndex` | const | `packages/foundation/modeling/schema/src/Graph/Graph.primitives.ts:30` | Branded schema for graph node indices. |
@@ -10193,27 +10194,27 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `NonNegNum` | type | `packages/foundation/modeling/schema/src/Number.ts:163` | Type for {@link NonNegNum}. |
 | `@beep/schema` | `NonPositiveInt` | const | `packages/foundation/modeling/schema/src/Int.ts:197` | Branded schema for non-positive integers (zero or less). |
 | `@beep/schema` | `NonPositiveInt` | type | `packages/foundation/modeling/schema/src/Int.ts:223` | Type for {@link NonPositiveInt}. |
-| `@beep/schema` | `NormalizedBooleanString` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:126` | Schema that normalizes common boolean string spellings (`"true"`, `"1"`, `"yes"`, `"on"`, etc.) to `boolean`. |
-| `@beep/schema` | `NormalizedBooleanString` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:154` | Type for {@link NormalizedBooleanString}. |
-| `@beep/schema` | `NormalizeHexColor` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:150` | Canonicalization schema from boundary hex input to canonical hex output. |
-| `@beep/schema` | `NormalizeHexColor` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:171` | Type for {@link NormalizeHexColor}. |
-| `@beep/schema` | `normalizePath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:104` | Normalize a file-system path string to POSIX separators. |
+| `@beep/schema` | `NormalizedBooleanString` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:122` | Schema that normalizes common boolean string spellings (`"true"`, `"1"`, `"yes"`, `"on"`, etc.) to `boolean`. |
+| `@beep/schema` | `NormalizedBooleanString` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:148` | Type for {@link NormalizedBooleanString}. |
+| `@beep/schema` | `NormalizeHexColor` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:146` | Canonicalization schema from boundary hex input to canonical hex output. |
+| `@beep/schema` | `NormalizeHexColor` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:165` | Type for {@link NormalizeHexColor}. |
+| `@beep/schema` | `normalizePath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:100` | Normalize a file-system path string to POSIX separators. |
 | `@beep/schema` | `NullableStr` | const | `packages/foundation/modeling/schema/src/String.ts:104` | A nullable string schema that accepts `string \| null`. |
 | `@beep/schema` | `NullableStr` | type | `packages/foundation/modeling/schema/src/String.ts:124` | Type for {@link NullableStr}. |
-| `@beep/schema` | `OklchChroma` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:178` | Canonical OKLCH chroma component. |
-| `@beep/schema` | `OklchChroma` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:194` | Type for {@link OklchChroma}. |
-| `@beep/schema` | `OklchColor` | class | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:243` | Canonical OKLCH color object. |
+| `@beep/schema` | `OklchChroma` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:174` | Canonical OKLCH chroma component. |
+| `@beep/schema` | `OklchChroma` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:188` | Type for {@link OklchChroma}. |
+| `@beep/schema` | `OklchColor` | class | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:235` | Canonical OKLCH color object. |
 | `@beep/schema` | `OklchCoordinate` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:131` | Branded finite OKLCH coordinate. |
-| `@beep/schema` | `OklchCoordinate` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:146` | Type for {@link OklchCoordinate}. |
-| `@beep/schema` | `OklchHue` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:202` | Canonical OKLCH hue component. |
-| `@beep/schema` | `OklchHue` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:218` | Type for {@link OklchHue}. |
-| `@beep/schema` | `OklchInput` | class | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:226` | OKLCH object with finite coordinates. |
-| `@beep/schema` | `OklchLightness` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:154` | Canonical OKLCH lightness component. |
-| `@beep/schema` | `OklchLightness` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:170` | Type for {@link OklchLightness}. |
-| `@beep/schema` | `OklchToHex` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:174` | Transformation schema for encoding OKLCH coordinates into canonical hex. |
-| `@beep/schema` | `OklchToHex` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:192` | Type for {@link OklchToHex}. |
-| `@beep/schema` | `OklchToRgb` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:119` | Transformation schema for encoding OKLCH coordinates into RGB input values. |
-| `@beep/schema` | `OklchToRgb` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:137` | Type for {@link OklchToRgb}. |
+| `@beep/schema` | `OklchCoordinate` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:144` | Type for {@link OklchCoordinate}. |
+| `@beep/schema` | `OklchHue` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:196` | Canonical OKLCH hue component. |
+| `@beep/schema` | `OklchHue` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:210` | Type for {@link OklchHue}. |
+| `@beep/schema` | `OklchInput` | class | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:218` | OKLCH object with finite coordinates. |
+| `@beep/schema` | `OklchLightness` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:152` | Canonical OKLCH lightness component. |
+| `@beep/schema` | `OklchLightness` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:166` | Type for {@link OklchLightness}. |
+| `@beep/schema` | `OklchToHex` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:164` | Transformation schema for encoding OKLCH coordinates into canonical hex. |
+| `@beep/schema` | `OklchToHex` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:180` | Type for {@link OklchToHex}. |
+| `@beep/schema` | `OklchToRgb` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:113` | Transformation schema for encoding OKLCH coordinates into RGB input values. |
+| `@beep/schema` | `OklchToRgb` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:129` | Type for {@link OklchToRgb}. |
 | `@beep/schema` | `OptionFromNullableStr` | const | `packages/foundation/modeling/schema/src/String.ts:141` | A nullable string that decodes to `Option<string>` using `S.OptionFromNullOr`. |
 | `@beep/schema` | `OptionFromNullableStr` | type | `packages/foundation/modeling/schema/src/String.ts:154` | Type for {@link OptionFromNullableStr}. |
 | `@beep/schema` | `OptionFromOptionalNullishKey` | const | `packages/foundation/modeling/schema/src/Options.ts:78` | Decodes an optional object key whose value may also be `null` or `undefined` |
@@ -10224,46 +10225,46 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `PosInt` | const | `packages/foundation/modeling/schema/src/Int.ts:72` | Branded schema for positive integers (greater than zero). |
 | `@beep/schema` | `PosInt` | type | `packages/foundation/modeling/schema/src/Int.ts:98` | Type for {@link PosInt}. |
 | `@beep/schema` | `PosixPath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:31` | Branded schema for path strings using only POSIX `/` separators. |
-| `@beep/schema` | `PosixPath` | type | `packages/foundation/modeling/schema/src/PosixPath.ts:53` | Type for {@link PosixPath}. |
+| `@beep/schema` | `PosixPath` | type | `packages/foundation/modeling/schema/src/PosixPath.ts:51` | Type for {@link PosixPath}. |
 | `@beep/schema` | `PostgresSerialInt` | const | `packages/foundation/modeling/schema/src/Int.ts:115` | Branded schema for PostgreSQL `serial` column values. |
 | `@beep/schema` | `PostgresSerialInt` | type | `packages/foundation/modeling/schema/src/Int.ts:137` | Type for {@link PostgresSerialInt}. |
 | `@beep/schema` | `Primitive` | const | `packages/foundation/modeling/schema/src/Primitive.ts:28` | Schema for JavaScript primitive types (`string \| number \| boolean \| bigint \| null \| undefined`). |
 | `@beep/schema` | `Primitive` | type | `packages/foundation/modeling/schema/src/Primitive.ts:47` | {@inheritDoc Primitive} |
 | `@beep/schema` | `PromiseSchema` | const | `packages/foundation/modeling/schema/src/PromiseSchema.ts:91` | Declared schema for native JavaScript `Promise` values. |
 | `@beep/schema` | `PromiseSchema` | type | `packages/foundation/modeling/schema/src/PromiseSchema.ts:112` | {@inheritDoc PromiseSchema} |
-| `@beep/schema` | `RegExpFromStr` | const | `packages/foundation/modeling/schema/src/RegExp.ts:107` | One-way schema that decodes a valid pattern string into a JavaScript `RegExp` object. |
-| `@beep/schema` | `RegExpFromStr` | type | `packages/foundation/modeling/schema/src/RegExp.ts:135` | Type for {@link RegExpFromStr}. |
+| `@beep/schema` | `RegExpFromStr` | const | `packages/foundation/modeling/schema/src/RegExp.ts:105` | One-way schema that decodes a valid pattern string into a JavaScript `RegExp` object. |
+| `@beep/schema` | `RegExpFromStr` | type | `packages/foundation/modeling/schema/src/RegExp.ts:131` | Type for {@link RegExpFromStr}. |
 | `@beep/schema` | `RegExpStr` | const | `packages/foundation/modeling/schema/src/RegExp.ts:58` | Branded schema for strings that can be converted directly to a JavaScript `RegExp`. |
-| `@beep/schema` | `RegExpStr` | type | `packages/foundation/modeling/schema/src/RegExp.ts:80` | Type for {@link RegExpStr}. |
-| `@beep/schema` | `Rgb` | class | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:94` | RGB object with normalized channels. |
+| `@beep/schema` | `RegExpStr` | type | `packages/foundation/modeling/schema/src/RegExp.ts:78` | Type for {@link RegExpStr}. |
+| `@beep/schema` | `Rgb` | class | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:90` | RGB object with normalized channels. |
 | `@beep/schema` | `RgbaColorString` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:83` | CSS rgba color string produced by with-alpha helpers. |
-| `@beep/schema` | `RgbaColorString` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:98` | Type for {@link RgbaColorString}. |
-| `@beep/schema` | `RgbChannel` | const | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:53` | Branded normalized RGB channel in the range 0 through 1. |
-| `@beep/schema` | `RgbChannel` | type | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:69` | Type for {@link RgbChannel}. |
-| `@beep/schema` | `RgbInput` | class | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:77` | RGB object with finite channel inputs. |
+| `@beep/schema` | `RgbaColorString` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:96` | Type for {@link RgbaColorString}. |
+| `@beep/schema` | `RgbChannel` | const | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:51` | Branded normalized RGB channel in the range 0 through 1. |
+| `@beep/schema` | `RgbChannel` | type | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:65` | Type for {@link RgbChannel}. |
+| `@beep/schema` | `RgbInput` | class | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:73` | RGB object with finite channel inputs. |
 | `@beep/schema` | `RgbInputChannel` | const | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:30` | Branded finite RGB input channel. |
-| `@beep/schema` | `RgbInputChannel` | type | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:45` | Type for {@link RgbInputChannel}. |
-| `@beep/schema` | `RgbToHex` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:67` | Transformation schema for encoding RGB input into canonical hex. |
-| `@beep/schema` | `RgbToHex` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:85` | Type for {@link RgbToHex}. |
-| `@beep/schema` | `RgbToOklch` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:93` | Transformation schema for decoding normalized RGB into canonical OKLCH. |
-| `@beep/schema` | `RgbToOklch` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:111` | Type for {@link RgbToOklch}. |
-| `@beep/schema` | `RowSchemaWithFields` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:40` | Object-like row schema contract accepted by the CSV schema factory. |
-| `@beep/schema` | `Schema` | const | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:128` | Primary glob schema role alias. |
-| `@beep/schema` | `Schema` | type | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:136` | Runtime type extracted from {@link Schema}. |
+| `@beep/schema` | `RgbInputChannel` | type | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:43` | Type for {@link RgbInputChannel}. |
+| `@beep/schema` | `RgbToHex` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:65` | Transformation schema for encoding RGB input into canonical hex. |
+| `@beep/schema` | `RgbToHex` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:81` | Type for {@link RgbToHex}. |
+| `@beep/schema` | `RgbToOklch` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:89` | Transformation schema for decoding normalized RGB into canonical OKLCH. |
+| `@beep/schema` | `RgbToOklch` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:105` | Type for {@link RgbToOklch}. |
+| `@beep/schema` | `RowSchemaWithFields` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:38` | Object-like row schema contract accepted by the CSV schema factory. |
+| `@beep/schema` | `Schema` | const | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:126` | Primary glob schema role alias. |
+| `@beep/schema` | `Schema` | type | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:134` | Runtime type extracted from {@link Schema}. |
 | `@beep/schema` | `SchemaUtils` | SourceFile | `packages/foundation/modeling/schema/src/SchemaUtils/index.ts:12` |  |
 | `@beep/schema` | `SemanticVersion` | const | `packages/foundation/modeling/schema/src/SemanticVersion.ts:46` | A Semantic Versioning (SemVer) schema for validating `MAJOR.MINOR.PATCH` version strings. |
 | `@beep/schema` | `SemanticVersion` | type | `packages/foundation/modeling/schema/src/SemanticVersion.ts:75` | {@inheritDoc SemanticVersion} |
 | `@beep/schema` | `SeverityLevel` | const | `packages/foundation/modeling/schema/src/SeverityLevel.ts:30` | Generic four-level severity scale: `"low"`, `"medium"`, `"high"`, `"critical"`. |
 | `@beep/schema` | `SeverityLevel` | type | `packages/foundation/modeling/schema/src/SeverityLevel.ts:49` | Type for {@link SeverityLevel}. |
 | `@beep/schema` | `Sha256Hex` | const | `packages/foundation/modeling/schema/src/Sha256.ts:57` | Branded schema for canonical lowercase SHA-256 hex digests (64 hex characters). |
-| `@beep/schema` | `Sha256Hex` | type | `packages/foundation/modeling/schema/src/Sha256.ts:79` | Type for {@link Sha256Hex}. |
-| `@beep/schema` | `Sha256HexFromBytes` | const | `packages/foundation/modeling/schema/src/Sha256.ts:101` | One-way schema that decodes a byte array into a canonical lowercase SHA-256 |
-| `@beep/schema` | `Sha256HexFromBytes` | type | `packages/foundation/modeling/schema/src/Sha256.ts:126` | Type for {@link Sha256HexFromBytes}. |
-| `@beep/schema` | `Sha256HexFromHexBytes` | const | `packages/foundation/modeling/schema/src/Sha256.ts:147` | One-way schema that decodes a hex-encoded byte string into a canonical |
-| `@beep/schema` | `Sha256HexFromHexBytes` | type | `packages/foundation/modeling/schema/src/Sha256.ts:169` | Type for {@link Sha256HexFromHexBytes}. |
+| `@beep/schema` | `Sha256Hex` | type | `packages/foundation/modeling/schema/src/Sha256.ts:77` | Type for {@link Sha256Hex}. |
+| `@beep/schema` | `Sha256HexFromBytes` | const | `packages/foundation/modeling/schema/src/Sha256.ts:99` | One-way schema that decodes a byte array into a canonical lowercase SHA-256 |
+| `@beep/schema` | `Sha256HexFromBytes` | type | `packages/foundation/modeling/schema/src/Sha256.ts:122` | Type for {@link Sha256HexFromBytes}. |
+| `@beep/schema` | `Sha256HexFromHexBytes` | const | `packages/foundation/modeling/schema/src/Sha256.ts:143` | One-way schema that decodes a hex-encoded byte string into a canonical |
+| `@beep/schema` | `Sha256HexFromHexBytes` | type | `packages/foundation/modeling/schema/src/Sha256.ts:163` | Type for {@link Sha256HexFromHexBytes}. |
 | `@beep/schema` | `Slug` | const | `packages/foundation/modeling/schema/src/Slug.ts:83` | Branded schema for canonical lowercase kebab-case slugs. |
-| `@beep/schema` | `Slug` | type | `packages/foundation/modeling/schema/src/Slug.ts:98` | Branded slug string type extracted from {@link Slug}. |
-| `@beep/schema` | `SlugFromStr` | const | `packages/foundation/modeling/schema/src/Slug.ts:106` | Non-empty string schema used as the source input for {@link Slug}. |
+| `@beep/schema` | `Slug` | type | `packages/foundation/modeling/schema/src/Slug.ts:96` | Branded slug string type extracted from {@link Slug}. |
+| `@beep/schema` | `SlugFromStr` | const | `packages/foundation/modeling/schema/src/Slug.ts:104` | Non-empty string schema used as the source input for {@link Slug}. |
 | `@beep/schema` | `SnakeCaseStr` | const | `packages/foundation/modeling/schema/src/SnakeStr.ts:28` | Branded snake_case string schema. |
 | `@beep/schema` | `SnakeCaseStr` | type | `packages/foundation/modeling/schema/src/SnakeStr.ts:54` | Type for {@link SnakeCaseStr}. |
 | `@beep/schema` | `startOfMonth` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:396` | Return the first day of the month for the given `LocalDate`. |
@@ -10278,8 +10279,8 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `StatusCauseTaggedErrorClassWithStatics` | type | `packages/foundation/modeling/schema/src/StatusCauseTaggedErrorClass/StatusCauseTaggedErrorClass.errors.ts:170` | Tagged error class returned by {@link StatusCauseTaggedErrorClass}, including dual status/cause helpers. |
 | `@beep/schema` | `SupportedPathFamily` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:31` | Literal union of file-path families recognized by {@link FilePath}. |
 | `@beep/schema` | `SupportedPathFamily` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:43` | Type for {@link SupportedPathFamily}. |
-| `@beep/schema` | `SupportedWindowsNamespace` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:60` | Branded schema for path strings that do not use unsupported Windows device |
-| `@beep/schema` | `SupportedWindowsNamespace` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:82` | Type for {@link SupportedWindowsNamespace}. |
+| `@beep/schema` | `SupportedWindowsNamespace` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:58` | Branded schema for path strings that do not use unsupported Windows device |
+| `@beep/schema` | `SupportedWindowsNamespace` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:78` | Type for {@link SupportedWindowsNamespace}. |
 | `@beep/schema` | `TaggedErrorClass` | const | `packages/foundation/modeling/schema/src/TaggedErrorClass/TaggedErrorClass.errors.ts:294` | Create a tagged error class with `_tag` discrimination and constructor input inferred from the schema. |
 | `@beep/schema` | `TaggedErrorClassConstructor` | type | `packages/foundation/modeling/schema/src/TaggedErrorClass/TaggedErrorClass.errors.ts:244` | Callable constructor type for building tagged error classes. |
 | `@beep/schema` | `TaggedErrorClassFactory` | interface | `packages/foundation/modeling/schema/src/TaggedErrorClass/TaggedErrorClass.errors.ts:208` | Factory interface returned by {@link TaggedErrorClass} that accepts a tag, fields, and optional annotations. |
@@ -10299,7 +10300,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `todayEffect` | const | `packages/foundation/modeling/schema/src/LocalDate/LocalDate.schema.ts:253` | Get today's UTC date as an `Effect` using the Clock service, testable with `TestClock`. |
 | `@beep/schema` | `TomlTextToUnknown` | const | `packages/foundation/modeling/schema/src/Toml.ts:94` | Schema transformation that decodes TOML text into an unknown record using |
 | `@beep/schema` | `TrimmedNonEmptyText` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:36` | Trimmed and non-empty text schema that strips whitespace and rejects empty results. |
-| `@beep/schema` | `TrimmedNonEmptyText` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:64` | Type for {@link TrimmedNonEmptyText}. |
+| `@beep/schema` | `TrimmedNonEmptyText` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:62` | Type for {@link TrimmedNonEmptyText}. |
 | `@beep/schema` | `UndirectedGraph` | const | `packages/foundation/modeling/schema/src/Graph/Graph.transforms.ts:184` | Schema for immutable undirected graphs. |
 | `@beep/schema` | `UndirectedGraph` | interface | `packages/foundation/modeling/schema/src/Graph/Graph.transforms.ts:40` | Schema for decoding encoded graph payloads into immutable undirected graphs. |
 | `@beep/schema` | `UndirectedGraphFromSelf` | const | `packages/foundation/modeling/schema/src/Graph/Graph.from-self.ts:286` | Schema for validating existing immutable undirected Effect graphs. |
@@ -10308,22 +10309,22 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `UnknownRecord` | type | `packages/foundation/modeling/schema/src/Record/Record.schema.ts:49` | Runtime type extracted from the {@link UnknownRecord} schema. |
 | `@beep/schema` | `URLStr` | const | `packages/foundation/modeling/schema/src/URL.ts:60` | A branded schema for URL-encoded strings validated against `new URL()`. |
 | `@beep/schema` | `URLStr` | type | `packages/foundation/modeling/schema/src/URL.ts:85` | {@inheritDoc URLStr} |
-| `@beep/schema` | `UsesPosixSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:90` | Branded schema for strings that contain a POSIX separator. |
-| `@beep/schema` | `UsesPosixSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:112` | Type for {@link UsesPosixSeparator}. |
-| `@beep/schema` | `UsesWindowsSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:120` | Branded schema for strings that contain a Windows separator. |
-| `@beep/schema` | `UsesWindowsSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:142` | Type for {@link UsesWindowsSeparator}. |
+| `@beep/schema` | `UsesPosixSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:86` | Branded schema for strings that contain a POSIX separator. |
+| `@beep/schema` | `UsesPosixSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:106` | Type for {@link UsesPosixSeparator}. |
+| `@beep/schema` | `UsesWindowsSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:114` | Branded schema for strings that contain a Windows separator. |
+| `@beep/schema` | `UsesWindowsSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:134` | Type for {@link UsesWindowsSeparator}. |
 | `@beep/schema` | `UUID` | const | `packages/foundation/modeling/schema/src/String.ts:66` | Branded UUID string schema that validates RFC 4122 format. |
 | `@beep/schema` | `UUID` | type | `packages/foundation/modeling/schema/src/String.ts:87` | Type for {@link UUID}. |
-| `@beep/schema` | `ValidWindowsPathSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:130` | Branded schema for Windows path segments that may be either plain segments or |
-| `@beep/schema` | `ValidWindowsPathSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:145` | Type for {@link ValidWindowsPathSegment}. |
+| `@beep/schema` | `ValidWindowsPathSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:126` | Branded schema for Windows path segments that may be either plain segments or |
+| `@beep/schema` | `ValidWindowsPathSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:139` | Type for {@link ValidWindowsPathSegment}. |
 | `@beep/schema` | `ValidWindowsPlainPathSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:46` | Branded schema for Windows path segments that are plain names rather than |
-| `@beep/schema` | `ValidWindowsPlainPathSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:89` | Type for {@link ValidWindowsPlainPathSegment}. |
-| `@beep/schema` | `ValidWindowsRootSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:99` | Branded schema for Windows root segments such as UNC server and share names. |
-| `@beep/schema` | `ValidWindowsRootSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:121` | Type for {@link ValidWindowsRootSegment}. |
-| `@beep/schema` | `ValidWindowsUncRest` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:177` | Branded schema for the tail segment list of a UNC file path after the server |
-| `@beep/schema` | `ValidWindowsUncRest` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:192` | Type for {@link ValidWindowsUncRest}. |
-| `@beep/schema` | `ValidWindowsUncSegments` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:200` | Branded schema for a full UNC segment list `[server, share, ...rest]`. |
-| `@beep/schema` | `ValidWindowsUncSegments` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:218` | Type for {@link ValidWindowsUncSegments}. |
+| `@beep/schema` | `ValidWindowsPlainPathSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:87` | Type for {@link ValidWindowsPlainPathSegment}. |
+| `@beep/schema` | `ValidWindowsRootSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:97` | Branded schema for Windows root segments such as UNC server and share names. |
+| `@beep/schema` | `ValidWindowsRootSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:117` | Type for {@link ValidWindowsRootSegment}. |
+| `@beep/schema` | `ValidWindowsUncRest` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:169` | Branded schema for the tail segment list of a UNC file path after the server |
+| `@beep/schema` | `ValidWindowsUncRest` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:182` | Type for {@link ValidWindowsUncRest}. |
+| `@beep/schema` | `ValidWindowsUncSegments` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:190` | Branded schema for a full UNC segment list `[server, share, ...rest]`. |
+| `@beep/schema` | `ValidWindowsUncSegments` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:206` | Type for {@link ValidWindowsUncSegments}. |
 | `@beep/schema` | `VariantSchema` | SourceFile | `packages/foundation/modeling/schema/src/VariantSchema/index.ts:14` |  |
 | `@beep/schema` | `VERSION` | const | `packages/foundation/modeling/schema/src/index.ts:14` |  |
 | `@beep/schema` | `VideoFileExtension` | const | `packages/foundation/modeling/schema/src/FileExtension.ts:138` | Schema for file extensions associated with `video/*` mime types. |
@@ -10333,20 +10334,20 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema` | `WindowsDotSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:25` | Literal union for Windows dot-segment markers. |
 | `@beep/schema` | `WindowsDotSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:37` | Type for {@link WindowsDotSegment}. |
 | `@beep/schema` | `WindowsDrivePath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:35` | Branded schema for Windows drive paths with a leaf segment. |
-| `@beep/schema` | `WindowsDrivePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:84` | Type for {@link WindowsDrivePath}. |
+| `@beep/schema` | `WindowsDrivePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:82` | Type for {@link WindowsDrivePath}. |
 | `@beep/schema` | `WindowsDriveRoot` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:19` | Branded schema for Windows drive roots such as `C:` and `C:\\`. |
-| `@beep/schema` | `WindowsDriveRoot` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:41` | Type for {@link WindowsDriveRoot}. |
-| `@beep/schema` | `WindowsRelativePath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:157` | Branded schema for Windows relative paths that use backslash separators and |
-| `@beep/schema` | `WindowsRelativePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:224` | Type for {@link WindowsRelativePath}. |
-| `@beep/schema` | `WindowsSegments` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:153` | Branded schema for a non-empty Windows path segment list. |
-| `@beep/schema` | `WindowsSegments` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:168` | Type for {@link WindowsSegments}. |
-| `@beep/schema` | `WindowsUncPath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:93` | Branded schema for Windows UNC file paths with server, share, and leaf |
-| `@beep/schema` | `WindowsUncPath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:148` | Type for {@link WindowsUncPath}. |
-| `@beep/schema` | `WindowsUncRoot` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:49` | Branded schema for UNC roots such as `\\\\server\\share`. |
-| `@beep/schema` | `WindowsUncRoot` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:71` | Type for {@link WindowsUncRoot}. |
-| `@beep/schema` | `WithAlpha` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:272` | One-way schema for rendering an rgba string. |
-| `@beep/schema` | `WithAlpha` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:290` | Type for {@link WithAlpha}. |
-| `@beep/schema` | `WithAlphaInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:256` | Request schema for converting a color plus alpha to an rgba string. |
+| `@beep/schema` | `WindowsDriveRoot` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:39` | Type for {@link WindowsDriveRoot}. |
+| `@beep/schema` | `WindowsRelativePath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:153` | Branded schema for Windows relative paths that use backslash separators and |
+| `@beep/schema` | `WindowsRelativePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:218` | Type for {@link WindowsRelativePath}. |
+| `@beep/schema` | `WindowsSegments` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:147` | Branded schema for a non-empty Windows path segment list. |
+| `@beep/schema` | `WindowsSegments` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:160` | Type for {@link WindowsSegments}. |
+| `@beep/schema` | `WindowsUncPath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:91` | Branded schema for Windows UNC file paths with server, share, and leaf |
+| `@beep/schema` | `WindowsUncPath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:144` | Type for {@link WindowsUncPath}. |
+| `@beep/schema` | `WindowsUncRoot` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:47` | Branded schema for UNC roots such as `\\\\server\\share`. |
+| `@beep/schema` | `WindowsUncRoot` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:67` | Type for {@link WindowsUncRoot}. |
+| `@beep/schema` | `WithAlpha` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:262` | One-way schema for rendering an rgba string. |
+| `@beep/schema` | `WithAlpha` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:278` | Type for {@link WithAlpha}. |
+| `@beep/schema` | `WithAlphaInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:246` | Request schema for converting a color plus alpha to an rgba string. |
 | `@beep/schema` | `XmlTextToUnknown` | const | `packages/foundation/modeling/schema/src/Xml.ts:79` | Schema transformation that decodes XML text into an unknown parsed document |
 | `@beep/schema` | `YamlTextToUnknown` | const | `packages/foundation/modeling/schema/src/Yaml.ts:96` | Schema transformation that decodes YAML text into an unknown parsed value. |
 | `@beep/schema/AbortSignal` | `AbortSig` | const | `packages/foundation/modeling/schema/src/AbortSignal.ts:46` | Declared schema for `AbortSignal` instances. |
@@ -10392,73 +10393,73 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/CauseTaggedError` | `CauseTaggedErrorConstructor` | type | `packages/foundation/modeling/schema/src/CauseTaggedError/CauseTaggedError.errors.ts:249` | Callable constructor for creating cause-tagged error class factories. |
 | `@beep/schema/CauseTaggedError` | `CauseTaggedErrorFactory` | interface | `packages/foundation/modeling/schema/src/CauseTaggedError/CauseTaggedError.errors.ts:210` | Factory returned by {@link CauseTaggedError} after an identity namespace has been selected. |
 | `@beep/schema/CauseTaggedError` | `CauseTaggedErrorWithStatics` | type | `packages/foundation/modeling/schema/src/CauseTaggedError/CauseTaggedError.errors.ts:164` | Tagged error class returned by {@link CauseTaggedError}, including dual construction helpers. |
-| `@beep/schema/Color` | `ColorAmount` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:106` | Shared finite amount used by color helper request schemas. |
-| `@beep/schema/Color` | `ColorAmount` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:121` | Type for {@link ColorAmount}. |
-| `@beep/schema/Color` | `Darken` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:230` | One-way schema for darkening a color. |
-| `@beep/schema/Color` | `Darken` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:248` | Type for {@link Darken}. |
-| `@beep/schema/Color` | `DarkenInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:214` | Request schema for darkening a color. |
-| `@beep/schema/Color` | `GenerateAlphaScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:263` | One-way schema for generating an alpha-blended 12-step scale. |
-| `@beep/schema/Color` | `GenerateAlphaScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:283` | Type for {@link GenerateAlphaScale}. |
-| `@beep/schema/Color` | `GenerateAlphaScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:247` | Request schema for generating an alpha-blended 12-step scale. |
-| `@beep/schema/Color` | `GenerateNeutralScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:219` | One-way schema for generating a neutral 12-step scale. |
-| `@beep/schema/Color` | `GenerateNeutralScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:239` | Type for {@link GenerateNeutralScale}. |
-| `@beep/schema/Color` | `GenerateNeutralScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:203` | Request schema for generating a neutral 12-step scale. |
-| `@beep/schema/Color` | `GenerateScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:175` | One-way schema for generating a chromatic 12-step scale. |
-| `@beep/schema/Color` | `GenerateScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:195` | Type for {@link GenerateScale}. |
-| `@beep/schema/Color` | `GenerateScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:159` | Request schema for generating a chromatic 12-step scale. |
-| `@beep/schema/Color` | `HexColor` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:127` | Canonical lowercase six-digit hex color schema. |
-| `@beep/schema/Color` | `HexColor` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:142` | Type for {@link HexColor}. |
+| `@beep/schema/Color` | `ColorAmount` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:104` | Shared finite amount used by color helper request schemas. |
+| `@beep/schema/Color` | `ColorAmount` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:117` | Type for {@link ColorAmount}. |
+| `@beep/schema/Color` | `Darken` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:222` | One-way schema for darkening a color. |
+| `@beep/schema/Color` | `Darken` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:238` | Type for {@link Darken}. |
+| `@beep/schema/Color` | `DarkenInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:206` | Request schema for darkening a color. |
+| `@beep/schema/Color` | `GenerateAlphaScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:255` | One-way schema for generating an alpha-blended 12-step scale. |
+| `@beep/schema/Color` | `GenerateAlphaScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:273` | Type for {@link GenerateAlphaScale}. |
+| `@beep/schema/Color` | `GenerateAlphaScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:239` | Request schema for generating an alpha-blended 12-step scale. |
+| `@beep/schema/Color` | `GenerateNeutralScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:213` | One-way schema for generating a neutral 12-step scale. |
+| `@beep/schema/Color` | `GenerateNeutralScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:231` | Type for {@link GenerateNeutralScale}. |
+| `@beep/schema/Color` | `GenerateNeutralScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:197` | Request schema for generating a neutral 12-step scale. |
+| `@beep/schema/Color` | `GenerateScale` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:171` | One-way schema for generating a chromatic 12-step scale. |
+| `@beep/schema/Color` | `GenerateScale` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:189` | Type for {@link GenerateScale}. |
+| `@beep/schema/Color` | `GenerateScaleInput` | class | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:155` | Request schema for generating a chromatic 12-step scale. |
+| `@beep/schema/Color` | `HexColor` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:125` | Canonical lowercase six-digit hex color schema. |
+| `@beep/schema/Color` | `HexColor` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:138` | Type for {@link HexColor}. |
 | `@beep/schema/Color` | `HexColorInput` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:105` | Boundary schema for hex color input strings. |
-| `@beep/schema/Color` | `HexColorInput` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:119` | Type for {@link HexColorInput}. |
+| `@beep/schema/Color` | `HexColorInput` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:117` | Type for {@link HexColorInput}. |
 | `@beep/schema/Color` | `HexColorScale12` | const | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:124` | Fixed-size 12-step canonical hex color scale. |
-| `@beep/schema/Color` | `HexColorScale12` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:141` | Type for {@link HexColorScale12}. |
-| `@beep/schema/Color` | `HexToOklch` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:145` | Transformation schema for decoding boundary hex input into canonical OKLCH. |
-| `@beep/schema/Color` | `HexToOklch` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:166` | Type for {@link HexToOklch}. |
+| `@beep/schema/Color` | `HexColorScale12` | type | `packages/foundation/modeling/schema/src/Color/Color.scale.ts:139` | Type for {@link HexColorScale12}. |
+| `@beep/schema/Color` | `HexToOklch` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:137` | Transformation schema for decoding boundary hex input into canonical OKLCH. |
+| `@beep/schema/Color` | `HexToOklch` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:156` | Type for {@link HexToOklch}. |
 | `@beep/schema/Color` | `HexToRgb` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:38` | Transformation schema for decoding boundary hex input into normalized RGB. |
-| `@beep/schema/Color` | `HexToRgb` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:59` | Type for {@link HexToRgb}. |
-| `@beep/schema/Color` | `Lighten` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:188` | One-way schema for lightening a color. |
-| `@beep/schema/Color` | `Lighten` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:206` | Type for {@link Lighten}. |
-| `@beep/schema/Color` | `LightenInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:172` | Request schema for lightening a color. |
-| `@beep/schema/Color` | `MixColors` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:146` | One-way schema for mixing two colors. |
-| `@beep/schema/Color` | `MixColors` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:164` | Type for {@link MixColors}. |
-| `@beep/schema/Color` | `MixColorsInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:129` | Request schema for mixing two colors. |
-| `@beep/schema/Color` | `NormalizeHexColor` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:150` | Canonicalization schema from boundary hex input to canonical hex output. |
-| `@beep/schema/Color` | `NormalizeHexColor` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:171` | Type for {@link NormalizeHexColor}. |
-| `@beep/schema/Color` | `OklchChroma` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:178` | Canonical OKLCH chroma component. |
-| `@beep/schema/Color` | `OklchChroma` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:194` | Type for {@link OklchChroma}. |
-| `@beep/schema/Color` | `OklchColor` | class | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:243` | Canonical OKLCH color object. |
+| `@beep/schema/Color` | `HexToRgb` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:57` | Type for {@link HexToRgb}. |
+| `@beep/schema/Color` | `Lighten` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:182` | One-way schema for lightening a color. |
+| `@beep/schema/Color` | `Lighten` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:198` | Type for {@link Lighten}. |
+| `@beep/schema/Color` | `LightenInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:166` | Request schema for lightening a color. |
+| `@beep/schema/Color` | `MixColors` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:142` | One-way schema for mixing two colors. |
+| `@beep/schema/Color` | `MixColors` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:158` | Type for {@link MixColors}. |
+| `@beep/schema/Color` | `MixColorsInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:125` | Request schema for mixing two colors. |
+| `@beep/schema/Color` | `NormalizeHexColor` | const | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:146` | Canonicalization schema from boundary hex input to canonical hex output. |
+| `@beep/schema/Color` | `NormalizeHexColor` | type | `packages/foundation/modeling/schema/src/Color/Color.hex.ts:165` | Type for {@link NormalizeHexColor}. |
+| `@beep/schema/Color` | `OklchChroma` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:174` | Canonical OKLCH chroma component. |
+| `@beep/schema/Color` | `OklchChroma` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:188` | Type for {@link OklchChroma}. |
+| `@beep/schema/Color` | `OklchColor` | class | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:235` | Canonical OKLCH color object. |
 | `@beep/schema/Color` | `OklchCoordinate` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:131` | Branded finite OKLCH coordinate. |
-| `@beep/schema/Color` | `OklchCoordinate` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:146` | Type for {@link OklchCoordinate}. |
-| `@beep/schema/Color` | `OklchHue` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:202` | Canonical OKLCH hue component. |
-| `@beep/schema/Color` | `OklchHue` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:218` | Type for {@link OklchHue}. |
-| `@beep/schema/Color` | `OklchInput` | class | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:226` | OKLCH object with finite coordinates. |
-| `@beep/schema/Color` | `OklchLightness` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:154` | Canonical OKLCH lightness component. |
-| `@beep/schema/Color` | `OklchLightness` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:170` | Type for {@link OklchLightness}. |
-| `@beep/schema/Color` | `OklchToHex` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:174` | Transformation schema for encoding OKLCH coordinates into canonical hex. |
-| `@beep/schema/Color` | `OklchToHex` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:192` | Type for {@link OklchToHex}. |
-| `@beep/schema/Color` | `OklchToRgb` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:119` | Transformation schema for encoding OKLCH coordinates into RGB input values. |
-| `@beep/schema/Color` | `OklchToRgb` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:137` | Type for {@link OklchToRgb}. |
-| `@beep/schema/Color` | `Rgb` | class | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:94` | RGB object with normalized channels. |
+| `@beep/schema/Color` | `OklchCoordinate` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:144` | Type for {@link OklchCoordinate}. |
+| `@beep/schema/Color` | `OklchHue` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:196` | Canonical OKLCH hue component. |
+| `@beep/schema/Color` | `OklchHue` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:210` | Type for {@link OklchHue}. |
+| `@beep/schema/Color` | `OklchInput` | class | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:218` | OKLCH object with finite coordinates. |
+| `@beep/schema/Color` | `OklchLightness` | const | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:152` | Canonical OKLCH lightness component. |
+| `@beep/schema/Color` | `OklchLightness` | type | `packages/foundation/modeling/schema/src/Color/Color.oklch.ts:166` | Type for {@link OklchLightness}. |
+| `@beep/schema/Color` | `OklchToHex` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:164` | Transformation schema for encoding OKLCH coordinates into canonical hex. |
+| `@beep/schema/Color` | `OklchToHex` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:180` | Type for {@link OklchToHex}. |
+| `@beep/schema/Color` | `OklchToRgb` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:113` | Transformation schema for encoding OKLCH coordinates into RGB input values. |
+| `@beep/schema/Color` | `OklchToRgb` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:129` | Type for {@link OklchToRgb}. |
+| `@beep/schema/Color` | `Rgb` | class | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:90` | RGB object with normalized channels. |
 | `@beep/schema/Color` | `RgbaColorString` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:83` | CSS rgba color string produced by with-alpha helpers. |
-| `@beep/schema/Color` | `RgbaColorString` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:98` | Type for {@link RgbaColorString}. |
-| `@beep/schema/Color` | `RgbChannel` | const | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:53` | Branded normalized RGB channel in the range 0 through 1. |
-| `@beep/schema/Color` | `RgbChannel` | type | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:69` | Type for {@link RgbChannel}. |
-| `@beep/schema/Color` | `RgbInput` | class | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:77` | RGB object with finite channel inputs. |
+| `@beep/schema/Color` | `RgbaColorString` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:96` | Type for {@link RgbaColorString}. |
+| `@beep/schema/Color` | `RgbChannel` | const | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:51` | Branded normalized RGB channel in the range 0 through 1. |
+| `@beep/schema/Color` | `RgbChannel` | type | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:65` | Type for {@link RgbChannel}. |
+| `@beep/schema/Color` | `RgbInput` | class | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:73` | RGB object with finite channel inputs. |
 | `@beep/schema/Color` | `RgbInputChannel` | const | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:30` | Branded finite RGB input channel. |
-| `@beep/schema/Color` | `RgbInputChannel` | type | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:45` | Type for {@link RgbInputChannel}. |
-| `@beep/schema/Color` | `RgbToHex` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:67` | Transformation schema for encoding RGB input into canonical hex. |
-| `@beep/schema/Color` | `RgbToHex` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:85` | Type for {@link RgbToHex}. |
-| `@beep/schema/Color` | `RgbToOklch` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:93` | Transformation schema for decoding normalized RGB into canonical OKLCH. |
-| `@beep/schema/Color` | `RgbToOklch` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:111` | Type for {@link RgbToOklch}. |
-| `@beep/schema/Color` | `WithAlpha` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:272` | One-way schema for rendering an rgba string. |
-| `@beep/schema/Color` | `WithAlpha` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:290` | Type for {@link WithAlpha}. |
-| `@beep/schema/Color` | `WithAlphaInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:256` | Request schema for converting a color plus alpha to an rgba string. |
-| `@beep/schema/CommonTextSchemas` | `CommaSeparatedList` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:81` | Schema that decodes a comma-separated string into a trimmed non-empty string array. |
-| `@beep/schema/CommonTextSchemas` | `CommaSeparatedList` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:109` | Type for {@link CommaSeparatedList}. |
-| `@beep/schema/CommonTextSchemas` | `NormalizedBooleanString` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:126` | Schema that normalizes common boolean string spellings (`"true"`, `"1"`, `"yes"`, `"on"`, etc.) to `boolean`. |
-| `@beep/schema/CommonTextSchemas` | `NormalizedBooleanString` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:154` | Type for {@link NormalizedBooleanString}. |
+| `@beep/schema/Color` | `RgbInputChannel` | type | `packages/foundation/modeling/schema/src/Color/Color.rgb.ts:43` | Type for {@link RgbInputChannel}. |
+| `@beep/schema/Color` | `RgbToHex` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:65` | Transformation schema for encoding RGB input into canonical hex. |
+| `@beep/schema/Color` | `RgbToHex` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:81` | Type for {@link RgbToHex}. |
+| `@beep/schema/Color` | `RgbToOklch` | const | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:89` | Transformation schema for decoding normalized RGB into canonical OKLCH. |
+| `@beep/schema/Color` | `RgbToOklch` | type | `packages/foundation/modeling/schema/src/Color/Color.transforms.ts:105` | Type for {@link RgbToOklch}. |
+| `@beep/schema/Color` | `WithAlpha` | const | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:262` | One-way schema for rendering an rgba string. |
+| `@beep/schema/Color` | `WithAlpha` | type | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:278` | Type for {@link WithAlpha}. |
+| `@beep/schema/Color` | `WithAlphaInput` | class | `packages/foundation/modeling/schema/src/Color/Color.adjust.ts:246` | Request schema for converting a color plus alpha to an rgba string. |
+| `@beep/schema/CommonTextSchemas` | `CommaSeparatedList` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:79` | Schema that decodes a comma-separated string into a trimmed non-empty string array. |
+| `@beep/schema/CommonTextSchemas` | `CommaSeparatedList` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:105` | Type for {@link CommaSeparatedList}. |
+| `@beep/schema/CommonTextSchemas` | `NormalizedBooleanString` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:122` | Schema that normalizes common boolean string spellings (`"true"`, `"1"`, `"yes"`, `"on"`, etc.) to `boolean`. |
+| `@beep/schema/CommonTextSchemas` | `NormalizedBooleanString` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:148` | Type for {@link NormalizedBooleanString}. |
 | `@beep/schema/CommonTextSchemas` | `TrimmedNonEmptyText` | const | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:36` | Trimmed and non-empty text schema that strips whitespace and rejects empty results. |
-| `@beep/schema/CommonTextSchemas` | `TrimmedNonEmptyText` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:64` | Type for {@link TrimmedNonEmptyText}. |
+| `@beep/schema/CommonTextSchemas` | `TrimmedNonEmptyText` | type | `packages/foundation/modeling/schema/src/CommonTextSchemas.ts:62` | Type for {@link TrimmedNonEmptyText}. |
 | `@beep/schema/CrossOriginEmbedderPolicy` | `COEPResponseHeader` | class | `packages/foundation/modeling/schema/src/CrossOriginEmbedderPolicy/CrossOriginEmbedderPolicy.schema.ts:67` | Schema for the Cross-Origin-Embedder-Policy response header output. |
 | `@beep/schema/CrossOriginEmbedderPolicy` | `CoepValue` | const | `packages/foundation/modeling/schema/src/CrossOriginEmbedderPolicy/CrossOriginEmbedderPolicy.schema.ts:30` |  |
 | `@beep/schema/CrossOriginEmbedderPolicy` | `CoepValue` | type | `packages/foundation/modeling/schema/src/CrossOriginEmbedderPolicy/CrossOriginEmbedderPolicy.schema.ts:41` |  |
@@ -10496,21 +10497,21 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/CrossOriginResourcePolicy` | `Option` | type | `packages/foundation/modeling/schema/src/CrossOriginResourcePolicy/CrossOriginResourcePolicy.schema.ts:58` |  |
 | `@beep/schema/CrossOriginResourcePolicy` | `ResponseHeader` | class | `packages/foundation/modeling/schema/src/CrossOriginResourcePolicy/CrossOriginResourcePolicy.schema.ts:64` |  |
 | `@beep/schema/CryptoTxnHash` | `CryptoTxnHash` | const | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:60` | Branded schema for canonical mainnet blockchain transaction identifiers. |
-| `@beep/schema/CryptoTxnHash` | `CryptoTxnHash` | type | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:75` | Type for {@link CryptoTxnHash}. |
-| `@beep/schema/CryptoTxnHash` | `CryptoTxnHashRedacted` | const | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:83` | Redacted schema for canonical mainnet blockchain transaction identifiers. |
-| `@beep/schema/CryptoTxnHash` | `CryptoTxnHashRedacted` | type | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:101` | Type for {@link CryptoTxnHashRedacted}. |
-| `@beep/schema/CryptoTxnHash` | `Redacted` | const | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:83` | Redacted schema for canonical mainnet blockchain transaction identifiers. |
-| `@beep/schema/CryptoTxnHash` | `Redacted` | type | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:101` | Type for {@link CryptoTxnHashRedacted}. |
+| `@beep/schema/CryptoTxnHash` | `CryptoTxnHash` | type | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:73` | Type for {@link CryptoTxnHash}. |
+| `@beep/schema/CryptoTxnHash` | `CryptoTxnHashRedacted` | const | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:81` | Redacted schema for canonical mainnet blockchain transaction identifiers. |
+| `@beep/schema/CryptoTxnHash` | `CryptoTxnHashRedacted` | type | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:97` | Type for {@link CryptoTxnHashRedacted}. |
+| `@beep/schema/CryptoTxnHash` | `Redacted` | const | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:81` | Redacted schema for canonical mainnet blockchain transaction identifiers. |
+| `@beep/schema/CryptoTxnHash` | `Redacted` | type | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:97` | Type for {@link CryptoTxnHashRedacted}. |
 | `@beep/schema/CryptoTxnHash` | `Schema` | const | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:60` | Branded schema for canonical mainnet blockchain transaction identifiers. |
-| `@beep/schema/CryptoTxnHash` | `Schema` | type | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:75` | Type for {@link CryptoTxnHash}. |
+| `@beep/schema/CryptoTxnHash` | `Schema` | type | `packages/foundation/modeling/schema/src/CryptoTxnHash/CryptoTxnHash.schema.ts:73` | Type for {@link CryptoTxnHash}. |
 | `@beep/schema/CryptoWalletAddress` | `CryptoWalletAddress` | const | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:181` | Branded schema for canonical mainnet blockchain wallet addresses. |
-| `@beep/schema/CryptoWalletAddress` | `CryptoWalletAddress` | type | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:196` | Type for {@link CryptoWalletAddress}. |
-| `@beep/schema/CryptoWalletAddress` | `CryptoWalletAddressRedacted` | const | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:204` | Redacted Branded schema for canonical mainnet blockchain wallet addresses. |
-| `@beep/schema/CryptoWalletAddress` | `CryptoWalletAddressRedacted` | type | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:223` | Type for {@link CryptoWalletAddressRedacted}. |
-| `@beep/schema/CryptoWalletAddress` | `Redacted` | const | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:204` | Redacted Branded schema for canonical mainnet blockchain wallet addresses. |
-| `@beep/schema/CryptoWalletAddress` | `Redacted` | type | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:223` | Type for {@link CryptoWalletAddressRedacted}. |
+| `@beep/schema/CryptoWalletAddress` | `CryptoWalletAddress` | type | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:194` | Type for {@link CryptoWalletAddress}. |
+| `@beep/schema/CryptoWalletAddress` | `CryptoWalletAddressRedacted` | const | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:202` | Redacted Branded schema for canonical mainnet blockchain wallet addresses. |
+| `@beep/schema/CryptoWalletAddress` | `CryptoWalletAddressRedacted` | type | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:218` | Type for {@link CryptoWalletAddressRedacted}. |
+| `@beep/schema/CryptoWalletAddress` | `Redacted` | const | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:202` | Redacted Branded schema for canonical mainnet blockchain wallet addresses. |
+| `@beep/schema/CryptoWalletAddress` | `Redacted` | type | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:218` | Type for {@link CryptoWalletAddressRedacted}. |
 | `@beep/schema/CryptoWalletAddress` | `Schema` | const | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:181` | Branded schema for canonical mainnet blockchain wallet addresses. |
-| `@beep/schema/CryptoWalletAddress` | `Schema` | type | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:196` | Type for {@link CryptoWalletAddress}. |
+| `@beep/schema/CryptoWalletAddress` | `Schema` | type | `packages/foundation/modeling/schema/src/CryptoWalletAddress/CryptoWalletAddress.schema.ts:194` | Type for {@link CryptoWalletAddress}. |
 | `@beep/schema/Csp` | `ContentSecurityPolicyHeader` | const | `packages/foundation/modeling/schema/src/Csp/Csp.schema.ts:583` |  |
 | `@beep/schema/Csp` | `ContentSecurityPolicyHeader` | type | `packages/foundation/modeling/schema/src/Csp/Csp.schema.ts:648` |  |
 | `@beep/schema/Csp` | `ContentSecurityPolicyHeaderName` | const | `packages/foundation/modeling/schema/src/Csp/Csp.schema.ts:48` |  |
@@ -10539,14 +10540,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/Csp` | `ResponseHeader` | class | `packages/foundation/modeling/schema/src/Csp/Csp.schema.ts:499` |  |
 | `@beep/schema/Csp` | `Sandbox` | const | `packages/foundation/modeling/schema/src/Csp/Csp.schema.ts:179` |  |
 | `@beep/schema/Csp` | `Sandbox` | type | `packages/foundation/modeling/schema/src/Csp/Csp.schema.ts:190` |  |
-| `@beep/schema/Csv` | `Csv` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:293` | Schema factory for CSV documents whose rows are validated by the provided |
-| `@beep/schema/Csv` | `CSV` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:293` | Schema factory for CSV documents whose rows are validated by the provided |
-| `@beep/schema/Csv` | `CSV` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:336` | Runtime type extracted from the {@link CSV} alias. |
-| `@beep/schema/Csv` | `CsvDocument` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:50` | Schema transformation returned by the CSV schema factory for a row schema. |
-| `@beep/schema/Csv` | `CsvText` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:320` | Branded runtime type for CSV document text produced by encoding a `CSV` |
-| `@beep/schema/Csv` | `RowSchemaWithFields` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:40` | Object-like row schema contract accepted by the CSV schema factory. |
-| `@beep/schema/Csv` | `Schema` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:293` | Schema factory for CSV documents whose rows are validated by the provided |
-| `@beep/schema/Csv` | `Schema` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:344` | Runtime type extracted from the {@link Schema} alias. |
+| `@beep/schema/Csv` | `Csv` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:289` | Schema factory for CSV documents whose rows are validated by the provided |
+| `@beep/schema/Csv` | `CSV` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:289` | Schema factory for CSV documents whose rows are validated by the provided |
+| `@beep/schema/Csv` | `CSV` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:332` | Runtime type extracted from the {@link CSV} alias. |
+| `@beep/schema/Csv` | `CsvDocument` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:48` | Schema transformation returned by the CSV schema factory for a row schema. |
+| `@beep/schema/Csv` | `CsvText` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:316` | Branded runtime type for CSV document text produced by encoding a `CSV` |
+| `@beep/schema/Csv` | `RowSchemaWithFields` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:38` | Object-like row schema contract accepted by the CSV schema factory. |
+| `@beep/schema/Csv` | `Schema` | const | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:289` | Schema factory for CSV documents whose rows are validated by the provided |
+| `@beep/schema/Csv` | `Schema` | type | `packages/foundation/modeling/schema/src/Csv/Csv.schema.ts:340` | Runtime type extracted from the {@link Schema} alias. |
 | `@beep/schema/CsvCodecOptions` | `CsvCodecOptions` | class | `packages/foundation/modeling/schema/src/CsvCodecOptions/CsvCodecOptions.schema.ts:38` | Schema-backed CSV text codec options. |
 | `@beep/schema/CsvCodecOptions` | `CsvCodecOptionsArgs` | type | `packages/foundation/modeling/schema/src/CsvCodecOptions/CsvCodecOptions.schema.ts:105` | Encoded/raw constructor input for {@link CsvCodecOptions}. |
 | `@beep/schema/CsvCodecOptions` | `CsvCodecOptionsParseOptions` | const | `packages/foundation/modeling/schema/src/CsvCodecOptions/CsvCodecOptions.schema.ts:113` | Parse options used when normalizing raw CSV codec option input. |
@@ -10584,23 +10585,23 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/CurrencyCode` | `JPY` | const | `packages/foundation/modeling/schema/src/CurrencyCode.ts:103` | ISO 4217 constant for Japanese Yen. |
 | `@beep/schema/CurrencyCode` | `SGD` | const | `packages/foundation/modeling/schema/src/CurrencyCode.ts:145` | ISO 4217 constant for Singapore Dollar. |
 | `@beep/schema/CurrencyCode` | `USD` | const | `packages/foundation/modeling/schema/src/CurrencyCode.ts:82` | ISO 4217 constant for United States Dollar. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInput` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:418` | Union of raw and tagged values accepted by {@link DateTimeUtcFromValid}. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInput` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:449` | {@inheritDoc DateTimeInput} |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputDate` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:244` | Valid JavaScript `Date` input accepted by Effect `DateTime.make`. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputDate` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:265` | {@inheritDoc DateTimeInputDate} |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputDateTime` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:286` | Existing Effect `DateTime` values accepted by {@link DateTimeUtcFromValid}. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputDateTime` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:307` | {@inheritDoc DateTimeInputDateTime} |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputInstant` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:323` | Tagged Effect `DateTime.Instant` transport value. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputInstantWithZone` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:350` | Tagged Effect `DateTime.InstantWithZone` transport value. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInput` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:416` | Union of raw and tagged values accepted by {@link DateTimeUtcFromValid}. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInput` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:447` | {@inheritDoc DateTimeInput} |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputDate` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:242` | Valid JavaScript `Date` input accepted by Effect `DateTime.make`. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputDate` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:263` | {@inheritDoc DateTimeInputDate} |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputDateTime` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:284` | Existing Effect `DateTime` values accepted by {@link DateTimeUtcFromValid}. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputDateTime` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:305` | {@inheritDoc DateTimeInputDateTime} |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputInstant` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:321` | Tagged Effect `DateTime.Instant` transport value. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputInstantWithZone` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:348` | Tagged Effect `DateTime.InstantWithZone` transport value. |
 | `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputKind` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:34` | Literal discriminator values used by tagged date-time input representations. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputKind` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:64` | {@inheritDoc DateTimeInputKind} |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputNumber` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:202` | Valid numeric epoch-millisecond input accepted by Effect `DateTime.make`. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputNumber` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:223` | {@inheritDoc DateTimeInputNumber} |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputParts` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:383` | Tagged `Partial<DateTime.Parts>` transport value. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputString` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:159` | Valid string input accepted by Effect `DateTime.make`. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputString` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:180` | {@inheritDoc DateTimeInputString} |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeUtcFromValid` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:512` | Bidirectional schema transformation from valid DateTime input to `DateTime.Utc`. |
-| `@beep/schema/DateTimeUtcFromValid` | `DateTimeUtcFromValid` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:540` | {@inheritDoc DateTimeUtcFromValid} |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputKind` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:62` | {@inheritDoc DateTimeInputKind} |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputNumber` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:200` | Valid numeric epoch-millisecond input accepted by Effect `DateTime.make`. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputNumber` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:221` | {@inheritDoc DateTimeInputNumber} |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputParts` | class | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:381` | Tagged `Partial<DateTime.Parts>` transport value. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputString` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:157` | Valid string input accepted by Effect `DateTime.make`. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeInputString` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:178` | {@inheritDoc DateTimeInputString} |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeUtcFromValid` | const | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:510` | Bidirectional schema transformation from valid DateTime input to `DateTime.Utc`. |
+| `@beep/schema/DateTimeUtcFromValid` | `DateTimeUtcFromValid` | type | `packages/foundation/modeling/schema/src/DateTimeUtcFromValid/DateTimeUtcFromValid.schema.ts:538` | {@inheritDoc DateTimeUtcFromValid} |
 | `@beep/schema/DomainModel` | `defaultFields` | const | `packages/foundation/modeling/schema/src/DomainModel.ts:33` | Default audit and bookkeeping fields for persisted domain models. |
 | `@beep/schema/DomainModel` | `DomainModel` | class | `packages/foundation/modeling/schema/src/DomainModel.ts:65` | Base class for persisted domain models that share audit metadata. |
 | `@beep/schema/DomCssProperties` | `DomCssProperties` | const | `packages/foundation/modeling/schema/src/DomCssProperties/DomCssProperties.schema.ts:33` | A React.CSSProperties object. |
@@ -10646,21 +10647,21 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/DomReactNode` | `Schema` | type | `packages/foundation/modeling/schema/src/DomReactNode/DomReactNode.schema.ts:52` | Type for {@link DOMReactNode}. |
 | `@beep/schema/Duration` | `Duration` | const | `packages/foundation/modeling/schema/src/Duration/Duration.schema.ts:41` | Compatibility alias for the primary Effect Duration schema. |
 | `@beep/schema/Duration` | `Duration` | type | `packages/foundation/modeling/schema/src/Duration/Duration.schema.ts:49` | Runtime type extracted from {@link Duration}. |
-| `@beep/schema/Duration` | `DurationFromInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:226` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
-| `@beep/schema/Duration` | `DurationFromInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:246` | Decoded duration type extracted from {@link DurationFromInput}. |
-| `@beep/schema/Duration` | `DurationInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:167` | Union schema for all duration input shapes accepted by {@link DurationFromInput}. |
-| `@beep/schema/Duration` | `DurationInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:189` | Duration input type extracted from {@link DurationInput}. |
-| `@beep/schema/Duration` | `DurationObject` | class | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:127` | Structured duration input with additive unit fields. |
+| `@beep/schema/Duration` | `DurationFromInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:222` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
+| `@beep/schema/Duration` | `DurationFromInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:240` | Decoded duration type extracted from {@link DurationFromInput}. |
+| `@beep/schema/Duration` | `DurationInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:165` | Union schema for all duration input shapes accepted by {@link DurationFromInput}. |
+| `@beep/schema/Duration` | `DurationInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:185` | Duration input type extracted from {@link DurationInput}. |
+| `@beep/schema/Duration` | `DurationObject` | class | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:125` | Structured duration input with additive unit fields. |
 | `@beep/schema/Duration` | `DurationUnit` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:65` | Literal union of duration unit labels accepted by {@link DurationInput}. |
-| `@beep/schema/Duration` | `DurationUnit` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:96` | Duration unit string type extracted from {@link DurationUnit}. |
-| `@beep/schema/Duration` | `FromInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:226` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
-| `@beep/schema/Duration` | `FromInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:246` | Decoded duration type extracted from {@link DurationFromInput}. |
-| `@beep/schema/Duration` | `Input` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:167` | Union schema for all duration input shapes accepted by {@link DurationFromInput}. |
-| `@beep/schema/Duration` | `Input` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:189` | Duration input type extracted from {@link DurationInput}. |
-| `@beep/schema/Duration` | `Object` | class | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:127` | Structured duration input with additive unit fields. |
+| `@beep/schema/Duration` | `DurationUnit` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:94` | Duration unit string type extracted from {@link DurationUnit}. |
+| `@beep/schema/Duration` | `FromInput` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:222` | One-way schema that decodes {@link DurationInput} into an Effect `Duration`. |
+| `@beep/schema/Duration` | `FromInput` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:240` | Decoded duration type extracted from {@link DurationFromInput}. |
+| `@beep/schema/Duration` | `Input` | const | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:165` | Union schema for all duration input shapes accepted by {@link DurationFromInput}. |
+| `@beep/schema/Duration` | `Input` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:185` | Duration input type extracted from {@link DurationInput}. |
+| `@beep/schema/Duration` | `Object` | class | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:125` | Structured duration input with additive unit fields. |
 | `@beep/schema/Duration` | `Schema` | const | `packages/foundation/modeling/schema/src/Duration/Duration.schema.ts:25` | Schema for Effect `Duration` values. |
 | `@beep/schema/Duration` | `Schema` | type | `packages/foundation/modeling/schema/src/Duration/Duration.schema.ts:33` | Runtime type extracted from {@link Schema}. |
-| `@beep/schema/Duration` | `Unit` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:104` | Backwards-compatible alias for {@link DurationUnit}. |
+| `@beep/schema/Duration` | `Unit` | type | `packages/foundation/modeling/schema/src/Duration/Duration.input.ts:102` | Backwards-compatible alias for {@link DurationUnit}. |
 | `@beep/schema/EffectSchema` | `EffectSchema` | const | `packages/foundation/modeling/schema/src/EffectSchema.ts:76` | Declared schema for Effect runtime values. |
 | `@beep/schema/EffectSchema` | `EffectSchema` | type | `packages/foundation/modeling/schema/src/EffectSchema.ts:98` | {@inheritDoc EffectSchema} |
 | `@beep/schema/EffectSchema` | `isEffect` | const | `packages/foundation/modeling/schema/src/EffectSchema.ts:56` | Type guard that checks whether a value is an Effect runtime value. |
@@ -10731,26 +10732,26 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/EntitySchema` | `VariantFieldFor` | type | `packages/foundation/modeling/schema/src/EntitySchema/EntitySchema.definition.ts:159` | Variant field schema selected for a persisted field descriptor. |
 | `@beep/schema/EntitySchema` | `VariantFieldForInput` | type | `packages/foundation/modeling/schema/src/EntitySchema/EntitySchema.definition.ts:188` | Variant field schema selected for a field input and persisted descriptor. |
 | `@beep/schema/EntitySchema` | `VariantFieldsFor` | type | `packages/foundation/modeling/schema/src/EntitySchema/EntitySchema.definition.ts:199` | Variant field map derived from entity inputs and persistence descriptors. |
-| `@beep/schema/EthAmount` | `EthAmount` | const | `packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts:48` | ETH-denominated amount decoded from a non-negative JSON number into Effect |
-| `@beep/schema/EthAmount` | `EthAmount` | type | `packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts:66` | Type for {@link EthAmount}. |
-| `@beep/schema/EthAmount` | `Schema` | const | `packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts:48` | ETH-denominated amount decoded from a non-negative JSON number into Effect |
-| `@beep/schema/EthAmount` | `Schema` | type | `packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts:66` | Type for {@link EthAmount}. |
+| `@beep/schema/EthAmount` | `EthAmount` | const | `packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts:46` | ETH-denominated amount decoded from a non-negative JSON number into Effect |
+| `@beep/schema/EthAmount` | `EthAmount` | type | `packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts:62` | Type for {@link EthAmount}. |
+| `@beep/schema/EthAmount` | `Schema` | const | `packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts:46` | ETH-denominated amount decoded from a non-negative JSON number into Effect |
+| `@beep/schema/EthAmount` | `Schema` | type | `packages/foundation/modeling/schema/src/EthAmount/EthAmount.schema.ts:62` | Type for {@link EthAmount}. |
 | `@beep/schema/EthereumValidatorPublicKey` | `EthereumValidatorPublicKey` | const | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:41` | Branded schema for canonical Ethereum validator public keys. |
-| `@beep/schema/EthereumValidatorPublicKey` | `EthereumValidatorPublicKey` | type | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:56` | Type for {@link EthereumValidatorPublicKey}. |
-| `@beep/schema/EthereumValidatorPublicKey` | `EthereumValidatorPublicKeyRedacted` | const | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:64` | Redacted schema for canonical Ethereum validator public keys. |
-| `@beep/schema/EthereumValidatorPublicKey` | `EthereumValidatorPublicKeyRedacted` | type | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:82` | Type for {@link EthereumValidatorPublicKeyRedacted}. |
-| `@beep/schema/EthereumValidatorPublicKey` | `Redacted` | const | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:64` | Redacted schema for canonical Ethereum validator public keys. |
-| `@beep/schema/EthereumValidatorPublicKey` | `Redacted` | type | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:82` | Type for {@link EthereumValidatorPublicKeyRedacted}. |
+| `@beep/schema/EthereumValidatorPublicKey` | `EthereumValidatorPublicKey` | type | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:54` | Type for {@link EthereumValidatorPublicKey}. |
+| `@beep/schema/EthereumValidatorPublicKey` | `EthereumValidatorPublicKeyRedacted` | const | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:62` | Redacted schema for canonical Ethereum validator public keys. |
+| `@beep/schema/EthereumValidatorPublicKey` | `EthereumValidatorPublicKeyRedacted` | type | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:78` | Type for {@link EthereumValidatorPublicKeyRedacted}. |
+| `@beep/schema/EthereumValidatorPublicKey` | `Redacted` | const | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:62` | Redacted schema for canonical Ethereum validator public keys. |
+| `@beep/schema/EthereumValidatorPublicKey` | `Redacted` | type | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:78` | Type for {@link EthereumValidatorPublicKeyRedacted}. |
 | `@beep/schema/EthereumValidatorPublicKey` | `Schema` | const | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:41` | Branded schema for canonical Ethereum validator public keys. |
-| `@beep/schema/EthereumValidatorPublicKey` | `Schema` | type | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:56` | Type for {@link EthereumValidatorPublicKey}. |
+| `@beep/schema/EthereumValidatorPublicKey` | `Schema` | type | `packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/EthereumValidatorPublicKey.schema.ts:54` | Type for {@link EthereumValidatorPublicKey}. |
 | `@beep/schema/EvmAddress` | `EvmAddress` | const | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:78` | Branded schema for canonical mainnet EVM wallet addresses. |
-| `@beep/schema/EvmAddress` | `EvmAddress` | type | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:93` | Type for {@link EvmAddress}. |
-| `@beep/schema/EvmAddress` | `EvmAddressRedacted` | const | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:101` | Redacted schema for canonical mainnet EVM wallet addresses. |
-| `@beep/schema/EvmAddress` | `EvmAddressRedacted` | type | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:119` | Type for {@link EvmAddressRedacted}. |
-| `@beep/schema/EvmAddress` | `Redacted` | const | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:101` | Redacted schema for canonical mainnet EVM wallet addresses. |
-| `@beep/schema/EvmAddress` | `Redacted` | type | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:119` | Type for {@link EvmAddressRedacted}. |
+| `@beep/schema/EvmAddress` | `EvmAddress` | type | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:91` | Type for {@link EvmAddress}. |
+| `@beep/schema/EvmAddress` | `EvmAddressRedacted` | const | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:99` | Redacted schema for canonical mainnet EVM wallet addresses. |
+| `@beep/schema/EvmAddress` | `EvmAddressRedacted` | type | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:115` | Type for {@link EvmAddressRedacted}. |
+| `@beep/schema/EvmAddress` | `Redacted` | const | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:99` | Redacted schema for canonical mainnet EVM wallet addresses. |
+| `@beep/schema/EvmAddress` | `Redacted` | type | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:115` | Type for {@link EvmAddressRedacted}. |
 | `@beep/schema/EvmAddress` | `Schema` | const | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:78` | Branded schema for canonical mainnet EVM wallet addresses. |
-| `@beep/schema/EvmAddress` | `Schema` | type | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:93` | Type for {@link EvmAddress}. |
+| `@beep/schema/EvmAddress` | `Schema` | type | `packages/foundation/modeling/schema/src/EvmAddress/EvmAddress.schema.ts:91` | Type for {@link EvmAddress}. |
 | `@beep/schema/ExpectCt` | `Config` | class | `packages/foundation/modeling/schema/src/ExpectCt/ExpectCt.schema.ts:28` |  |
 | `@beep/schema/ExpectCt` | `ExpectCTConfig` | class | `packages/foundation/modeling/schema/src/ExpectCt/ExpectCt.schema.ts:28` |  |
 | `@beep/schema/ExpectCt` | `ExpectCTEnabled` | const | `packages/foundation/modeling/schema/src/ExpectCt/ExpectCt.schema.ts:43` |  |
@@ -10782,46 +10783,46 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/FileExtension` | `VideoFileExtension` | type | `packages/foundation/modeling/schema/src/FileExtension.ts:160` | Union of literals accepted by {@link VideoFileExtension}. |
 | `@beep/schema/FileName` | `FileName` | const | `packages/foundation/modeling/schema/src/FileName.ts:100` |  |
 | `@beep/schema/FileName` | `FileName` | type | `packages/foundation/modeling/schema/src/FileName.ts:118` | Type for {@link FileName}. |
-| `@beep/schema/FilePath` | `EndsWithSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:150` | Branded schema for strings that end with a POSIX or Windows path separator. |
-| `@beep/schema/FilePath` | `EndsWithSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:172` | Type for {@link EndsWithSeparator}. |
+| `@beep/schema/FilePath` | `EndsWithSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:142` | Branded schema for strings that end with a POSIX or Windows path separator. |
+| `@beep/schema/FilePath` | `EndsWithSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:162` | Type for {@link EndsWithSeparator}. |
 | `@beep/schema/FilePath` | `FilePath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:139` | Branded schema for file path strings that are valid on at least one major OS. |
-| `@beep/schema/FilePath` | `FilePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:154` | Branded file path string type extracted from {@link FilePath}. |
-| `@beep/schema/FilePath` | `HasLeafSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:83` | Branded schema for path strings that include a non-root leaf segment. |
-| `@beep/schema/FilePath` | `HasLeafSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:132` | Type for {@link HasLeafSegment}. |
+| `@beep/schema/FilePath` | `FilePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:152` | Branded file path string type extracted from {@link FilePath}. |
+| `@beep/schema/FilePath` | `HasLeafSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:79` | Branded schema for path strings that include a non-root leaf segment. |
+| `@beep/schema/FilePath` | `HasLeafSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:126` | Type for {@link HasLeafSegment}. |
 | `@beep/schema/FilePath` | `HasNullByte` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:29` | Branded schema for strings that contain an embedded NUL byte. |
-| `@beep/schema/FilePath` | `HasNullByte` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:51` | Branded string type containing an embedded NUL byte. |
+| `@beep/schema/FilePath` | `HasNullByte` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:49` | Branded string type containing an embedded NUL byte. |
 | `@beep/schema/FilePath` | `SupportedPathFamily` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:31` | Literal union of file-path families recognized by {@link FilePath}. |
 | `@beep/schema/FilePath` | `SupportedPathFamily` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.schema.ts:43` | Type for {@link SupportedPathFamily}. |
-| `@beep/schema/FilePath` | `SupportedWindowsNamespace` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:60` | Branded schema for path strings that do not use unsupported Windows device |
-| `@beep/schema/FilePath` | `SupportedWindowsNamespace` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:82` | Type for {@link SupportedWindowsNamespace}. |
-| `@beep/schema/FilePath` | `UsesPosixSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:90` | Branded schema for strings that contain a POSIX separator. |
-| `@beep/schema/FilePath` | `UsesPosixSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:112` | Type for {@link UsesPosixSeparator}. |
-| `@beep/schema/FilePath` | `UsesWindowsSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:120` | Branded schema for strings that contain a Windows separator. |
-| `@beep/schema/FilePath` | `UsesWindowsSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:142` | Type for {@link UsesWindowsSeparator}. |
-| `@beep/schema/FilePath` | `ValidWindowsPathSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:130` | Branded schema for Windows path segments that may be either plain segments or |
-| `@beep/schema/FilePath` | `ValidWindowsPathSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:145` | Type for {@link ValidWindowsPathSegment}. |
+| `@beep/schema/FilePath` | `SupportedWindowsNamespace` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:58` | Branded schema for path strings that do not use unsupported Windows device |
+| `@beep/schema/FilePath` | `SupportedWindowsNamespace` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:78` | Type for {@link SupportedWindowsNamespace}. |
+| `@beep/schema/FilePath` | `UsesPosixSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:86` | Branded schema for strings that contain a POSIX separator. |
+| `@beep/schema/FilePath` | `UsesPosixSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:106` | Type for {@link UsesPosixSeparator}. |
+| `@beep/schema/FilePath` | `UsesWindowsSeparator` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:114` | Branded schema for strings that contain a Windows separator. |
+| `@beep/schema/FilePath` | `UsesWindowsSeparator` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.guards.ts:134` | Type for {@link UsesWindowsSeparator}. |
+| `@beep/schema/FilePath` | `ValidWindowsPathSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:126` | Branded schema for Windows path segments that may be either plain segments or |
+| `@beep/schema/FilePath` | `ValidWindowsPathSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:139` | Type for {@link ValidWindowsPathSegment}. |
 | `@beep/schema/FilePath` | `ValidWindowsPlainPathSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:46` | Branded schema for Windows path segments that are plain names rather than |
-| `@beep/schema/FilePath` | `ValidWindowsPlainPathSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:89` | Type for {@link ValidWindowsPlainPathSegment}. |
-| `@beep/schema/FilePath` | `ValidWindowsRootSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:99` | Branded schema for Windows root segments such as UNC server and share names. |
-| `@beep/schema/FilePath` | `ValidWindowsRootSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:121` | Type for {@link ValidWindowsRootSegment}. |
-| `@beep/schema/FilePath` | `ValidWindowsUncRest` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:177` | Branded schema for the tail segment list of a UNC file path after the server |
-| `@beep/schema/FilePath` | `ValidWindowsUncRest` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:192` | Type for {@link ValidWindowsUncRest}. |
-| `@beep/schema/FilePath` | `ValidWindowsUncSegments` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:200` | Branded schema for a full UNC segment list `[server, share, ...rest]`. |
-| `@beep/schema/FilePath` | `ValidWindowsUncSegments` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:218` | Type for {@link ValidWindowsUncSegments}. |
+| `@beep/schema/FilePath` | `ValidWindowsPlainPathSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:87` | Type for {@link ValidWindowsPlainPathSegment}. |
+| `@beep/schema/FilePath` | `ValidWindowsRootSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:97` | Branded schema for Windows root segments such as UNC server and share names. |
+| `@beep/schema/FilePath` | `ValidWindowsRootSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:117` | Type for {@link ValidWindowsRootSegment}. |
+| `@beep/schema/FilePath` | `ValidWindowsUncRest` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:169` | Branded schema for the tail segment list of a UNC file path after the server |
+| `@beep/schema/FilePath` | `ValidWindowsUncRest` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:182` | Type for {@link ValidWindowsUncRest}. |
+| `@beep/schema/FilePath` | `ValidWindowsUncSegments` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:190` | Branded schema for a full UNC segment list `[server, share, ...rest]`. |
+| `@beep/schema/FilePath` | `ValidWindowsUncSegments` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:206` | Type for {@link ValidWindowsUncSegments}. |
 | `@beep/schema/FilePath` | `WindowsDotSegment` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:25` | Literal union for Windows dot-segment markers. |
 | `@beep/schema/FilePath` | `WindowsDotSegment` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:37` | Type for {@link WindowsDotSegment}. |
 | `@beep/schema/FilePath` | `WindowsDrivePath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:35` | Branded schema for Windows drive paths with a leaf segment. |
-| `@beep/schema/FilePath` | `WindowsDrivePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:84` | Type for {@link WindowsDrivePath}. |
+| `@beep/schema/FilePath` | `WindowsDrivePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:82` | Type for {@link WindowsDrivePath}. |
 | `@beep/schema/FilePath` | `WindowsDriveRoot` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:19` | Branded schema for Windows drive roots such as `C:` and `C:\\`. |
-| `@beep/schema/FilePath` | `WindowsDriveRoot` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:41` | Type for {@link WindowsDriveRoot}. |
-| `@beep/schema/FilePath` | `WindowsRelativePath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:157` | Branded schema for Windows relative paths that use backslash separators and |
-| `@beep/schema/FilePath` | `WindowsRelativePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:224` | Type for {@link WindowsRelativePath}. |
-| `@beep/schema/FilePath` | `WindowsSegments` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:153` | Branded schema for a non-empty Windows path segment list. |
-| `@beep/schema/FilePath` | `WindowsSegments` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:168` | Type for {@link WindowsSegments}. |
-| `@beep/schema/FilePath` | `WindowsUncPath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:93` | Branded schema for Windows UNC file paths with server, share, and leaf |
-| `@beep/schema/FilePath` | `WindowsUncPath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:148` | Type for {@link WindowsUncPath}. |
-| `@beep/schema/FilePath` | `WindowsUncRoot` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:49` | Branded schema for UNC roots such as `\\\\server\\share`. |
-| `@beep/schema/FilePath` | `WindowsUncRoot` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:71` | Type for {@link WindowsUncRoot}. |
+| `@beep/schema/FilePath` | `WindowsDriveRoot` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:39` | Type for {@link WindowsDriveRoot}. |
+| `@beep/schema/FilePath` | `WindowsRelativePath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:153` | Branded schema for Windows relative paths that use backslash separators and |
+| `@beep/schema/FilePath` | `WindowsRelativePath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:218` | Type for {@link WindowsRelativePath}. |
+| `@beep/schema/FilePath` | `WindowsSegments` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:147` | Branded schema for a non-empty Windows path segment list. |
+| `@beep/schema/FilePath` | `WindowsSegments` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.segments.ts:160` | Type for {@link WindowsSegments}. |
+| `@beep/schema/FilePath` | `WindowsUncPath` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:91` | Branded schema for Windows UNC file paths with server, share, and leaf |
+| `@beep/schema/FilePath` | `WindowsUncPath` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.windows.ts:144` | Type for {@link WindowsUncPath}. |
+| `@beep/schema/FilePath` | `WindowsUncRoot` | const | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:47` | Branded schema for UNC roots such as `\\\\server\\share`. |
+| `@beep/schema/FilePath` | `WindowsUncRoot` | type | `packages/foundation/modeling/schema/src/FilePath/FilePath.roots.ts:67` | Type for {@link WindowsUncRoot}. |
 | `@beep/schema/Float16Array` | `Float16Arr` | const | `packages/foundation/modeling/schema/src/Float16Array.ts:74` | Schema that accepts native `Float16Array` instances. |
 | `@beep/schema/Float16Array` | `Float16Arr` | type | `packages/foundation/modeling/schema/src/Float16Array.ts:86` | Type for {@link Float16Arr}. |
 | `@beep/schema/Float16Array` | `Float16ArrayField` | const | `packages/foundation/modeling/schema/src/Float16Array.ts:179` | Model field helper for storing `Float16Array` values in variant-based model |
@@ -10888,9 +10889,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/FrameGuard` | `Option` | type | `packages/foundation/modeling/schema/src/FrameGuard/FrameGuard.schema.ts:87` |  |
 | `@beep/schema/FrameGuard` | `ResponseHeader` | class | `packages/foundation/modeling/schema/src/FrameGuard/FrameGuard.schema.ts:93` |  |
 | `@beep/schema/Glob` | `Glob` | const | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:105` | Branded schema for portable non-empty glob pattern strings. |
-| `@beep/schema/Glob` | `Glob` | type | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:120` | Type for {@link Glob}. |
-| `@beep/schema/Glob` | `Schema` | const | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:128` | Primary glob schema role alias. |
-| `@beep/schema/Glob` | `Schema` | type | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:136` | Runtime type extracted from {@link Schema}. |
+| `@beep/schema/Glob` | `Glob` | type | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:118` | Type for {@link Glob}. |
+| `@beep/schema/Glob` | `Schema` | const | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:126` | Primary glob schema role alias. |
+| `@beep/schema/Glob` | `Schema` | type | `packages/foundation/modeling/schema/src/Glob/Glob.schema.ts:134` | Runtime type extracted from {@link Schema}. |
 | `@beep/schema/Graph` | `DirectedGraph` | const | `packages/foundation/modeling/schema/src/Graph/Graph.transforms.ts:160` | Schema for immutable directed graphs. |
 | `@beep/schema/Graph` | `DirectedGraph` | interface | `packages/foundation/modeling/schema/src/Graph/Graph.transforms.ts:27` | Schema for decoding encoded graph payloads into immutable directed graphs. |
 | `@beep/schema/Graph` | `DirectedGraphFromSelf` | const | `packages/foundation/modeling/schema/src/Graph/Graph.from-self.ts:265` | Schema for validating existing immutable directed Effect graphs. |
@@ -11152,10 +11153,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/Json` | `JsonArray` | type | `packages/foundation/modeling/schema/src/Json.ts:68` | Runtime type extracted from the {@link JsonArray} schema. |
 | `@beep/schema/Json` | `JsonObject` | const | `packages/foundation/modeling/schema/src/Json.ts:27` | Schema for a JSON object (a record of string keys to JSON-compatible values). |
 | `@beep/schema/Json` | `JsonObject` | type | `packages/foundation/modeling/schema/src/Json.ts:39` | Runtime type extracted from the {@link JsonObject} schema. |
-| `@beep/schema/Jsonc` | `decodeJsoncTextAs` | const | `packages/foundation/modeling/schema/src/Jsonc.ts:127` | Builds a decoder that parses JSONC text and then decodes the result through a |
+| `@beep/schema/Jsonc` | `decodeJsoncTextAs` | const | `packages/foundation/modeling/schema/src/Jsonc.ts:125` | Builds a decoder that parses JSONC text and then decodes the result through a |
 | `@beep/schema/Jsonc` | `JsoncParseDiagnostic` | class | `packages/foundation/modeling/schema/src/Jsonc.ts:32` | Typed representation of a single JSONC parse diagnostic produced by `jsonc-parser`. |
 | `@beep/schema/Jsonc` | `JsoncTextToUnknown` | const | `packages/foundation/modeling/schema/src/Jsonc.ts:90` | Schema transformation that decodes a JSONC string (JSON with comments and |
-| `@beep/schema/Jsonl` | `decodeJsonlTextAs` | const | `packages/foundation/modeling/schema/src/Jsonl.ts:136` | Builds a decoder that parses JSONL text and then decodes the resulting value |
+| `@beep/schema/Jsonl` | `decodeJsonlTextAs` | const | `packages/foundation/modeling/schema/src/Jsonl.ts:134` | Builds a decoder that parses JSONL text and then decodes the resulting value |
 | `@beep/schema/Jsonl` | `JsonlTextToUnknown` | const | `packages/foundation/modeling/schema/src/Jsonl.ts:102` | Schema transformation that decodes JSONL (JSON Lines) text into an array of |
 | `@beep/schema/KebabStr` | `KebabCaseStr` | const | `packages/foundation/modeling/schema/src/KebabStr.ts:28` | Branded kebab-case string schema with a lowercase leading letter. |
 | `@beep/schema/KebabStr` | `KebabCaseStr` | type | `packages/foundation/modeling/schema/src/KebabStr.ts:54` | Type for {@link KebabCaseStr}. |
@@ -11201,10 +11202,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/MappedLiteralKit` | `MappedLiteralDuplicateError` | class | `packages/foundation/modeling/schema/src/MappedLiteralKit/MappedLiteralKit.schema.ts:97` | Error thrown when `MappedLiteralKit` receives duplicate literals on the |
 | `@beep/schema/MappedLiteralKit` | `MappedLiteralKit` | function | `packages/foundation/modeling/schema/src/MappedLiteralKit/MappedLiteralKit.schema.ts:334` | Builds a mapped literal schema kit from a non-empty tuple of literal pairs. |
 | `@beep/schema/MappedLiteralKit` | `MappedLiteralKit` | interface | `packages/foundation/modeling/schema/src/MappedLiteralKit/MappedLiteralKit.schema.ts:303` | Public schema module export. |
-| `@beep/schema/Markdown` | `decodeMarkdownTextAs` | const | `packages/foundation/modeling/schema/src/Markdown.ts:210` | Builds a decoder that renders Markdown text to HTML and then decodes the |
+| `@beep/schema/Markdown` | `decodeMarkdownTextAs` | const | `packages/foundation/modeling/schema/src/Markdown.ts:206` | Builds a decoder that renders Markdown text to HTML and then decodes the |
 | `@beep/schema/Markdown` | `Markdown` | const | `packages/foundation/modeling/schema/src/Markdown.ts:122` | Branded schema for Markdown document strings accepted by the active parser. |
-| `@beep/schema/Markdown` | `Markdown` | type | `packages/foundation/modeling/schema/src/Markdown.ts:141` | Branded Markdown document string type extracted from {@link Markdown}. |
-| `@beep/schema/Markdown` | `MarkdownTextToHtml` | const | `packages/foundation/modeling/schema/src/Markdown.ts:169` | Schema factory that renders Markdown text into HTML using `Bun.markdown.html`. |
+| `@beep/schema/Markdown` | `Markdown` | type | `packages/foundation/modeling/schema/src/Markdown.ts:139` | Branded Markdown document string type extracted from {@link Markdown}. |
+| `@beep/schema/Markdown` | `MarkdownTextToHtml` | const | `packages/foundation/modeling/schema/src/Markdown.ts:167` | Schema factory that renders Markdown text into HTML using `Bun.markdown.html`. |
 | `@beep/schema/MimeType` | `ApplicationMimeType` | const | `packages/foundation/modeling/schema/src/MimeType.ts:168` | Schema for `application/*` mime-type literals. |
 | `@beep/schema/MimeType` | `ApplicationMimeType` | type | `packages/foundation/modeling/schema/src/MimeType.ts:192` | Union of application mime-type literals. |
 | `@beep/schema/MimeType` | `AudioMimeType` | const | `packages/foundation/modeling/schema/src/MimeType.ts:337` | Schema for `audio/*` mime-type literals. |
@@ -11387,10 +11388,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/PermittedCrossDomainPolicies` | `ResponseHeader` | class | `packages/foundation/modeling/schema/src/PermittedCrossDomainPolicies/PermittedCrossDomainPolicies.schema.ts:71` |  |
 | `@beep/schema/PermittedCrossDomainPolicies` | `Value` | const | `packages/foundation/modeling/schema/src/PermittedCrossDomainPolicies/PermittedCrossDomainPolicies.schema.ts:35` |  |
 | `@beep/schema/PermittedCrossDomainPolicies` | `Value` | type | `packages/foundation/modeling/schema/src/PermittedCrossDomainPolicies/PermittedCrossDomainPolicies.schema.ts:46` |  |
-| `@beep/schema/PosixPath` | `NativePathToPosixPath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:70` | Schema transformation that converts native file-system paths (with backslashes) to POSIX separators. |
-| `@beep/schema/PosixPath` | `normalizePath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:104` | Normalize a file-system path string to POSIX separators. |
+| `@beep/schema/PosixPath` | `NativePathToPosixPath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:68` | Schema transformation that converts native file-system paths (with backslashes) to POSIX separators. |
+| `@beep/schema/PosixPath` | `normalizePath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:100` | Normalize a file-system path string to POSIX separators. |
 | `@beep/schema/PosixPath` | `PosixPath` | const | `packages/foundation/modeling/schema/src/PosixPath.ts:31` | Branded schema for path strings using only POSIX `/` separators. |
-| `@beep/schema/PosixPath` | `PosixPath` | type | `packages/foundation/modeling/schema/src/PosixPath.ts:53` | Type for {@link PosixPath}. |
+| `@beep/schema/PosixPath` | `PosixPath` | type | `packages/foundation/modeling/schema/src/PosixPath.ts:51` | Type for {@link PosixPath}. |
 | `@beep/schema/Primitive` | `Primitive` | const | `packages/foundation/modeling/schema/src/Primitive.ts:28` | Schema for JavaScript primitive types (`string \| number \| boolean \| bigint \| null \| undefined`). |
 | `@beep/schema/Primitive` | `Primitive` | type | `packages/foundation/modeling/schema/src/Primitive.ts:47` | {@inheritDoc Primitive} |
 | `@beep/schema/PromiseSchema` | `isPromise` | const | `packages/foundation/modeling/schema/src/PromiseSchema.ts:64` | Type guard that checks whether a value is a native JavaScript `Promise`. |
@@ -11414,10 +11415,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/ReferrerPolicy` | `ResponseHeader` | class | `packages/foundation/modeling/schema/src/ReferrerPolicy/ReferrerPolicy.schema.ts:87` |  |
 | `@beep/schema/ReferrerPolicy` | `Value` | const | `packages/foundation/modeling/schema/src/ReferrerPolicy/ReferrerPolicy.schema.ts:38` |  |
 | `@beep/schema/ReferrerPolicy` | `Value` | type | `packages/foundation/modeling/schema/src/ReferrerPolicy/ReferrerPolicy.schema.ts:49` |  |
-| `@beep/schema/RegExp` | `RegExpFromStr` | const | `packages/foundation/modeling/schema/src/RegExp.ts:107` | One-way schema that decodes a valid pattern string into a JavaScript `RegExp` object. |
-| `@beep/schema/RegExp` | `RegExpFromStr` | type | `packages/foundation/modeling/schema/src/RegExp.ts:135` | Type for {@link RegExpFromStr}. |
+| `@beep/schema/RegExp` | `RegExpFromStr` | const | `packages/foundation/modeling/schema/src/RegExp.ts:105` | One-way schema that decodes a valid pattern string into a JavaScript `RegExp` object. |
+| `@beep/schema/RegExp` | `RegExpFromStr` | type | `packages/foundation/modeling/schema/src/RegExp.ts:131` | Type for {@link RegExpFromStr}. |
 | `@beep/schema/RegExp` | `RegExpStr` | const | `packages/foundation/modeling/schema/src/RegExp.ts:58` | Branded schema for strings that can be converted directly to a JavaScript `RegExp`. |
-| `@beep/schema/RegExp` | `RegExpStr` | type | `packages/foundation/modeling/schema/src/RegExp.ts:80` | Type for {@link RegExpStr}. |
+| `@beep/schema/RegExp` | `RegExpStr` | type | `packages/foundation/modeling/schema/src/RegExp.ts:78` | Type for {@link RegExpStr}. |
 | `@beep/schema/SchemaUtils` | `BoolDefaultFalse` | const | `packages/foundation/modeling/schema/src/SchemaUtils/withEncodeDefault.ts:101` | Boolean schema field that decodes missing keys as `false`. |
 | `@beep/schema/SchemaUtils` | `BoolDefaultFalse` | type | `packages/foundation/modeling/schema/src/SchemaUtils/withEncodeDefault.ts:121` | {@inheritDoc BoolDefaultFalse} |
 | `@beep/schema/SchemaUtils` | `BoolDefaultTrue` | const | `packages/foundation/modeling/schema/src/SchemaUtils/withEncodeDefault.ts:139` | Boolean schema field that decodes missing keys as `true`. |
@@ -11520,14 +11521,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/Sex` | `Sex` | const | `packages/foundation/modeling/schema/src/Sex/Sex.schema.ts:16` | The sex of a person ("male" or "female"). |
 | `@beep/schema/Sex` | `Sex` | type | `packages/foundation/modeling/schema/src/Sex/Sex.schema.ts:27` | {@inheritDoc Sex} |
 | `@beep/schema/Sha256` | `Sha256Hex` | const | `packages/foundation/modeling/schema/src/Sha256.ts:57` | Branded schema for canonical lowercase SHA-256 hex digests (64 hex characters). |
-| `@beep/schema/Sha256` | `Sha256Hex` | type | `packages/foundation/modeling/schema/src/Sha256.ts:79` | Type for {@link Sha256Hex}. |
-| `@beep/schema/Sha256` | `Sha256HexFromBytes` | const | `packages/foundation/modeling/schema/src/Sha256.ts:101` | One-way schema that decodes a byte array into a canonical lowercase SHA-256 |
-| `@beep/schema/Sha256` | `Sha256HexFromBytes` | type | `packages/foundation/modeling/schema/src/Sha256.ts:126` | Type for {@link Sha256HexFromBytes}. |
-| `@beep/schema/Sha256` | `Sha256HexFromHexBytes` | const | `packages/foundation/modeling/schema/src/Sha256.ts:147` | One-way schema that decodes a hex-encoded byte string into a canonical |
-| `@beep/schema/Sha256` | `Sha256HexFromHexBytes` | type | `packages/foundation/modeling/schema/src/Sha256.ts:169` | Type for {@link Sha256HexFromHexBytes}. |
+| `@beep/schema/Sha256` | `Sha256Hex` | type | `packages/foundation/modeling/schema/src/Sha256.ts:77` | Type for {@link Sha256Hex}. |
+| `@beep/schema/Sha256` | `Sha256HexFromBytes` | const | `packages/foundation/modeling/schema/src/Sha256.ts:99` | One-way schema that decodes a byte array into a canonical lowercase SHA-256 |
+| `@beep/schema/Sha256` | `Sha256HexFromBytes` | type | `packages/foundation/modeling/schema/src/Sha256.ts:122` | Type for {@link Sha256HexFromBytes}. |
+| `@beep/schema/Sha256` | `Sha256HexFromHexBytes` | const | `packages/foundation/modeling/schema/src/Sha256.ts:143` | One-way schema that decodes a hex-encoded byte string into a canonical |
+| `@beep/schema/Sha256` | `Sha256HexFromHexBytes` | type | `packages/foundation/modeling/schema/src/Sha256.ts:163` | Type for {@link Sha256HexFromHexBytes}. |
 | `@beep/schema/Slug` | `Slug` | const | `packages/foundation/modeling/schema/src/Slug.ts:83` | Branded schema for canonical lowercase kebab-case slugs. |
-| `@beep/schema/Slug` | `Slug` | type | `packages/foundation/modeling/schema/src/Slug.ts:98` | Branded slug string type extracted from {@link Slug}. |
-| `@beep/schema/Slug` | `SlugFromStr` | const | `packages/foundation/modeling/schema/src/Slug.ts:106` | Non-empty string schema used as the source input for {@link Slug}. |
+| `@beep/schema/Slug` | `Slug` | type | `packages/foundation/modeling/schema/src/Slug.ts:96` | Branded slug string type extracted from {@link Slug}. |
+| `@beep/schema/Slug` | `SlugFromStr` | const | `packages/foundation/modeling/schema/src/Slug.ts:104` | Non-empty string schema used as the source input for {@link Slug}. |
 | `@beep/schema/SnakeStr` | `SnakeCaseStr` | const | `packages/foundation/modeling/schema/src/SnakeStr.ts:28` | Branded snake_case string schema. |
 | `@beep/schema/SnakeStr` | `SnakeCaseStr` | type | `packages/foundation/modeling/schema/src/SnakeStr.ts:54` | Type for {@link SnakeCaseStr}. |
 | `@beep/schema/StatusCauseError` | `makeStatusCauseError` | const | `packages/foundation/modeling/schema/src/StatusCauseError.ts:193` | Build a tagged error directly or derive a reusable `(message, status, cause?) => Error` builder. |
@@ -11590,7 +11591,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/Timestamp` | `ToIsoString` | type | `packages/foundation/modeling/schema/src/Timestamp/Timestamp.schema.ts:130` | Normalized ISO string type extracted from {@link ToIsoStr}. |
 | `@beep/schema/Timezone` | `Timezone` | const | `packages/foundation/modeling/schema/src/Timezone.ts:28` | IANA timezone identifier schema covering standard regions and UTC offsets. |
 | `@beep/schema/Timezone` | `Timezone` | type | `packages/foundation/modeling/schema/src/Timezone.ts:493` | Runtime type for {@link Timezone}. |
-| `@beep/schema/Toml` | `decodeTomlTextAs` | const | `packages/foundation/modeling/schema/src/Toml.ts:128` | Builds a decoder that parses TOML text and then decodes the result through a |
+| `@beep/schema/Toml` | `decodeTomlTextAs` | const | `packages/foundation/modeling/schema/src/Toml.ts:126` | Builds a decoder that parses TOML text and then decodes the result through a |
 | `@beep/schema/Toml` | `TomlTextToUnknown` | const | `packages/foundation/modeling/schema/src/Toml.ts:94` | Schema transformation that decodes TOML text into an unknown record using |
 | `@beep/schema/Transformations` | `destructiveTransform` | const | `packages/foundation/modeling/schema/src/Transformations.ts:47` | Applies a lossy transform by inferring the target type from a callback result. |
 | `@beep/schema/URL` | `URLStr` | const | `packages/foundation/modeling/schema/src/URL.ts:60` | A branded schema for URL-encoded strings validated against `new URL()`. |
@@ -11614,7 +11615,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/VariantSchema` | `TypeId` | const | `packages/foundation/modeling/schema/src/VariantSchema/VariantSchema.core.ts:20` |  |
 | `@beep/schema/VariantSchema` | `Union` | interface | `packages/foundation/modeling/schema/src/VariantSchema/VariantSchema.core.ts:345` |  |
 | `@beep/schema/VariantSchema` | `Union` | namespace | `packages/foundation/modeling/schema/src/VariantSchema/VariantSchema.core.ts:354` |  |
-| `@beep/schema/Xml` | `decodeXmlTextAs` | const | `packages/foundation/modeling/schema/src/Xml.ts:119` | Builds a decoder that parses XML text and then decodes the result through a |
+| `@beep/schema/Xml` | `decodeXmlTextAs` | const | `packages/foundation/modeling/schema/src/Xml.ts:117` | Builds a decoder that parses XML text and then decodes the result through a |
 | `@beep/schema/Xml` | `XmlTextToUnknown` | const | `packages/foundation/modeling/schema/src/Xml.ts:79` | Schema transformation that decodes XML text into an unknown parsed document |
 | `@beep/schema/XssProtection` | `Header` | const | `packages/foundation/modeling/schema/src/XssProtection/XssProtection.schema.ts:145` |  |
 | `@beep/schema/XssProtection` | `Header` | type | `packages/foundation/modeling/schema/src/XssProtection/XssProtection.schema.ts:196` |  |
@@ -11633,7 +11634,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/schema/XssProtection` | `XSSProtectionReport` | type | `packages/foundation/modeling/schema/src/XssProtection/XssProtection.schema.ts:70` |  |
 | `@beep/schema/XssProtection` | `XSSProtectionReportConfig` | class | `packages/foundation/modeling/schema/src/XssProtection/XssProtection.schema.ts:47` |  |
 | `@beep/schema/XssProtection` | `XSSProtectionResponseHeader` | class | `packages/foundation/modeling/schema/src/XssProtection/XssProtection.schema.ts:92` |  |
-| `@beep/schema/Yaml` | `decodeYamlTextAs` | const | `packages/foundation/modeling/schema/src/Yaml.ts:133` | Builds a decoder that parses YAML text and then decodes the result through a |
+| `@beep/schema/Yaml` | `decodeYamlTextAs` | const | `packages/foundation/modeling/schema/src/Yaml.ts:131` | Builds a decoder that parses YAML text and then decodes the result through a |
 | `@beep/schema/Yaml` | `parseYaml` | const | `packages/foundation/modeling/schema/src/Yaml.ts:73` | Parses a YAML string into a JavaScript value. Uses `Bun.YAML` when available |
 | `@beep/schema/Yaml` | `YamlTextToUnknown` | const | `packages/foundation/modeling/schema/src/Yaml.ts:96` | Schema transformation that decodes YAML text into an unknown parsed value. |
 
@@ -12102,20 +12103,20 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/observability` | `NotFoundError` | class | `packages/foundation/capability/observability/src/HttpError.ts:232` | 404 tagged error. |
 | `@beep/observability` | `ObservabilityCoreConfig` | const | `packages/foundation/capability/observability/src/CoreConfig.ts:42` | Browser-safe shared observability configuration. |
 | `@beep/observability` | `ObservabilityCoreConfig` | type | `packages/foundation/capability/observability/src/CoreConfig.ts:71` | Type of {@link ObservabilityCoreConfig} |
-| `@beep/observability` | `ObservedCause` | const | `packages/foundation/capability/observability/src/Observed.ts:234` | A transport-safe schema for full Effect causes. |
-| `@beep/observability` | `ObservedCause` | type | `packages/foundation/capability/observability/src/Observed.ts:256` | Runtime type for {@link ObservedCause}. |
-| `@beep/observability` | `ObservedCauseReason` | const | `packages/foundation/capability/observability/src/Observed.ts:197` | One serialized failure reason from a Cause. |
-| `@beep/observability` | `ObservedCauseReason` | type | `packages/foundation/capability/observability/src/Observed.ts:219` | Runtime type for {@link ObservedCauseReason}. |
-| `@beep/observability` | `ObservedDefect` | const | `packages/foundation/capability/observability/src/Observed.ts:120` | A transport-safe schema for defects. |
-| `@beep/observability` | `ObservedDefect` | type | `packages/foundation/capability/observability/src/Observed.ts:142` | Runtime type for {@link ObservedDefect}. |
-| `@beep/observability` | `ObservedDefectWithStack` | const | `packages/foundation/capability/observability/src/Observed.ts:160` | A transport-safe schema for defects that preserves stacks when possible. |
-| `@beep/observability` | `ObservedDefectWithStack` | type | `packages/foundation/capability/observability/src/Observed.ts:182` | Runtime type for {@link ObservedDefectWithStack}. |
+| `@beep/observability` | `ObservedCause` | const | `packages/foundation/capability/observability/src/Observed.ts:224` | A transport-safe schema for full Effect causes. |
+| `@beep/observability` | `ObservedCause` | type | `packages/foundation/capability/observability/src/Observed.ts:244` | Runtime type for {@link ObservedCause}. |
+| `@beep/observability` | `ObservedCauseReason` | const | `packages/foundation/capability/observability/src/Observed.ts:189` | One serialized failure reason from a Cause. |
+| `@beep/observability` | `ObservedCauseReason` | type | `packages/foundation/capability/observability/src/Observed.ts:209` | Runtime type for {@link ObservedCauseReason}. |
+| `@beep/observability` | `ObservedDefect` | const | `packages/foundation/capability/observability/src/Observed.ts:116` | A transport-safe schema for defects. |
+| `@beep/observability` | `ObservedDefect` | type | `packages/foundation/capability/observability/src/Observed.ts:136` | Runtime type for {@link ObservedDefect}. |
+| `@beep/observability` | `ObservedDefectWithStack` | const | `packages/foundation/capability/observability/src/Observed.ts:154` | A transport-safe schema for defects that preserves stacks when possible. |
+| `@beep/observability` | `ObservedDefectWithStack` | type | `packages/foundation/capability/observability/src/Observed.ts:174` | Runtime type for {@link ObservedDefectWithStack}. |
 | `@beep/observability` | `ObservedError` | const | `packages/foundation/capability/observability/src/Observed.ts:40` | A transport-safe schema for expected errors (message only, no stack). |
-| `@beep/observability` | `ObservedError` | type | `packages/foundation/capability/observability/src/Observed.ts:62` | Runtime type for {@link ObservedError}. |
-| `@beep/observability` | `ObservedErrorWithStack` | const | `packages/foundation/capability/observability/src/Observed.ts:80` | A transport-safe schema for expected errors that preserves stacks. |
-| `@beep/observability` | `ObservedErrorWithStack` | type | `packages/foundation/capability/observability/src/Observed.ts:102` | Runtime type for {@link ObservedErrorWithStack}. |
-| `@beep/observability` | `ObservedExit` | const | `packages/foundation/capability/observability/src/Observed.ts:271` | A transport-safe schema for exits carrying unknown success values. |
-| `@beep/observability` | `ObservedExit` | type | `packages/foundation/capability/observability/src/Observed.ts:293` | Runtime type for {@link ObservedExit}. |
+| `@beep/observability` | `ObservedError` | type | `packages/foundation/capability/observability/src/Observed.ts:60` | Runtime type for {@link ObservedError}. |
+| `@beep/observability` | `ObservedErrorWithStack` | const | `packages/foundation/capability/observability/src/Observed.ts:78` | A transport-safe schema for expected errors that preserves stacks. |
+| `@beep/observability` | `ObservedErrorWithStack` | type | `packages/foundation/capability/observability/src/Observed.ts:98` | Runtime type for {@link ObservedErrorWithStack}. |
+| `@beep/observability` | `ObservedExit` | const | `packages/foundation/capability/observability/src/Observed.ts:259` | A transport-safe schema for exits carrying unknown success values. |
+| `@beep/observability` | `ObservedExit` | type | `packages/foundation/capability/observability/src/Observed.ts:279` | Runtime type for {@link ObservedExit}. |
 | `@beep/observability` | `ObservedExitSummary` | const | `packages/foundation/capability/observability/src/CauseDiagnostics.ts:255` | Summary of an observed Effect exit including outcome classification and cause analysis. |
 | `@beep/observability` | `ObservedExitSummary` | type | `packages/foundation/capability/observability/src/CauseDiagnostics.ts:275` | Type of {@link ObservedExitSummary} |
 | `@beep/observability` | `observeHttpRequest` | const | `packages/foundation/capability/observability/src/Metric.ts:442` | Observes HTTP request duration and status metrics for an Effect. |
@@ -12162,20 +12163,20 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/observability/server` | `layerFilteredDevTools` | const | `packages/foundation/capability/observability/src/server/DevTools.ts:88` | Mirror only selected spans to the Effect devtools websocket. |
 | `@beep/observability/server` | `layerHttpApiTelemetryMiddleware` | const | `packages/foundation/capability/observability/src/server/HttpApiTelemetry.ts:502` | Build a layer that instruments all endpoints where the middleware is |
 | `@beep/observability/server` | `layerLocalLgtmServer` | const | `packages/foundation/capability/observability/src/server/Layer.ts:31` | Server-only local LGTM wiring for Effect OTLP + optional devtools. |
-| `@beep/observability/server` | `layerNodeSdkServer` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:293` | Build a shared Node SDK layer for server runtimes. |
-| `@beep/observability/server` | `layerNodeSdkServerTraces` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:329` | Build a shared trace-only Node SDK layer for server runtimes. |
+| `@beep/observability/server` | `layerNodeSdkServer` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:285` | Build a shared Node SDK layer for server runtimes. |
+| `@beep/observability/server` | `layerNodeSdkServerTraces` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:321` | Build a shared trace-only Node SDK layer for server runtimes. |
 | `@beep/observability/server` | `layerPrometheusMetricsHttp` | const | `packages/foundation/capability/observability/src/server/Prometheus.ts:47` | Create a sanitized Prometheus metrics route. |
 | `@beep/observability/server` | `makeConsoleErrorReporter` | const | `packages/foundation/capability/observability/src/server/ErrorReporting.ts:29` | Create a console-backed error reporter with cause fingerprints and pretty rendering. |
 | `@beep/observability/server` | `makeHttpApiMetrics` | const | `packages/foundation/capability/observability/src/server/HttpApiTelemetry.ts:188` | Create a reusable HTTP API metric set for one metric prefix. |
 | `@beep/observability/server` | `makeHttpApiTelemetryDescriptor` | const | `packages/foundation/capability/observability/src/server/HttpApiTelemetry.ts:266` | Create a telemetry descriptor directly from Effect HttpApi metadata. |
-| `@beep/observability/server` | `makeNodeSdkServerConfig` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:171` | Build a Node SDK configuration with OTLP HTTP defaults for local LGTM. |
-| `@beep/observability/server` | `makeNodeSdkServerTraceConfig` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:255` | Build a Node SDK configuration that exports traces only. |
-| `@beep/observability/server` | `NodeSdkServerOptions` | class | `packages/foundation/capability/observability/src/server/NodeSdk.ts:99` | Additional controls for the shared Node SDK layer. |
+| `@beep/observability/server` | `makeNodeSdkServerConfig` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:163` | Build a Node SDK configuration with OTLP HTTP defaults for local LGTM. |
+| `@beep/observability/server` | `makeNodeSdkServerTraceConfig` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:247` | Build a Node SDK configuration that exports traces only. |
+| `@beep/observability/server` | `NodeSdkServerOptions` | class | `packages/foundation/capability/observability/src/server/NodeSdk.ts:91` | Additional controls for the shared Node SDK layer. |
 | `@beep/observability/server` | `observeHttpApiEffect` | const | `packages/foundation/capability/observability/src/server/HttpApiTelemetry.ts:426` | Observes an HTTP API Effect and records request metrics. |
 | `@beep/observability/server` | `observeHttpApiHandler` | const | `packages/foundation/capability/observability/src/server/HttpApiTelemetry.ts:585` | Observes an HTTP API handler Effect and records request metrics. |
 | `@beep/observability/server` | `sanitizePrometheusMetrics` | const | `packages/foundation/capability/observability/src/server/Prometheus.ts:28` | Strip duplicate terminal histogram buckets from Prometheus exposition text. |
 | `@beep/observability/server` | `ServerObservabilityConfig` | class | `packages/foundation/capability/observability/src/server/Config.ts:37` | Server-only observability configuration. |
-| `@beep/observability/server` | `toNodeSdkResource` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:143` | Convert the shared server observability config into a Node SDK resource shape. |
+| `@beep/observability/server` | `toNodeSdkResource` | const | `packages/foundation/capability/observability/src/server/NodeSdk.ts:135` | Convert the shared server observability config into a Node SDK resource shape. |
 | `@beep/observability/server` | `toOtlpResource` | const | `packages/foundation/capability/observability/src/server/Config.ts:69` | Convert server config into OTLP resource attributes. |
 | `@beep/observability/server` | `withIncomingTraceContext` | const | `packages/foundation/capability/observability/src/server/TraceContext.ts:93` | Runs an Effect with trace context extracted from incoming headers. |
 | `@beep/observability/web` | `layerWebSdk` | const | `packages/foundation/capability/observability/src/web/Layer.ts:35` | Thin browser-safe wrapper around `@effect/opentelemetry/WebSdk.layer`. |
@@ -12619,23 +12620,23 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/ui/components/ui/tooltip` | `TooltipProvider` | function | `packages/foundation/ui-system/ui/src/components/ui/tooltip.tsx:12` | Tooltip timing context shared across tooltip instances. |
 | `@beep/ui/components/ui/tooltip` | `TooltipTrigger` | function | `packages/foundation/ui-system/ui/src/components/ui/tooltip.tsx:28` |  |
 | `@beep/ui/hooks/index` | `AudioFormat` | enum | `node_modules/@elevenlabs/client/dist/scribe/scribe.d.ts:2` |  |
-| `@beep/ui/hooks/index` | `BoundaryParams` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:228` | Schema describing optional numeric bounds and controlled values for number input hooks. |
+| `@beep/ui/hooks/index` | `BoundaryParams` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:224` | Schema describing optional numeric bounds and controlled values for number input hooks. |
 | `@beep/ui/hooks/index` | `CommitStrategy` | enum | `node_modules/@elevenlabs/client/dist/scribe/scribe.d.ts:11` |  |
-| `@beep/ui/hooks/index` | `getStepFactor` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:356` | Compute the effective step multiplier for an increment or decrement gesture. |
-| `@beep/ui/hooks/index` | `maxSafeInteger` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:220` | Highest safe integer supported by the hook defaults. |
-| `@beep/ui/hooks/index` | `minSafeInteger` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:212` | Lowest safe integer supported by the hook defaults. |
-| `@beep/ui/hooks/index` | `NumberInputChangeMetadata` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:416` | Metadata passed to `UseNumberInputOptions.onChange`. |
-| `@beep/ui/hooks/index` | `NumberInputError` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:396` | Error states reported through the `onChange` metadata callback. |
-| `@beep/ui/hooks/index` | `NumberInputError` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:408` | Runtime type for {@link NumberInputError}. |
-| `@beep/ui/hooks/index` | `NumberInputEventType` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:376` | Event types reported through the `onChange` metadata callback. |
-| `@beep/ui/hooks/index` | `NumberInputEventType` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:388` | Runtime type for {@link NumberInputEventType}. |
-| `@beep/ui/hooks/index` | `numberToString` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:309` | Format an optional numeric value using a fixed decimal precision. |
+| `@beep/ui/hooks/index` | `getStepFactor` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:352` | Compute the effective step multiplier for an increment or decrement gesture. |
+| `@beep/ui/hooks/index` | `maxSafeInteger` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:216` | Highest safe integer supported by the hook defaults. |
+| `@beep/ui/hooks/index` | `minSafeInteger` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:208` | Lowest safe integer supported by the hook defaults. |
+| `@beep/ui/hooks/index` | `NumberInputChangeMetadata` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:412` | Metadata passed to `UseNumberInputOptions.onChange`. |
+| `@beep/ui/hooks/index` | `NumberInputError` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:392` | Error states reported through the `onChange` metadata callback. |
+| `@beep/ui/hooks/index` | `NumberInputError` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:404` | Runtime type for {@link NumberInputError}. |
+| `@beep/ui/hooks/index` | `NumberInputEventType` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:372` | Event types reported through the `onChange` metadata callback. |
+| `@beep/ui/hooks/index` | `NumberInputEventType` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:384` | Runtime type for {@link NumberInputEventType}. |
+| `@beep/ui/hooks/index` | `numberToString` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:305` | Format an optional numeric value using a fixed decimal precision. |
 | `@beep/ui/hooks/index` | `ScribeStatus` | type | `packages/foundation/ui-system/ui/src/hooks/use-scribe.ts:39` | Connection status for the realtime Scribe hook. |
-| `@beep/ui/hooks/index` | `SpinParams` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:246` | Schema describing step and precision overrides for spinner changes. |
-| `@beep/ui/hooks/index` | `toNumber` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:277` | Convert editable number-input text into a number when the text is parseable. |
-| `@beep/ui/hooks/index` | `useNumberBoundary` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:519` | Low-level number-input state hook for parsing, formatting, and boundary management. |
-| `@beep/ui/hooks/index` | `useNumberInput` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:595` | Fully managed number-input hook with keyboard and spinner controls. |
-| `@beep/ui/hooks/index` | `UseNumberInputOptions` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:454` | Options accepted by {@link useNumberBoundary} and {@link useNumberInput}. |
+| `@beep/ui/hooks/index` | `SpinParams` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:242` | Schema describing step and precision overrides for spinner changes. |
+| `@beep/ui/hooks/index` | `toNumber` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:273` | Convert editable number-input text into a number when the text is parseable. |
+| `@beep/ui/hooks/index` | `useNumberBoundary` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:515` | Low-level number-input state hook for parsing, formatting, and boundary management. |
+| `@beep/ui/hooks/index` | `useNumberInput` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:591` | Fully managed number-input hook with keyboard and spinner controls. |
+| `@beep/ui/hooks/index` | `UseNumberInputOptions` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:450` | Options accepted by {@link useNumberBoundary} and {@link useNumberInput}. |
 | `@beep/ui/hooks/index` | `useScribe` | function | `packages/foundation/ui-system/ui/src/hooks/use-scribe.ts:145` | Manage an ElevenLabs realtime Scribe connection from React components. |
 | `@beep/ui/hooks/use-scribe` | `AudioFormat` | enum | `node_modules/@elevenlabs/client/dist/scribe/scribe.d.ts:2` |  |
 | `@beep/ui/hooks/use-scribe` | `CommitStrategy` | enum | `node_modules/@elevenlabs/client/dist/scribe/scribe.d.ts:11` |  |
@@ -12643,21 +12644,21 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/ui/hooks/use-scribe` | `useScribe` | function | `packages/foundation/ui-system/ui/src/hooks/use-scribe.ts:145` | Manage an ElevenLabs realtime Scribe connection from React components. |
 | `@beep/ui/hooks/useMobile` | `resolveIsMobile` | const | `packages/foundation/ui-system/ui/src/hooks/useMobile.ts:24` | Resolve an optional mobile flag to a concrete boolean value. |
 | `@beep/ui/hooks/useMobile` | `useIsMobile` | function | `packages/foundation/ui-system/ui/src/hooks/useMobile.ts:32` | React hook that tracks whether the current viewport matches the mobile media query. |
-| `@beep/ui/hooks/useNumberInput` | `BoundaryParams` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:228` | Schema describing optional numeric bounds and controlled values for number input hooks. |
-| `@beep/ui/hooks/useNumberInput` | `getStepFactor` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:356` | Compute the effective step multiplier for an increment or decrement gesture. |
-| `@beep/ui/hooks/useNumberInput` | `maxSafeInteger` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:220` | Highest safe integer supported by the hook defaults. |
-| `@beep/ui/hooks/useNumberInput` | `minSafeInteger` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:212` | Lowest safe integer supported by the hook defaults. |
-| `@beep/ui/hooks/useNumberInput` | `NumberInputChangeMetadata` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:416` | Metadata passed to `UseNumberInputOptions.onChange`. |
-| `@beep/ui/hooks/useNumberInput` | `NumberInputError` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:396` | Error states reported through the `onChange` metadata callback. |
-| `@beep/ui/hooks/useNumberInput` | `NumberInputError` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:408` | Runtime type for {@link NumberInputError}. |
-| `@beep/ui/hooks/useNumberInput` | `NumberInputEventType` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:376` | Event types reported through the `onChange` metadata callback. |
-| `@beep/ui/hooks/useNumberInput` | `NumberInputEventType` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:388` | Runtime type for {@link NumberInputEventType}. |
-| `@beep/ui/hooks/useNumberInput` | `numberToString` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:309` | Format an optional numeric value using a fixed decimal precision. |
-| `@beep/ui/hooks/useNumberInput` | `SpinParams` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:246` | Schema describing step and precision overrides for spinner changes. |
-| `@beep/ui/hooks/useNumberInput` | `toNumber` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:277` | Convert editable number-input text into a number when the text is parseable. |
-| `@beep/ui/hooks/useNumberInput` | `useNumberBoundary` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:519` | Low-level number-input state hook for parsing, formatting, and boundary management. |
-| `@beep/ui/hooks/useNumberInput` | `useNumberInput` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:595` | Fully managed number-input hook with keyboard and spinner controls. |
-| `@beep/ui/hooks/useNumberInput` | `UseNumberInputOptions` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:454` | Options accepted by {@link useNumberBoundary} and {@link useNumberInput}. |
+| `@beep/ui/hooks/useNumberInput` | `BoundaryParams` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:224` | Schema describing optional numeric bounds and controlled values for number input hooks. |
+| `@beep/ui/hooks/useNumberInput` | `getStepFactor` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:352` | Compute the effective step multiplier for an increment or decrement gesture. |
+| `@beep/ui/hooks/useNumberInput` | `maxSafeInteger` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:216` | Highest safe integer supported by the hook defaults. |
+| `@beep/ui/hooks/useNumberInput` | `minSafeInteger` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:208` | Lowest safe integer supported by the hook defaults. |
+| `@beep/ui/hooks/useNumberInput` | `NumberInputChangeMetadata` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:412` | Metadata passed to `UseNumberInputOptions.onChange`. |
+| `@beep/ui/hooks/useNumberInput` | `NumberInputError` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:392` | Error states reported through the `onChange` metadata callback. |
+| `@beep/ui/hooks/useNumberInput` | `NumberInputError` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:404` | Runtime type for {@link NumberInputError}. |
+| `@beep/ui/hooks/useNumberInput` | `NumberInputEventType` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:372` | Event types reported through the `onChange` metadata callback. |
+| `@beep/ui/hooks/useNumberInput` | `NumberInputEventType` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:384` | Runtime type for {@link NumberInputEventType}. |
+| `@beep/ui/hooks/useNumberInput` | `numberToString` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:305` | Format an optional numeric value using a fixed decimal precision. |
+| `@beep/ui/hooks/useNumberInput` | `SpinParams` | class | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:242` | Schema describing step and precision overrides for spinner changes. |
+| `@beep/ui/hooks/useNumberInput` | `toNumber` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:273` | Convert editable number-input text into a number when the text is parseable. |
+| `@beep/ui/hooks/useNumberInput` | `useNumberBoundary` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:515` | Low-level number-input state hook for parsing, formatting, and boundary management. |
+| `@beep/ui/hooks/useNumberInput` | `useNumberInput` | const | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:591` | Fully managed number-input hook with keyboard and spinner controls. |
+| `@beep/ui/hooks/useNumberInput` | `UseNumberInputOptions` | type | `packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts:450` | Options accepted by {@link useNumberBoundary} and {@link useNumberInput}. |
 | `@beep/ui/hooks/useSpinner` | `useSpinner` | function | `packages/foundation/ui-system/ui/src/hooks/useSpinner.ts:122` | Spinner button hook with press-and-hold repeat behavior. |
 | `@beep/ui/lib/index` | `cn` | function | `packages/foundation/ui-system/ui/src/lib/utils.ts:22` | Merge Tailwind CSS class names with conflict resolution. |
 | `@beep/ui/lib/index` | `sanitizeAnchorHref` | const | `packages/foundation/ui-system/ui/src/lib/url.ts:89` | Replaces active script URL protocols with a harmless fragment. |


### PR DESCRIPTION
## What

Migrates the hand-wired schema-annotation anti-pattern to the identity composer's `annoteSchema` helper across the entire repo, and fixes the docs that were teaching the old pattern.

The wrong pattern hand-wires `$I.annote(...)` (which returns a plain annotations object) into a schema `annotate` call. `$I.annoteSchema(id, extras)` is the intended helper — it threads the same identity annotation **and** runs `preserveSchemaStatics`, so it is strictly safer (kit schemas like `LiteralKit` would otherwise drop their statics).

Two syntactic forms were migrated:

```ts
// Pipe form
schema.pipe(..., S.annotate($I.annote("X", { description })))
// ->
schema.pipe(..., $I.annoteSchema("X", { description }))

// Direct method form
someSchema.annotate($I.annote("X", { description }))
// ->
someSchema.pipe($I.annoteSchema("X", { description }))
```

Class/struct constructor annotation **arguments** (`S.Class(...)(fields, $I.annote(...))`) are correct usage and were left untouched.

## How

Applied via a one-off ts-morph AST codemod (structural match on `.annotate(<x>.annote(...))`, deleted after the run), followed by the repo formatter. A handful of resulting `x.pipe(a).pipe($I.annoteSchema(...))` chains were merged into a single `pipe(...)` to satisfy the `unnecessaryPipeChain` rule.

## Doc remediation (stop the pattern propagating)

- `standards/effect-first-development.md`
- `.claude/skills/effect-first-development/SKILL.md`

## Notes

- Regenerates `standards/repo-exports.catalog.{md,jsonc}` — the large diff is source-line shifts from collapsing the multi-line wrappers, not export-surface changes.
- Includes two incidental, **pre-existing** formatter fixes (`@beep/acp`, `@beep/ai-provider-cli`) that were failing `lint` on `main`, required for the gate to pass on this branch.
- Empty-frontmatter changeset (no release bump) per the repo's internal-change convention; all affected packages are `private`.

## Quality gates

- `bun run check` — 79/79 ✅
- `bun run lint` — 79/79 ✅
- `bun run test` — 86/86 ✅
- `bun run repo-exports:catalog:check` — current ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Unified schema annotation mechanism across the codebase by standardizing how metadata is attached to schema definitions throughout multiple packages and libraries. No user-facing changes or API modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->