### PR TITLE
fix(repo): add cspell dictionary entries for @beep/ui story words

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -49,6 +49,8 @@ unfocuses
 Unifi
 Unradio
 Unsandboxed
+unticked
+unticking
 USPTO
 vsearch
 yeet

--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -30,3 +30,8 @@ Segoe
 Starenky
 Stroustrup
 Yukihiro
+Benoit
+Colm
+Diaz
+Duarte
+Tuite

--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -220,3 +220,7 @@ tolower
 Unfailable
 uvicorn
 venv
+affordances
+notif
+unhover
+unhovers


### PR DESCRIPTION
## Summary

The shadcn UI baseline (#186) introduced Storybook stories whose text uses legitimate sample names and UI interaction terms that the shared `cspell` dictionary didn't yet know, causing the `Lint` lane's `lint:spell` step to fail (31 issues across 12 story files).

Adds the missing words to the appropriate `.cspell/` dictionaries:

- **names** (`names.txt`): `Benoit`, `Colm`, `Diaz`, `Duarte`, `Tuite` — demo data in context-menu/dropdown-menu/etc. stories
- **tech terms** (`tech-terms.txt`): `affordances`, `notif`, `unhover`, `unhovers`
- **custom words** (`custom-words.txt`): `unticked`, `unticking` — alongside existing UI terms like `Uncheckbox`/`Unradio`/`unfocuses`

## Verification

- `cspell .` → clean (0 issues)
- full `bun run lint` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal spell check configuration files to improve text validation accuracy across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->