### PR TITLE
fix(repo-cli): address PR #228 review + docgen

### DIFF
--- a/packages/tooling/tool/cli/.beep/repo-exports/catalog.shard.jsonc
+++ b/packages/tooling/tool/cli/.beep/repo-exports/catalog.shard.jsonc
@@ -13,7 +13,7 @@
   },
   "fingerprint": {
     "algorithm": "sha256",
-    "digest": "2d7323755f94c9c922d4f8c848a5c4d91e1b7aef175115211f981f3858a704b9",
+    "digest": "945537f9daa53a2fc53c287824e27b6f0a333e2882b4187a9fbad19b01a0a224",
     "inputs": [
       {
         "path": "generator:repo-exports-catalog",
@@ -402,8 +402,8 @@
       },
       {
         "path": "packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts",
-        "sha256": "88e7f8fd362ecc2391e46fb19901afbad6cdd9d7cc600ff5496d15eb0b45f3ee",
-        "bytes": 11000
+        "sha256": "a9665e64cab16e131b06259c6f2b426d6baadea6e8e58521eb66d41db6ab3595",
+        "bytes": 10746
       },
       {
         "path": "packages/tooling/tool/cli/src/commands/Lint/SchemaFirst.ts",
@@ -27320,7 +27320,7 @@
         "symbolName": "lintReflectionArtifactsCommand",
         "exportKind": "const",
         "sourcePath": "packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts",
-        "sourceLine": 318,
+        "sourceLine": 309,
         "summary": "`bun run beep lint reflection-artifacts` — enforce closeout reflections.",
         "categories": [
           "commands"
@@ -27345,7 +27345,7 @@
         "symbolName": "ReflectionFinding",
         "exportKind": "namespace",
         "sourcePath": "packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts",
-        "sourceLine": 104,
+        "sourceLine": 105,
         "summary": "Namespace for {@link ReflectionFinding} companion types.",
         "categories": [
           "models"
@@ -27370,7 +27370,7 @@
         "symbolName": "runReflectionArtifactLint",
         "exportKind": "const",
         "sourcePath": "packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts",
-        "sourceLine": 218,
+        "sourceLine": 221,
         "summary": "Verifies completed goal packets carry a schema-valid closeout reflection.",
         "categories": [
           "commands"

--- a/packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts
+++ b/packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts
@@ -13,10 +13,11 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { decodeYamlTextAs, LiteralKit } from "@beep/schema";
 import { A, thunkEmptyStr } from "@beep/utils";
-import { Console, Effect, FileSystem, Path, SchemaGetter } from "effect";
+import { Console, Effect, FileSystem, Path, pipe, SchemaGetter } from "effect";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { Command } from "effect/unstable/cli";
 import { parse } from "jsonc-parser";
 import { failWithReportedExit } from "../../internal/cli/ExitCodeError.js";
@@ -153,16 +154,18 @@ const logPolicyFinding = Effect.fn("logReflectionFinding")(function* (finding: R
 
 const decodeFrontmatter = decodeYamlTextAs(ReflectionFrontmatter);
 
+const normalizeFrontmatterNewlines = Str.replace(/\r\n/g, "\n");
+
 const extractFrontmatter = (raw: string): O.Option<string> => {
-  if (!raw.startsWith("---")) {
+  const normalized = normalizeFrontmatterNewlines(raw);
+  if (!Str.startsWith("---")(normalized)) {
     return O.none();
   }
-  const rest = raw.slice(3);
-  const endIndex = rest.indexOf("\n---");
-  if (endIndex < 0) {
-    return O.none();
-  }
-  return O.some(rest.slice(0, endIndex).trim());
+  const rest = Str.slice(3)(normalized);
+  return pipe(
+    Str.indexOf("\n---")(rest),
+    O.map((endIndex) => Str.trim(Str.slice(0, endIndex)(rest)))
+  );
 };
 
 const frontmatterIsValid = (raw: string): Effect.Effect<boolean> =>
@@ -258,13 +261,10 @@ export const runReflectionArtifactLint = Effect.fn(function* () {
       continue;
     }
 
-    let anyValid = false;
     for (const file of reflectionFiles) {
       const raw = yield* fs.readFileString(path.join(reflectionsDir, file));
       const valid = yield* frontmatterIsValid(raw);
-      if (valid) {
-        anyValid = true;
-      } else {
+      if (!valid) {
         const finding = makeFinding(
           slug,
           reflectionRequired ? "error" : "warning",
@@ -274,15 +274,6 @@ export const runReflectionArtifactLint = Effect.fn(function* () {
         );
         (reflectionRequired ? blocking : advisories).push(finding);
       }
-    }
-    if (!anyValid && reflectionFiles.length > 0) {
-      const finding = makeFinding(
-        slug,
-        reflectionRequired ? "error" : "warning",
-        `Completed goal "${slug}" has reflection files but none validate against ReflectionFrontmatter.`,
-        REMEDIATION
-      );
-      (reflectionRequired ? blocking : advisories).push(finding);
     }
   }
 

--- a/packages/tooling/tool/cli/test/reflection-lint.test.ts
+++ b/packages/tooling/tool/cli/test/reflection-lint.test.ts
@@ -3,6 +3,7 @@ import { FsUtilsLive } from "@beep/repo-utils/FsUtils";
 import { NodeServices } from "@effect/platform-node";
 import { Cause, Effect, Exit, FileSystem, Layer, Path, Runtime } from "effect";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { Command } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
 
@@ -41,7 +42,7 @@ const withTempWorkingDirectory = <A, E, R>(use: Effect.Effect<A, E, R>) =>
       })
   );
 
-const writeCompletedGoal = Effect.fn("writeCompletedGoal")(function* (slug: string) {
+const writeCompletedGoal = Effect.fn("writeCompletedGoal")(function* (slug: string, reflectionRequired = true) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   yield* fs.makeDirectory(path.join("goals", slug, "ops"), { recursive: true });
@@ -50,7 +51,7 @@ const writeCompletedGoal = Effect.fn("writeCompletedGoal")(function* (slug: stri
     `${encodeJson({
       schemaVersion: "initiative-manifest/v1",
       initiative: { id: slug, title: slug, status: "completed-retained" },
-      reflectionRequired: true,
+      reflectionRequired,
     })}\n`
   );
 });
@@ -72,6 +73,8 @@ todos:
 
 # Reflection
 `;
+
+const VALID_REFLECTION_CRLF = Str.replaceAll("\n", "\r\n")(VALID_REFLECTION);
 
 const writeReflection = Effect.fn("writeReflection")(function* (slug: string, file: string, body: string) {
   const fs = yield* FileSystem.FileSystem;
@@ -113,6 +116,22 @@ describe("reflection-artifacts lint command", { concurrent: false }, () => {
   );
 
   it(
+    "accepts CRLF-delimited reflection frontmatter",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeCompletedGoal("example");
+            yield* writeReflection("example", "2026-06-09-claude.md", VALID_REFLECTION_CRLF);
+            const exit = yield* Effect.exit(runLintCommand(["reflection-artifacts"]));
+            expect(Exit.isSuccess(exit)).toBe(true);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+
+  it(
     "blocks when a reflection artifact has invalid frontmatter",
     () =>
       Effect.runPromise(
@@ -122,6 +141,37 @@ describe("reflection-artifacts lint command", { concurrent: false }, () => {
             yield* writeReflection("example", "2026-06-09-claude.md", "# no frontmatter here\n");
             const exit = yield* Effect.exit(runLintCommand(["reflection-artifacts"]));
             expectReportedFailure(exit);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+
+  it(
+    "reports advisory-only findings for completed goals without reflectionRequired",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeCompletedGoal("example", false);
+            const exit = yield* Effect.exit(runLintCommand(["reflection-artifacts"]));
+            expect(Exit.isSuccess(exit)).toBe(true);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+
+  it(
+    "passes when a completed goal without reflectionRequired has a valid reflection",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeCompletedGoal("example", false);
+            yield* writeReflection("example", "2026-06-09-claude.md", VALID_REFLECTION);
+            const exit = yield* Effect.exit(runLintCommand(["reflection-artifacts"]));
+            expect(Exit.isSuccess(exit)).toBe(true);
           })
         ).pipe(provideScopedLayer(testLayer))
       ),


### PR DESCRIPTION
## Summary
- keep completed goals without `reflectionRequired` advisory-only when reflections are absent
- accept CRLF-delimited reflection frontmatter
- refresh repo-export catalog artifacts for the repo-cli changes

## Verification
- bunx --bun vitest run packages/tooling/tool/cli/test/reflection-lint.test.ts
- bun run docgen:local
- bunx --bun biome check --write packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts packages/tooling/tool/cli/test/reflection-lint.test.ts
- bun run beep:check (in packages/tooling/tool/cli)
- bun run beep yeet verify --tier review-fix
- bun run repo-exports:catalog:check
- bun run beep yeet publish --message "fix(repo-cli): address PR #228 review + docgen"