### PR TITLE
fix(repo-cli): make yeet canonical quality path

### DIFF
--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: yeet
+description: Canonical repo-quality operator workflow for beep-effect. Use when repairing local changes, proving quality, committing, pushing, opening or monitoring a PR, or moving a branch toward mergeable GitHub state with `bun run beep yeet`.
+---
+
+# Yeet Quality Path
+
+Use this skill when a user asks to repair, verify, publish, push, open a PR, or
+make a branch mergeable in this repository. Yeet is the canonical operator path
+for End-to-End Green: deterministic local repair, full local proof, reviewed
+commit, push, PR checks, review closeout, and merge readiness.
+
+## Ground First
+
+1. Inspect the current branch and worktree:
+
+```bash
+git status --short --branch
+git diff --name-status
+```
+
+2. If the checkout is on `main` or another protected/default branch, create a
+   feature branch from the intended base before editing or publishing.
+3. If the worktree contains unrelated changes, stage only the intended files.
+   Never publish unrelated paths silently.
+4. Check for already-running heavyweight quality commands before starting a
+   Yeet lane:
+
+```bash
+ps -eo pid,ppid,stat,etime,cmd | rg 'bun run|beep yeet|audit:github|turbo|gh pr|git ' | rg -v 'rg|ps -eo' || true
+```
+
+## Canonical Commands
+
+- Repair local work:
+
+```bash
+bun run beep yeet repair
+```
+
+- Prove the branch without committing or pushing:
+
+```bash
+bun run beep yeet verify
+```
+
+- Commit reviewed staged changes, run the full local pre-push proof, then push:
+
+```bash
+bun run beep yeet publish --message "type(scope): summary"
+```
+
+- Monitor hosted PR checks for the current branch:
+
+```bash
+bun run beep yeet monitor
+```
+
+Use plan mode before long or risky runs when you need to inspect the shape:
+
+```bash
+bun run beep yeet repair --plan --json
+bun run beep yeet verify --plan --json
+bun run beep yeet publish --message "type(scope): summary" --plan --json
+```
+
+## Mergeable PR Workflow
+
+1. Run `bun run beep yeet repair` when local changes need deterministic fixers,
+   docgen, repo-export catalog repair, or affected feedback.
+2. Stage the reviewed files explicitly.
+3. Run `bun run beep yeet publish --message "type(scope): summary"`.
+4. If no pull request exists for the pushed branch, create a draft PR with
+   `gh pr create --draft --fill`.
+5. Run `bun run beep yeet monitor` and inspect PR checks, mergeability, and
+   review threads.
+6. Address failed checks or actionable review comments with follow-up commits
+   through the same Yeet publish path.
+7. Mark the PR ready only when checks are green, there are no unresolved
+   actionable review threads, and GitHub reports the branch as mergeable or not
+   conflicted.
+
+## Fast Plus Monitor
+
+`bun run beep yeet publish --fast --monitor --message "..."` is opt-in only. Use
+it only on an existing PR branch when the user explicitly accepts replacing the
+local full pre-push wait with hosted PR-check monitoring. It must remain paired
+with `--monitor`; Yeet rejects `--fast` without it.
+
+`bun run audit:github pre-push` remains the named full local fallback for
+secrets, security, SAST, Nix, and any lane that must be proven outside Yeet.
+
+## Failure Handling
+
+- If Yeet fails after creating a local commit but before pushing, fix the issue,
+  then amend or reset the unpushed commit before retrying.
+- If Yeet refuses untracked, unstaged, or newly generated paths, inspect the
+  paths and decide whether they belong in the reviewed publish intent.
+- If there is no open PR for `yeet monitor`, create the draft PR first or run
+  `bun run audit:github pre-push` as the full local fallback.
+- Do not weaken GitHub check names, hosted PR checks, or manual fallback lanes
+  to make a branch appear green faster.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,16 @@ Build and maintain features with effect first development.
   the compatibility index for agent lookup. Use
   `bun run repo-exports:catalog:full` only when a non-sharded fallback proof is
   explicitly required.
-- Yeet workflow hardening is in proof mode: use `bun run beep yeet repair`,
-  `bun run beep yeet verify`, and `bun run beep yeet publish --message "..."`
-  for proving the path, but do not treat Yeet as the canonical replacement for
-  manual quality lanes until its dedicated proof PR is green in GitHub Actions
-  and the Yeet agent skill is added.
+- Yeet is the canonical repo-quality operator path. Use the `yeet` skill and
+  `bun run beep yeet repair`, `bun run beep yeet verify`,
+  `bun run beep yeet publish --message "..."`, and
+  `bun run beep yeet monitor` for End-to-End Green: repair, proof, commit,
+  push, PR checks, review closeout, and merge readiness.
 - Yeet fast-plus-monitor is opt-in only: `bun run beep yeet publish --fast
-  --monitor --message "..."` is PR-branch guarded, and
-  `bun run audit:github pre-push` remains the explicit full local fallback.
+  --monitor --message "..."` is PR-branch guarded. Use the normal
+  `publish --message` path by default, and keep `bun run audit:github pre-push`
+  as the explicit full local fallback for secrets, security, SAST, Nix, or any
+  lane that needs manual proof outside Yeet.
 - Use `bun run beep architecture` for canonical slice, concept, role, and
   architecture proof generation instead of hand-authoring boilerplate.
 - For architecture concepts, use the canonical `--domain-kind` archetypes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,14 +24,16 @@ Ship reliable code with effect first and schema first patterns.
   artifacts, while the root `standards/repo-exports.catalog.{jsonc,md}` remains
   the compatibility lookup surface. Use `bun run repo-exports:catalog:full`
   only for an explicit full-scan fallback proof.
-- Yeet workflow hardening is in proof mode: use `bun run beep yeet repair`,
-  `bun run beep yeet verify`, and `bun run beep yeet publish --message "..."`
-  for proving the path, but do not treat Yeet as the canonical replacement for
-  manual quality lanes until its dedicated proof PR is green in GitHub Actions
-  and the Yeet agent skill is added.
+- Yeet is the canonical repo-quality operator path. Use the `yeet` skill and
+  `bun run beep yeet repair`, `bun run beep yeet verify`,
+  `bun run beep yeet publish --message "..."`, and
+  `bun run beep yeet monitor` for End-to-End Green: repair, proof, commit,
+  push, PR checks, review closeout, and merge readiness.
 - Yeet fast-plus-monitor is opt-in only: `bun run beep yeet publish --fast
-  --monitor --message "..."` is PR-branch guarded, and
-  `bun run audit:github pre-push` remains the explicit full local fallback.
+  --monitor --message "..."` is PR-branch guarded. Use the normal
+  `publish --message` path by default, and keep `bun run audit:github pre-push`
+  as the explicit full local fallback for secrets, security, SAST, Nix, or any
+  lane that needs manual proof outside Yeet.
 
 ## Prompt-cache discipline
 Claude Code auto-caches the stable conversation prefix (system prompt, tool

--- a/packages/tooling/tool/cli/README.md
+++ b/packages/tooling/tool/cli/README.md
@@ -434,31 +434,34 @@ bun run beep quality changeset-graph
 
 ### `yeet`
 
-Run the repo-native agent workflow candidate for repair, verification, and
-publishing. Yeet is not considered the canonical replacement for manual quality
-lanes until the dedicated proof PR passes GitHub Actions end to end.
+Run the canonical End-to-End Green operator path: deterministic repair, full
+local proof, reviewed commit, push, hosted PR check monitoring, and merge
+readiness.
 
 ```bash
 bun run beep yeet repair
 bun run beep yeet verify
-bun run beep yeet publish --message "feat(repo-cli): harden yeet proof"
+bun run beep yeet publish --message "type(scope): summary"
+bun run beep yeet monitor
 ```
 
-`repair` is the only mode that runs deterministic write steps. It currently
-runs changed-file lint fixes, local docgen, `repo-exports:catalog`, and then affected
-feedback. Affected test feedback is scoped to unit and type-test lanes; the
-integration lane is reserved for the full proof. `verify` is read-only and runs
-`quality github-checks pre-push`, the shared proof surface that mirrors the
-all-up local GitHub Actions proof, without duplicate affected feedback first.
-`publish` does not run repair steps: it requires reviewed staged changes,
+`repair` runs deterministic write steps: changed-file lint fixes, local docgen,
+`repo-exports:catalog`, and affected feedback. Affected test feedback is scoped
+to unit and type-test lanes; integration stays in the full proof. `verify` runs
+the canonical full local `quality github-checks pre-push` proof without
+duplicate affected feedback first. `publish` requires reviewed staged changes,
 commits them, runs the same `pre-push` proof against the new local commit, and
-pushes only after that proof passes. Bare `yeet --message ...` remains a publish
-alias.
+pushes only after that proof passes. `monitor` watches hosted PR checks for the
+current branch. Bare `yeet --message ...` remains a publish alias.
 
-If `yeet verify` or `yeet publish` passes locally but the proof PR fails in
-GitHub Actions, treat that as a Yeet/quality parity bug or environment drift
-unless the failure is clearly an external outage. The custom Yeet agent skill
-should be added only after this proof loop is green.
+Use `--plan --json` on any mode to inspect the planned steps without running
+them. `publish --fast --monitor` is an explicit PR-branch-only exception for
+cases where hosted PR checks replace the local full pre-push wait; the normal
+`publish --message` path remains the default. `bun run audit:github pre-push`
+remains the named full local fallback for secrets, security, SAST, Nix, and
+manual proof outside Yeet. If Yeet passes locally but the PR fails in GitHub
+Actions, treat that as a Yeet/quality parity bug or environment drift unless
+the failure is clearly an external outage.
 
 ### `ci`
 

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -46,6 +46,19 @@ const GROUPED_STEP_OUTPUT_MAX_CHARS = 256 * 1024;
 const CHANGED_PATH_DIFF_FILTER = ["A", "C", "M", "R", "T", "U", "X", "B"].join("");
 const LOCAL_BIOME_BIN = "./node_modules/.bin/biome";
 const BIOME_FIX_CHANGED_ARGS = ["check", "--write", "--files-ignore-unknown=true"] as const;
+const BIOME_FIX_CHANGED_FILE_SUFFIXES = [
+  ".cjs",
+  ".css",
+  ".cts",
+  ".js",
+  ".json",
+  ".jsonc",
+  ".jsx",
+  ".mjs",
+  ".mts",
+  ".ts",
+  ".tsx",
+] as const;
 const LINT_FIX_AGGREGATE_ARGS = ["--full", "--repo"] as const;
 const ROOT_TURBO_CONCURRENCY_ARG = "--concurrency=3";
 const QUALITY_TASK_BYPASS_ARG_NAMES = ["--completions", "--help", "--log-level", "--version", "-h", "-v"] as const;
@@ -644,6 +657,12 @@ const collectExistingWorkingTreeChangedFiles = Effect.fn("QualityTasks.collectEx
   }
 );
 
+const isBiomeFixChangedFile = (file: string): boolean =>
+  A.some(BIOME_FIX_CHANGED_FILE_SUFFIXES, (suffix) => Str.endsWith(suffix)(file));
+
+const biomeFixChangedFiles = (files: ReadonlyArray<string>): ReadonlyArray<string> =>
+  pipe(files, A.filter(isBiomeFixChangedFile));
+
 const lintFixChangedStep = (repoRoot: string, files: ReadonlyArray<string>) =>
   QualityTaskStep.make({
     label: "lint:fix:changed",
@@ -1181,9 +1200,9 @@ const runRootLintTask = Effect.fn("QualityTasks.runRootLintTask")(function* (
 ) {
   const strippedLintArgs = fix ? stripLintFixAggregateArgs(args) : args;
   if (fix && !shouldForceAggregateLintFix(args) && isUnscopedInvocation(strippedLintArgs)) {
-    const files = yield* collectExistingWorkingTreeChangedFiles(repoRoot);
+    const files = yield* collectExistingWorkingTreeChangedFiles(repoRoot).pipe(Effect.map(biomeFixChangedFiles));
     if (A.isReadonlyArrayEmpty(files)) {
-      yield* Console.log("[beep-cli] lint:fix: no changed files");
+      yield* Console.log("[beep-cli] lint:fix: no Biome-processable changed files");
       return;
     }
 
@@ -1505,6 +1524,22 @@ export const runQualityTaskStepGroupForTesting = runStepGroup;
  * @since 0.0.0
  */
 export const collectLintFixChangedFilesForTesting = collectExistingWorkingTreeChangedFiles;
+
+/**
+ * Filter changed files to the suffixes handled by the root Biome fix fast path.
+ *
+ * @param files - Changed file paths collected from Git.
+ * @returns Files that should be passed to Biome.
+ * @example
+ * ```ts
+ * import { biomeFixChangedFilesForTesting } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(biomeFixChangedFilesForTesting(["AGENTS.md", "src/index.ts"]))
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+export const biomeFixChangedFilesForTesting = biomeFixChangedFiles;
 
 /**
  * Build the root lint fix changed-file step. Exposed for focused unit tests.

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -45,20 +45,7 @@ const LINT_POLICY_GROUP_CONCURRENCY = 3;
 const GROUPED_STEP_OUTPUT_MAX_CHARS = 256 * 1024;
 const CHANGED_PATH_DIFF_FILTER = ["A", "C", "M", "R", "T", "U", "X", "B"].join("");
 const LOCAL_BIOME_BIN = "./node_modules/.bin/biome";
-const BIOME_FIX_CHANGED_ARGS = ["check", "--write", "--files-ignore-unknown=true"] as const;
-const BIOME_FIX_CHANGED_FILE_SUFFIXES = [
-  ".cjs",
-  ".css",
-  ".cts",
-  ".js",
-  ".json",
-  ".jsonc",
-  ".jsx",
-  ".mjs",
-  ".mts",
-  ".ts",
-  ".tsx",
-] as const;
+const BIOME_FIX_CHANGED_ARGS = ["check", "--write", "--files-ignore-unknown=true", "--no-errors-on-unmatched"] as const;
 const LINT_FIX_AGGREGATE_ARGS = ["--full", "--repo"] as const;
 const ROOT_TURBO_CONCURRENCY_ARG = "--concurrency=3";
 const QUALITY_TASK_BYPASS_ARG_NAMES = ["--completions", "--help", "--log-level", "--version", "-h", "-v"] as const;
@@ -657,12 +644,6 @@ const collectExistingWorkingTreeChangedFiles = Effect.fn("QualityTasks.collectEx
   }
 );
 
-const isBiomeFixChangedFile = (file: string): boolean =>
-  A.some(BIOME_FIX_CHANGED_FILE_SUFFIXES, (suffix) => Str.endsWith(suffix)(file));
-
-const biomeFixChangedFiles = (files: ReadonlyArray<string>): ReadonlyArray<string> =>
-  pipe(files, A.filter(isBiomeFixChangedFile));
-
 const lintFixChangedStep = (repoRoot: string, files: ReadonlyArray<string>) =>
   QualityTaskStep.make({
     label: "lint:fix:changed",
@@ -1200,9 +1181,9 @@ const runRootLintTask = Effect.fn("QualityTasks.runRootLintTask")(function* (
 ) {
   const strippedLintArgs = fix ? stripLintFixAggregateArgs(args) : args;
   if (fix && !shouldForceAggregateLintFix(args) && isUnscopedInvocation(strippedLintArgs)) {
-    const files = yield* collectExistingWorkingTreeChangedFiles(repoRoot).pipe(Effect.map(biomeFixChangedFiles));
+    const files = yield* collectExistingWorkingTreeChangedFiles(repoRoot);
     if (A.isReadonlyArrayEmpty(files)) {
-      yield* Console.log("[beep-cli] lint:fix: no Biome-processable changed files");
+      yield* Console.log("[beep-cli] lint:fix: no changed files");
       return;
     }
 
@@ -1524,22 +1505,6 @@ export const runQualityTaskStepGroupForTesting = runStepGroup;
  * @since 0.0.0
  */
 export const collectLintFixChangedFilesForTesting = collectExistingWorkingTreeChangedFiles;
-
-/**
- * Filter changed files to the suffixes handled by the root Biome fix fast path.
- *
- * @param files - Changed file paths collected from Git.
- * @returns Files that should be passed to Biome.
- * @example
- * ```ts
- * import { biomeFixChangedFilesForTesting } from "@beep/repo-cli/test/Quality"
- *
- * console.log(biomeFixChangedFilesForTesting(["AGENTS.md", "src/index.ts"]))
- * ```
- * @category utilities
- * @since 0.0.0
- */
-export const biomeFixChangedFilesForTesting = biomeFixChangedFiles;
 
 /**
  * Build the root lint fix changed-file step. Exposed for focused unit tests.

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -1,5 +1,4 @@
 import {
-  biomeFixChangedFilesForTesting,
   collectEffectTsgoDiagnosticLines,
   lintFixChangedStepForTesting,
   parseQualityTaskInvocation,
@@ -313,23 +312,33 @@ describe("quality task adapter", () => {
     expect(step).toMatchObject({
       label: "lint:fix:changed",
       command: "./node_modules/.bin/biome",
-      args: ["check", "--write", "--files-ignore-unknown=true", "packages/example/src/index.ts"],
+      args: [
+        "check",
+        "--write",
+        "--files-ignore-unknown=true",
+        "--no-errors-on-unmatched",
+        "packages/example/src/index.ts",
+      ],
       cwd: "/repo",
     });
   });
 
-  it("drops non-Biome files from the changed-file lint fix fast path", () => {
-    expect(
-      biomeFixChangedFilesForTesting([
-        ".claude/skills/yeet/SKILL.md",
-        "AGENTS.md",
-        "CLAUDE.md",
-        "package.json",
-        "packages/example/src/index.ts",
-        "packages/example/src/worker.mts",
-        "packages/tooling/tool/cli/README.md",
-      ])
-    ).toEqual(["package.json", "packages/example/src/index.ts", "packages/example/src/worker.mts"]);
+  it("lets Biome own changed-file matching in the lint fix fast path", () => {
+    const step = lintFixChangedStepForTesting("/repo", [
+      ".claude/skills/yeet/SKILL.md",
+      "packages/example/src/index.ts",
+      "schema/example.graphql",
+    ]);
+
+    expect(step.args).toEqual([
+      "check",
+      "--write",
+      "--files-ignore-unknown=true",
+      "--no-errors-on-unmatched",
+      ".claude/skills/yeet/SKILL.md",
+      "packages/example/src/index.ts",
+      "schema/example.graphql",
+    ]);
   });
 
   it("runs combined root coverage tasks in report-only mode", () => {

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -1,4 +1,5 @@
 import {
+  biomeFixChangedFilesForTesting,
   collectEffectTsgoDiagnosticLines,
   lintFixChangedStepForTesting,
   parseQualityTaskInvocation,
@@ -315,6 +316,20 @@ describe("quality task adapter", () => {
       args: ["check", "--write", "--files-ignore-unknown=true", "packages/example/src/index.ts"],
       cwd: "/repo",
     });
+  });
+
+  it("drops non-Biome files from the changed-file lint fix fast path", () => {
+    expect(
+      biomeFixChangedFilesForTesting([
+        ".claude/skills/yeet/SKILL.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "package.json",
+        "packages/example/src/index.ts",
+        "packages/example/src/worker.mts",
+        "packages/tooling/tool/cli/README.md",
+      ])
+    ).toEqual(["package.json", "packages/example/src/index.ts", "packages/example/src/worker.mts"]);
   });
 
   it("runs combined root coverage tasks in report-only mode", () => {


### PR DESCRIPTION
## Summary

- add a repo-local `yeet` skill for the canonical End-to-End Green operator workflow
- update live agent guidance in `AGENTS.md` and `CLAUDE.md` to route agents through Yeet by default
- update repo-cli docs for Yeet repair/verify/publish/monitor and fix docs-only `lint:fix` so Yeet repair does not fail when changed files are Markdown-only

## Validation

- `bun run beep yeet --help`
- `bun run beep yeet repair --plan --json`
- `bun run beep yeet verify --plan --json`
- `bun run beep yeet publish --message "docs(repo): make yeet canonical quality path" --plan --json`
- `git diff --check -- AGENTS.md CLAUDE.md .claude/skills/yeet packages/tooling/tool/cli/README.md`
- `bun run lint:fix`
- `bun run test -- --filter=@beep/repo-cli -- quality-tasks` (unit test passed; wrapper type-test forwarded `quality-tasks` to TSTyche and failed because no dtslint files matched that path)

## Publish Note

Committed and pushed with `--no-verify` per request so CI/review can start in parallel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Yeet workflow guide with step-by-step operator procedures, command examples, and clarified "fast + monitor" as an opt-in, PR-branch–guarded path; preserved the documented local fallback path.
  * Clarified repository-quality operation guidance across docs and README examples.

* **Improvements**
  * Lint/repair invocation now tolerates non-source/unknown paths to avoid failures on mixed file sets.

* **Tests**
  * Expanded unit coverage for the changed-file lint-fix fast path to include mixed file types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->