### PR TITLE
chore(repo): restore end-to-end green quality gates

### DIFF
--- a/.changeset/pandoc-ast-table-youtube-mapping.md
+++ b/.changeset/pandoc-ast-table-youtube-mapping.md
@@ -2,9 +2,9 @@
 "@beep/pandoc-ast": patch
 ---
 
-Complete the Md→Pandoc compatibility mapping for the new `table` and `youtube`
+Complete the Md→Pandoc compatibility mapping for the new table and YouTube
 Md block variants. Md tables degrade to a paragraph capture (the v1 Pandoc-core
 profile records tables as gap nodes) and YouTube embeds project to a plain
 Pandoc link, both with recorded compatibility issues, and both render in
-plain-text extraction. Restores the `@beep/pandoc-ast` build after the
-`table`/`youtube` blocks were introduced to `@beep/md`.
+plain-text extraction. Restores the `@beep/pandoc-ast` build after the table
+and YouTube blocks were introduced to `@beep/md`.

--- a/.changeset/pandoc-ast-table-youtube-mapping.md
+++ b/.changeset/pandoc-ast-table-youtube-mapping.md
@@ -1,0 +1,10 @@
+---
+"@beep/pandoc-ast": patch
+---
+
+Complete the Md→Pandoc compatibility mapping for the new `table` and `youtube`
+Md block variants. Md tables degrade to a paragraph capture (the v1 Pandoc-core
+profile records tables as gap nodes) and YouTube embeds project to a plain
+Pandoc link, both with recorded compatibility issues, and both render in
+plain-text extraction. Restores the `@beep/pandoc-ast` build after the
+`table`/`youtube` blocks were introduced to `@beep/md`.

--- a/_typos.toml
+++ b/_typos.toml
@@ -59,6 +59,9 @@ odf = "odf"
 opf = "opf"
 vor = "vor"
 
+# 3D / Three.js material API names (not typos)
+metalness = "metalness"
+
 [files]
 extend-exclude = [
   # Exploration capture files are verbatim, append-only human dumps

--- a/apps/professional-desktop/.beep/repo-exports/catalog.shard.jsonc
+++ b/apps/professional-desktop/.beep/repo-exports/catalog.shard.jsonc
@@ -13,7 +13,7 @@
   },
   "fingerprint": {
     "algorithm": "sha256",
-    "digest": "3a7e4d84a56350670351a5c3d774eb1f9a503ad18d9660ca393edca05db2f37c",
+    "digest": "dfe0475e9bb116ba0a46297f8db540dec1e347652f44aa02c401007aa97bb34e",
     "inputs": [
       {
         "path": "apps/professional-desktop/package.json",
@@ -82,8 +82,8 @@
       },
       {
         "path": "apps/professional-desktop/src/runtime/Observability.ts",
-        "sha256": "993c0d4d243fcba654a0ab9a75a848dd53db5a90b378063c5d707bdca328dec3",
-        "bytes": 3640
+        "sha256": "495efc022ae1921d0279bce7a14f8e07101c894ce236bcec7d5e7bb956547c30",
+        "bytes": 3661
       },
       {
         "path": "apps/professional-desktop/src/runtime/Pglite.ts",

--- a/apps/professional-desktop/test/chat-contract.test.ts
+++ b/apps/professional-desktop/test/chat-contract.test.ts
@@ -11,7 +11,7 @@ import { FixtureTurnKernel, fixtureBlocksFor } from "@beep/agents-use-cases/proo
 import { AgentTurnKernel, TurnHistoryItem } from "@beep/agents-use-cases/public";
 import * as Md from "@beep/md/Md.model";
 import * as WorkspaceIdentity from "@beep/shared-domain/identity/Workspace";
-import { provideScopedLayer } from "@beep/test-utils";
+import { assertSchemaArbitraryDecodesToSelf, provideScopedLayer } from "@beep/test-utils";
 import { ThreadStoreInMemoryLayer } from "@beep/workspace-server/aggregates/Thread";
 import { Thread } from "@beep/workspace-use-cases/server";
 import { describe, expect, it } from "@effect/vitest";
@@ -329,4 +329,8 @@ describe("@beep/professional-desktop chat contract", () => {
       expect(decodedHistory).toStrictEqual(history);
     })
   );
+
+  it("round-trips schema-derived turn history items through the wire contract", () => {
+    assertSchemaArbitraryDecodesToSelf(TurnHistoryItem, { numRuns: 25 });
+  });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -245,6 +245,7 @@
       },
       "devDependencies": {
         "@beep/test-utils": "workspace:^",
+        "@effect/platform-node": "catalog:",
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
       },

--- a/cspell.json
+++ b/cspell.json
@@ -60,6 +60,7 @@
     "bun.lock",
     "patches/**",
     "_typos.toml",
+    "osv-scanner.toml",
     "node_modules",
     ".repos",
     "*.snap",

--- a/docs/BEEPGRAPH_ARCHITECTURE.md
+++ b/docs/BEEPGRAPH_ARCHITECTURE.md
@@ -1,0 +1,326 @@
+# BeepGraph Architecture — effect-ontology vs TrustGraph, and the synthesis
+
+> **Type**: Architecture decision (decision-grade synthesis)
+> **Status**: Proposed — sharpens the 2026-05-12 "Context Graph Capability Portfolio" decision
+> **Date**: 2026-06-15
+> **Supersedes**: the "BeepGraph (Effect-native TrustGraph rewrite)" framing in
+> `standards/memory-architecture/01-memory-layer-taxonomy.md:105`
+> **Evidence base**: `~/YeeBois/dev/effect-ontology/packages/@core-v2/docs/ontology_research/trustgraph_comparison_research.md`
+
+---
+
+## 1. Executive verdict
+
+**For beep-effect's knowledge-graph / ontology spine, adopt the *effect-ontology*-style
+architecture as the AUTHORITY SPINE, wrapped by a *TrustGraph*-style PROJECTION + RETRIEVAL
+shell. The synthesis is named *BeepGraph*.**
+
+- **effect-ontology (EO) wins the spine** — Effect-native, schema-first *typed* authority,
+  ontology-*guided* extraction, evidence/provenance, monoid-fold merge, SHACL validation, a
+  single durable in-repo app. That is beep-effect's DNA. TrustGraph is schema-light Python
+  pub/sub microservices over external graph DBs — the opposite of local-first typed authority.
+- **TrustGraph (TG) wins the shell** — pluggable graph **projection** (FalkorDB/Cypher),
+  **GraphRAG** subgraph retrieval + **explainability DAG**, graph-vs-document embeddings,
+  portable **Knowledge Cores**, and the **Librarian** curated-doc/processing-queue. EO has no
+  external store (in-memory N3 only) and a thinner retrieval/packaging story; TG fills exactly
+  that gap.
+- **One-liner:** *EO is the spine; TG is the shell.* BeepGraph = an EO-style typed,
+  ontology-guided, provenance-first extraction core whose accepted output is **projected** into
+  a TG-style FalkorDB graph + GraphRAG retrieval, with vectors/semantic memory as a **managed
+  cache** — never as authority.
+
+This is not a reversal of the 2026-05-12 decision; it **sharpens** it. That decision said
+"TrustGraph for design influence, Effect Schema for authority, FalkorDB projection." The
+sharpening is naming the authority spine's *exemplar*: it is **effect-ontology** (an
+Effect-native typed ontology-guided extraction pipeline), not raw TrustGraph. So "BeepGraph =
+Effect-native TrustGraph rewrite" understates the EO-style typed core — BeepGraph is the **EO
+spine + TG shell**.
+
+---
+
+## 2. Context & the question
+
+beep-effect has three goal packets that all need knowledge-graph machinery, but at different
+altitudes:
+
+- **`goals/agentic-professional-runtime`** — the durable product spine. Doctrine: *claim +
+  evidence + provenance + lifecycle is the authoritative memory primitive; graph views are
+  rebuildable projections* (`SPEC.md`).
+- **`goals/ip-law-knowledge-graph`** — a typed, OWL-grounded IP-law graph (7 published
+  ontologies → Effect Schema → FalkorDB/Cypher). Carries an **unresolved P0**: *is FalkorDB a
+  second source of truth, or a projection?* (`research/ontology-grounding-corpus.md:29-39`).
+- **`goals/oppold-corpus-pipeline`** — completed batch salvage (8,438 files → DuckDB catalog +
+  `@beep/file-processing` manifests) that **feeds** the other two.
+
+And the user's `standards/memory-architecture/` vision frames all of it: the **No-Escape
+Theorem** (semantic memory degrades at scale; deterministic layers are the foundation, semantic
+memory is a *managed cache*), a **four-layer taxonomy**, and the **authority / projection /
+cache** discipline.
+
+The question this doc answers: *between the two reference architectures I compared
+(effect-ontology and TrustGraph), which is the better spine for beep-effect — and what do we
+graft from each?* The user asked for **one** choice, plus the cherry-picks.
+
+> A full concept-by-concept comparison of the two reference systems lives at
+> `~/YeeBois/dev/effect-ontology/packages/@core-v2/docs/ontology_research/trustgraph_comparison_research.md`.
+> This doc does not repeat it; it *decides* against it.
+
+---
+
+## 3. The two architectures in one frame
+
+| Axis | effect-ontology (EO) | TrustGraph (TG-Py / TG-TS) |
+|------|----------------------|----------------------------|
+| Core | Single durable Effect app | Distributed pub/sub microservices (Pulsar / NATS) |
+| Authority altitude | **Typed** `Entity`/`Relation`, ontology-guided | Raw `Triple(s,p,o,g)`, schema-light |
+| Ontology | OWL-2 reasoning + SHACL | schema.org + SKOS, no reasoning |
+| Store | **In-memory N3 only** (+ Oxigraph SPARQL); pgvector for embeddings | **External graph DBs** (Cassandra/Neo4j/Memgraph/FalkorDB; TS: FalkorDB) + vector DBs |
+| Extraction | One ontology-guided pipeline + **monoid-fold** merge | Discrete processors (`kg-extract-*`) emitting triples |
+| Retrieval | GraphRAG (in-memory) | GraphRAG + **explainability DAG**, graph-vs-doc embeddings |
+| Packaging | (none) | **Knowledge Cores**; **Librarian** curated-doc + processing queue |
+| Runtime | Effect Service/Layer/Stream/Workflow | FlowProcessor + message bus |
+
+EO's strength is the **typed, provenance-first, ontology-guided extraction core**. TG's strength
+is the **multi-store projection, retrieval, and packaging shell**. They are complementary, not
+competing — which is exactly why the verdict is "spine from one, shell from the other."
+
+---
+
+## 4. Decision criteria — beep-effect's non-negotiables
+
+These are not invented for this doc; they are already binding in beep-effect's standards and
+packets. The spine must satisfy them.
+
+1. **Authority is typed, schema-first, evidence-backed, replayable.** Durable truth is
+   repo-native Effect Schema claims with source spans, provenance, and an event log
+   (`standards/memory-architecture/05-context-graph-capability-assessment.md`;
+   `agentic-professional-runtime/SPEC.md`).
+2. **Authority / projection / cache discipline.** Graph stores are *projections*; GraphRAG /
+   OntologyRAG / vectors are *candidate producers / managed caches*; they never become
+   source-of-truth (`04-decision-log.md:18-31`, `54-56`).
+3. **No-Escape Theorem.** Semantic retrieval degrades at scale → deterministic layers are the
+   foundation; semantic memory is a bounded, managed cache (`00-no-escape-theorem.md`).
+4. **Four-layer taxonomy.** L1 durable · L2 session · L3 procedural · L4 relational
+   (`01-memory-layer-taxonomy.md`).
+5. **Local-first, single-app.** No required message broker, no Cassandra; SQLite/Postgres-local
+   first (`trustgraph-port/SPEC.md` "intentionally not ported: gateway/flow topology, Cassandra").
+6. **OWL is design-time only; runtime validation is bounded SHACL.** *No OWL reasoner in the
+   runtime dependency graph* (`ip-law-knowledge-graph/SPEC.md` ADR; `@beep/semantic-web`
+   ships `BoundedShaclValidationService`, not a full reasoner).
+7. **Effect Schema is the typed authority; ontology is annotation + projection.** *Effect Schema
+   classes remain the source of truth; ontology metadata is stored in schema annotations;
+   projections (JSON-LD, Turtle) are derived* (`ontology-modeling-foundation/SPEC.md:10-11`).
+
+---
+
+## 5. Verdict, criterion by criterion
+
+| Criterion | EO-as-spine | TG-as-spine | Spine winner |
+|-----------|-------------|-------------|--------------|
+| 1. Typed schema-first authority | Typed `Entity`/`Relation`, `Schema.Class` | Raw schema-light triples | **EO** |
+| 2. Authority/projection/cache fit | Extraction core = authority; store is incidental | Store *is* the system; authority is the graph DB | **EO** (clean authority separation) |
+| 3. No-Escape alignment | Deterministic ontology-guided extraction + SHACL gate | Semantic triples into a store; weaker determinism story | **EO** |
+| 4. Layer fit | Slots as L4 relational atop L1 claims | Whole-system; doesn't decompose into the layers | **EO** |
+| 5. Local-first single-app | One Effect app, in-process | Requires broker + external stores | **EO** |
+| 6. OWL design-time + bounded SHACL | Has SHACL; OWL reasoning is *adaptable down* to design-time | No OWL/SHACL at all | **EO** |
+| 7. Effect Schema authority + projections | Effect-native, schema-first | Python dataclasses / `S.Struct` triples, no typed authority | **EO** |
+| **Projection: pluggable graph store** | In-memory N3 only (gap) | FalkorDB/Cypher, 4 backends | **TG** |
+| **Retrieval: GraphRAG + explainability** | GraphRAG in-memory, thinner | GraphRAG + explainability DAG, graph/doc embeddings | **TG** |
+| **Packaging / ingestion** | none | Knowledge Cores, Librarian curated-doc + queue | **TG** |
+
+**Read-out:** EO wins all seven *authority* criteria; TG wins the three *projection / retrieval
+/ packaging* dimensions where EO is silent. Hence **EO is the spine, TG is the shell**.
+
+---
+
+## 6. Cherry-pick — what to take from each (mapped to authority / projection / cache)
+
+### Take from effect-ontology → **authority spine**
+
+| Pattern | EO source | Role in BeepGraph |
+|---------|-----------|-------------------|
+| Ontology-*guided* extraction (class hierarchy → allowed types → scoped predicates) | `Workflow/StreamingExtraction.ts`, `Domain/Model/Ontology.ts` | Candidate producer constrained by `@beep/ontology` types |
+| Typed `Entity`/`Relation` (not raw triples) | `Domain/Model/Entity.ts` | Authority shape over Effect Schema |
+| **Monoid-fold merge** (associative, identity = empty graph) | `Workflow/Merge.ts:161` | Deterministic, order-independent claim/graph reduction |
+| Evidence spans + provenance | `Domain/Model/Entity.ts` (`EvidenceSpan`), `claims#` ns | Maps to `@beep/epistemic-domain` Evidence + PROV-O |
+| **SHACL validation** | `Service/Shacl.ts` | Already mirrored by `@beep/semantic-web` bounded SHACL |
+| Entity resolution (mention → canonical) | `Domain/Model/EntityResolution.ts` | Candidate de-dup before acceptance |
+| *(optional)* executable SPARQL over a materialized store (Oxigraph) | `Service/Sparql.ts` | **Deferred** — beep currently chooses Cypher (ADR-005), no SPARQL runtime |
+
+### Take from TrustGraph → **projection + cache shell**
+
+| Pattern | TG source | Role in BeepGraph |
+|---------|-----------|-------------------|
+| Pluggable graph **projection** (FalkorDB/Cypher) | TG-TS `ts/packages/flow/src/storage/triples/falkordb.ts` | The ip-law-KG FalkorDB read-model |
+| **GraphRAG** subgraph retrieval + tuning limits | TG-TS `ts/packages/flow/src/retrieval/graph-rag.ts` | L4 retrieval over the projection |
+| **Explainability DAG** (`explain_graph`/`explain_triples`) | TG-Py `trustgraph-base/.../base/graph_rag_client.py` | Audit-grade "why this answer" for regulated legal work |
+| Graph-vs-document embeddings (separated) | TG-Py `.../storage/graph_embeddings/*` | pgvector cache (graph entity vs chunk) |
+| **Knowledge Cores** (portable triples+embeddings bundle) | TG-TS `ts/packages/flow/src/cores/service.ts` | Portable, loadable domain-KG snapshots |
+| **Librarian** curated-doc library + processing queue | TG-TS `ts/packages/flow/src/librarian/service.ts` | Already the target of `goals/trustgraph-port` Phase 1 |
+| Multi-store decomposition (relational / vector / graph) | TG storage adapters | The authority / projection / cache split itself |
+
+### Leave from effect-ontology
+
+- **In-memory N3 as store-of-record** — beep uses EventLog authority + FalkorDB projection.
+- **OWL-as-runtime-authority / live reasoner** — beep keeps OWL *design-time only*; Effect
+  Schema is the typed authority (criterion 6–7). EO's `getAllSuperClasses`/`owl:imports`
+  reasoning is a *design-time* aid, not a runtime dependency.
+
+### Leave from TrustGraph
+
+- **Pub/sub topology + FlowProcessor mesh** (`trustgraph-port/SPEC.md` "intentionally not
+  ported").
+- **Cassandra / external object-store assumptions.**
+- **Schema-light triples as authority** — the single biggest mismatch with beep's typed-authority rule.
+- **Python microservice runtime.**
+
+---
+
+## 7. BeepGraph, defined (canonical)
+
+> **BeepGraph** is beep-effect's knowledge-graph architecture: an **effect-ontology-style typed,
+> ontology-guided, provenance-first extraction spine** whose *accepted* output is **projected**
+> into a **TrustGraph-style FalkorDB graph + GraphRAG retrieval shell**, with vector/semantic
+> memory as a **managed cache**. It is governed by the authority / projection / cache discipline
+> and the No-Escape Theorem.
+
+| Tier | What | beep-effect home |
+|------|------|------------------|
+| **Authority** (spine) | Effect Schema claims + evidence + provenance + lifecycle; ontology-guided extraction emits *candidates*; SHACL gate; monoid-fold merge; EventLog mutation history | `@beep/epistemic-domain`, `@beep/ontology` (specced), `@beep/semantic-web` (PROV-O + bounded SHACL), `@beep/rdf`, EventLog (`knowledge-workspace/00-event-sourced-graph.md`) |
+| **Projection** (read model) | FalkorDB graph (Cypher), GraphRAG subgraph + explainability DAG — **rebuildable** from authority | `ip-law-knowledge-graph` (FalkorDB), `knowledge-workspace` graph projection |
+| **Cache** (candidates) | Graph/doc embeddings, semantic + temporal (Graphiti-style) memory — TTL'd, pruned, **candidates only** | pgvector (`docker-compose.yml` `pgvector/pgvector:pg17`, currently unused) |
+
+**This supersedes** `01-memory-layer-taxonomy.md:105` ("BeepGraph (Effect-native TrustGraph
+rewrite)... port the provenance and verification layers"). The sharpening: BeepGraph's spine
+exemplar is **effect-ontology**, not raw TrustGraph; TrustGraph contributes the **shell**
+(projection + retrieval + packaging), and its provenance/explainability ideas live in the
+projection's audit trail rather than defining the core.
+
+---
+
+## 8. Per-memory-layer placement (L1–L4)
+
+| Layer | Theorem status | What lands here | Source of pattern |
+|-------|----------------|-----------------|-------------------|
+| **L1 — Durable** | Outside | Curated docs + `@beep/epistemic-domain` accepted claims/evidence (authority) | EO (typed claims) + files |
+| **L2 — Session** | Inside (managed) | Bi-temporal session cache, consolidation/pruning | Graphiti-style; TG GraphRAG cache |
+| **L3 — Procedural** | Outside | Deterministic AST/JSDoc capability graph — the competitive edge | beep `EffectCapabilityKG.ts` (done) |
+| **L4 — Relational** | Inside (managed) | **BeepGraph**: EO extraction spine → FalkorDB projection + GraphRAG | EO spine + TG shell |
+
+The verdict only governs **L4** (and the authority that feeds it). L1/L3 are already settled and
+sit *outside* the theorem; L2 stays a bounded cache. BeepGraph is the L4 relational layer, and
+its discipline (candidates → SHACL → accepted → projected) is what keeps L4's inevitable
+semantic degradation *managed* rather than load-bearing.
+
+---
+
+## 9. Per-packet architecture calls
+
+### `ip-law-knowledge-graph` — resolves the open P0
+
+**Call: FalkorDB is a PROJECTION (rebuildable read model), not a second source of truth.**
+
+This resolves the P0 flagged in `research/ontology-grounding-corpus.md:29-39` in favor of the
+runtime doctrine. Concretely:
+
+- The 7 OWL ontologies (LKIF-Core, IPRonto/ALIS, Copyright Ontology, JudO, LCBR, ESTRELLA, WIPO
+  IPC; plus FOLIO as backbone) are **design-time grounding** → `@beep/ontology` Effect-Schema
+  typed authority with ontology annotations (`ontology-modeling-foundation/SPEC.md:10-11`).
+- LLM extraction (EO-style, ontology-guided) emits **candidate** nodes/edges with evidence spans.
+- **Bounded SHACL** validates shape; accepted claims land in the epistemic authority.
+- FalkorDB (ADR-002) + Cypher (ADR-005, *no SPARQL runtime*) is the **projection** rebuilt from
+  accepted claims for sub-graph/path traversal. No change to ADR-002/005 is required — only the
+  classification: the store is downstream of authority, not parallel to it.
+
+### `agentic-professional-runtime`
+
+**Call: unchanged and reinforced.** Claim + evidence + provenance + lifecycle authority
+(`@beep/epistemic-domain` + EventLog). The EO-style extraction kernel runs as a **candidate
+producer**; human/policy approval gates promote candidates to authoritative state; all graph
+views (BeepGraph projection) are rebuildable. v1 stays deterministic-fixture-driven. BeepGraph is
+the runtime's L4 recall surface, fed by — never ahead of — accepted claims.
+
+### `oppold-corpus-pipeline`
+
+**Call: feeder, no KG of its own.** The completed DuckDB catalog + `@beep/file-processing`
+manifests are the **ingestion source** for the runtime's corpus lane → EO-style extraction →
+candidate claims → (on acceptance) BeepGraph projection. It contributes corpus + provenance, not
+graph authority.
+
+---
+
+## 10. Have vs build (mapping the cherry-picks to beep-effect)
+
+| BeepGraph need | Status in beep-effect | Path |
+|----------------|-----------------------|------|
+| RDF value models (IRI/Quad/Dataset, OWL/PROV vocab) | **Live** | `packages/foundation/modeling/rdf/src/Rdf.ts`, `Vocab/Owl.ts` |
+| PROV-O provenance + bounded SHACL | **Live** | `packages/foundation/capability/semantic-web/src/prov.ts`, `adapters/shacl-engine.ts` |
+| Epistemic authority (claims/evidence/lifecycle) | **Live (domain only)** | `packages/epistemic/domain/src/entities/{CandidateClaim,Evidence,Activity}`, `values/ClaimLifecycle` |
+| Deterministic L3 capability graph | **Live (complete)** | `packages/tooling/library/repo-utils/src/EffectCapabilityKG.ts` |
+| Ontology authoring over Effect Schema → JSON-LD/Turtle | **Specced, blocked** | `goals/ontology-modeling-foundation/SPEC.md` (`@beep/ontology`, retired) |
+| EventLog → graph projection | **Specced** | `goals/knowledge-workspace/00-event-sourced-graph.md` |
+| Curated-doc library + processing queue + grounded retrieval | **Specced** | `goals/trustgraph-port/{SPEC,PLAN}.md` → `packages/repo-memory` |
+| FalkorDB projection + Cypher | **Specced** | `goals/ip-law-knowledge-graph/SPEC.md` (ADR-002/005) |
+| GraphRAG + explainability DAG; Knowledge Cores; graph/doc embeddings | **Net-new (graft from TG)** | pgvector available (`docker-compose.yml`), unused |
+| EO-style ontology-guided extraction + monoid-fold merge | **Net-new (graft from EO)** | pattern bridge cited in `ip-law-knowledge-graph/research/ontology-grounding-corpus.md:13` |
+
+Net: the **authority spine is largely already built**; the **projection/retrieval shell** (TG
+grafts) and the **extraction kernel** (EO graft) are the principal net-new work, and both already
+have homes (`trustgraph-port`, `ip-law-knowledge-graph`, `knowledge-workspace`).
+
+---
+
+## 11. Proposed decision-log entry
+
+> Paste into `standards/memory-architecture/04-decision-log.md` (above the
+> `_Future decisions should be appended above this line_` marker) when ratified. Not yet applied.
+
+```markdown
+## 2026-06-15: BeepGraph Spine — effect-ontology core, TrustGraph shell
+
+**Context:** A concept-by-concept comparison of the two reference architectures
+(effect-ontology and TrustGraph, the latter in both its Python original and full
+Effect-TS port) was run against beep-effect's three KG packets
+(agentic-professional-runtime, ip-law-knowledge-graph, oppold-corpus-pipeline) and the
+memory-architecture standard. See `docs/BEEPGRAPH_ARCHITECTURE.md`.
+
+**Decision:** BeepGraph adopts the effect-ontology-style architecture as the typed
+authority/extraction SPINE and the TrustGraph-style architecture as the projection +
+retrieval + packaging SHELL.
+
+1. Authority spine = effect-ontology-style: Effect-Schema typed claims, ontology-guided
+   extraction (candidates only), evidence/provenance, monoid-fold merge, bounded SHACL.
+2. Projection shell = TrustGraph-style: FalkorDB/Cypher graph, GraphRAG + explainability
+   DAG, Knowledge Cores, Librarian curated-doc/processing-queue — all rebuildable.
+3. Vector/semantic/temporal memory remains a managed cache (candidates only).
+4. ip-law-knowledge-graph P0 resolved: FalkorDB is a projection, not a second source of truth.
+
+**Rationale:** beep-effect's non-negotiables (typed schema-first authority, evidence/provenance,
+local-first single-app, OWL design-time only + bounded SHACL, EventLog) are effect-ontology's
+DNA, not TrustGraph's schema-light pub/sub-over-external-stores design. TrustGraph supplies the
+multi-store projection, retrieval, and packaging that effect-ontology lacks.
+
+**Consequences:**
+- Sharpens the 2026-05-12 portfolio decision: the authority-spine exemplar is effect-ontology,
+  not raw TrustGraph.
+- Supersedes "BeepGraph = Effect-native TrustGraph rewrite" (01-memory-layer-taxonomy.md): the
+  spine is EO-style; TrustGraph contributes the shell and the projection's audit trail.
+- trustgraph-port Phase 1 (Librarian/processing/retrieval) and ip-law-knowledge-graph (FalkorDB
+  projection) proceed as shell work; @beep/ontology + EO-style extraction kernel are the spine's
+  net-new work.
+```
+
+---
+
+## 12. Appendix — evidence
+
+**Repo legend:** `beep` = `/home/elpresidank/YeeBois/projects/beep-effect/` ·
+`EO` = `~/YeeBois/dev/effect-ontology/packages/@core-v2/src/` ·
+`TG-Py` = `~/YeeBois/dev/trustgraph/` · `TG-TS` = `~/YeeBois/dev/trustgraph/ts/`
+
+- **Authority / criteria:** `beep standards/memory-architecture/{00-no-escape-theorem,01-memory-layer-taxonomy,04-decision-log,05-context-graph-capability-assessment}.md`; `beep goals/agentic-professional-runtime/SPEC.md`; `beep goals/ontology-modeling-foundation/SPEC.md:10-11`.
+- **beep live:** `beep packages/foundation/modeling/rdf/src/{Rdf.ts,Vocab/Owl.ts}`; `beep packages/foundation/capability/semantic-web/src/{prov.ts,adapters/shacl-engine.ts}`; `beep packages/epistemic/domain/src/entities/{CandidateClaim,Evidence,Activity}`, `values/ClaimLifecycle`; `beep packages/tooling/library/repo-utils/src/EffectCapabilityKG.ts`; `beep docker-compose.yml` (`pgvector/pgvector:pg17`).
+- **beep specced:** `beep goals/{trustgraph-port,knowledge-workspace,ip-law-knowledge-graph,ontology-modeling-foundation}/`.
+- **EO spine:** `EO Workflow/{StreamingExtraction.ts,Merge.ts:161}`; `EO Service/{Shacl,Sparql,GraphRAG,EntityResolution}.ts`; `EO Domain/Model/{Ontology,Entity,EntityResolution}.ts`; `EO Repository/Embedding.ts`.
+- **TG shell:** `TG-Py trustgraph-flow/trustgraph/storage/triples/{cassandra,neo4j,memgraph,falkordb}`, `trustgraph-base/trustgraph/schema/knowledge/knowledge.py`, `trustgraph-base/trustgraph/base/graph_rag_client.py`; `TG-TS ts/packages/flow/src/{storage/triples/falkordb.ts,retrieval/graph-rag.ts,cores/service.ts,librarian/service.ts}`.
+- **Full comparison:** `EO ../docs/ontology_research/trustgraph_comparison_research.md`.

--- a/docs/BEEPGRAPH_ARCHITECTURE.md
+++ b/docs/BEEPGRAPH_ARCHITECTURE.md
@@ -5,7 +5,8 @@
 > **Date**: 2026-06-15
 > **Supersedes**: the "BeepGraph (Effect-native TrustGraph rewrite)" framing in
 > `standards/memory-architecture/01-memory-layer-taxonomy.md:105`
-> **Evidence base**: `~/YeeBois/dev/effect-ontology/packages/@core-v2/docs/ontology_research/trustgraph_comparison_research.md`
+> **Evidence base**: external research notes — the effect-ontology TrustGraph
+> comparison study (maintained outside this repository; not tracked here)
 
 ---
 

--- a/docs/PROSE_TO_PROOF_ARCHITECTURE_MAP.md
+++ b/docs/PROSE_TO_PROOF_ARCHITECTURE_MAP.md
@@ -1,0 +1,148 @@
+# Prose-to-Proof — Architecture Map
+
+> How the product vision lands on real code. Every capability below points at a
+> concrete package or goal packet, with an honest **have / specced / build** status.
+> This is the bridge between the [Vision](./PROSE_TO_PROOF_VISION.md) /
+> [User Story](./PROSE_TO_PROOF_USER_STORY.md) and the engineering reality.
+>
+> It **complements, not replaces**, the existing
+> `goals/agentic-professional-runtime/docs/architecture-map.md` (slice ownership and
+> boundary rules) and `docs/BEEPGRAPH_ARCHITECTURE.md` (the authority/projection/cache
+> decision). Where they overlap, those documents win.
+
+---
+
+## 1. The shape in one picture
+
+```
+                          RETRIEVAL FAMILY                BOUNDARY               LOGIC FAMILY
+                          (proposes, fallibly)         (confidence→proof)        (proves, soundly)
+ documents ─► read+ground ──► candidates ──────────►  SHACL gate · consistency ──► proven graph ──► ask & check
+   files       @beep/md         @beep/epistemic-domain    @beep/semantic-web        @beep/rdf +          GraphRAG +
+   (canon)     @beep/pandoc-ast  CandidateClaim/Evidence   prov.ts · shacl-engine    FalkorDB (proj.)     conflict checks
+               @beep/langextract                          (the approval gate)        + reasoner
+               @beep/nlp-mcp                                                          (specced)
+                    │                                                                     ▲
+                    └───────────────── editor as portal (@beep/lexical-schema · artifact-ref) ──────────────┘
+                                              governed by the ontology TBox (§4) · everything local
+```
+
+The invariant that organizes everything: **left of the boundary nothing computes an
+entailment** (vectors + an LLM, revisable guesses); **right of it, everything does**
+(consequences true in every model). The product's job is to make the crossing honest.
+
+## 2. Capability → code map
+
+| Product capability | What it means to Tom | Carrier in the repo | Status |
+|---|---|---|---|
+| **Canonical documents** | The file is the truth; format is per-document | `@beep/md` (`packages/foundation/modeling/md`), DOCX/PDF bridge `@beep/pandoc-ast` | **Have** (core slice) |
+| **Editor as portal** | Hover Figure 1 → CAD; term → definition; party → matter | `@beep/lexical-schema` `ArtifactRefNode` (`packages/foundation/modeling/lexical/src/Lexical.model.ts`) | **Have** (primitive) |
+| **Read & ground to the exact line** | "Show me the source," highlighted | `@beep/langextract` `GroundedExtraction.span` (`…/capability/langextract/src/Extraction`) | **Have** (capability) |
+| **NLP precision (offsets, entities)** | The machinery behind span highlighting | `@beep/nlp-mcp` (42 tools, `AiToken.start/end`) over `@beep/nlp` + `@beep/wink` (`packages/drivers/nlp-mcp`) | **Have** (driver) |
+| **Typed claims + evidence + provenance** | Every fact knows what justifies it and who approved it | `@beep/epistemic-domain` — `CandidateClaim`, `Evidence`, `Activity`, `UsageRecord` (`packages/epistemic/domain/src/entities`) | **Have** (domain) |
+| **The approval gate (shape + consistency)** | A guess can't become a fact on its own | `@beep/semantic-web` — `prov.ts` (PROV-O), `adapters/shacl-engine.ts` (bounded SHACL) | **Have** (capability) |
+| **RDF substrate** | The triples the graph is made of | `@beep/rdf` — `Rdf.ts` (Quad/Dataset), `Vocab/Owl.ts` (`packages/foundation/modeling/rdf`) | **Have** (modeling) |
+| **Persisted epistemic store** | Claims/evidence survive restarts | `@beep/epistemic-tables` (Drizzle), local **PGlite** in the desktop app | **Have** (tables) |
+| **Chat / agent turns** | Ask the workbench in natural language | `@beep/agents-{domain,client,server,use-cases}`; `ChatRpcs`, `AnthropicTurnKernel`, `FixtureTurnKernel` | **Have** (today's app) |
+| **Workspace / threads / tasks / approvals** | The practice's containers and work items | `@beep/workspace-{domain,server,use-cases}`; `@beep/shared-domain` | **Have** (slices) |
+| **Law-specific overlays** | Clients, matters, IP assets, filings, docket | `@beep/law-practice` (domain; thin) + `goals/ip-law-knowledge-graph` | **Specced / partial** |
+| **Graph projection (Cypher traversal)** | Walk the practice graph fast | FalkorDB, fed from accepted claims — `goals/ip-law-knowledge-graph/SPEC.md` (ADR-002), `goals/trustgraph-port` | **Specced** |
+| **Ask & check (GraphRAG + conflicts)** | Q&A and cross-matter conflict checks | BeepGraph retrieval shell — `docs/BEEPGRAPH_ARCHITECTURE.md` | **Specced** |
+| **Reasoner (entailment)** | Compute what *follows*, soundly | OWL 2 EL/RL reasoning over the TBox (§4) | **Build** |
+| **AI librarian (ingest the corpus)** | The tireless filer | corpus lane over `goals/oppold-corpus-pipeline` output | **Build** |
+| **Sync engine + backups** | FS ↔ Box/S3/local, document-aware | per the system diagram; Box Events → ingest | **Build** |
+| **On-device embeddings** | Vectors computed locally, nothing sent out | Ollama (e.g. `mxbai-embed-large`) per the system diagram | **Build** |
+
+## 3. The four faces, mapped
+
+1. **Document portal** — `@beep/lexical-schema` (editor state + `artifact-ref`) over `@beep/md`/`@beep/pandoc-ast`; the app's `@beep/editor`. Links are subgraph edges; the editor is the window.
+2. **DMS** — canonical files on disk + sync to interchangeable backends; **identity is minted and stable**, locators (`box:fileId`, `s3:key`, `sha256`) are properties. (Sync engine = build.)
+3. **Knowledge graph** — authority in `@beep/epistemic-domain` + `@beep/semantic-web` + `@beep/rdf`; projection in FalkorDB; governed by the ontology TBox.
+4. **Ask & check** — GraphRAG over the corpus + conflict checks across walled matters; a query only one unified graph can answer.
+
+## 4. The ontology TBox (the schema that governs the graph)
+
+A layered, standards-backed stack — design-time grounding, not a live runtime authority
+(authority stays typed Effect Schema; the ontology supplies the vocabulary and the
+constraints). Each layer is a published standard so the model is defensible, not bespoke.
+
+| Layer | Standard(s) | Role | Governance note |
+|---|---|---|---|
+| Language | **OWL 2** (EL + RL profiles) | how the schema is written; EL classifies, RL materializes | W3C |
+| Upper | **BFO** | keeps the schema satisfiable; never sees a document | ISO/IEC 21838-2:2021 |
+| Document model | **FRBR / LRM / LRMoo** (WEMI) | a `.md` and a `.docx` are two *Manifestations* of one *Expression*; each copy an *Item* | IFLA |
+| Legal practice | **FOLIO** | matters, actors, document/practice vocabulary | ALEA-maintained; SALI/SOLI lineage — describe as "open, ALEA-stewarded," not an uncontested single standard |
+| Legal core | **LKIF-Core** | norms, roles, actions (legal reasoning primitives) | academic core |
+| IP rights | **IPRonto / Copyright Ontology** | patents, trademarks, designs, copyright works/rights | academic |
+| Rights / licensing | **ODRL** | who may do what with which IP under what conditions | W3C Recommendation (2018) |
+| Concepts | **SKOS** | lightweight concept schemes | W3C |
+| Patent class. | **CPC / IPC** | classification taxonomy the EL reasoner classifies over | EPO+USPTO / WIPO |
+| Provenance | **PROV-O** | the documented history of every fact | W3C Recommendation |
+| Validation | **SHACL** | the shape gate at the boundary | W3C Recommendation |
+
+> The `ip-law-knowledge-graph` packet locks a **7-ontology source-of-truth set** (S1 LKIF-Core,
+> S2 IPRonto/ALIS, S3 Copyright Ontology, S4 JudO, S5 LCBR, S6 ESTRELLA, S7 WIPO IPC) and
+> requires every node/edge type to cite ≥1 source. See `goals/ip-law-knowledge-graph/SPEC.md`
+> and `goals/ip-law-knowledge-graph/research/ontology-grounding-corpus.md`. The FOLIO ontology
+> lives at `…/research/ontology_research/legal_ontologies/openlegalstandards_folio/FOLIO/FOLIO.owl`
+> (≈18k concepts; **shallow on patent/trademark specifics** — it's the backbone, not the IP layer).
+
+## 5. Authority / projection / cache (BeepGraph)
+
+The discipline that keeps the graph trustworthy at scale (full argument in
+[BeepGraph](./BEEPGRAPH_ARCHITECTURE.md), grounded in
+`standards/memory-architecture/`):
+
+| Tier | What lives here | Carrier |
+|---|---|---|
+| **Authority** | Typed claims + evidence + provenance + lifecycle — the only source of truth | `@beep/epistemic-domain`, `@beep/semantic-web`, `@beep/rdf`; the EventLog/`Activity` record |
+| **Projection** | Rebuildable views for traversal/search/timeline | FalkorDB (Cypher), search index, GraphRAG packets — **rebuilt from authority, never a second source** |
+| **Cache** | Candidates and similarity | vectors / embeddings (on-device), the unasserted corpus |
+
+This resolves the `ip-law-knowledge-graph` P0 directly: **FalkorDB is a projection**, not a
+second source of truth.
+
+## 6. The corpus feeder
+
+`goals/oppold-corpus-pipeline` (status: completed-retained) produced the seed: **8,438 files**
+salvaged, deduplicated, name-restored, text-extracted, organized into 643 docket files across
+105 families, and USPTO-enriched — exposed as a **DuckDB catalog + `@beep/file-processing`
+manifests**. The librarian/ingestion lane (build) reads that surface, runs span-grounded
+extraction, and emits candidate claims into the authority spine.
+
+> **Boundary that must hold:** the real corpus and any privileged data stay **outside the
+> repository** (`/home/elpresidank/data-home/oppold-corpus/`). The repo carries only synthetic
+> fixtures. Dogfooding runs on the local machine, not in git.
+
+## 7. Have vs. build — the honest ledger
+
+| Status | Items |
+|---|---|
+| **Have today** | `@beep/md`, `@beep/pandoc-ast`, `@beep/lexical-schema` (+`artifact-ref`), `@beep/langextract` (spans), `@beep/nlp-mcp`/`@beep/nlp`/`@beep/wink`, `@beep/epistemic-domain` (claims/evidence/provenance/usage) + `@beep/epistemic-tables`, `@beep/semantic-web` (PROV-O + bounded SHACL), `@beep/rdf`, `@beep/agents-*` chat kernel, `@beep/workspace-*`, the Tauri+React+Bun desktop chat app with local PGlite |
+| **Specced** | `ip-law-knowledge-graph` (7-ontology TBox, typed entities, FalkorDB projection, seed pipeline), the document-portal product slice, the runtime data loop (`runtime-data-loop.md`), approval policy, `trustgraph-port` extraction kernel, GraphRAG ask-and-check |
+| **Build (net-new)** | OWL 2 EL/RL reasoner integration, the AI librarian/ingestion lane over the corpus, the sync engine (FS ↔ backends, Box Events → ingest), on-device embeddings (Ollama), matter-as-named-subgraph wall enforcement, bitemporal instance store |
+
+## 8. Non-negotiable boundaries (inherited)
+
+From `goals/agentic-professional-runtime/SPEC.md` and `standards/ARCHITECTURE.md`:
+
+- **Authority vs. projection.** Claim + evidence + provenance + lifecycle is the authoritative
+  memory primitive; graph/search/retrieval are projections.
+- **Candidate-only writes.** Agents propose; human/policy approval promotes to authoritative
+  state. Professional judgment stays approval-gated.
+- **SDK-first.** The internal Effect/TypeScript SDK is the canonical contract; MCP / Claude
+  Desktop / native app are adapters over it.
+- **Slice isolation.** No direct slice-to-slice imports; cross-slice language is promoted only
+  through `shared/*`. Drivers hold no product language.
+- **Storage-neutral domain.** First local adapter is a Postgres-compatible Drizzle path (PGlite);
+  domain language must not depend on it.
+
+---
+
+## Related documents
+
+- [Product Vision](./PROSE_TO_PROOF_VISION.md) · [For Tom](./PROSE_TO_PROOF_FOR_TOM.md) · [User Story](./PROSE_TO_PROOF_USER_STORY.md) · [Visualization](./PROSE_TO_PROOF_VISUALIZATION.html) · [Draft PRD](./product/prose-to-proof.md)
+- [BeepGraph Architecture](./BEEPGRAPH_ARCHITECTURE.md) — authority/projection/cache; EO spine + TG shell
+- `goals/agentic-professional-runtime/docs/architecture-map.md` — slice ownership & boundary rules
+- `goals/ip-law-knowledge-graph/SPEC.md` — the 7-ontology TBox and FalkorDB projection
+- `goals/oppold-corpus-pipeline/SPEC.md` — the corpus feeder

--- a/docs/PROSE_TO_PROOF_CHAT.html
+++ b/docs/PROSE_TO_PROOF_CHAT.html
@@ -19,7 +19,7 @@
     --safe:#7cc293;
     --membrane:#d7ccbe;
     --neutral:#8893a0;
-    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#586673;
+    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#6b7886;
     --line:rgba(255,255,255,.10); --line-soft:rgba(255,255,255,.05);
     --card:rgba(255,255,255,.022);
     --mono:'IBM Plex Mono',ui-monospace,monospace;
@@ -37,7 +37,7 @@
   .wrap{max-width:880px;margin:0 auto}
 
   /* shared tab bar */
-  .tabbar{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:18px;
+  .tabbar{position:sticky;top:0;z-index:40;display:flex;flex-wrap:wrap;align-items:center;gap:18px;
     padding:11px 20px;margin:0 -20px 0;border-bottom:1px solid var(--line);
     background:rgba(10,13,16,.82);backdrop-filter:blur(10px)}
   .tabbar .brand{display:flex;align-items:center;gap:9px;font-family:var(--disp);font-weight:700;font-size:.96rem;color:var(--ink);text-decoration:none;letter-spacing:-.01em}
@@ -58,7 +58,7 @@
   .thesis b{color:var(--ink);font-weight:600}
 
   /* mode toggle */
-  .modes{display:flex;align-items:center;gap:8px;margin:20px 0 6px}
+  .modes{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin:20px 0 6px}
   .modes .lbl{font-family:var(--mono);font-size:.64rem;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-faint);margin-right:4px}
   .mode{font-family:var(--mono);font-size:.72rem;color:var(--ink-dim);background:var(--card);border:1px solid var(--line);border-radius:20px;padding:6px 13px;cursor:pointer;transition:.15s}
   .mode:hover{border-color:rgba(255,255,255,.25);color:var(--ink)}
@@ -74,7 +74,8 @@
   .ans{font-size:.95rem;color:var(--ink);line-height:1.62}
   .ans p{margin-bottom:9px}
   .cite{display:inline;border-bottom:1px dashed var(--logic);color:var(--logic-soft);cursor:pointer;padding:0 1px;border-radius:2px;transition:background .15s}
-  .cite:hover,.cite:focus-visible{background:rgba(95,198,214,.14);outline:none}
+  .cite:hover{background:rgba(95,198,214,.14)}
+  .cite:focus-visible{background:rgba(95,198,214,.14);outline:2px solid var(--logic);outline-offset:2px;border-radius:3px}
   .cite::before{content:"⌖ ";font-family:var(--mono);font-size:.8em;color:var(--logic);opacity:.7}
 
   /* grounding expander */
@@ -152,13 +153,13 @@
           <button class="groundbtn open"><span class="chev">▸</span><span class="net">⓰</span> View source graph <span class="badge">1 subgraph</span></button>
           <div class="groundpanel open">
             <div class="groundstat"><span class="ns"></span><span class="tbadges"></span></div>
-            <div class="minicanvaswrap"><canvas></canvas><span class="minihint">click a citation ↑ · drag · scroll-zoom</span></div>
+            <div class="minicanvaswrap"><canvas role="img" aria-label="Source subgraph that grounds the answer above — the nodes and labelled relationships the assistant relied on. Click a citation in the answer to highlight the relevant nodes."></canvas><span class="minihint">click a citation ↑ · drag · scroll-zoom</span></div>
           </div>
         </div>
       </div>
 
       <!-- turn 2 -->
-      <div class="msg user"><div class="who" style="justify-content:flex-end"><i style="background:var(--logic)"></i> you</div><div class="bubble user">Any conflicts before I take Beacon Roasters as a client?</div></div>
+      <div class="msg user"><div class="who" style="justify-content:flex-end"><i style="background:var(--logic)"></i> you</div><div class="bubble user">Any conflicts if I take on the Beacon Roasters matter?</div></div>
 
       <div class="msg assistant" data-graph="g2">
         <div class="who"><i style="background:var(--safe)"></i> assistant · graph-rag</div>
@@ -170,7 +171,7 @@
           <button class="groundbtn"><span class="chev">▸</span><span class="net">⓰</span> View source graph <span class="badge">1 subgraph</span></button>
           <div class="groundpanel">
             <div class="groundstat"><span class="ns"></span><span class="tbadges"></span></div>
-            <div class="minicanvaswrap"><canvas></canvas><span class="minihint">the walls hold · only the attorney node joins</span></div>
+            <div class="minicanvaswrap"><canvas role="img" aria-label="Source subgraph that grounds the answer above — the nodes and labelled relationships the assistant relied on. Click a citation in the answer to highlight the relevant nodes."></canvas><span class="minihint">the walls hold · only the attorney node joins</span></div>
           </div>
         </div>
       </div>
@@ -230,12 +231,13 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
   nodes.forEach(n=>n.degree=0); links.forEach(l=>{l.source.degree++;l.target.degree++;});
   let scale=opts.scale||1.05, tx=0, ty=0, centered=false, alpha=1;
   let hover=null, dragging=null, panning=false, last=null, focusSet=null;
+  const reduced=matchMedia('(prefers-reduced-motion: reduce)').matches; let visible=true;
   const radius=n=>Math.max(4,Math.sqrt(n.degree+1)*3.0);
 
   function resize(){ const r=canvas.getBoundingClientRect(); W=r.width; H=r.height; DPR=Math.min(window.devicePixelRatio||1,2);
     canvas.width=Math.max(1,W*DPR); canvas.height=Math.max(1,H*DPR);
     if(!centered && W>0){ tx=W/2; ty=H/2; centered=true; } }
-  function reheat(a=0.8){ alpha=Math.max(alpha,a); }
+  function reheat(a=0.8){ alpha=Math.max(alpha,a); if(reduced){ for(let i=0;i<360 && alpha>=0.01;i++) tick(); draw(); } }
   function tick(){ if(alpha<0.005) return;
     for(let i=0;i<nodes.length;i++){ const a=nodes[i];
       for(let j=i+1;j<nodes.length;j++){ const b=nodes[j];
@@ -271,13 +273,15 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
         ctx.fillStyle='rgba(233,238,243,0.85)'; ctx.fillText(n.label,n.x,n.y+r+2/scale); }
       ctx.globalAlpha=1; }
     ctx.restore(); }
-  function frame(){ tick(); draw(); requestAnimationFrame(frame); }
+  function frame(){ requestAnimationFrame(frame); if(!visible) return; if(!reduced) tick(); draw(); }
   function pick(sx,sy){ const [wx,wy]=s2w(sx,sy); let best=null,bd=1e9; for(const n of nodes){ const d=Math.hypot(n.x-wx,n.y-wy); if(d<radius(n)+6/scale&&d<bd){bd=d;best=n;} } return best; }
 
-  canvas.addEventListener('mousemove',e=>{ const r=canvas.getBoundingClientRect(),sx=e.clientX-r.left,sy=e.clientY-r.top;
-    if(dragging){ const [wx,wy]=s2w(sx,sy); dragging.x=wx; dragging.y=wy; dragging.vx=0; dragging.vy=0; reheat(0.4); return; }
-    if(panning&&last){ tx+=sx-last[0]; ty+=sy-last[1]; last=[sx,sy]; return; }
-    hover=pick(sx,sy); const tip=document.getElementById('gtip');
+  window.addEventListener('mousemove',e=>{ const r=canvas.getBoundingClientRect(),sx=e.clientX-r.left,sy=e.clientY-r.top;
+    if(dragging){ const [wx,wy]=s2w(sx,sy); dragging.x=wx; dragging.y=wy; dragging.vx=0; dragging.vy=0; reheat(0.4); if(reduced) draw(); return; }
+    if(panning&&last){ tx+=sx-last[0]; ty+=sy-last[1]; last=[sx,sy]; if(reduced||!visible) draw(); return; }
+    const inB=sx>=0&&sy>=0&&sx<=r.width&&sy<=r.height; const tip=document.getElementById('gtip');
+    if(!inB){ if(hover){ hover=null; if(reduced) draw(); } tip.classList.remove('show'); return; }
+    const n=pick(sx,sy); if(n!==hover){ hover=n; if(reduced) draw(); }
     if(hover){ tip.innerHTML=`<div class="tt"><i style="background:${hover.type==='matter'?COL.matter:COL[hover.type]}"></i>${hover.label}</div><div class="tm">${ntype(hover)} · ${hover.degree} edge${hover.degree===1?'':'s'}</div>`;
       tip.style.left=Math.min(e.clientX+13,window.innerWidth-230)+'px'; tip.style.top=(e.clientY+13)+'px'; tip.classList.add('show'); }
     else tip.classList.remove('show'); });
@@ -285,11 +289,12 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
   canvas.addEventListener('mousedown',e=>{ const r=canvas.getBoundingClientRect(),sx=e.clientX-r.left,sy=e.clientY-r.top; const n=pick(sx,sy); if(n){dragging=n;}else{panning=true;last=[sx,sy];} });
   window.addEventListener('mouseup',()=>{dragging=null;panning=false;});
   canvas.addEventListener('wheel',e=>{ e.preventDefault(); const r=canvas.getBoundingClientRect(),sx=e.clientX-r.left,sy=e.clientY-r.top,[wx,wy]=s2w(sx,sy);
-    scale=Math.max(0.4,Math.min(3.4,scale*(e.deltaY<0?1.12:0.89))); tx=sx-wx*scale; ty=sy-wy*scale; },{passive:false});
+    scale=Math.max(0.4,Math.min(3.4,scale*(e.deltaY<0?1.12:0.89))); tx=sx-wx*scale; ty=sy-wy*scale; if(reduced) draw(); },{passive:false});
   function ntype(n){ return n.type==='matter'?'matter':n.type==='entity'?'proven entity':n.type==='claim'?'proposed':n.type==='artifact'?'evidence':'external'; }
 
-  if('ResizeObserver' in window) new ResizeObserver(()=>resize()).observe(canvas);
-  window.addEventListener('resize',resize); resize(); frame();
+  if('ResizeObserver' in window) new ResizeObserver(()=>{resize(); if(reduced||!visible) draw();}).observe(canvas);
+  if('IntersectionObserver' in window) new IntersectionObserver(es=>{ visible=es[0].isIntersecting; if(visible&&reduced) reheat(1); }).observe(canvas);
+  window.addEventListener('resize',()=>{resize(); if(reduced) draw();}); resize(); if(reduced) reheat(1); frame();
   return { focus(ids){ focusSet=ids&&ids.length?new Set(ids):null; reheat(0.4); }, resize,
     counts(){ return {n:nodes.length,e:links.length}; }, types(){ return [...new Set(nodes.map(n=>n.type))]; } };
 }
@@ -306,7 +311,8 @@ document.querySelectorAll('.msg.assistant').forEach(msg=>{
   msg.querySelector('.tbadges').innerHTML=api.types().map(t=>`<span class="tb">${TYPE_LABEL[t]}</span>`).join('');
   // expander
   const btn=msg.querySelector('.groundbtn'), panel=msg.querySelector('.groundpanel');
-  btn.addEventListener('click',()=>{ const open=panel.classList.toggle('open'); btn.classList.toggle('open',open); if(open) setTimeout(()=>api.resize(),30); });
+  btn.setAttribute('aria-expanded', panel.classList.contains('open'));
+  btn.addEventListener('click',()=>{ const open=panel.classList.toggle('open'); btn.classList.toggle('open',open); btn.setAttribute('aria-expanded',open); if(open) setTimeout(()=>api.resize(),30); });
   // citations
   msg.querySelectorAll('.cite').forEach(c=>{
     const ids=(c.dataset.focus||'').split(',').filter(Boolean);
@@ -316,7 +322,7 @@ document.querySelectorAll('.msg.assistant').forEach(msg=>{
   });
 });
 // mode toggle (visual)
-document.querySelectorAll('.mode').forEach(m=>m.addEventListener('click',()=>{ document.querySelectorAll('.mode').forEach(x=>x.classList.remove('on')); m.classList.add('on'); }));
+document.querySelectorAll('.mode').forEach(m=>{ m.setAttribute('aria-pressed', m.classList.contains('on')); m.addEventListener('click',()=>{ document.querySelectorAll('.mode').forEach(x=>{x.classList.remove('on'); x.setAttribute('aria-pressed','false');}); m.classList.add('on'); m.setAttribute('aria-pressed','true'); }); });
 </script>
 </body>
 </html>

--- a/docs/PROSE_TO_PROOF_CHAT.html
+++ b/docs/PROSE_TO_PROOF_CHAT.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Prose-to-Proof · Grounded chat</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#0a0d10;
+    --retrieval:#d99a5b; --retrieval-soft:#ecc196;
+    --logic:#5fc6d6;     --logic-soft:#aee6ee;
+    --inferred:#b08ae8;
+    --prov:#cda968;
+    --reject:#e0706f;
+    --check:#7aa6e8;
+    --safe:#7cc293;
+    --membrane:#d7ccbe;
+    --neutral:#8893a0;
+    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#586673;
+    --line:rgba(255,255,255,.10); --line-soft:rgba(255,255,255,.05);
+    --card:rgba(255,255,255,.022);
+    --mono:'IBM Plex Mono',ui-monospace,monospace;
+    --sans:'IBM Plex Sans',system-ui,sans-serif;
+    --disp:'Space Grotesk',var(--sans);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{font-family:var(--sans);color:var(--ink);line-height:1.55;min-height:100vh;-webkit-font-smoothing:antialiased;
+    padding:0 20px 80px;
+    background:
+      radial-gradient(130% 60% at 50% -10%, rgba(217,154,91,.10), transparent 50%),
+      radial-gradient(130% 70% at 50% 112%, rgba(95,198,214,.10), transparent 50%),
+      linear-gradient(180deg,#110d0b 0%,#0c0e11 46%,#090f12 100%);
+    background-attachment:fixed;}
+  .wrap{max-width:880px;margin:0 auto}
+
+  /* shared tab bar */
+  .tabbar{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:18px;
+    padding:11px 20px;margin:0 -20px 0;border-bottom:1px solid var(--line);
+    background:rgba(10,13,16,.82);backdrop-filter:blur(10px)}
+  .tabbar .brand{display:flex;align-items:center;gap:9px;font-family:var(--disp);font-weight:700;font-size:.96rem;color:var(--ink);text-decoration:none;letter-spacing:-.01em}
+  .tabbar .brand .logo{display:grid;place-items:center;width:25px;height:25px;border:1px solid var(--logic);border-radius:6px;color:var(--logic);font-family:var(--mono);font-size:.95rem}
+  .tabbar .tabs{display:flex;gap:4px}
+  .tabbar .tab{font-family:var(--mono);font-size:.74rem;letter-spacing:.04em;color:var(--ink-dim);text-decoration:none;padding:7px 13px;border-radius:6px;border:1px solid transparent;transition:.18s}
+  .tabbar .tab:hover{color:var(--ink);background:rgba(255,255,255,.04)}
+  .tabbar .tab.on{color:var(--ink);background:rgba(95,198,214,.10);border-color:rgba(95,198,214,.3)}
+  .tabbar .conn{margin-left:auto;font-family:var(--mono);font-size:.66rem;color:var(--safe);display:flex;align-items:center;gap:7px}
+  .tabbar .conn::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--safe);box-shadow:0 0 8px var(--safe)}
+
+  header{padding:34px 0 6px}
+  .eyebrow{font-family:var(--mono);font-size:.7rem;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-faint)}
+  .eyebrow b{color:var(--retrieval-soft);font-weight:500} .eyebrow i{color:var(--logic-soft);font-style:normal;font-weight:500}
+  h1{font-family:var(--disp);font-weight:700;line-height:1.04;letter-spacing:-.022em;font-size:clamp(2rem,5vw,2.8rem);margin:12px 0 0}
+  h1 .b{color:var(--logic)}
+  .thesis{color:var(--ink-dim);max-width:72ch;margin-top:13px;font-size:.95rem}
+  .thesis b{color:var(--ink);font-weight:600}
+
+  /* mode toggle */
+  .modes{display:flex;align-items:center;gap:8px;margin:20px 0 6px}
+  .modes .lbl{font-family:var(--mono);font-size:.64rem;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-faint);margin-right:4px}
+  .mode{font-family:var(--mono);font-size:.72rem;color:var(--ink-dim);background:var(--card);border:1px solid var(--line);border-radius:20px;padding:6px 13px;cursor:pointer;transition:.15s}
+  .mode:hover{border-color:rgba(255,255,255,.25);color:var(--ink)}
+  .mode.on{color:var(--bg);background:var(--safe);border-color:var(--safe);font-weight:500}
+
+  /* chat */
+  .chat{display:flex;flex-direction:column;gap:18px;margin-top:14px}
+  .msg{max-width:100%}
+  .msg.user{align-self:flex-end;max-width:78%;margin-left:auto}
+  .bubble.user{background:rgba(95,198,214,.07);border:1px solid rgba(95,198,214,.22);border-radius:12px 12px 4px 12px;padding:11px 15px;font-size:.92rem;color:var(--ink)}
+  .who{font-family:var(--mono);font-size:.6rem;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-faint);margin-bottom:6px;display:flex;align-items:center;gap:7px}
+  .who i{width:7px;height:7px;border-radius:50%}
+  .ans{font-size:.95rem;color:var(--ink);line-height:1.62}
+  .ans p{margin-bottom:9px}
+  .cite{display:inline;border-bottom:1px dashed var(--logic);color:var(--logic-soft);cursor:pointer;padding:0 1px;border-radius:2px;transition:background .15s}
+  .cite:hover,.cite:focus-visible{background:rgba(95,198,214,.14);outline:none}
+  .cite::before{content:"⌖ ";font-family:var(--mono);font-size:.8em;color:var(--logic);opacity:.7}
+
+  /* grounding expander */
+  .ground{margin-top:12px;border:1px solid var(--line);border-radius:9px;overflow:hidden;background:rgba(255,255,255,.012)}
+  .groundbtn{width:100%;display:flex;align-items:center;gap:9px;background:transparent;border:none;cursor:pointer;
+    font-family:var(--mono);font-size:.74rem;color:var(--ink-dim);padding:11px 13px;text-align:left}
+  .groundbtn:hover{background:rgba(255,255,255,.03);color:var(--ink)}
+  .groundbtn .chev{transition:transform .2s;color:var(--ink-faint)}
+  .groundbtn.open .chev{transform:rotate(90deg)}
+  .groundbtn .net{color:var(--safe)}
+  .groundbtn .badge{font-family:var(--mono);font-size:.62rem;color:var(--logic-soft);background:rgba(95,198,214,.1);border:1px solid rgba(95,198,214,.28);border-radius:20px;padding:2px 9px}
+  .groundpanel{border-top:1px solid var(--line-soft);display:none}
+  .groundpanel.open{display:block}
+  .groundstat{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 13px;font-family:var(--mono);font-size:.66rem;color:var(--ink-faint);flex-wrap:wrap}
+  .groundstat .tbadges{display:flex;gap:5px;flex-wrap:wrap}
+  .groundstat .tb{font-size:.58rem;border:1px solid var(--line);border-radius:4px;padding:1px 6px;color:var(--ink-dim)}
+  .minicanvaswrap{height:280px;position:relative;background:rgba(0,0,0,.18)}
+  .minicanvaswrap canvas{display:block;width:100%;height:100%;cursor:grab}
+  .minihint{position:absolute;right:10px;bottom:8px;font-family:var(--mono);font-size:.6rem;color:var(--ink-faint);pointer-events:none}
+
+  /* composer */
+  .composer{margin-top:22px;display:flex;align-items:center;gap:10px;border:1px solid var(--line);border-radius:12px;background:var(--card);padding:9px 9px 9px 15px}
+  .composer input{flex:1;background:transparent;border:none;outline:none;color:var(--ink);font-family:var(--sans);font-size:.92rem}
+  .composer input::placeholder{color:var(--ink-faint)}
+  .composer .send{width:38px;height:38px;flex-shrink:0;border:none;border-radius:9px;background:var(--logic);color:#06222a;font-size:1rem;cursor:pointer;display:grid;place-items:center;transition:.15s}
+  .composer .send:hover{filter:brightness(1.1)}
+  .note{font-family:var(--mono);font-size:.64rem;color:var(--ink-faint);margin-top:9px;text-align:center}
+
+  .gtip{position:fixed;z-index:60;pointer-events:none;opacity:0;transform:translateY(4px);transition:opacity .12s;
+    border:1px solid var(--line);border-radius:7px;background:rgba(16,20,24,.96);backdrop-filter:blur(6px);padding:7px 10px;max-width:220px;box-shadow:0 10px 30px rgba(0,0,0,.45)}
+  .gtip.show{opacity:1;transform:none}
+  .gtip .tt{font-family:var(--disp);font-weight:600;font-size:.78rem;display:flex;align-items:center;gap:6px}
+  .gtip .tt i{width:8px;height:8px;border-radius:50%}
+  .gtip .tm{font-family:var(--mono);font-size:.6rem;color:var(--ink-faint);margin-top:2px;text-transform:uppercase;letter-spacing:.08em}
+
+  footer{margin-top:34px;font-family:var(--mono);font-size:.68rem;color:var(--ink-faint);letter-spacing:.03em;line-height:1.7;text-align:center}
+</style>
+</head>
+<body>
+  <nav class="tabbar">
+    <a class="brand" href="PROSE_TO_PROOF_VISUALIZATION.html"><span class="logo">⊢</span> Prose-to-Proof</a>
+    <div class="tabs">
+      <a class="tab" href="PROSE_TO_PROOF_VISUALIZATION.html">Workbench</a>
+      <a class="tab" href="PROSE_TO_PROOF_GRAPH.html">Graph</a>
+      <a class="tab on" href="PROSE_TO_PROOF_CHAT.html">Chat</a>
+    </div>
+    <span class="conn">local · on device</span>
+  </nav>
+
+  <div class="wrap">
+    <header>
+      <div class="eyebrow"><b>retrieval</b> asks · <i>logic</i> grounds</div>
+      <h1>Grounded <span class="b">chat</span></h1>
+      <p class="thesis">Ask the practice in plain language; every answer carries the <b>source subgraph</b> that justifies it. Click a <span class="cite" style="cursor:default">citation</span> to light up the exact nodes that back the claim. The answer is <b>retrieval</b>; the receipt is <b>logic</b>. Nothing is asserted without a source.</p>
+    </header>
+
+    <div class="modes">
+      <span class="lbl">mode</span>
+      <button class="mode on">Graph RAG</button>
+      <button class="mode">Doc RAG</button>
+      <button class="mode">Agent</button>
+    </div>
+
+    <div class="chat">
+      <!-- turn 1 -->
+      <div class="msg user"><div class="who" style="justify-content:flex-end"><i style="background:var(--logic)"></i> you</div><div class="bubble user">What's the strongest distinction for the Aanstoot office action — and what backs it up?</div></div>
+
+      <div class="msg assistant" data-graph="g1">
+        <div class="who"><i style="background:var(--safe)"></i> assistant · graph-rag</div>
+        <div class="ans">
+          <p>The strongest distinction is <b>functional and temporal</b>. The claimed <span class="cite" tabindex="0" data-focus="cl1,t_sensor">burr alignment sensor (Claim 1)</span> operates <em>before</em> grinding, to set burr geometry; <span class="cite" tabindex="0" data-focus="ha,t_grind">Halvorsen</span> measures grind size <em>downstream</em>, after grinding.</p>
+          <p>That is a <b>teaching-away</b>: Halvorsen's downstream placement presupposes the fixed burr geometry that the claimed sensor exists to establish. It is supported in the specification at <span class="cite" tabindex="0" data-focus="spec">¶0021</span>, depicted in <span class="cite" tabindex="0" data-focus="fig3">Figure 3</span>, and corroborated by the <span class="cite" tabindex="0" data-focus="email">inventor email</span> ("before the grind, not after").</p>
+        </div>
+        <div class="ground">
+          <button class="groundbtn open"><span class="chev">▸</span><span class="net">⓰</span> View source graph <span class="badge">1 subgraph</span></button>
+          <div class="groundpanel open">
+            <div class="groundstat"><span class="ns"></span><span class="tbadges"></span></div>
+            <div class="minicanvaswrap"><canvas></canvas><span class="minihint">click a citation ↑ · drag · scroll-zoom</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- turn 2 -->
+      <div class="msg user"><div class="who" style="justify-content:flex-end"><i style="background:var(--logic)"></i> you</div><div class="bubble user">Any conflicts before I take Beacon Roasters as a client?</div></div>
+
+      <div class="msg assistant" data-graph="g2">
+        <div class="who"><i style="background:var(--safe)"></i> assistant · graph-rag</div>
+        <div class="ans">
+          <p><b>No substantive conflict.</b> <span class="cite" tabindex="0" data-focus="m_beacon,c_beacon">Beacon Roasters</span> is a trademark matter with no shared parties, IP assets, or adverse positions against the <span class="cite" tabindex="0" data-focus="m_aanstoot">Aanstoot</span> or <span class="cite" tabindex="0" data-focus="m_mesh">Mesh Labs</span> matters.</p>
+          <p>The only node they share is <span class="cite" tabindex="0" data-focus="p_tom">you (Tom Oppold)</span>, as attorney of record — which is exactly how this check runs as a <em>single query</em> across otherwise sealed matters. The matters stay walled; only the join the conflict check needs crosses them.</p>
+        </div>
+        <div class="ground">
+          <button class="groundbtn"><span class="chev">▸</span><span class="net">⓰</span> View source graph <span class="badge">1 subgraph</span></button>
+          <div class="groundpanel">
+            <div class="groundstat"><span class="ns"></span><span class="tbadges"></span></div>
+            <div class="minicanvaswrap"><canvas></canvas><span class="minihint">the walls hold · only the attorney node joins</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="composer">
+      <input type="text" placeholder="Ask using Graph RAG… (static demo)" aria-label="chat input">
+      <button class="send" title="send">➤</button>
+    </div>
+    <div class="note">a static demo of the live Graph-RAG chat · in the product, every sentence resolves to span-grounded evidence</div>
+
+    <footer>retrieval asks · logic grounds · every answer carries its source subgraph · <a href="PROSE_TO_PROOF_GRAPH.html" style="color:var(--logic-soft)">open the full graph →</a></footer>
+  </div>
+
+  <div class="gtip" id="gtip"></div>
+
+<script>
+function getCssVar(n){ return getComputedStyle(document.documentElement).getPropertyValue(n).trim(); }
+const COL = { entity:getCssVar('--safe'), claim:getCssVar('--retrieval'), artifact:getCssVar('--inferred'), external:getCssVar('--neutral'), matter:getCssVar('--logic') };
+
+/* source subgraphs that ground each answer */
+const SUB = {
+  g1: {
+    nodes:[
+      ['pat','US App 18/441,209','entity'],['cl1','Claim 1','claim'],['t_sensor','burr alignment sensor','claim'],
+      ['spec','Spec ¶0021','artifact'],['fig3','Figure 3','artifact'],['email','Inventor email','artifact'],
+      ['ha','Halvorsen · US 9,xxx','external'],['t_grind','grind size','external'],['oa','Office Action','external'],
+    ],
+    links:[
+      ['pat','cl1','recites'],['cl1','t_sensor','recites'],['t_sensor','spec','defined in'],
+      ['fig3','t_sensor','depicts'],['email','t_sensor','corroborates'],
+      ['oa','pat','rejects'],['oa','ha','cites'],['ha','t_grind','teaches'],
+    ]
+  },
+  g2: {
+    nodes:[
+      ['p_tom','Tom Oppold','entity'],
+      ['m_aanstoot','Aanstoot — grinder','matter'],['m_beacon','Beacon Roasters — TM','matter'],['m_mesh','Mesh Labs — provisional','matter'],
+      ['c_aanstoot','Aanstoot Coffee Co.','entity'],['c_beacon','Beacon Roasters LLC','entity'],['c_mesh','Mesh Labs Inc.','entity'],
+      ['mark','“BEACON” mark','entity'],
+    ],
+    links:[
+      ['p_tom','m_aanstoot','attorney'],['p_tom','m_beacon','attorney'],['p_tom','m_mesh','attorney'],
+      ['c_aanstoot','m_aanstoot','engages'],['c_beacon','m_beacon','engages'],['c_mesh','m_mesh','engages'],
+      ['m_beacon','mark','covers'],
+    ]
+  }
+};
+
+/* ---------- compact force-graph renderer (shared) ---------- */
+function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
+  const ctx=canvas.getContext('2d');
+  let DPR=Math.min(window.devicePixelRatio||1,2), W=0,H=0;
+  const nodes=rawNodes.map(n=>({id:n[0],label:n[1],type:n[2],x:(Math.random()-0.5)*180,y:(Math.random()-0.5)*180,vx:0,vy:0}));
+  const byId=new Map(nodes.map(n=>[n.id,n]));
+  const links=rawLinks.map(l=>({source:byId.get(l[0]),target:byId.get(l[1]),label:l[2]})).filter(l=>l.source&&l.target);
+  nodes.forEach(n=>n.degree=0); links.forEach(l=>{l.source.degree++;l.target.degree++;});
+  let scale=opts.scale||1.05, tx=0, ty=0, centered=false, alpha=1;
+  let hover=null, dragging=null, panning=false, last=null, focusSet=null;
+  const radius=n=>Math.max(4,Math.sqrt(n.degree+1)*3.0);
+
+  function resize(){ const r=canvas.getBoundingClientRect(); W=r.width; H=r.height; DPR=Math.min(window.devicePixelRatio||1,2);
+    canvas.width=Math.max(1,W*DPR); canvas.height=Math.max(1,H*DPR);
+    if(!centered && W>0){ tx=W/2; ty=H/2; centered=true; } }
+  function reheat(a=0.8){ alpha=Math.max(alpha,a); }
+  function tick(){ if(alpha<0.005) return;
+    for(let i=0;i<nodes.length;i++){ const a=nodes[i];
+      for(let j=i+1;j<nodes.length;j++){ const b=nodes[j];
+        let dx=a.x-b.x,dy=a.y-b.y,d2=dx*dx+dy*dy; if(d2<0.01)d2=0.01; let d=Math.sqrt(d2),f=2400/d2,fx=f*dx/d,fy=f*dy/d;
+        a.vx+=fx;a.vy+=fy;b.vx-=fx;b.vy-=fy; } }
+    for(const l of links){ let dx=l.target.x-l.source.x,dy=l.target.y-l.source.y,d=Math.hypot(dx,dy)||0.01;
+      let f=0.05*(d-74),fx=f*dx/d,fy=f*dy/d; l.source.vx+=fx;l.source.vy+=fy;l.target.vx-=fx;l.target.vy-=fy; }
+    for(const n of nodes){ n.vx+=-n.x*0.016; n.vy+=-n.y*0.016; if(n===dragging)continue;
+      n.vx*=0.85; n.vy*=0.85; n.x+=n.vx*Math.min(1,alpha*2); n.y+=n.vy*Math.min(1,alpha*2); }
+    alpha*=0.985; }
+  const s2w=(x,y)=>[(x-tx)/scale,(y-ty)/scale];
+  function dim(n){ return focusSet && !focusSet.has(n.id); }
+  function draw(){ ctx.setTransform(DPR,0,0,DPR,0,0); ctx.clearRect(0,0,W,H);
+    ctx.save(); ctx.translate(tx,ty); ctx.scale(scale,scale);
+    for(const l of links){ const faded=focusSet&&(dim(l.source)&&dim(l.target));
+      const hi=hover&&(l.source===hover||l.target===hover);
+      const sx=l.source.x,sy=l.source.y,ex=l.target.x,ey=l.target.y,mx=(sx+ex)/2,my=(sy+ey)/2;
+      const nx=-(ey-sy),ny=(ex-sx),nl=Math.hypot(nx,ny)||1,len=Math.hypot(ex-sx,ey-sy);
+      const cx=mx+nx/nl*len*0.10,cy=my+ny/nl*len*0.10;
+      ctx.beginPath(); ctx.moveTo(sx,sy); ctx.quadraticCurveTo(cx,cy,ex,ey);
+      ctx.lineWidth=(hi?1.9:1.3)/scale; ctx.strokeStyle=faded?'rgba(124,194,147,0.06)':(hi?'rgba(174,230,238,0.55)':'rgba(124,194,147,0.26)'); ctx.stroke();
+      const t=0.86,it=1-t,ax=it*it*sx+2*it*t*cx+t*t*ex,ay=it*it*sy+2*it*t*cy+t*t*ey;
+      const dxx=2*it*(cx-sx)+2*t*(ex-cx),dyy=2*it*(cy-sy)+2*t*(ey-cy),ang=Math.atan2(dyy,dxx),asz=6/scale;
+      if(!faded){ ctx.fillStyle=hi?'rgba(174,230,238,0.85)':'rgba(174,209,174,0.7)';
+        ctx.beginPath(); ctx.moveTo(ax,ay); ctx.lineTo(ax-asz*Math.cos(ang-0.4),ay-asz*Math.sin(ang-0.4)); ctx.lineTo(ax-asz*Math.cos(ang+0.4),ay-asz*Math.sin(ang+0.4)); ctx.closePath(); ctx.fill(); }
+      if(scale>0.9 && !faded){ const fs=Math.max(8/scale,2.6); ctx.font=`${fs}px 'IBM Plex Mono',monospace`; ctx.textAlign='center'; ctx.textBaseline='middle';
+        ctx.fillStyle=hi?'rgba(233,238,243,0.85)':'rgba(154,166,177,0.55)'; ctx.fillText(l.label,mx,my); } }
+    for(const n of nodes){ const r=radius(n)*(n===hover?1.3:1), fill=n.type==='matter'?COL.matter:COL[n.type]||COL.entity;
+      const a=dim(n)?0.18:1; ctx.globalAlpha=a;
+      if(n===hover||(focusSet&&focusSet.has(n.id))){ ctx.beginPath(); ctx.arc(n.x,n.y,r+5/scale,0,7); ctx.fillStyle=fill; ctx.globalAlpha=a*0.2; ctx.fill(); ctx.globalAlpha=a; }
+      ctx.beginPath(); ctx.arc(n.x,n.y,r,0,7); ctx.fillStyle=fill; ctx.fill(); ctx.lineWidth=1.4/scale; ctx.strokeStyle='rgba(10,13,16,0.85)'; ctx.stroke();
+      if(scale>0.55 && !dim(n)){ const fs=Math.max(9.5/scale,2.6); ctx.font=`${fs}px 'IBM Plex Sans',sans-serif`; ctx.textAlign='center'; ctx.textBaseline='top';
+        ctx.fillStyle='rgba(233,238,243,0.85)'; ctx.fillText(n.label,n.x,n.y+r+2/scale); }
+      ctx.globalAlpha=1; }
+    ctx.restore(); }
+  function frame(){ tick(); draw(); requestAnimationFrame(frame); }
+  function pick(sx,sy){ const [wx,wy]=s2w(sx,sy); let best=null,bd=1e9; for(const n of nodes){ const d=Math.hypot(n.x-wx,n.y-wy); if(d<radius(n)+6/scale&&d<bd){bd=d;best=n;} } return best; }
+
+  canvas.addEventListener('mousemove',e=>{ const r=canvas.getBoundingClientRect(),sx=e.clientX-r.left,sy=e.clientY-r.top;
+    if(dragging){ const [wx,wy]=s2w(sx,sy); dragging.x=wx; dragging.y=wy; dragging.vx=0; dragging.vy=0; reheat(0.4); return; }
+    if(panning&&last){ tx+=sx-last[0]; ty+=sy-last[1]; last=[sx,sy]; return; }
+    hover=pick(sx,sy); const tip=document.getElementById('gtip');
+    if(hover){ tip.innerHTML=`<div class="tt"><i style="background:${hover.type==='matter'?COL.matter:COL[hover.type]}"></i>${hover.label}</div><div class="tm">${ntype(hover)} · ${hover.degree} edge${hover.degree===1?'':'s'}</div>`;
+      tip.style.left=Math.min(e.clientX+13,window.innerWidth-230)+'px'; tip.style.top=(e.clientY+13)+'px'; tip.classList.add('show'); }
+    else tip.classList.remove('show'); });
+  canvas.addEventListener('mouseleave',()=>{hover=null;document.getElementById('gtip').classList.remove('show');});
+  canvas.addEventListener('mousedown',e=>{ const r=canvas.getBoundingClientRect(),sx=e.clientX-r.left,sy=e.clientY-r.top; const n=pick(sx,sy); if(n){dragging=n;}else{panning=true;last=[sx,sy];} });
+  window.addEventListener('mouseup',()=>{dragging=null;panning=false;});
+  canvas.addEventListener('wheel',e=>{ e.preventDefault(); const r=canvas.getBoundingClientRect(),sx=e.clientX-r.left,sy=e.clientY-r.top,[wx,wy]=s2w(sx,sy);
+    scale=Math.max(0.4,Math.min(3.4,scale*(e.deltaY<0?1.12:0.89))); tx=sx-wx*scale; ty=sy-wy*scale; },{passive:false});
+  function ntype(n){ return n.type==='matter'?'matter':n.type==='entity'?'proven entity':n.type==='claim'?'proposed':n.type==='artifact'?'evidence':'external'; }
+
+  if('ResizeObserver' in window) new ResizeObserver(()=>resize()).observe(canvas);
+  window.addEventListener('resize',resize); resize(); frame();
+  return { focus(ids){ focusSet=ids&&ids.length?new Set(ids):null; reheat(0.4); }, resize,
+    counts(){ return {n:nodes.length,e:links.length}; }, types(){ return [...new Set(nodes.map(n=>n.type))]; } };
+}
+
+/* ---------- wire chat ---------- */
+const TYPE_LABEL={entity:'entity',claim:'claim',artifact:'evidence',external:'external',matter:'matter'};
+document.querySelectorAll('.msg.assistant').forEach(msg=>{
+  const key=msg.dataset.graph, sub=SUB[key];
+  const canvas=msg.querySelector('canvas');
+  const api=ForceGraph(canvas, sub.nodes, sub.links, {});
+  msg.__api=api;
+  const c=api.counts();
+  msg.querySelector('.ns').textContent=`${c.n} nodes, ${c.e} edges`;
+  msg.querySelector('.tbadges').innerHTML=api.types().map(t=>`<span class="tb">${TYPE_LABEL[t]}</span>`).join('');
+  // expander
+  const btn=msg.querySelector('.groundbtn'), panel=msg.querySelector('.groundpanel');
+  btn.addEventListener('click',()=>{ const open=panel.classList.toggle('open'); btn.classList.toggle('open',open); if(open) setTimeout(()=>api.resize(),30); });
+  // citations
+  msg.querySelectorAll('.cite').forEach(c=>{
+    const ids=(c.dataset.focus||'').split(',').filter(Boolean);
+    const act=()=>{ if(!panel.classList.contains('open')){ panel.classList.add('open'); btn.classList.add('open'); setTimeout(()=>api.resize(),30); } api.focus(ids); };
+    c.addEventListener('click',act);
+    c.addEventListener('keydown',e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); act(); } });
+  });
+});
+// mode toggle (visual)
+document.querySelectorAll('.mode').forEach(m=>m.addEventListener('click',()=>{ document.querySelectorAll('.mode').forEach(x=>x.classList.remove('on')); m.classList.add('on'); }));
+</script>
+</body>
+</html>

--- a/docs/PROSE_TO_PROOF_FOR_TOM.md
+++ b/docs/PROSE_TO_PROOF_FOR_TOM.md
@@ -1,0 +1,56 @@
+# For Tom — what I'm building you, in plain English
+
+*Working name: **Prose-to-Proof**. This is the plain-language companion to the [Vision](./PROSE_TO_PROOF_VISION.md). No jargon. If a word needs explaining, I explain it.*
+
+---
+
+Dad —
+
+You're starting your own practice after 25 years. That's the bravest thing, and it also means you're now the partner, the associate, the paralegal, the librarian, and the IT department all at once. I'm building you a tool so you don't have to be all of those people. Here's what it is, in your terms.
+
+## The one-line version
+
+It's a workbench that reads everything in your practice, organizes it the way *you* think, and helps you do your IP work faster — and it can **show you the exact source behind every single thing it tells you.** Think of it as *Obsidian for lawyers* — a private notebook where everything is linked — except this one **proves where every fact came from.**
+
+## What it does for your day
+
+**You never lose a document, and you never lose what's *in* it.** Drop in your emails, applications, office actions, contracts, and figures. The system reads them and remembers — not just "here's the file," but "here's what this file *says*, and here's how it connects to the client, the matter, and the deadline."
+
+**It's a librarian who never sleeps.** Twenty-five years of your work is a lot to keep in your head. This tireless librarian reads all of it, files it correctly, and notices the connections — *this* inventor on *that* patent also shows up in *this* old email thread. You ask a question; it answers from your own archive.
+
+**It highlights the exact line — every time.** You know how a good search engine can jump you straight to the precise sentence on a webpage and light it up yellow? The system does that for your whole practice. When it tells you something, you can click and land on the *exact words* in the *exact document* that back it up. Nothing is ever "trust me." Everything is "here, see for yourself."
+
+**It drafts in *your* voice.** It learns from your past responses and applications how *you* build an argument — your phrasing, your structure, your house style. When it helps you draft an office-action response, the first draft already sounds like you, not like a robot. (There's a full walkthrough of exactly this in the [User Story](./PROSE_TO_PROOF_USER_STORY.md).)
+
+**It catches conflicts you'd have to check by hand.** Before you take a new client, it can check across *every* matter you've ever touched and flag a possible conflict of interest — something that's nearly impossible to do reliably from memory or scattered folders.
+
+**It never misses the deadline.** Office-action due dates, filing windows, follow-ups — it surfaces them and reminds you, with the source document attached so you can verify.
+
+## The two promises that make it different
+
+There are plenty of legal AI tools now. Most of them break one of these two promises. This one keeps both:
+
+**1. Your data stays on your machine.** By default, *nothing leaves your computer.* No client file gets uploaded to someone else's cloud to be read. This matters for you specifically: when client material is processed on an outside company's servers, that can count as sharing it with a third party — which is exactly the kind of thing that can put confidentiality and privilege at risk. The tools that are best at "showing their work" almost all run in the cloud. The tools that run privately on your machine mostly *can't* show their work well. Yours does both. As far as I can tell, nobody is doing local-and-grounded *and* built for patent work — that gap is the whole point.
+
+**2. It proves its sources — never makes them up.** The biggest danger with AI and law is the confident lie: a tool that invents a citation that doesn't exist. This system is built so it *cannot* assert something without pointing at the real words that justify it. If it can't ground a statement in a real source, it doesn't get to call it a fact — it stays a *suggestion* in a review pile until you say otherwise. **The machine guesses; you decide; the record only keeps what's proven.**
+
+## What it is *not* (so we're honest)
+
+- It's **not** going to practice law for you. It proposes; you approve. Every piece of legal judgment — advice, filings, anything a client sees — waits for your sign-off. You're always the attorney of record.
+- It's **not** replacing your email, your billing, or the Patent Office. It sits alongside them and connects the dots.
+- It's **not** finished. Today it's basically a smart chat window. The next step is turning it into the real document workbench. I'll show you each piece as it comes online.
+
+## Why us, why this
+
+Here's the part that matters most to me. This works *because* it's you and me.
+
+Your 25 years of work is the raw material — your old matters, your responses, your style become the thing the system learns from. You'll be the first person to actually use it, on real matters. And every time you fix a draft or correct a connection, it gets a little more like *you*. So the more you use it, the better it serves you. You built the knowledge over a career; I'm building the machine that makes it work for you; and the two of us using it together, refining it on your real practice, is how it becomes genuinely good instead of just a nice idea.
+
+We're going to dogfood our own product — build it, use it, fix it, repeat — as father and son. That's how we make something incredible.
+
+Love,
+Ben
+
+---
+
+*Plain-language brief · companion to the [Vision](./PROSE_TO_PROOF_VISION.md), [User Story](./PROSE_TO_PROOF_USER_STORY.md), and [Visualization](./PROSE_TO_PROOF_VISUALIZATION.html).*

--- a/docs/PROSE_TO_PROOF_GRAPH.html
+++ b/docs/PROSE_TO_PROOF_GRAPH.html
@@ -19,7 +19,7 @@
     --safe:#7cc293;
     --membrane:#d7ccbe;
     --neutral:#8893a0;
-    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#586673;
+    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#6b7886;
     --line:rgba(255,255,255,.10); --line-soft:rgba(255,255,255,.05);
     --card:rgba(255,255,255,.022);
     --mono:'IBM Plex Mono',ui-monospace,monospace;
@@ -37,7 +37,7 @@
   .wrap{max-width:1060px;margin:0 auto}
 
   /* shared tab bar */
-  .tabbar{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:18px;
+  .tabbar{position:sticky;top:0;z-index:40;display:flex;flex-wrap:wrap;align-items:center;gap:18px;
     padding:11px 20px;margin:0 -20px 0;border-bottom:1px solid var(--line);
     background:rgba(10,13,16,.82);backdrop-filter:blur(10px)}
   .tabbar .brand{display:flex;align-items:center;gap:9px;font-family:var(--disp);font-weight:700;font-size:.96rem;color:var(--ink);text-decoration:none;letter-spacing:-.01em}
@@ -144,7 +144,7 @@
     </div>
 
     <div class="stage" id="stage">
-      <canvas id="gcanvas"></canvas>
+      <canvas id="gcanvas" role="img" aria-label="Interactive force-directed knowledge graph of the practice: matters, clients, inventors, patents, claims, prior art and evidence — colour-coded by type and joined by labelled relationships. An illustrative dummy of the live Graph-RAG view."></canvas>
       <div class="legend2">
         <span><i style="background:var(--safe)"></i> proven entity</span>
         <span><i style="background:var(--retrieval)"></i> proposed / claim</span>
@@ -269,6 +269,7 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
 
   let scale = 1, tx = 0, ty = 0, centered=false;
   let alpha = 1;
+  let visible = true;
   let hover=null, selected=null, dragging=null, panning=false, last=null, query='', showLabels=true, focusSet=null;
   let visibleIds=null;
 
@@ -278,9 +279,9 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
     const r = canvas.getBoundingClientRect();
     W=r.width; H=r.height; DPR=Math.min(window.devicePixelRatio||1,2);
     canvas.width=W*DPR; canvas.height=H*DPR;
-    if(!centered){ tx=W/2; ty=H/2; centered=true; }
+    if(!centered && W>0){ tx=W/2; ty=H/2; centered=true; }
   }
-  function reheat(a=0.9){ alpha=Math.max(alpha,a); }
+  function reheat(a=0.9){ alpha=Math.max(alpha,a); if(reduced){ for(let i=0;i<360 && alpha>=0.01;i++) tick(); draw(); } }
 
   function tick(){
     if(alpha<0.005) return;
@@ -390,7 +391,7 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
     ctx.restore();
   }
 
-  function frame(){ tick(); draw(); requestAnimationFrame(frame); }
+  function frame(){ requestAnimationFrame(frame); if(!visible) return; if(!reduced) tick(); draw(); }
 
   function pick(sx,sy){
     const [wx,wy]=s2w(sx,sy);
@@ -402,13 +403,16 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
   }
 
   // events
-  canvas.addEventListener('mousemove', e=>{
+  window.addEventListener('mousemove', e=>{
     const r=canvas.getBoundingClientRect(), sx=e.clientX-r.left, sy=e.clientY-r.top;
-    if(dragging){ const [wx,wy]=s2w(sx,sy); dragging.x=wx; dragging.y=wy; dragging.vx=0; dragging.vy=0; reheat(0.5); return; }
-    if(panning&&last){ tx+=sx-last[0]; ty+=sy-last[1]; last=[sx,sy]; return; }
-    const n=pick(sx,sy);
-    hover=n; canvas.classList.toggle('onnode',!!n);
+    if(dragging){ const [wx,wy]=s2w(sx,sy); dragging.x=wx; dragging.y=wy; dragging.vx=0; dragging.vy=0; reheat(0.5); if(reduced) draw(); return; }
+    if(panning&&last){ tx+=sx-last[0]; ty+=sy-last[1]; last=[sx,sy]; if(reduced||!visible) draw(); return; }
+    const inB = sx>=0 && sy>=0 && sx<=r.width && sy<=r.height;
     const tip=document.getElementById('gtip');
+    if(!inB){ if(hover){ hover=null; canvas.classList.remove('onnode'); if(reduced) draw(); } tip.classList.remove('show'); return; }
+    const n=pick(sx,sy);
+    if(n!==hover){ hover=n; if(reduced) draw(); }
+    canvas.classList.toggle('onnode',!!n);
     if(n){ tip.innerHTML=`<div class="tt"><i style="background:${n.type==='matter'?COL.matter:COL[n.type]}"></i>${n.label}</div><div class="tm">${ntype(n)} · ${n.degree} edge${n.degree===1?'':'s'}</div>`;
       tip.style.left=Math.min(e.clientX+14,window.innerWidth-250)+'px'; tip.style.top=(e.clientY+14)+'px'; tip.classList.add('show'); }
     else tip.classList.remove('show');
@@ -435,7 +439,7 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
     const r=canvas.getBoundingClientRect(), sx=e.clientX-r.left, sy=e.clientY-r.top;
     const [wx,wy]=s2w(sx,sy);
     const f=e.deltaY<0?1.12:0.89; scale=Math.max(0.3,Math.min(4.2,scale*f));
-    tx=sx-wx*scale; ty=sy-wy*scale;
+    tx=sx-wx*scale; ty=sy-wy*scale; if(reduced) draw();
   },{passive:false});
 
   function ntype(n){ return n.type==='matter'?'matter':n.type==='entity'?'proven entity':n.type==='claim'?'proposed':n.type==='artifact'?'evidence':'external'; }
@@ -445,9 +449,10 @@ function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
     return {out,inc};
   }
 
-  if('ResizeObserver' in window) new ResizeObserver(()=>resize()).observe(canvas);
-  window.addEventListener('resize',resize);
-  resize(); frame();
+  if('ResizeObserver' in window) new ResizeObserver(()=>{resize(); if(reduced||!visible) draw();}).observe(canvas);
+  window.addEventListener('resize',()=>{resize(); if(reduced) draw();});
+  if('IntersectionObserver' in window) new IntersectionObserver(es=>{ visible=es[0].isIntersecting; }).observe(canvas);
+  resize(); if(reduced) reheat(1); frame();
 
   return {
     setSearch(q){ query=(q||'').trim().toLowerCase(); focusSet=null; reheat(0.3); },

--- a/docs/PROSE_TO_PROOF_GRAPH.html
+++ b/docs/PROSE_TO_PROOF_GRAPH.html
@@ -1,0 +1,495 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Prose-to-Proof · The knowledge graph</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#0a0d10;
+    --retrieval:#d99a5b; --retrieval-soft:#ecc196;
+    --logic:#5fc6d6;     --logic-soft:#aee6ee;
+    --inferred:#b08ae8;
+    --prov:#cda968;
+    --reject:#e0706f;
+    --check:#7aa6e8;
+    --safe:#7cc293;
+    --membrane:#d7ccbe;
+    --neutral:#8893a0;
+    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#586673;
+    --line:rgba(255,255,255,.10); --line-soft:rgba(255,255,255,.05);
+    --card:rgba(255,255,255,.022);
+    --mono:'IBM Plex Mono',ui-monospace,monospace;
+    --sans:'IBM Plex Sans',system-ui,sans-serif;
+    --disp:'Space Grotesk',var(--sans);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{font-family:var(--sans);color:var(--ink);line-height:1.55;min-height:100vh;-webkit-font-smoothing:antialiased;
+    padding:0 20px 80px;
+    background:
+      radial-gradient(130% 60% at 50% -10%, rgba(217,154,91,.10), transparent 50%),
+      radial-gradient(130% 70% at 50% 112%, rgba(95,198,214,.10), transparent 50%),
+      linear-gradient(180deg,#110d0b 0%,#0c0e11 46%,#090f12 100%);
+    background-attachment:fixed;}
+  .wrap{max-width:1060px;margin:0 auto}
+
+  /* shared tab bar */
+  .tabbar{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:18px;
+    padding:11px 20px;margin:0 -20px 0;border-bottom:1px solid var(--line);
+    background:rgba(10,13,16,.82);backdrop-filter:blur(10px)}
+  .tabbar .brand{display:flex;align-items:center;gap:9px;font-family:var(--disp);font-weight:700;font-size:.96rem;color:var(--ink);text-decoration:none;letter-spacing:-.01em}
+  .tabbar .brand .logo{display:grid;place-items:center;width:25px;height:25px;border:1px solid var(--logic);border-radius:6px;color:var(--logic);font-family:var(--mono);font-size:.95rem}
+  .tabbar .tabs{display:flex;gap:4px}
+  .tabbar .tab{font-family:var(--mono);font-size:.74rem;letter-spacing:.04em;color:var(--ink-dim);text-decoration:none;padding:7px 13px;border-radius:6px;border:1px solid transparent;transition:.18s}
+  .tabbar .tab:hover{color:var(--ink);background:rgba(255,255,255,.04)}
+  .tabbar .tab.on{color:var(--ink);background:rgba(95,198,214,.10);border-color:rgba(95,198,214,.3)}
+  .tabbar .conn{margin-left:auto;font-family:var(--mono);font-size:.66rem;color:var(--safe);display:flex;align-items:center;gap:7px}
+  .tabbar .conn::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--safe);box-shadow:0 0 8px var(--safe)}
+
+  header{padding:38px 0 8px}
+  .eyebrow{font-family:var(--mono);font-size:.7rem;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-faint)}
+  .eyebrow b{color:var(--logic-soft);font-weight:500}
+  h1{font-family:var(--disp);font-weight:700;line-height:1.04;letter-spacing:-.022em;font-size:clamp(2rem,5vw,2.9rem);margin:12px 0 0}
+  h1 .b{color:var(--logic)}
+  .thesis{color:var(--ink-dim);max-width:74ch;margin-top:14px;font-size:.96rem}
+  .thesis b{color:var(--ink);font-weight:600}
+
+  /* toolbar */
+  .toolbar{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:22px 0 12px}
+  .counts{display:flex;gap:7px;font-family:var(--mono);font-size:.68rem}
+  .chip{border:1px solid var(--line);border-radius:20px;padding:4px 11px;color:var(--ink-dim)}
+  .chip b{color:var(--logic-soft);font-weight:500}
+  .search{flex:1;min-width:200px;display:flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:7px;background:var(--card);padding:8px 12px}
+  .search input{flex:1;background:transparent;border:none;outline:none;color:var(--ink);font-family:var(--sans);font-size:.86rem}
+  .search input::placeholder{color:var(--ink-faint)}
+  .search .ic{color:var(--ink-faint);font-family:var(--mono)}
+  .tbtn{font-family:var(--mono);font-size:.72rem;color:var(--ink-dim);background:var(--card);border:1px solid var(--line);border-radius:7px;padding:8px 12px;cursor:pointer;transition:.15s}
+  .tbtn:hover{border-color:rgba(255,255,255,.26);color:var(--ink)}
+  .tbtn.on{color:var(--bg);background:var(--logic-soft);border-color:var(--logic-soft)}
+  select.tbtn{appearance:none;padding-right:26px;background-image:linear-gradient(45deg,transparent 50%,var(--ink-faint) 50%),linear-gradient(135deg,var(--ink-faint) 50%,transparent 50%);background-position:calc(100% - 14px) 16px,calc(100% - 9px) 16px;background-size:5px 5px;background-repeat:no-repeat}
+
+  /* graph stage */
+  .stage{position:relative;border:1px solid var(--line);border-radius:10px;background:rgba(255,255,255,.012);overflow:hidden;height:600px}
+  #gcanvas{display:block;width:100%;height:100%;cursor:grab}
+  #gcanvas.grabbing{cursor:grabbing}
+  #gcanvas.onnode{cursor:pointer}
+  .legend2{position:absolute;left:14px;bottom:14px;z-index:4;display:flex;flex-direction:column;gap:6px;
+    font-family:var(--mono);font-size:.66rem;color:var(--ink-dim);background:rgba(10,13,16,.7);border:1px solid var(--line);border-radius:8px;padding:11px 13px;backdrop-filter:blur(6px)}
+  .legend2 span{display:inline-flex;align-items:center;gap:8px}
+  .legend2 i{width:10px;height:10px;border-radius:50%;flex-shrink:0}
+  .hint{position:absolute;right:14px;bottom:14px;z-index:4;font-family:var(--mono);font-size:.64rem;color:var(--ink-faint);
+    background:rgba(10,13,16,.6);border:1px solid var(--line-soft);border-radius:20px;padding:5px 12px}
+
+  /* hover tooltip */
+  .gtip{position:fixed;z-index:60;pointer-events:none;opacity:0;transform:translateY(4px);transition:opacity .12s;
+    border:1px solid var(--line);border-radius:7px;background:rgba(16,20,24,.96);backdrop-filter:blur(6px);padding:8px 11px;max-width:240px;box-shadow:0 10px 30px rgba(0,0,0,.45)}
+  .gtip.show{opacity:1;transform:none}
+  .gtip .tt{font-family:var(--disp);font-weight:600;font-size:.82rem;display:flex;align-items:center;gap:7px}
+  .gtip .tt i{width:9px;height:9px;border-radius:50%;flex-shrink:0}
+  .gtip .tm{font-family:var(--mono);font-size:.64rem;color:var(--ink-faint);margin-top:3px;text-transform:uppercase;letter-spacing:.08em}
+
+  /* node detail panel */
+  .detail{position:absolute;right:14px;top:14px;z-index:5;width:280px;max-width:calc(100% - 28px);border:1px solid var(--line);border-radius:9px;
+    background:rgba(14,18,22,.94);backdrop-filter:blur(8px);box-shadow:0 14px 40px rgba(0,0,0,.5);
+    opacity:0;visibility:hidden;transform:translateY(-6px);transition:opacity .18s,transform .18s,visibility .18s}
+  .detail.show{opacity:1;visibility:visible;transform:none}
+  .detail .dh{display:flex;align-items:flex-start;gap:9px;padding:13px 14px 10px;border-bottom:1px solid var(--line-soft)}
+  .detail .dh i{width:11px;height:11px;border-radius:50%;margin-top:4px;flex-shrink:0}
+  .detail .dt{font-family:var(--disp);font-weight:600;font-size:.96rem;line-height:1.25}
+  .detail .dk{font-family:var(--mono);font-size:.6rem;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-faint);margin-top:3px}
+  .detail .dx{margin-left:auto;color:var(--ink-faint);cursor:pointer;font-family:var(--mono);font-size:.95rem;line-height:1;padding:0 2px}
+  .detail .dx:hover{color:var(--ink)}
+  .detail .dbody{max-height:300px;overflow-y:auto;padding:10px 14px 14px;scrollbar-width:thin}
+  .detail .erow{font-family:var(--mono);font-size:.7rem;color:var(--ink-dim);padding:5px 0;display:flex;gap:7px;align-items:baseline;cursor:pointer;border-radius:5px}
+  .detail .erow:hover{color:var(--ink)}
+  .detail .erow .rel{color:var(--logic-soft);min-width:0;flex-shrink:0}
+  .detail .erow .dir{color:var(--ink-faint)}
+  .detail .sec{font-family:var(--mono);font-size:.58rem;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-faint);margin:10px 0 4px}
+
+  .gcap{font-family:var(--mono);font-size:.66rem;color:var(--ink-faint);padding:12px 2px 0;line-height:1.6}
+  footer{margin-top:30px;font-family:var(--mono);font-size:.68rem;color:var(--ink-faint);letter-spacing:.03em;line-height:1.7}
+</style>
+</head>
+<body>
+  <nav class="tabbar">
+    <a class="brand" href="PROSE_TO_PROOF_VISUALIZATION.html"><span class="logo">⊢</span> Prose-to-Proof</a>
+    <div class="tabs">
+      <a class="tab" href="PROSE_TO_PROOF_VISUALIZATION.html">Workbench</a>
+      <a class="tab on" href="PROSE_TO_PROOF_GRAPH.html">Graph</a>
+      <a class="tab" href="PROSE_TO_PROOF_CHAT.html">Chat</a>
+    </div>
+    <span class="conn">local · on device</span>
+  </nav>
+
+  <div class="wrap">
+    <header>
+      <div class="eyebrow">the <b>logic</b> family · one graph, walled by matter</div>
+      <h1>The knowledge <span class="b">graph</span></h1>
+      <p class="thesis">Everything the practice has proven, in one place. A document is a provenance-coloured set of edges; a matter is a named subgraph — joinable for conflict checks, sealed for substantive reads. <b>Green is proven, amber is proposed, grey is context.</b> Drag a node, scroll to zoom, search to focus, click for its edges. This is a dummy of the live Graph-RAG view.</p>
+    </header>
+
+    <div class="toolbar">
+      <div class="search"><span class="ic">⌕</span><input id="search" type="text" placeholder="Search the graph… (try “sensor”, “Halvorsen”, “Oppold”)" autocomplete="off"></div>
+      <select class="tbtn" id="limit" title="max nodes">
+        <option value="999">all nodes</option>
+        <option value="24">top 24</option>
+        <option value="16">top 16</option>
+      </select>
+      <button class="tbtn on" id="labels">Labels</button>
+      <button class="tbtn" id="reseed" title="re-run layout">↻ Relayout</button>
+      <div class="counts"><span class="chip"><b id="ncount">0</b> nodes</span><span class="chip"><b id="ecount">0</b> edges</span></div>
+    </div>
+
+    <div class="stage" id="stage">
+      <canvas id="gcanvas"></canvas>
+      <div class="legend2">
+        <span><i style="background:var(--safe)"></i> proven entity</span>
+        <span><i style="background:var(--retrieval)"></i> proposed / claim</span>
+        <span><i style="background:var(--inferred)"></i> evidence / artifact</span>
+        <span><i style="background:var(--neutral)"></i> external context</span>
+        <span><i style="background:var(--logic)"></i> matter (focal)</span>
+      </div>
+      <div class="hint">drag · scroll-zoom · click a node</div>
+      <div class="detail" id="detail"></div>
+    </div>
+
+    <div class="gcap">
+      one logical graph · the Aanstoot matter sits in a cluster with the practice's other matters · the attorney node connects them all — which is exactly how a conflict check becomes a single query
+    </div>
+
+    <footer>green proves · amber proposes · grey grounds · one graph, walled by matter · everything on device · <a href="PROSE_TO_PROOF_CHAT.html" style="color:var(--logic-soft)">see it ground an answer →</a></footer>
+  </div>
+
+  <div class="gtip" id="gtip"></div>
+
+<script>
+/* ============================================================
+   dummy IP-practice knowledge graph
+   types → colour:  entity=green · claim=amber · artifact=purple
+                    external=grey · matter=cyan(focal)
+   ============================================================ */
+const COL = {
+  entity:   getCssVar('--safe'),
+  claim:    getCssVar('--retrieval'),
+  artifact: getCssVar('--inferred'),
+  external: getCssVar('--neutral'),
+  matter:   getCssVar('--logic'),
+};
+function getCssVar(n){ return getComputedStyle(document.documentElement).getPropertyValue(n).trim(); }
+
+const N = [
+  // Aanstoot cluster
+  ['m_aanstoot','Aanstoot — burr grinder','matter'],
+  ['c_aanstoot','Aanstoot Coffee Co.','entity'],
+  ['p_jaan','J. Aanstoot','entity'],
+  ['p_stahl','K. Stahl','entity'],
+  ['pat_aan','US App 18/441,209','entity'],
+  ['cl1','Claim 1','claim'],
+  ['cl4','Claim 4','claim'],
+  ['cl7','Claim 7','claim'],
+  ['t_sensor','burr alignment sensor','claim'],
+  ['fig3','Figure 3','artifact'],
+  ['cad','grinder_v3.step','artifact'],
+  ['email','Inventor email · 2026-02-11','artifact'],
+  ['spec','Spec ¶0021','artifact'],
+  ['resp','Prior response · 2025-09','artifact'],
+  ['oa','Office Action (non-final)','external'],
+  ['dl','Deadline · Apr 12','external'],
+  ['exr','Examiner','external'],
+  ['ha','Halvorsen · US 9,xxx','external'],
+  ['ref2','Secondary reference','external'],
+  ['t_grind','grind size','external'],
+  ['cpc1','CPC A47J42/38','external'],
+  ['cpc2','CPC G01B','external'],
+  // attorney (hub) + other matters
+  ['p_tom','Tom Oppold','entity'],
+  ['m_beacon','Beacon Roasters — TM','matter'],
+  ['c_beacon','Beacon Roasters LLC','entity'],
+  ['mark','“BEACON” word mark','entity'],
+  ['m_mesh','Mesh Labs — provisional','matter'],
+  ['c_mesh','Mesh Labs Inc.','entity'],
+  ['p_mehta','R. Mehta','entity'],
+  ['prov','Provisional 63/xxx','entity'],
+  ['t_mesh','mesh interface','claim'],
+];
+const L = [
+  ['c_aanstoot','m_aanstoot','engages'],
+  ['m_aanstoot','pat_aan','covers'],
+  ['p_jaan','pat_aan','inventor of'],
+  ['p_stahl','pat_aan','inventor of'],
+  ['pat_aan','c_aanstoot','assigned to'],
+  ['p_tom','m_aanstoot','attorney of record'],
+  ['pat_aan','cl1','recites'],
+  ['pat_aan','cl4','recites'],
+  ['pat_aan','cl7','recites'],
+  ['cl1','t_sensor','recites'],
+  ['cl4','t_sensor','recites'],
+  ['cl7','t_sensor','recites'],
+  ['t_sensor','spec','defined in'],
+  ['fig3','t_sensor','depicts'],
+  ['fig3','cad','generated from'],
+  ['email','t_sensor','corroborates'],
+  ['oa','pat_aan','rejects'],
+  ['oa','ha','cites'],
+  ['oa','ref2','cites'],
+  ['exr','oa','issued'],
+  ['oa','dl','triggers'],
+  ['ha','t_grind','teaches'],
+  ['pat_aan','cpc1','classified as'],
+  ['t_sensor','cpc2','classified as'],
+  ['resp','ha','distinguished'],
+  ['resp','t_sensor','supports'],
+  // other matters via the attorney hub
+  ['p_tom','m_beacon','attorney of record'],
+  ['c_beacon','m_beacon','engages'],
+  ['m_beacon','mark','covers'],
+  ['p_tom','m_mesh','attorney of record'],
+  ['c_mesh','m_mesh','engages'],
+  ['m_mesh','prov','covers'],
+  ['p_mehta','prov','inventor of'],
+  ['prov','t_mesh','recites'],
+];
+
+/* ---------- force-directed canvas renderer ---------- */
+function ForceGraph(canvas, rawNodes, rawLinks, opts={}){
+  const ctx = canvas.getContext('2d');
+  const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let DPR = Math.min(window.devicePixelRatio||1, 2);
+  let W=0, H=0;
+  const nodes = rawNodes.map(n => ({ id:n[0], label:n[1], type:n[2],
+    x:(Math.random()-0.5)*240, y:(Math.random()-0.5)*240, vx:0, vy:0 }));
+  const byId = new Map(nodes.map(n=>[n.id,n]));
+  const links = rawLinks.map(l => ({ source:byId.get(l[0]), target:byId.get(l[1]), label:l[2] }))
+                        .filter(l=>l.source&&l.target);
+  nodes.forEach(n=>n.degree=0);
+  links.forEach(l=>{ l.source.degree++; l.target.degree++; });
+
+  let scale = 1, tx = 0, ty = 0, centered=false;
+  let alpha = 1;
+  let hover=null, selected=null, dragging=null, panning=false, last=null, query='', showLabels=true, focusSet=null;
+  let visibleIds=null;
+
+  const radius = n => Math.max(4, Math.sqrt(n.degree+1)*3.1);
+
+  function resize(){
+    const r = canvas.getBoundingClientRect();
+    W=r.width; H=r.height; DPR=Math.min(window.devicePixelRatio||1,2);
+    canvas.width=W*DPR; canvas.height=H*DPR;
+    if(!centered){ tx=W/2; ty=H/2; centered=true; }
+  }
+  function reheat(a=0.9){ alpha=Math.max(alpha,a); }
+
+  function tick(){
+    if(alpha<0.005) return;
+    const act = nodes.filter(n=> !visibleIds || visibleIds.has(n.id));
+    for(let i=0;i<act.length;i++){
+      const a=act[i];
+      for(let j=i+1;j<act.length;j++){
+        const b=act[j];
+        let dx=a.x-b.x, dy=a.y-b.y, d2=dx*dx+dy*dy; if(d2<0.01)d2=0.01;
+        let d=Math.sqrt(d2), f=2800/d2, fx=f*dx/d, fy=f*dy/d;
+        a.vx+=fx; a.vy+=fy; b.vx-=fx; b.vy-=fy;
+      }
+    }
+    for(const l of links){
+      if(visibleIds && (!visibleIds.has(l.source.id)||!visibleIds.has(l.target.id))) continue;
+      let dx=l.target.x-l.source.x, dy=l.target.y-l.source.y, d=Math.hypot(dx,dy)||0.01;
+      let f=0.045*(d-78), fx=f*dx/d, fy=f*dy/d;
+      l.source.vx+=fx; l.source.vy+=fy; l.target.vx-=fx; l.target.vy-=fy;
+    }
+    for(const n of act){
+      n.vx += -n.x*0.014; n.vy += -n.y*0.014;
+      if(n===dragging){ continue; }
+      n.vx*=0.85; n.vy*=0.85;
+      n.x += n.vx*Math.min(1,alpha*2); n.y += n.vy*Math.min(1,alpha*2);
+    }
+    alpha *= 0.985;
+  }
+
+  const w2s = (x,y)=>[x*scale+tx, y*scale+ty];
+  const s2w = (x,y)=>[(x-tx)/scale, (y-ty)/scale];
+
+  function stateOf(n){
+    if(query){
+      if(n.label.toLowerCase().includes(query)) return 'match';
+      // neighbor of a match?
+      for(const l of links){ if((l.source===n&&l.target.label.toLowerCase().includes(query))||(l.target===n&&l.source.label.toLowerCase().includes(query))) return 'near'; }
+      return 'dim';
+    }
+    if(focusSet){ return focusSet.has(n.id)?'match':'dim'; }
+    return 'on';
+  }
+
+  function draw(){
+    ctx.setTransform(DPR,0,0,DPR,0,0);
+    ctx.clearRect(0,0,W,H);
+    ctx.save(); ctx.translate(tx,ty); ctx.scale(scale,scale);
+
+    // links
+    for(const l of links){
+      if(visibleIds && (!visibleIds.has(l.source.id)||!visibleIds.has(l.target.id))) continue;
+      const st = (stateOf(l.source)==='dim'&&stateOf(l.target)==='dim')?'dim':'on';
+      const hi = hover && (l.source===hover||l.target===hover) || selected && (l.source===selected||l.target===selected);
+      const sx=l.source.x, sy=l.source.y, tx2=l.target.x, ty2=l.target.y;
+      const mx=(sx+tx2)/2, my=(sy+ty2)/2;
+      const nx=-(ty2-sy), ny=(tx2-sx); const nl=Math.hypot(nx,ny)||1;
+      const cx=mx+nx/nl*Math.hypot(tx2-sx,ty2-sy)*0.10, cy=my+ny/nl*Math.hypot(tx2-sx,ty2-sy)*0.10;
+      ctx.beginPath(); ctx.moveTo(sx,sy); ctx.quadraticCurveTo(cx,cy,tx2,ty2);
+      ctx.lineWidth=(hi?1.9:1.3)/scale;
+      ctx.strokeStyle = st==='dim' ? 'rgba(124,194,147,0.06)' : (hi?'rgba(174,230,238,0.55)':'rgba(124,194,147,0.26)');
+      ctx.stroke();
+      // arrowhead at ~0.86 along the curve
+      const t=0.86, it=1-t;
+      const ax=it*it*sx+2*it*t*cx+t*t*tx2, ay=it*it*sy+2*it*t*cy+t*t*ty2;
+      const dxx=2*it*(cx-sx)+2*t*(tx2-cx), dyy=2*it*(cy-sy)+2*t*(ty2-cy); const dl=Math.hypot(dxx,dyy)||1;
+      const ang=Math.atan2(dyy,dxx), asz=6/scale;
+      if(st!=='dim'){
+        ctx.fillStyle = hi?'rgba(174,230,238,0.85)':'rgba(174,209,174,0.7)';
+        ctx.beginPath(); ctx.moveTo(ax,ay);
+        ctx.lineTo(ax-asz*Math.cos(ang-0.4),ay-asz*Math.sin(ang-0.4));
+        ctx.lineTo(ax-asz*Math.cos(ang+0.4),ay-asz*Math.sin(ang+0.4));
+        ctx.closePath(); ctx.fill();
+      }
+      // edge label
+      if(scale>1.25 && st!=='dim'){
+        const fs=Math.max(8/scale,2.4);
+        ctx.font=`${fs}px 'IBM Plex Mono', monospace`; ctx.textAlign='center'; ctx.textBaseline='middle';
+        ctx.fillStyle = hi?'rgba(233,238,243,0.85)':'rgba(154,166,177,0.6)';
+        ctx.fillText(l.label, mx, my);
+      }
+    }
+
+    // nodes
+    for(const n of nodes){
+      if(visibleIds && !visibleIds.has(n.id)) continue;
+      const st=stateOf(n); if(st==='dim'&&!hover) {/*draw faint*/}
+      const r=radius(n)*(n===hover||n===selected?1.32:1);
+      const [x,y]=[n.x,n.y];
+      let fill = n.type==='matter'?COL.matter : COL[n.type]||COL.entity;
+      let alphaN = st==='dim'?0.18 : st==='near'?0.7 : 1;
+      ctx.globalAlpha=alphaN;
+      // halo for focal / selected / matches
+      if(n===selected||n===hover|| (focusSet&&focusSet.has(n.id)) || (query&&st==='match')){
+        ctx.beginPath(); ctx.arc(x,y,r+5/scale,0,7); ctx.fillStyle=fill; ctx.globalAlpha=alphaN*0.18; ctx.fill(); ctx.globalAlpha=alphaN;
+      }
+      ctx.beginPath(); ctx.arc(x,y,r,0,7); ctx.fillStyle=fill; ctx.fill();
+      ctx.lineWidth=1.4/scale; ctx.strokeStyle='rgba(10,13,16,0.85)'; ctx.stroke();
+      if(n===selected){ ctx.beginPath(); ctx.arc(x,y,r+3/scale,0,7); ctx.lineWidth=1.6/scale; ctx.strokeStyle=getCssVar('--logic-soft'); ctx.stroke(); }
+      // labels
+      if(showLabels && scale>0.62 && st!=='dim'){
+        const fs=Math.max(10/scale,2.6);
+        ctx.font=`${fs}px 'IBM Plex Sans', sans-serif`; ctx.textAlign='center'; ctx.textBaseline='top';
+        ctx.fillStyle='rgba(233,238,243,0.86)';
+        ctx.fillText(n.label, x, y+r+2/scale);
+      }
+      ctx.globalAlpha=1;
+    }
+    ctx.restore();
+  }
+
+  function frame(){ tick(); draw(); requestAnimationFrame(frame); }
+
+  function pick(sx,sy){
+    const [wx,wy]=s2w(sx,sy);
+    let best=null,bd=1e9;
+    for(const n of nodes){ if(visibleIds&&!visibleIds.has(n.id))continue;
+      const d=Math.hypot(n.x-wx,n.y-wy), rr=radius(n)+6/scale;
+      if(d<rr && d<bd){bd=d;best=n;} }
+    return best;
+  }
+
+  // events
+  canvas.addEventListener('mousemove', e=>{
+    const r=canvas.getBoundingClientRect(), sx=e.clientX-r.left, sy=e.clientY-r.top;
+    if(dragging){ const [wx,wy]=s2w(sx,sy); dragging.x=wx; dragging.y=wy; dragging.vx=0; dragging.vy=0; reheat(0.5); return; }
+    if(panning&&last){ tx+=sx-last[0]; ty+=sy-last[1]; last=[sx,sy]; return; }
+    const n=pick(sx,sy);
+    hover=n; canvas.classList.toggle('onnode',!!n);
+    const tip=document.getElementById('gtip');
+    if(n){ tip.innerHTML=`<div class="tt"><i style="background:${n.type==='matter'?COL.matter:COL[n.type]}"></i>${n.label}</div><div class="tm">${ntype(n)} · ${n.degree} edge${n.degree===1?'':'s'}</div>`;
+      tip.style.left=Math.min(e.clientX+14,window.innerWidth-250)+'px'; tip.style.top=(e.clientY+14)+'px'; tip.classList.add('show'); }
+    else tip.classList.remove('show');
+  });
+  canvas.addEventListener('mouseleave',()=>{ hover=null; document.getElementById('gtip').classList.remove('show'); });
+  canvas.addEventListener('mousedown', e=>{
+    const r=canvas.getBoundingClientRect(), sx=e.clientX-r.left, sy=e.clientY-r.top;
+    const n=pick(sx,sy);
+    if(n){ dragging=n; canvas.classList.add('grabbing'); }
+    else { panning=true; last=[sx,sy]; canvas.classList.add('grabbing'); }
+  });
+  window.addEventListener('mouseup', ()=>{
+    if(dragging){ dragging.vx=0; dragging.vy=0; }
+    dragging=null; panning=false; canvas.classList.remove('grabbing');
+  });
+  canvas.addEventListener('click', e=>{
+    const r=canvas.getBoundingClientRect(), sx=e.clientX-r.left, sy=e.clientY-r.top;
+    const n=pick(sx,sy);
+    if(n){ selected=n; opts.onSelect&&opts.onSelect(n, edgesOf(n)); }
+    else { selected=null; opts.onSelect&&opts.onSelect(null); }
+  });
+  canvas.addEventListener('wheel', e=>{
+    e.preventDefault();
+    const r=canvas.getBoundingClientRect(), sx=e.clientX-r.left, sy=e.clientY-r.top;
+    const [wx,wy]=s2w(sx,sy);
+    const f=e.deltaY<0?1.12:0.89; scale=Math.max(0.3,Math.min(4.2,scale*f));
+    tx=sx-wx*scale; ty=sy-wy*scale;
+  },{passive:false});
+
+  function ntype(n){ return n.type==='matter'?'matter':n.type==='entity'?'proven entity':n.type==='claim'?'proposed':n.type==='artifact'?'evidence':'external'; }
+  function edgesOf(n){
+    const out=[],inc=[];
+    for(const l of links){ if(l.source===n) out.push({label:l.label,node:l.target}); if(l.target===n) inc.push({label:l.label,node:l.source}); }
+    return {out,inc};
+  }
+
+  if('ResizeObserver' in window) new ResizeObserver(()=>resize()).observe(canvas);
+  window.addEventListener('resize',resize);
+  resize(); frame();
+
+  return {
+    setSearch(q){ query=(q||'').trim().toLowerCase(); focusSet=null; reheat(0.3); },
+    setLabels(b){ showLabels=b; },
+    setLimit(n){ if(n>=nodes.length){ visibleIds=null; } else {
+        const top=[...nodes].sort((a,b)=>b.degree-a.degree).slice(0,n); visibleIds=new Set(top.map(x=>x.id)); }
+      reheat(0.7); },
+    reseed(){ nodes.forEach(n=>{ n.x=(Math.random()-0.5)*240; n.y=(Math.random()-0.5)*240; n.vx=0; n.vy=0; }); centered=false; resize(); reheat(1); },
+    focus(ids){ focusSet=ids?new Set(ids):null; query=''; reheat(0.3); },
+    select(id){ const n=byId.get(id); if(n){ selected=n; opts.onSelect&&opts.onSelect(n, edgesOf(n)); } },
+    counts(){ return {n:nodes.length, e:links.length}; },
+    byId
+  };
+}
+
+/* ---------- wire the page ---------- */
+const canvas = document.getElementById('gcanvas');
+const detail = document.getElementById('detail');
+const G = ForceGraph(canvas, N, L, { onSelect:(n,edges)=>showDetail(n,edges) });
+
+const c=G.counts();
+document.getElementById('ncount').textContent=c.n;
+document.getElementById('ecount').textContent=c.e;
+
+function showDetail(n,edges){
+  if(!n){ detail.classList.remove('show'); return; }
+  const col = n.type==='matter'?COL.matter:COL[n.type];
+  const kind = n.type==='matter'?'matter · named subgraph':n.type==='entity'?'proven entity':n.type==='claim'?'proposed / claim':n.type==='artifact'?'evidence / artifact':'external context';
+  const rows = (arr,dir)=>arr.map(e=>`<div class="erow" data-id="${e.node.id}"><span class="dir">${dir}</span><span class="rel">${e.label}</span><span>${e.node.label}</span></div>`).join('') || `<div class="erow" style="color:var(--ink-faint)">— none —</div>`;
+  detail.innerHTML =
+    `<div class="dh"><i style="background:${col}"></i><div><div class="dt">${n.label}</div><div class="dk">${kind} · ${n.degree} edges</div></div><span class="dx" id="dclose">✕</span></div>`+
+    `<div class="dbody"><div class="sec">outgoing →</div>${rows(edges.out,'→')}<div class="sec">incoming ←</div>${rows(edges.inc,'←')}</div>`;
+  detail.classList.add('show');
+  document.getElementById('dclose').onclick=()=>{ detail.classList.remove('show'); G.select && (G.focus(null)); };
+  detail.querySelectorAll('.erow[data-id]').forEach(el=>el.onclick=()=>G.select(el.dataset.id));
+}
+
+document.getElementById('search').addEventListener('input', e=>G.setSearch(e.target.value));
+const labelsBtn=document.getElementById('labels');
+labelsBtn.addEventListener('click',()=>{ const on=labelsBtn.classList.toggle('on'); G.setLabels(on); });
+document.getElementById('reseed').addEventListener('click',()=>G.reseed());
+document.getElementById('limit').addEventListener('change',e=>G.setLimit(+e.target.value));
+</script>
+</body>
+</html>

--- a/docs/PROSE_TO_PROOF_USER_STORY.md
+++ b/docs/PROSE_TO_PROOF_USER_STORY.md
@@ -1,0 +1,124 @@
+# User Story — "The Office Action"
+
+> A day in the practice, told from Tom's chair. Every scene is annotated with the
+> capability behind the glass, so product and engineering read the same story.
+> Part of the **Prose-to-Proof** doc set — companion to the [Vision](./PROSE_TO_PROOF_VISION.md),
+> the [PRD](./product/prose-to-proof.md), and the [Architecture Map](./PROSE_TO_PROOF_ARCHITECTURE_MAP.md).
+>
+> *All names, matters, and documents below are illustrative. Real client material
+> never lives in the repository — only synthetic fixtures do.*
+
+---
+
+## The cast
+
+- **Tom** — solo IP attorney, 25 years in, the user.
+- **The matter** — *Aanstoot v. examiner* (illustrative): a utility patent application for a coffee grinder with a "burr alignment sensor," filed eight months ago for a long-time client.
+- **The trigger** — a **non-final Office Action** arrives from the USPTO. The examiner has rejected claims 1–8 as obvious (§103) over two prior-art references and wants the application narrowed or argued. Tom has three months to respond.
+
+> *What an Office Action is, in one breath: the patent examiner's written ruling
+> rejecting some or all of your claims and citing earlier patents ("prior art")
+> as the reason. To respond you must answer every rejection — usually by amending
+> claims to be narrower, and/or arguing that the cited art doesn't actually
+> disclose your invention. Miss the deadline and the application can go abandoned.*
+
+---
+
+## Scene 1 — It lands, and it's already understood
+
+Tom drops the Office Action PDF into the workbench. By the time he's poured his coffee, it's not just *stored* — it's *read*.
+
+The system has pulled out the moving parts: the two cited references, the specific claims rejected, the examiner's reasoning, and the response deadline. Each one is a tidy card. Tom clicks the deadline; it lands him on the exact line of the PDF that states it, highlighted.
+
+> **Behind the glass.** The document is parsed into the canonical document model
+> (`@beep/md`, with DOCX/PDF-origin structure bridged via `@beep/pandoc-ast`). The
+> NLP driver (`packages/drivers/nlp-mcp`, 42 tools) tokenizes and finds entities and
+> dates *with character offsets*. Span-grounded extraction (`@beep/langextract`,
+> `GroundedExtraction.span`) turns "respond by April 12" into a typed **candidate
+> claim** whose evidence is the exact character range in the source — the "jump to
+> the highlighted line" behavior, the same UX pattern the best document-AI tools use.
+
+## Scene 2 — The prior art, side by side with his own words
+
+The examiner cited two references. Tom opens the first. The system has already lined up the examiner's argument against Tom's own claim language — and, crucially, against the **original application**, surfacing the paragraphs of the specification that support the very limitation the examiner says is missing.
+
+Hovering over "the burr alignment sensor of claim 1," a card appears: the claim text, the spec paragraphs that describe it, **and a link to the CAD file for Figure 3** where the sensor is drawn. Tom hasn't gone looking for any of it. It came to him.
+
+> **Behind the glass.** This is the **editor-as-portal**. The hover card is an
+> `ArtifactRefNode` (`packages/foundation/modeling/lexical/src/Lexical.model.ts`) —
+> a block that links a spot in the document to a runtime artifact (here, the CAD
+> file) by a stable id, surfaced as `artifact://…`. The "claim ↔ spec ↔ figure"
+> links are edges in the matter's subgraph; the editor is a window onto it.
+
+## Scene 3 — A distinction worth making
+
+The system flags something Tom would have caught eventually: reference 1 describes a sensor that measures *grind size after the fact*, while Tom's claim is a sensor that aligns the burrs *before* grinding. That's a real, arguable distinction. It proposes a draft argument making exactly that point — and pulls the supporting sentence from reference 1's own text to use against it.
+
+But it does **not** assert "the references are distinguishable" as a fact. It marks it as a **suggestion awaiting Tom's judgment**, because that's a legal conclusion, and legal conclusions are his to make.
+
+> **Behind the glass.** The proposed distinction is a **candidate claim** with
+> attached **evidence** and **provenance** (`packages/epistemic/domain/src/entities/`
+> — `CandidateClaim`, `Evidence`, `Activity`). It is *candidate*, not accepted: the
+> agent may read context and propose writes, but only human approval promotes a
+> candidate into authoritative state (`goals/agentic-professional-runtime/SPEC.md`).
+> Before any proposal is even allowed to *become* a fact later, it must pass the
+> boundary — shape-checked by SHACL and proven consistent
+> (`packages/foundation/capability/semantic-web`). Confidence proposes; proof admits.
+
+## Scene 4 — The draft, in his voice
+
+Tom asks for a full response draft. What comes back already reads like *him* — the way he opens with the strongest distinction, his measured tone, his habit of quoting the reference's own language back at it. It's a first draft, not a final one, but it's a first draft he'd actually have written.
+
+Every factual sentence in the draft has a little anchor. Tom clicks one mid-paragraph — "Reference 1 teaches measurement *downstream* of grinding" — and lands on the exact line in reference 1 that says so, highlighted. He edits two sentences to sharpen the argument. The system notices the edit and quietly learns a little more of his style.
+
+> **Behind the glass.** Drafting is grounded generation: the model drafts, but each
+> assertion carries its evidence span, so "show me the source" is one click, not a
+> hope. Tom's edits are new signal in the dogfooding flywheel (see the Vision, §7) —
+> the corpus of his approved work is how the system comes to write like him.
+
+## Scene 5 — He signs, and the record remembers why
+
+Tom reviews the candidate set — the extracted deadline, the distinctions, the amended claim language, the draft response — in one approval view. He accepts most, rejects one weak argument, tweaks another. He hits **approve**.
+
+Only now does any of it become part of the practice's permanent memory. And when it does, it carries its whole story: what was claimed, the evidence span behind it, that *Tom* approved it, and when. Six months from now, "why did we make this argument?" has an answer with a receipt.
+
+> **Behind the glass.** Approval is the promotion gate. Accepted records join the
+> authority spine — typed claims + evidence + provenance + lifecycle, the
+> authoritative memory primitive (`goals/agentic-professional-runtime/docs/runtime-data-loop.md`).
+> The graph view, the search index, and any future GraphRAG answer are **projections**
+> rebuilt from that accepted truth, never a second source of it
+> ([BeepGraph](./BEEPGRAPH_ARCHITECTURE.md)). Everything happened on Tom's machine; the
+> client's file never left it.
+
+---
+
+## What just happened (the loop)
+
+```
+PDF dropped in
+   └─► read & structured            (md / pandoc-ast / nlp-mcp)
+   └─► claims grounded to spans      (langextract → evidence)
+   └─► portal links surfaced         (artifact-ref: claim ↔ spec ↔ figure)
+   └─► distinctions proposed         (candidate claims, NOT yet facts)
+   └─► draft written in his voice    (grounded generation + style corpus)
+   └─► Tom reviews & approves        (strict human gate)
+   └─► proven facts join the graph   (authority spine; everything local)
+```
+
+Ingest → extract → ground → portal → draft → **approve** → proof. The same runtime
+data loop the product is built on, walked once, on a real piece of work.
+
+## Coda — an ordinary Tuesday
+
+It isn't always an Office Action. Most days are smaller, and the workbench earns its keep in the margins:
+
+- A prospect emails asking about trademark availability. The system drafts a reply in Tom's tone and reminds him it's still *his* to send.
+- Before the intake call, Tom asks, "what do we already know about this company?" — and gets an answer assembled from old matters and emails, each point clickable to its source.
+- A new client comes in; a conflict check runs across every walled matter in seconds and comes back clean — a query Tom could never have run reliably from memory.
+- At 6pm, the librarian has quietly filed the day's correspondence into the right matters, flagged one deadline moving up, and left tomorrow's prep on top of the pile.
+
+None of it is dramatic. All of it is *proven*. And every night, the practice knows a little more of what Tom knows.
+
+---
+
+*User story · the boundary converts confidence into provenance · the attorney always signs.*

--- a/docs/PROSE_TO_PROOF_VISION.md
+++ b/docs/PROSE_TO_PROOF_VISION.md
@@ -1,0 +1,94 @@
+# Prose-to-Proof — Product Vision
+
+> **Prose in, proof out.**
+> A local-first, provenance-grounded knowledge workbench for a solo intellectual-property practice.
+> *Obsidian for lawyers — but it proves its sources.*
+
+- **Status:** Vision (north star) · **Working codename:** Prose-to-Proof · **Architecture name:** BeepGraph
+- **Product target:** `apps/professional-desktop` (today a chat shell; tomorrow the workbench)
+- **Companion docs:** [For Tom](./PROSE_TO_PROOF_FOR_TOM.md) · [User Story](./PROSE_TO_PROOF_USER_STORY.md) · [Visualization](./PROSE_TO_PROOF_VISUALIZATION.html) · [Architecture Map](./PROSE_TO_PROOF_ARCHITECTURE_MAP.md) · [Draft PRD](./product/prose-to-proof.md) · [BeepGraph Architecture](./BEEPGRAPH_ARCHITECTURE.md)
+
+---
+
+## 1. The one sentence
+
+A solo IP attorney's whole practice — every email, application, response, contract, and figure — flows through **one local machine** that reads the prose, **proposes** structured claims about it, **proves** those claims sound against a formal legal ontology, and admits only what survives into **one knowledge graph where every fact carries a link back to the exact words that justify it.**
+
+## 2. Why this exists — and why it's father and son
+
+This is not a feature list. It is a relationship encoded as a system.
+
+For 25 years my father, **Tom Oppold**, has done intellectual-property law — drafting patents, answering examiners, shepherding inventions from a napkin sketch to a granted claim. That work lives as a vast archive of documents and a deeper, unwritten thing: his *judgment* — how he frames an argument, how he distinguishes prior art, the house style of a well-built response. He is now opening a **solo practice**, and I am building him the machine that makes all of it computable.
+
+The structure of this is unusually clean, and it is the heart of the product:
+
+- **The corpus is his 25 years.** The already-salvaged, deduplicated, USPTO-enriched Oppold corpus — 8,438 files — is the seed data (`goals/oppold-corpus-pipeline/SPEC.md`). His past work *is* the training ground.
+- **The first user is him.** Not a persona. A real attorney with real matters and real deadlines.
+- **His use makes it smarter.** Every claim he approves, every draft he edits into his own voice, every correction he makes teaches the system his standard.
+
+Father built the knowledge. Son builds the machine that makes it legible. The machine serves the father. The father's work sharpens the machine. **We dogfood our own product** — that is how this becomes something real instead of a demo. The loop is the architecture (see §7).
+
+## 3. Prose in, proof out — the thesis
+
+A patent practice runs on prose: applications, office actions, correspondence, contracts. Prose is rich and fallible. A knowledge graph is structured and trustworthy. The hard problem is the **crossing** between them — and the entire design is organized around making that crossing honest.
+
+There are **two families** of computation, and they must never be confused:
+
+- **The retrieval family — *proposes*, fallibly.** A language model and NLP read the documents and *guess*: this string is an inventor, that clause is a license grant, this paragraph distinguishes prior art. Useful, fast, revisable — and never, on its own, true.
+- **The logic family — *proves*, soundly.** A formal ontology and a reasoner compute what *follows*: consequences true in every model, not guesses. What it asserts, it can defend.
+
+Between them sits **the boundary** — the one place where *confidence becomes provenance*. A proposal does not enter the graph because a model felt sure. It enters only after a **SHACL gate** validates its shape, a **consistency check** proves it doesn't contradict what's already known, and it is **materialized** into the record with a permanent link to its source span. Confidence gets you to the boundary; only proof gets you across.
+
+> The deepest invariant, stated as a single test: *does anything compute an entailment?* Left of the boundary, no — vectors and an LLM, revisable guesses. Right of it, yes — consequences true in every model. The surface form (triples, RDF, a graph database) never tells you which family you're in. That question does. The full articulation lives in the system diagram and is mapped to code in [the Architecture Map](./PROSE_TO_PROOF_ARCHITECTURE_MAP.md).
+
+## 4. What it is
+
+One application with four faces, all over the same graph:
+
+1. **A document portal.** A rich editor (`@beep/lexical-schema` + `@beep/md`) where the file is the source of truth and every document is a *portal into a subgraph*. Hover over "Figure 1" and a card surfaces the linked CAD file; hover over a defined term and see its definition and every place it's used; hover over a party and see the matter, the client, the emails. This is already a built primitive — the `ArtifactRefNode` (`packages/foundation/modeling/lexical/src/Lexical.model.ts`).
+2. **A document-management system (DMS).** Every file canonical on disk, synced to interchangeable backups (Box / S3 / local). Identity is *minted and stable*; storage locators (`box:fileId`, `s3:key`, `sha256`) are mere properties, never identity.
+3. **A knowledge graph.** Prose becomes structure: typed claims, evidence, and provenance (`@beep/epistemic-domain`), grounded against a stack of published legal ontologies (FOLIO, BFO, LKIF-Core, the WEMI/LRMoo document model, ODRL, CPC/IPC — see `goals/ip-law-knowledge-graph/SPEC.md`). One logical graph, **walled by matter** — each matter a named subgraph that doubles as an ethical wall with legal force.
+4. **Ask & check.** GraphRAG question-answering over the practice, and **conflict-of-interest checks across matters** — a query only a single unified graph can answer, even though each matter stays sealed for substantive reads.
+
+## 5. What it is *not*
+
+- **Not a cloud SaaS.** Local-first, on device by default; client data does not leave the machine unless a backup backend is explicitly chosen. Embeddings are computed locally. (The competitive landscape is telling: the tools that cite their sources well are cloud-bound; the tools that are truly local don't ground rigorously, and none are IP-specialized — see [the PRD](./product/prose-to-proof.md). The local-*and*-grounded intersection is essentially unoccupied.)
+- **Not a replacement for systems of record.** It does not replace email, calendar, billing, docketing, or the USPTO. It connects to them and keeps *its own* claims, evidence, drafts, approvals, and provenance (`goals/agentic-professional-runtime/SPEC.md`).
+- **Not an autonomous lawyer.** Agents *propose*. The attorney *approves*. Legal advice, filings, and client-facing judgment stay behind a strict human approval gate (`goals/agentic-professional-runtime/docs/approval-and-autonomy-policy.md`).
+- **Not a place for privileged data in the repo.** Real client material lives outside git (`/home/elpresidank/data-home/oppold-corpus/`); the repository carries only synthetic fixtures.
+
+## 6. Five principles
+
+1. **Local-first, every matter walled.** On-device by default; matters are named subgraphs that are also confidentiality boundaries with legal force.
+2. **The file is canonical.** One file = the truth for prose. Format is a per-document property carried by the extension, not a global mode. The graph indexes the file; it never replaces it.
+3. **The editor is a portal.** Documents link into subgraphs; reading is navigating; provenance is one hover away.
+4. **Provenance everywhere.** Nothing is asserted without a source. A **character span** is the provenance link — the exact words, highlightable, like a search engine jumping you to the precise sentence on a page. This is built: `GroundedExtraction.span` (`packages/foundation/capability/langextract/src/Extraction`).
+5. **Retrieval proposes, logic proves.** Confidence routes a guess to review; only proof admits a fact. The boundary is sacred.
+
+## 7. The dogfooding flywheel
+
+```
+Tom's 25 years  ──►  corpus (8,438 files)  ──►  extract + ground (spans)
+      ▲                                                   │
+      │                                                   ▼
+  sharper drafts,                                  candidate claims
+  faster review                                          │
+      │                                                   ▼
+      │                                          approval gate (Tom)
+      │                                                   │
+      └────────── practice memory ◄── proven graph ◄──────┘
+```
+
+Each turn of the wheel, the system knows more of what Tom knows, in a form it can prove. The product gets better precisely *because* the person it's built for uses it. That is the bet.
+
+## 8. Where it stands, and where it goes
+
+**Today.** `apps/professional-desktop` (v0.0.3) is honestly a local-first **chat app** — Tauri + React + a Bun sidecar, with chat turns persisted and cost tracked. The foundations beneath it are realer than the surface implies: span-grounded extraction, the artifact-ref portal node, a 42-tool NLP driver (`packages/drivers/nlp-mcp`), typed claims/evidence/provenance, PROV-O and bounded SHACL (`packages/foundation/capability/semantic-web`), and the RDF substrate (`packages/foundation/modeling/rdf`) all exist as built or specced primitives.
+
+**Next (MVP).** Turn the chat app into the **document portal**: ingest one matter's documents, extract and ground claims to spans, surface them in the Lexical editor with hover-card subgraph links, and gate everything behind attorney approval — the same **runtime data loop** already locked as the first proof (`goals/agentic-professional-runtime/docs/runtime-data-loop.md`), extended from email to documents. Detailed in [the PRD](./product/prose-to-proof.md).
+
+**Horizon (GA).** The full graph: FalkorDB projection for Cypher traversal, GraphRAG ask-and-check, cross-matter conflict checks, the legal-ontology TBox with a sound reasoner, and the AI librarian ingesting the full corpus. The architecture that gets us there — effect-ontology as the typed authority spine, TrustGraph as the projection/retrieval shell — is settled in [BeepGraph](./BEEPGRAPH_ARCHITECTURE.md).
+
+---
+
+*Prose in · the file stays canonical · the boundary converts confidence into provenance · proof out · one graph, walled by matter · everything on device.*

--- a/docs/PROSE_TO_PROOF_VISUALIZATION.html
+++ b/docs/PROSE_TO_PROOF_VISUALIZATION.html
@@ -47,7 +47,20 @@
   }
   .wrap{max-width:1060px;margin:0 auto}
 
-  header{padding:62px 0 26px}
+  /* shared tab bar */
+  .tabbar{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:18px;
+    padding:11px 20px;margin:0 -20px 0;border-bottom:1px solid var(--line);
+    background:rgba(10,13,16,.82);backdrop-filter:blur(10px)}
+  .tabbar .brand{display:flex;align-items:center;gap:9px;font-family:var(--disp);font-weight:700;font-size:.96rem;color:var(--ink);text-decoration:none;letter-spacing:-.01em}
+  .tabbar .brand .logo{display:grid;place-items:center;width:25px;height:25px;border:1px solid var(--logic);border-radius:6px;color:var(--logic);font-family:var(--mono);font-size:.95rem}
+  .tabbar .tabs{display:flex;gap:4px}
+  .tabbar .tab{font-family:var(--mono);font-size:.74rem;letter-spacing:.04em;color:var(--ink-dim);text-decoration:none;padding:7px 13px;border-radius:6px;border:1px solid transparent;transition:.18s}
+  .tabbar .tab:hover{color:var(--ink);background:rgba(255,255,255,.04)}
+  .tabbar .tab.on{color:var(--ink);background:rgba(95,198,214,.10);border-color:rgba(95,198,214,.3)}
+  .tabbar .conn{margin-left:auto;font-family:var(--mono);font-size:.66rem;color:var(--safe);display:flex;align-items:center;gap:7px}
+  .tabbar .conn::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--safe);box-shadow:0 0 8px var(--safe)}
+
+  header{padding:34px 0 26px}
   .eyebrow{font-family:var(--mono);font-size:.72rem;letter-spacing:.26em;text-transform:uppercase;color:var(--ink-faint)}
   .eyebrow b{color:var(--retrieval-soft);font-weight:500}
   .eyebrow i{color:var(--logic-soft);font-style:normal;font-weight:500}
@@ -235,6 +248,15 @@
 </style>
 </head>
 <body class="lens-stage">
+  <nav class="tabbar">
+    <a class="brand" href="PROSE_TO_PROOF_VISUALIZATION.html"><span class="logo">⊢</span> Prose-to-Proof</a>
+    <div class="tabs">
+      <a class="tab on" href="PROSE_TO_PROOF_VISUALIZATION.html">Workbench</a>
+      <a class="tab" href="PROSE_TO_PROOF_GRAPH.html">Graph</a>
+      <a class="tab" href="PROSE_TO_PROOF_CHAT.html">Chat</a>
+    </div>
+    <span class="conn">local · on device</span>
+  </nav>
 <div class="wrap">
 
   <header>

--- a/docs/PROSE_TO_PROOF_VISUALIZATION.html
+++ b/docs/PROSE_TO_PROOF_VISUALIZATION.html
@@ -27,7 +27,7 @@
     --safe:#7cc293;
     --membrane:#d7ccbe;
     --neutral:#8893a0;
-    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#586673;
+    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#6b7886;
     --line:rgba(255,255,255,.10); --line-soft:rgba(255,255,255,.05);
     --card:rgba(255,255,255,.022);
     --mono:'IBM Plex Mono',ui-monospace,monospace;
@@ -48,7 +48,7 @@
   .wrap{max-width:1060px;margin:0 auto}
 
   /* shared tab bar */
-  .tabbar{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:18px;
+  .tabbar{position:sticky;top:0;z-index:40;display:flex;flex-wrap:wrap;align-items:center;gap:18px;
     padding:11px 20px;margin:0 -20px 0;border-bottom:1px solid var(--line);
     background:rgba(10,13,16,.82);backdrop-filter:blur(10px)}
   .tabbar .brand{display:flex;align-items:center;gap:9px;font-family:var(--disp);font-weight:700;font-size:.96rem;color:var(--ink);text-decoration:none;letter-spacing:-.01em}
@@ -57,8 +57,8 @@
   .tabbar .tab{font-family:var(--mono);font-size:.74rem;letter-spacing:.04em;color:var(--ink-dim);text-decoration:none;padding:7px 13px;border-radius:6px;border:1px solid transparent;transition:.18s}
   .tabbar .tab:hover{color:var(--ink);background:rgba(255,255,255,.04)}
   .tabbar .tab.on{color:var(--ink);background:rgba(95,198,214,.10);border-color:rgba(95,198,214,.3)}
-  .tabbar .conn{margin-left:auto;font-family:var(--mono);font-size:.66rem;color:var(--safe);display:flex;align-items:center;gap:7px}
-  .tabbar .conn::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--safe);box-shadow:0 0 8px var(--safe)}
+  .tabbar .tbnet{margin-left:auto;font-family:var(--mono);font-size:.66rem;color:var(--safe);display:flex;align-items:center;gap:7px}
+  .tabbar .tbnet::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--safe);box-shadow:0 0 8px var(--safe)}
 
   header{padding:34px 0 26px}
   .eyebrow{font-family:var(--mono);font-size:.72rem;letter-spacing:.26em;text-transform:uppercase;color:var(--ink-faint)}
@@ -255,7 +255,7 @@
       <a class="tab" href="PROSE_TO_PROOF_GRAPH.html">Graph</a>
       <a class="tab" href="PROSE_TO_PROOF_CHAT.html">Chat</a>
     </div>
-    <span class="conn">local · on device</span>
+    <span class="tbnet">local · on device</span>
   </nav>
 <div class="wrap">
 
@@ -319,7 +319,7 @@
 
       <!-- the document -->
       <div class="doc" id="doc" data-stage="portal" data-trust="proving" data-loc="local">
-        <div class="docbar"><span class="dot3"><i></i><i></i><i></i></span> response-to-office-action.md · matter: Aanstoot · grinder burr sensor</div>
+        <div class="docbar"><span class="dot3"><i></i><i></i><i></i></span> response-to-office-action.md · matter: Aanstoot · grinder burr sensor · illustrative</div>
         <h4>Remarks</h4>
         <p>Claim 1 recites a <span class="link term" tabindex="0" data-card="term" id="span-sensor">burr alignment sensor</span> that registers alignment <em>prior to</em> grinding. Reference 1 (to <span class="link party" tabindex="0" data-card="party" id="span-halvorsen">Halvorsen</span>) instead teaches a sensor that measures grind size <span class="hl">downstream of the grinding operation</span> — a different function at a different stage of the apparatus.</p>
         <p>Support for the recited limitation appears throughout the specification and is depicted in <span class="link fig" tabindex="0" data-card="fig" id="span-fig3">Figure&nbsp;3</span>, which shows the sensor positioned at the burr interface, registering relative burr position before any grinding occurs.</p>
@@ -334,8 +334,8 @@
       <!-- viewer + subgraph -->
       <div class="panecol">
         <div class="cadview" id="cadview" data-stage="portal" data-loc="local">
-          <div class="cadhead"><i class="mdot" style="background:var(--inferred)"></i> figure 3 · burr interface · live CAD</div>
-          <div class="cadwrap" id="cadwrap">
+          <div class="cadhead"><i class="mdot" style="background:var(--inferred)"></i> figure 3 · burr interface · live 3D</div>
+          <div class="cadwrap" id="cadwrap" role="img" aria-label="Interactive 3D render of the patent figure — a conical grinder burr with the claimed alignment sensor highlighted. Drag to orbit, scroll to zoom. Illustrative, not a loaded CAD file.">
             <div class="cadfallback">
               <span>3D viewer needs WebGL (offline build falls back to the locator).</span>
               <span class="loc">artifact://cad/grinder_v3.step</span>
@@ -354,7 +354,7 @@
             <li><button class="sgitem party" data-action="cad"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Inventor email — sensor placement <span class="kind">email</span></span><span class="sgm">Aanstoot thread · 2026-02-11 · "before the grind, not after"</span></span><span class="arw">↗</span></button></li>
             <li><button class="sgitem fig" data-action="cad"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">CAD source — grinder_v3.step <span class="kind">artifact</span></span><span class="sgm">12 revisions · last edited 2026-01-30</span></span><span class="arw">↗</span></button></li>
             <li><button class="sgitem term" data-action="scroll" data-target="span-fig3"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Prior response — distinguished art <span class="kind">work product</span></span><span class="sgm">2025-09 · same teaching-away argument, allowed</span></span><span class="arw">↗</span></button></li>
-            <li><button class="sgitem party" data-action="scroll" data-target="span-halvorsen"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Deadline — respond by Apr 12 <span class="kind">docket</span></span><span class="sgm">Non-final action · 3-month statutory period</span></span><span class="arw">↗</span></button></li>
+            <li><button class="sgitem party" data-action="scroll" data-target="span-halvorsen"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Deadline — respond by Apr 12 <span class="kind">docket</span></span><span class="sgm">Non-final action · ~3-month shortened period (extendable)</span></span><span class="arw">↗</span></button></li>
           </ul>
         </div>
       </div>
@@ -520,6 +520,7 @@ document.querySelectorAll('#sglist .sgitem').forEach(btn => {
   function scheduleHide(){ clearTimeout(hideTimer); hideTimer = setTimeout(hide, 220); }
 
   document.querySelectorAll('.link').forEach(link => {
+    link.setAttribute('role','button');
     link.addEventListener('mouseenter', () => show(link));
     link.addEventListener('mouseleave', scheduleHide);
     link.addEventListener('focus', () => show(link));

--- a/docs/PROSE_TO_PROOF_VISUALIZATION.html
+++ b/docs/PROSE_TO_PROOF_VISUALIZATION.html
@@ -1,0 +1,658 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Prose-to-Proof · A day at the workbench</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+  }
+}
+</script>
+<style>
+  :root{
+    --bg:#0a0d10;
+    --retrieval:#d99a5b; --retrieval-soft:#ecc196;
+    --logic:#5fc6d6;     --logic-soft:#aee6ee;
+    --inferred:#b08ae8;
+    --prov:#cda968;
+    --reject:#e0706f;
+    --check:#7aa6e8;
+    --safe:#7cc293;
+    --membrane:#d7ccbe;
+    --neutral:#8893a0;
+    --ink:#e9eef3; --ink-dim:#9aa6b1; --ink-faint:#586673;
+    --line:rgba(255,255,255,.10); --line-soft:rgba(255,255,255,.05);
+    --card:rgba(255,255,255,.022);
+    --mono:'IBM Plex Mono',ui-monospace,monospace;
+    --sans:'IBM Plex Sans',system-ui,sans-serif;
+    --disp:'Space Grotesk',var(--sans);
+    --accent:var(--neutral);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{
+    font-family:var(--sans);color:var(--ink);line-height:1.55;min-height:100vh;
+    -webkit-font-smoothing:antialiased;padding:0 20px 90px;
+    background:
+      radial-gradient(130% 60% at 50% -10%, rgba(217,154,91,.12), transparent 50%),
+      radial-gradient(130% 70% at 50% 112%, rgba(95,198,214,.11), transparent 50%),
+      linear-gradient(180deg,#110d0b 0%,#0c0e11 46%,#090f12 100%);
+    background-attachment:fixed;
+  }
+  .wrap{max-width:1060px;margin:0 auto}
+
+  header{padding:62px 0 26px}
+  .eyebrow{font-family:var(--mono);font-size:.72rem;letter-spacing:.26em;text-transform:uppercase;color:var(--ink-faint)}
+  .eyebrow b{color:var(--retrieval-soft);font-weight:500}
+  .eyebrow i{color:var(--logic-soft);font-style:normal;font-weight:500}
+  h1{font-family:var(--disp);font-weight:700;line-height:1.0;letter-spacing:-.025em;
+     font-size:clamp(2.4rem,7.5vw,4.4rem);margin:16px 0 0}
+  h1 .a{color:var(--retrieval)} h1 .b{color:var(--logic)}
+  .thesis{color:var(--ink-dim);max-width:70ch;margin-top:18px;font-size:1.02rem}
+  .thesis b{color:var(--ink);font-weight:600}
+
+  .lenses{margin-top:30px;display:flex;flex-direction:column;gap:14px}
+  .lensrow{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .lensrow .lbl{font-family:var(--mono);font-size:.66rem;letter-spacing:.16em;text-transform:uppercase;color:var(--ink-faint);margin-right:4px}
+  .lensbtn{font-family:var(--mono);font-size:.78rem;letter-spacing:.03em;color:var(--ink-dim);
+    background:transparent;border:1px solid var(--line);border-radius:2px;padding:8px 14px;cursor:pointer;
+    transition:border-color .2s ease,color .2s ease,background .2s ease}
+  .lensbtn:hover{border-color:rgba(255,255,255,.25);color:var(--ink)}
+  .lensbtn.on{color:var(--bg);background:var(--ink);border-color:var(--ink);font-weight:500}
+  .lensbtn:focus-visible{outline:2px solid var(--logic);outline-offset:3px}
+  .legend{display:flex;gap:15px;flex-wrap:wrap;font-family:var(--mono);font-size:.7rem;color:var(--ink-dim)}
+  .legend.hidden{display:none}
+  .legend span{display:inline-flex;align-items:center;gap:7px}
+  .swatch{width:10px;height:10px;border-radius:2px;display:inline-block;flex-shrink:0}
+
+  .plane{margin-top:14px}
+  .planehead{display:flex;align-items:baseline;gap:13px;margin:46px 0 16px}
+  .planehead .px{font-family:var(--mono);font-size:.72rem;color:var(--ink-faint)}
+  .planehead h2{font-family:var(--disp);font-weight:600;font-size:1.04rem;letter-spacing:-.005em}
+  .planehead .ph{font-family:var(--mono);font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-faint);margin-left:auto;text-align:right}
+
+  /* ── the journey rail ── */
+  .rail{display:grid;grid-template-columns:repeat(7,1fr);gap:9px}
+  .step{position:relative;border:1px solid var(--line);border-radius:5px;background:var(--card);
+    padding:13px 12px 14px;transition:border-color .2s ease,opacity .5s ease,transform .5s ease;
+    opacity:0;transform:translateY(12px)}
+  .step.in{opacity:1;transform:none}
+  .step::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;border-radius:5px 0 0 5px;
+    background:var(--accent);transition:background .35s ease}
+  .step .n{font-family:var(--mono);font-size:.58rem;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-faint)}
+  .step .t{font-family:var(--disp);font-weight:600;font-size:.92rem;margin-top:5px;letter-spacing:-.005em}
+  .step p{color:var(--ink-dim);font-size:.74rem;line-height:1.42;margin-top:6px}
+  .railcap{display:flex;gap:16px;flex-wrap:wrap;font-family:var(--mono);font-size:.66rem;color:var(--ink-faint);padding:11px 2px 0}
+
+  /* ── editor-as-portal ── */
+  .portal{display:grid;grid-template-columns:1.32fr 1fr;gap:16px;align-items:stretch}
+  .panecol{display:flex;flex-direction:column;gap:16px;min-width:0}
+
+  .doc{border:1px solid var(--line);border-radius:8px;background:rgba(255,255,255,.014);padding:18px 20px;position:relative;
+    max-height:520px;overflow-y:auto;scrollbar-width:thin;scrollbar-color:rgba(255,255,255,.16) transparent}
+  .doc::-webkit-scrollbar{width:9px}
+  .doc::-webkit-scrollbar-thumb{background:rgba(255,255,255,.14);border-radius:6px}
+  .doc .docbar{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:.62rem;color:var(--ink-faint);
+    letter-spacing:.08em;text-transform:uppercase;border-bottom:1px solid var(--line-soft);padding-bottom:10px;margin-bottom:14px;position:sticky;top:-18px;background:linear-gradient(180deg,#0c0f12 70%,transparent);padding-top:4px}
+  .doc .dot3{display:inline-flex;gap:4px}
+  .doc .dot3 i{width:8px;height:8px;border-radius:50%;background:var(--line);display:inline-block}
+  .doc h4{font-family:var(--disp);font-weight:600;font-size:1.02rem;margin:14px 0 8px}
+  .doc h4:first-of-type{margin-top:2px}
+  .doc p{font-size:.86rem;color:var(--ink-dim);line-height:1.62;margin-bottom:9px}
+  .link{border-bottom:1px dashed;cursor:help;padding:0 1px 1px;color:var(--ink);font-weight:500;border-radius:2px;
+    transition:background .2s ease}
+  .link:hover,.link:focus-visible{background:rgba(255,255,255,.06);outline:none}
+  .link:focus-visible{box-shadow:0 0 0 2px var(--logic)}
+  .link.fig{border-color:var(--inferred);color:var(--inferred)}
+  .link.term{border-color:var(--logic);color:var(--logic-soft)}
+  .link.party{border-color:var(--retrieval);color:var(--retrieval-soft)}
+  .hl{background:rgba(122,166,232,.16);border-radius:2px;padding:0 3px;box-shadow:inset 0 -1px 0 var(--check)}
+  @keyframes flashspan{0%{background:rgba(122,166,232,.42)}100%{background:rgba(122,166,232,0)}}
+  .flash{animation:flashspan 1.6s ease-out}
+
+  /* ── CAD viewer ── */
+  .cadview{border:1px solid var(--line);border-radius:8px;background:rgba(95,198,214,.025);position:relative;overflow:hidden;
+    transition:border-color .3s ease,box-shadow .3s ease}
+  .cadview.pulse{border-color:rgba(176,138,232,.6);box-shadow:0 0 0 1px rgba(176,138,232,.4),0 0 26px rgba(176,138,232,.18)}
+  .cadhead{position:absolute;top:0;left:0;right:0;z-index:3;display:flex;align-items:center;gap:8px;
+    font-family:var(--mono);font-size:.6rem;letter-spacing:.13em;text-transform:uppercase;color:var(--inferred);
+    padding:10px 12px;background:linear-gradient(180deg,rgba(10,13,16,.85),transparent);pointer-events:none}
+  .cadwrap{height:280px;position:relative}
+  .cadwrap canvas{display:block;width:100%!important;height:100%!important;cursor:grab}
+  .cadwrap canvas:active{cursor:grabbing}
+  .cadfoot{position:absolute;bottom:0;left:0;right:0;z-index:3;display:flex;align-items:center;justify-content:space-between;gap:8px;
+    font-family:var(--mono);font-size:.64rem;color:var(--ink-faint);padding:9px 12px;
+    background:linear-gradient(0deg,rgba(10,13,16,.86),transparent);pointer-events:none}
+  .cadfoot .loc{color:var(--logic-soft);word-break:break-all}
+  .cadfoot .drag{color:var(--ink-faint)}
+  .cadfallback{position:absolute;inset:0;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;
+    text-align:center;padding:24px;color:var(--ink-dim);font-size:.8rem}
+  .cadfallback .loc{font-family:var(--mono);font-size:.72rem;color:var(--logic-soft);word-break:break-all}
+  .cadview.failed .cadfallback{display:flex}
+  .cadview.failed .cadwrap canvas{opacity:0}
+
+  /* ── subgraph scroll list ── */
+  .subgraph{border:1px solid var(--line);border-radius:8px;background:rgba(255,255,255,.012);display:flex;flex-direction:column;flex:1;min-height:0}
+  .sghead{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:.62rem;letter-spacing:.12em;text-transform:uppercase;
+    color:var(--ink-faint);padding:12px 14px 10px;border-bottom:1px solid var(--line-soft)}
+  .sghead .mdot{background:var(--logic)}
+  .sghead .count{margin-left:auto;color:var(--ink-faint)}
+  .sglist{list-style:none;overflow-y:auto;max-height:240px;padding:6px;scrollbar-width:thin;scrollbar-color:rgba(255,255,255,.16) transparent}
+  .sglist::-webkit-scrollbar{width:9px}
+  .sglist::-webkit-scrollbar-thumb{background:rgba(255,255,255,.14);border-radius:6px}
+  .sgitem{width:100%;display:flex;align-items:flex-start;gap:10px;text-align:left;background:transparent;border:1px solid transparent;
+    border-radius:6px;padding:9px 10px;cursor:pointer;color:var(--ink);font-family:var(--sans);transition:background .15s ease,border-color .15s ease}
+  .sgitem:hover,.sgitem:focus-visible{background:rgba(255,255,255,.04);border-color:var(--line);outline:none}
+  .sgitem:focus-visible{box-shadow:0 0 0 2px var(--logic)}
+  .sgicon{font-size:.92rem;line-height:1.3;width:20px;text-align:center;flex-shrink:0}
+  .sgbody{min-width:0;flex:1}
+  .sgt{font-size:.82rem;font-weight:500;display:flex;align-items:center;gap:7px}
+  .sgt .kind{font-family:var(--mono);font-size:.54rem;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-faint);
+    border:1px solid var(--line);border-radius:3px;padding:1px 5px}
+  .sgm{font-size:.72rem;color:var(--ink-dim);margin-top:2px;line-height:1.4;overflow:hidden;text-overflow:ellipsis}
+  .sgitem .arw{margin-left:auto;color:var(--ink-faint);font-family:var(--mono);font-size:.8rem;opacity:0;transition:opacity .15s}
+  .sgitem:hover .arw,.sgitem:focus-visible .arw{opacity:1}
+  .sgitem.fig{--accent:var(--inferred)} .sgitem.term{--accent:var(--logic)} .sgitem.party{--accent:var(--retrieval)}
+  .sgitem .sgicon{color:var(--accent,var(--neutral))}
+
+  /* ── popover (real hover card) ── */
+  .pop{position:fixed;z-index:60;width:268px;max-width:calc(100vw - 24px);border:1px solid var(--line);border-radius:8px;
+    background:rgba(16,20,24,.97);backdrop-filter:blur(7px);box-shadow:0 14px 40px rgba(0,0,0,.5);
+    padding:13px 14px;opacity:0;visibility:hidden;transform:translateY(5px) scale(.985);
+    transition:opacity .16s ease,transform .16s ease,visibility .16s;pointer-events:none}
+  .pop.show{opacity:1;visibility:visible;transform:none;pointer-events:auto}
+  .pop::before{content:"";position:absolute;left:0;top:13px;bottom:13px;width:3px;border-radius:8px 0 0 8px;background:var(--accent)}
+  .pop.fig{--accent:var(--inferred)} .pop.term{--accent:var(--logic)} .pop.party{--accent:var(--retrieval)}
+  .pop .pk{font-family:var(--mono);font-size:.56rem;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-faint);display:flex;align-items:center;gap:7px}
+  .pop .pt{font-family:var(--disp);font-weight:600;font-size:.96rem;margin:5px 0 5px}
+  .pop p{font-size:.78rem;color:var(--ink-dim);line-height:1.5}
+  .pop .meta{font-family:var(--mono);font-size:.68rem;color:var(--logic-soft);margin-top:8px;word-break:break-all}
+  .pop .act{margin-top:11px;display:inline-flex;align-items:center;gap:6px;font-family:var(--mono);font-size:.72rem;
+    color:var(--ink);background:rgba(255,255,255,.05);border:1px solid var(--line);border-radius:5px;padding:6px 10px;cursor:pointer;
+    transition:border-color .15s,background .15s}
+  .pop .act:hover{border-color:rgba(255,255,255,.3);background:rgba(255,255,255,.09)}
+  .mdot{width:8px;height:8px;border-radius:50%;background:var(--accent);flex-shrink:0}
+
+  /* ── review queue ── */
+  .queue{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+  .lane{border:1px solid var(--line);border-radius:6px;padding:14px;background:rgba(255,255,255,.012)}
+  .lane .lh{font-family:var(--mono);font-size:.64rem;letter-spacing:.12em;text-transform:uppercase;display:flex;align-items:center;gap:8px;margin-bottom:9px}
+  .lane p{font-size:.78rem;color:var(--ink-dim);line-height:1.5}
+  .lane .route{font-family:var(--mono);font-size:.68rem;color:var(--ink-faint);margin-top:9px;border-top:1px solid var(--line-soft);padding-top:8px}
+  .lane.hi .lh{color:var(--logic-soft)} .lane.hi .mdot{background:var(--logic)}
+  .lane.med .lh{color:var(--retrieval-soft)} .lane.med .mdot{background:var(--retrieval)}
+  .lane.lo .lh{color:var(--ink-dim)} .lane.lo .mdot{background:var(--neutral)}
+
+  .conn{display:flex;justify-content:center;padding:16px 0 2px}
+  .conn span{font-family:var(--mono);font-size:.68rem;color:var(--ink-faint);letter-spacing:.04em;
+    border:1px solid var(--line-soft);border-radius:20px;padding:5px 14px;background:rgba(255,255,255,.012)}
+
+  /* ── two promises coda ── */
+  .coda{margin-top:54px;border-top:1px solid var(--line-soft);padding-top:30px;display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  .promise{border:1px solid var(--line);border-radius:7px;padding:18px 20px;background:rgba(255,255,255,.012)}
+  .promise.local{border-color:rgba(124,194,147,.26);background:rgba(124,194,147,.04)}
+  .promise.proof{border-color:rgba(95,198,214,.24);background:rgba(95,198,214,.04)}
+  .promise .pg{font-family:var(--mono);font-size:.62rem;letter-spacing:.14em;text-transform:uppercase;display:flex;align-items:center;gap:8px;margin-bottom:9px}
+  .promise.local .pg{color:var(--safe)} .promise.proof .pg{color:var(--logic-soft)}
+  .promise h3{font-family:var(--disp);font-weight:600;font-size:1.04rem;margin-bottom:6px}
+  .promise p{color:var(--ink-dim);font-size:.86rem}
+
+  footer{margin-top:44px;font-family:var(--mono);font-size:.68rem;color:var(--ink-faint);letter-spacing:.03em;line-height:1.7}
+
+  /* ── lens accent maps ── */
+  .lens-stage [data-stage=drop]{--accent:var(--neutral)}
+  .lens-stage [data-stage=read]{--accent:var(--retrieval)}
+  .lens-stage [data-stage=portal]{--accent:var(--check)}
+  .lens-stage [data-stage=review]{--accent:var(--retrieval)}
+  .lens-stage [data-stage=approve]{--accent:var(--membrane)}
+  .lens-stage [data-stage=proven]{--accent:var(--logic)}
+  .lens-stage [data-stage=ask]{--accent:var(--logic)}
+  .lens-trust [data-trust=untrusted]{--accent:var(--reject)}
+  .lens-trust [data-trust=proposed]{--accent:var(--retrieval)}
+  .lens-trust [data-trust=proving]{--accent:var(--check)}
+  .lens-trust [data-trust=proven]{--accent:var(--logic)}
+  .lens-trust [data-trust=infra]{--accent:var(--neutral)}
+  .lens-loc [data-loc=local]{--accent:var(--safe)}
+  .lens-loc [data-loc=cross]{--accent:var(--prov)}
+  .lens-loc [data-loc=external]{--accent:var(--retrieval)}
+
+  @media (max-width:860px){
+    .rail{grid-template-columns:1fr 1fr}
+    .portal{grid-template-columns:1fr}
+    .queue{grid-template-columns:1fr}
+    .coda{grid-template-columns:1fr}
+  }
+  @media (prefers-reduced-motion:reduce){
+    .step{opacity:1;transform:none;transition:border-color .2s}
+    .flash{animation:none}
+  }
+</style>
+</head>
+<body class="lens-stage">
+<div class="wrap">
+
+  <header>
+    <div class="eyebrow">Prose-to-Proof · the product surface · <b>retrieval</b> proposes + <i>logic</i> proves</div>
+    <h1><span class="a">Prose</span> in,<br><span class="b">proof</span> out</h1>
+    <p class="thesis">The same system, read from the lawyer's chair. A document comes in; it is read and grounded to its exact words; it opens as a <b>portal</b> into everything it connects to; what the machine proposes waits in a review pile; the attorney <b>approves</b>; only then does it join a practice memory that can prove every fact it holds. This is the companion view to the system architecture — the <b>experience</b>, not the wiring. <i style="color:var(--ink-faint);font-style:normal">Hover the underlined links · drag the 3D part · click the subgraph.</i></p>
+
+    <div class="lenses">
+      <div class="lensrow">
+        <span class="lbl">read it by</span>
+        <button class="lensbtn on" data-lens="stage">journey</button>
+        <button class="lensbtn" data-lens="trust">trust</button>
+        <button class="lensbtn" data-lens="loc">locality</button>
+      </div>
+      <div class="legend" data-legend="stage">
+        <span><i class="swatch" style="background:var(--retrieval)"></i> machine proposes</span>
+        <span><i class="swatch" style="background:var(--check)"></i> you read &amp; navigate</span>
+        <span><i class="swatch" style="background:var(--membrane)"></i> the approval gate</span>
+        <span><i class="swatch" style="background:var(--logic)"></i> proven &amp; answerable</span>
+      </div>
+      <div class="legend hidden" data-legend="trust">
+        <span><i class="swatch" style="background:var(--reject)"></i> a guess</span>
+        <span><i class="swatch" style="background:var(--retrieval)"></i> proposed</span>
+        <span><i class="swatch" style="background:var(--check)"></i> being proved</span>
+        <span><i class="swatch" style="background:var(--logic)"></i> proven</span>
+        <span><i class="swatch" style="background:var(--neutral)"></i> infrastructure</span>
+      </div>
+      <div class="legend hidden" data-legend="loc">
+        <span><i class="swatch" style="background:var(--safe)"></i> on your device</span>
+        <span><i class="swatch" style="background:var(--prov)"></i> the crossing (sync)</span>
+        <span><i class="swatch" style="background:var(--retrieval)"></i> leaves device (optional backup)</span>
+      </div>
+    </div>
+  </header>
+
+  <!-- THE JOURNEY -->
+  <section class="plane">
+    <div class="planehead"><span class="px">✦</span><h2>A day at the workbench</h2><span class="ph">one document, end to end</span></div>
+    <div class="rail">
+      <div class="step" data-stage="drop"     data-trust="infra"     data-loc="local"><div class="n">01 · drop</div><div class="t">Drop it in</div><p>An email, an Office Action, a contract. The file stays canonical on disk.</p></div>
+      <div class="step" data-stage="read"     data-trust="proposed"  data-loc="local"><div class="n">02 · read</div><div class="t">It's read</div><p>Parsed, and every claim grounded to the exact words that justify it.</p></div>
+      <div class="step" data-stage="portal"   data-trust="proving"   data-loc="local"><div class="n">03 · portal</div><div class="t">A portal opens</div><p>Hover a figure, a term, a party — and see what it links to.</p></div>
+      <div class="step" data-stage="review"   data-trust="proposed"  data-loc="local"><div class="n">04 · review</div><div class="t">The review pile</div><p>Confidence routes each proposal: ready, review, or just searchable.</p></div>
+      <div class="step" data-stage="approve"  data-trust="proving"   data-loc="local"><div class="n">05 · approve</div><div class="t">You approve</div><p>The attorney signs. Nothing becomes fact without this gate.</p></div>
+      <div class="step" data-stage="proven"   data-trust="proven"    data-loc="local"><div class="n">06 · proven</div><div class="t">It's proven</div><p>Joins one graph, walled by matter, every fact carrying its source.</p></div>
+      <div class="step" data-stage="ask"      data-trust="proven"    data-loc="local"><div class="n">07 · ask</div><div class="t">Ask &amp; check</div><p>Question the practice; run a conflict check across every matter.</p></div>
+    </div>
+    <div class="railcap">
+      <span>→ a single document's path</span>
+      <span>cards recolor with the lens above ↑</span>
+    </div>
+  </section>
+
+  <div class="conn"><span>step 03, live ↓</span></div>
+
+  <!-- EDITOR AS PORTAL -->
+  <section class="plane">
+    <div class="planehead"><span class="px">A</span><h2>The editor is a portal</h2><span class="ph">hover a link · drag the part · click the subgraph</span></div>
+    <div class="portal">
+
+      <!-- the document -->
+      <div class="doc" id="doc" data-stage="portal" data-trust="proving" data-loc="local">
+        <div class="docbar"><span class="dot3"><i></i><i></i><i></i></span> response-to-office-action.md · matter: Aanstoot · grinder burr sensor</div>
+        <h4>Remarks</h4>
+        <p>Claim 1 recites a <span class="link term" tabindex="0" data-card="term" id="span-sensor">burr alignment sensor</span> that registers alignment <em>prior to</em> grinding. Reference 1 (to <span class="link party" tabindex="0" data-card="party" id="span-halvorsen">Halvorsen</span>) instead teaches a sensor that measures grind size <span class="hl">downstream of the grinding operation</span> — a different function at a different stage of the apparatus.</p>
+        <p>Support for the recited limitation appears throughout the specification and is depicted in <span class="link fig" tabindex="0" data-card="fig" id="span-fig3">Figure&nbsp;3</span>, which shows the sensor positioned at the burr interface, registering relative burr position before any grinding occurs.</p>
+        <h4>The rejection, restated</h4>
+        <p>The examiner rejected claims 1–8 under <span class="link party" tabindex="0" data-card="party" data-target="span-halvorsen">§103</span> as obvious over Halvorsen in view of a secondary reference. The combination is said to disclose every limitation of claim 1.</p>
+        <h4>Argument</h4>
+        <p>Applicant respectfully traverses. The <span class="link term" tabindex="0" data-card="term" data-target="span-sensor">alignment sensor</span> of claim 1 operates <em>before</em> grinding to set burr geometry; Halvorsen's sensor operates <em>after</em>, to characterize output. The references teach away from combination because Halvorsen's downstream placement presupposes a fixed burr geometry that the claimed sensor exists to establish. See <span class="link fig" tabindex="0" data-card="fig" data-target="span-fig3">Figure&nbsp;3</span> and specification ¶0021.</p>
+        <h4>Conclusion</h4>
+        <p>Claims 1–8 are believed to be in condition for allowance. Reconsideration and withdrawal of the rejection are respectfully requested.</p>
+      </div>
+
+      <!-- viewer + subgraph -->
+      <div class="panecol">
+        <div class="cadview" id="cadview" data-stage="portal" data-loc="local">
+          <div class="cadhead"><i class="mdot" style="background:var(--inferred)"></i> figure 3 · burr interface · live CAD</div>
+          <div class="cadwrap" id="cadwrap">
+            <div class="cadfallback">
+              <span>3D viewer needs WebGL (offline build falls back to the locator).</span>
+              <span class="loc">artifact://cad/grinder_v3.step</span>
+            </div>
+          </div>
+          <div class="cadfoot"><span class="loc">artifact://cad/grinder_v3.step</span><span class="drag">drag to orbit · scroll to zoom</span></div>
+        </div>
+
+        <div class="subgraph" data-stage="portal" data-loc="local">
+          <div class="sghead"><i class="mdot"></i> subgraph · Aanstoot · burr sensor <span class="count" id="sgcount"></span></div>
+          <ul class="sglist" id="sglist">
+            <li><button class="sgitem fig" data-action="cad"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Figure 3 — burr interface <span class="kind">figure → cad</span></span><span class="sgm">Generated from grinder_v3.step · frame in the 3D viewer</span></span><span class="arw">↗</span></button></li>
+            <li><button class="sgitem term" data-action="scroll" data-target="span-sensor"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">"burr alignment sensor" <span class="kind">defined term</span></span><span class="sgm">Spec ¶0021 · recited in claims 1, 4, 7</span></span><span class="arw">↗</span></button></li>
+            <li><button class="sgitem party" data-action="scroll" data-target="span-halvorsen"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Reference 1 — Halvorsen <span class="kind">prior art</span></span><span class="sgm">US 9,xxx,xxx · §103 rejection of claims 1–8</span></span><span class="arw">↗</span></button></li>
+            <li><button class="sgitem term" data-action="scroll" data-target="span-sensor"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Claim 1 <span class="kind">claim</span></span><span class="sgm">Recites the alignment sensor (independent)</span></span><span class="arw">↗</span></button></li>
+            <li><button class="sgitem party" data-action="cad"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Inventor email — sensor placement <span class="kind">email</span></span><span class="sgm">Aanstoot thread · 2026-02-11 · "before the grind, not after"</span></span><span class="arw">↗</span></button></li>
+            <li><button class="sgitem fig" data-action="cad"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">CAD source — grinder_v3.step <span class="kind">artifact</span></span><span class="sgm">12 revisions · last edited 2026-01-30</span></span><span class="arw">↗</span></button></li>
+            <li><button class="sgitem term" data-action="scroll" data-target="span-fig3"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Prior response — distinguished art <span class="kind">work product</span></span><span class="sgm">2025-09 · same teaching-away argument, allowed</span></span><span class="arw">↗</span></button></li>
+            <li><button class="sgitem party" data-action="scroll" data-target="span-halvorsen"><span class="sgicon">◆</span><span class="sgbody"><span class="sgt">Deadline — respond by Apr 12 <span class="kind">docket</span></span><span class="sgm">Non-final action · 3-month statutory period</span></span><span class="arw">↗</span></button></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="railcap"><span>every link above is an edge in the matter's subgraph · everything renders on your device</span></div>
+  </section>
+
+  <div class="conn"><span>what the machine proposes, before you decide ↓</span></div>
+
+  <!-- REVIEW QUEUE -->
+  <section class="plane">
+    <div class="planehead"><span class="px">B</span><h2>Confidence routes; you decide</h2><span class="ph">nothing is fact until you sign</span></div>
+    <div class="queue">
+      <div class="lane hi" data-trust="proposed" data-loc="local">
+        <div class="lh"><i class="mdot"></i> high confidence</div>
+        <p>Clean, well-grounded extractions — a deadline, a citation, an inventor name. Pre-filled, one glance to confirm.</p>
+        <div class="route">→ ready for approval</div>
+      </div>
+      <div class="lane med" data-trust="proposed" data-loc="local">
+        <div class="lh"><i class="mdot"></i> medium confidence</div>
+        <p>Judgment calls — a proposed distinction, an amended claim. Surfaced for the attorney's eyes, with the source attached.</p>
+        <div class="route">→ your review queue</div>
+      </div>
+      <div class="lane lo" data-trust="untrusted" data-loc="local">
+        <div class="lh"><i class="mdot"></i> low confidence</div>
+        <p>The fat remainder that never became a fact. Still indexed and searchable, just not asserted.</p>
+        <div class="route">→ searchable corpus</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- TWO PROMISES -->
+  <div class="coda">
+    <div class="promise local" data-loc="local">
+      <div class="pg">◆ promise one</div>
+      <h3>It stays on your machine</h3>
+      <p>Local-first by default. Client files don't leave the device to be read; embeddings are computed on-device. A backup backend (Box · S3 · local) is a choice you make, never a default — and it holds copies, never identity.</p>
+    </div>
+    <div class="promise proof" data-trust="proven">
+      <div class="pg">⊢ promise two</div>
+      <h3>It proves its sources</h3>
+      <p>Every fact carries a link to the exact words behind it. The machine may guess, but a guess only becomes part of the record after it passes the gate — shape-checked, proven consistent, and approved by you. Confidence proposes; proof admits.</p>
+    </div>
+  </div>
+
+  <footer>drop it in · it's read &amp; grounded · the editor is a portal · confidence routes, you decide · proof out · one graph, walled by matter · everything on your device</footer>
+
+</div>
+
+<!-- the live hover card -->
+<div class="pop" id="pop" role="tooltip"></div>
+
+<script>
+/* ---------- lenses + reveal ---------- */
+(() => {
+  const $$ = s => [...document.querySelectorAll(s)];
+  const rm = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (!rm && 'IntersectionObserver' in window) {
+    const io = new IntersectionObserver((es) => {
+      es.forEach(e => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+    }, { threshold: 0.12 });
+    $$('.step').forEach(el => io.observe(el));
+  } else { $$('.step').forEach(el => el.classList.add('in')); }
+
+  const body = document.body;
+  const setLens = (lens) => {
+    body.className = 'lens-' + lens;
+    $$('.lensbtn').forEach(b => b.classList.toggle('on', b.dataset.lens === lens));
+    $$('.legend').forEach(l => l.classList.toggle('hidden', l.dataset.legend !== lens));
+  };
+  $$('.lensbtn').forEach(b => b.addEventListener('click', () => setLens(b.dataset.lens)));
+  setLens('stage');
+})();
+
+/* ---------- document + subgraph interactions ---------- */
+const docEl = document.getElementById('doc');
+const cadviewEl = document.getElementById('cadview');
+
+function flashSpan(id){
+  const el = document.getElementById(id);
+  if(!el) return;
+  el.scrollIntoView({behavior:'smooth', block:'center'});
+  el.classList.remove('flash'); void el.offsetWidth; el.classList.add('flash');
+}
+function pulseCad(){
+  cadviewEl.classList.add('pulse');
+  if (window.__cadFrame) window.__cadFrame();
+  setTimeout(()=>cadviewEl.classList.remove('pulse'), 1100);
+}
+
+/* subgraph list */
+document.getElementById('sgcount').textContent =
+  document.querySelectorAll('#sglist .sgitem').length + ' nodes';
+document.querySelectorAll('#sglist .sgitem').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const action = btn.dataset.action;
+    if (action === 'cad') pulseCad();
+    else if (action === 'scroll') flashSpan(btn.dataset.target);
+  });
+});
+
+/* ---------- real hover cards ---------- */
+(() => {
+  const pop = document.getElementById('pop');
+  let hideTimer = null, current = null;
+
+  const CARDS = {
+    term: {
+      cls:'term', kind:'defined term → definition',
+      title:'"burr alignment sensor"',
+      body:'Defined in the specification at ¶0021. Recited in claims 1, 4, and 7, and central to the §103 argument.',
+      meta:'spec ¶0021 · claims 1 · 4 · 7 · +2 usages',
+      actLabel:'Show usages →', act:() => flashSpan('span-sensor')
+    },
+    party: {
+      cls:'party', kind:'party → prior art',
+      title:'Halvorsen (Reference 1)',
+      body:'Cited prior art in the §103 rejection. Links to the reference PDF, the examiner’s reasoning, and the rejected claim set.',
+      meta:'US 9,xxx,xxx · §103 · rejects claims 1–8',
+      actLabel:'Open reference →', act:() => flashSpan('span-halvorsen')
+    },
+    fig: {
+      cls:'fig', kind:'figure → CAD artifact',
+      title:'Figure 3 · burr interface',
+      body:'The drawing was generated from a CAD source. Frame it in the live 3D viewer, or trace it back to the design file.',
+      meta:'artifact://cad/grinder_v3.step',
+      actLabel:'Frame in 3D viewer →', act:() => pulseCad()
+    }
+  };
+
+  function buildCard(kind){
+    const c = CARDS[kind]; if(!c) return;
+    pop.className = 'pop ' + c.cls;
+    pop.innerHTML =
+      '<div class="pk"><i class="mdot"></i> '+c.kind+'</div>'+
+      '<div class="pt">'+c.title+'</div>'+
+      '<p>'+c.body+'</p>'+
+      '<div class="meta">'+c.meta+'</div>'+
+      '<button class="act" type="button">'+c.actLabel+'</button>';
+    pop.querySelector('.act').addEventListener('click', () => { c.act(); hide(); });
+  }
+  function place(target){
+    const r = target.getBoundingClientRect();
+    pop.style.visibility='hidden'; pop.classList.add('show');
+    const pw = pop.offsetWidth, ph = pop.offsetHeight;
+    pop.classList.remove('show'); pop.style.visibility='';
+    let x = r.left, y = r.bottom + 9;
+    if (x + pw > window.innerWidth - 12) x = window.innerWidth - 12 - pw;
+    if (x < 12) x = 12;
+    if (y + ph > window.innerHeight - 12) y = r.top - ph - 9;   // flip above
+    if (y < 12) y = 12;
+    pop.style.left = x + 'px'; pop.style.top = y + 'px';
+  }
+  function show(target){
+    const kind = target.dataset.card; if(!kind) return;
+    clearTimeout(hideTimer); current = target;
+    buildCard(kind); place(target);
+    requestAnimationFrame(() => pop.classList.add('show'));
+    // contextual 3D reaction
+    if (kind === 'fig') pulseCad();
+  }
+  function hide(){ pop.classList.remove('show'); current=null; }
+  function scheduleHide(){ clearTimeout(hideTimer); hideTimer = setTimeout(hide, 220); }
+
+  document.querySelectorAll('.link').forEach(link => {
+    link.addEventListener('mouseenter', () => show(link));
+    link.addEventListener('mouseleave', scheduleHide);
+    link.addEventListener('focus', () => show(link));
+    link.addEventListener('blur', hide);
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const t = link.dataset.target;
+      if (link.dataset.card === 'fig' && !t) pulseCad();
+      else if (t) flashSpan(t);
+      else if (link.id) flashSpan(link.id);
+    });
+    link.addEventListener('keydown', (e) => { if(e.key==='Enter'||e.key===' '){ e.preventDefault(); link.click(); } });
+  });
+  pop.addEventListener('mouseenter', () => clearTimeout(hideTimer));
+  pop.addEventListener('mouseleave', scheduleHide);
+  window.addEventListener('scroll', () => { if(pop.classList.contains('show') && current) place(current); }, true);
+  document.addEventListener('keydown', e => { if(e.key==='Escape') hide(); });
+})();
+</script>
+
+<!-- ---------- three.js CAD render ---------- -->
+<script type="module">
+const view = document.getElementById('cadview');
+const wrap = document.getElementById('cadwrap');
+function fail(){ view.classList.add('failed'); }
+
+const timeout = setTimeout(() => { if(!view.dataset.ready) fail(); }, 9000);
+
+try {
+  const THREE = await import('three');
+  const { OrbitControls } = await import('three/addons/controls/OrbitControls.js');
+  const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(42, 1, 0.1, 100);
+  const HOME = new THREE.Vector3(2.7, 1.9, 3.0);
+  camera.position.copy(HOME);
+
+  const renderer = new THREE.WebGLRenderer({ antialias:true, alpha:true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setSize(wrap.clientWidth, wrap.clientHeight, false);
+  wrap.appendChild(renderer.domElement);
+
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true; controls.dampingFactor = 0.08;
+  controls.enablePan = false; controls.minDistance = 2.4; controls.maxDistance = 8;
+  controls.autoRotate = !reduced; controls.autoRotateSpeed = 1.1;
+  controls.target.set(0, 0.05, 0);
+
+  // ── lighting ──
+  scene.add(new THREE.AmbientLight(0xffffff, 0.55));
+  const key = new THREE.DirectionalLight(0xffffff, 1.0); key.position.set(4, 6, 3); scene.add(key);
+  const rim = new THREE.PointLight(0x5fc6d6, 9, 24); rim.position.set(-4, 1.5, -3); scene.add(rim);
+  const warm = new THREE.PointLight(0xd99a5b, 6, 24); warm.position.set(3, -1.5, 4); scene.add(warm);
+
+  // ── the part: a conical grinder burr + housing + alignment sensor ──
+  const group = new THREE.Group();
+  const steel = new THREE.MeshStandardMaterial({ color:0x9aa6b1, metalness:0.92, roughness:0.32 });
+  const steelDark = new THREE.MeshStandardMaterial({ color:0x6b7682, metalness:0.85, roughness:0.45, side:THREE.DoubleSide });
+
+  // outer housing ring
+  const housing = new THREE.Mesh(new THREE.CylinderGeometry(1.4, 1.5, 0.62, 56, 1, true), steelDark);
+  housing.position.y = -0.05; group.add(housing);
+  const lip = new THREE.Mesh(new THREE.TorusGeometry(1.42, 0.06, 12, 56), steel);
+  lip.rotation.x = Math.PI/2; lip.position.y = 0.26; group.add(lip);
+
+  // conical burr
+  const burrGeo = new THREE.ConeGeometry(1.12, 1.25, 44);
+  const burr = new THREE.Mesh(burrGeo, steel); burr.position.y = 0.06; group.add(burr);
+  // blueprint edges for the CAD read
+  const edges = new THREE.LineSegments(new THREE.EdgesGeometry(burrGeo),
+    new THREE.LineBasicMaterial({ color:0xaee6ee, transparent:true, opacity:0.30 }));
+  burr.add(edges);
+
+  // radial cutting teeth around the burr
+  const toothGeo = new THREE.BoxGeometry(0.045, 1.18, 0.14);
+  const toothMat = new THREE.MeshStandardMaterial({ color:0xb8c2cc, metalness:0.9, roughness:0.28 });
+  const N = 30;
+  for (let i=0;i<N;i++){
+    const t = new THREE.Mesh(toothGeo, toothMat);
+    const a = (i/N) * Math.PI*2, r = 0.66;
+    t.position.set(Math.cos(a)*r, 0.06, Math.sin(a)*r);
+    t.lookAt(0, 0.06, 0); t.rotation.x += 0.30;
+    group.add(t);
+  }
+  // hub
+  const hub = new THREE.Mesh(new THREE.CylinderGeometry(0.14, 0.14, 0.5, 24), steel);
+  hub.position.y = 0.7; group.add(hub);
+
+  // ── the alignment sensor (the inventive bit) ──
+  const sensorMat = new THREE.MeshStandardMaterial({ color:0xb08ae8, emissive:0x6a4bb0, emissiveIntensity:0.5, metalness:0.5, roughness:0.4 });
+  const sensor = new THREE.Mesh(new THREE.BoxGeometry(0.26, 0.24, 0.5), sensorMat);
+  sensor.position.set(1.55, 0.22, 0); sensor.lookAt(0, 0.22, 0); group.add(sensor);
+  const mount = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.5, 0.12), steelDark);
+  mount.position.set(1.62, -0.05, 0); group.add(mount);
+  // measurement beam from sensor toward burr (pre-grind alignment)
+  const beamMat = new THREE.LineBasicMaterial({ color:0xb08ae8, transparent:true, opacity:0.7 });
+  const beam = new THREE.Line(new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(1.35, 0.22, 0), new THREE.Vector3(0.72, 0.34, 0)
+  ]), beamMat);
+  group.add(beam);
+
+  // base + polar grid for scale
+  const base = new THREE.Mesh(new THREE.CylinderGeometry(1.55, 1.6, 0.12, 56), steelDark);
+  base.position.y = -0.42; group.add(base);
+  const grid = new THREE.PolarGridHelper(2.4, 12, 6, 64, 0x2a3540, 0x1c252e);
+  grid.position.y = -0.49; group.add(grid);
+
+  group.rotation.y = -0.5;
+  scene.add(group);
+
+  // ── resize ──
+  function resize(){
+    const w = wrap.clientWidth, h = wrap.clientHeight;
+    if (!w || !h) return;
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h; camera.updateProjectionMatrix();
+  }
+  if ('ResizeObserver' in window) new ResizeObserver(resize).observe(wrap);
+  window.addEventListener('resize', resize);
+  resize();
+
+  // ── pause when offscreen (perf) ──
+  let visible = true;
+  if ('IntersectionObserver' in window) {
+    new IntersectionObserver(es => { visible = es[0].isIntersecting; }, {threshold:0.01}).observe(view);
+  }
+
+  // ── interactions exposed to the page ──
+  let kick = 0, sensorPulse = 0;
+  window.__cadFrame = () => {
+    controls.target.set(0, 0.05, 0);
+    camera.position.copy(HOME);
+    kick = 1.0; sensorPulse = 1.0;
+  };
+
+  // ── loop ──
+  function animate(){
+    requestAnimationFrame(animate);
+    if (!visible) return;
+    if (kick > 0){ controls.autoRotateSpeed = 1.1 + kick*7; kick = Math.max(0, kick-0.03); }
+    else controls.autoRotateSpeed = 1.1;
+    if (sensorPulse > 0){ sensor.material.emissiveIntensity = 0.5 + sensorPulse*1.6; sensorPulse = Math.max(0, sensorPulse-0.02); }
+    beam.material.opacity = 0.45 + 0.35*Math.abs(Math.sin(performance.now()*0.002));
+    controls.update();
+    renderer.render(scene, camera);
+  }
+  animate();
+  view.dataset.ready = '1';
+  clearTimeout(timeout);
+} catch (err) {
+  console.error('[cad] three.js failed to load:', err);
+  clearTimeout(timeout);
+  fail();
+}
+</script>
+</body>
+</html>

--- a/docs/product/prose-to-proof.md
+++ b/docs/product/prose-to-proof.md
@@ -1,0 +1,195 @@
+# Prose-to-Proof — Draft PRD
+
+> **Status:** Draft · **Codename:** Prose-to-Proof · **Architecture:** BeepGraph
+> **Product target:** `apps/professional-desktop` · **Owner:** @beep-team
+> **Scope of this PRD:** the **next buildable increment** — turning today's chat app into
+> the document portal — framed by the full [Vision](../PROSE_TO_PROOF_VISION.md).
+>
+> Reading order: [Vision](../PROSE_TO_PROOF_VISION.md) → [For Tom](../PROSE_TO_PROOF_FOR_TOM.md) →
+> [User Story](../PROSE_TO_PROOF_USER_STORY.md) → [Architecture Map](../PROSE_TO_PROOF_ARCHITECTURE_MAP.md) → **this**.
+> See also the [Visualization](../PROSE_TO_PROOF_VISUALIZATION.html).
+> Governing specs: `goals/agentic-professional-runtime/SPEC.md`, its `docs/runtime-data-loop.md`
+> and `docs/approval-and-autonomy-policy.md`, and `docs/BEEPGRAPH_ARCHITECTURE.md`.
+
+---
+
+## 1. Summary
+
+Prose-to-Proof is a **local-first, provenance-grounded knowledge workbench for a solo IP
+practice**. A document comes in; the system reads it, proposes structured claims grounded
+to the exact source text, surfaces them in a document-portal editor, and admits nothing to
+the practice's memory until the attorney approves. This PRD specs the **MVP**: extend the
+existing runtime data loop from email to documents, so a real matter's documents become
+evidence-backed, approval-gated practice memory inside `apps/professional-desktop`.
+
+The product's first user is the builder's father, a solo IP attorney; the team **dogfoods**
+the product on his real practice. That loop — his 25-year corpus as seed, his daily use as
+signal — is the product strategy, not a footnote.
+
+## 2. Problem & opportunity
+
+A solo IP attorney is the whole firm: partner, associate, paralegal, librarian, and IT.
+Existing tooling forces a bad trade:
+
+- **Cloud AI assistants** (Harvey, Thomson Reuters CoCounsel, Robin AI) cite their sources
+  well but run in the cloud — processing client material on third-party servers, a real
+  confidentiality/privilege concern for a solo. [1][2][3]
+- **Document management** consolidated to two cloud platforms (iManage, NetDocuments); the
+  on-prem option solos relied on (Worldox) was discontinued after acquisition. [4][5]
+- **Truly local AI tools** (e.g. Elephas, GPT4All) keep data on-device but lack rigorous,
+  every-assertion source grounding and aren't IP-specialized. [6]
+- **Patent-specific tools** (Rowan Patents, PatentPal, Patlytics, Solve Intelligence,
+  LexisNexis) are all cloud SaaS, and source-grounding is uneven. [7][8][9]
+
+**The gap:** *local-first **and** every-assertion-grounded **and** IP-specialized* is
+essentially unoccupied. That intersection is the product wedge.
+
+## 3. Goals & non-goals
+
+**Goals (this increment)**
+- G1. Ingest a real matter's documents on the local machine and produce **candidate claims grounded to source spans**.
+- G2. Surface those claims in the **document-portal editor** with hover-card subgraph links (`artifact-ref`).
+- G3. Gate everything behind **attorney approval**; accepted claims persist with provenance.
+- G4. Keep it **local-first**: no client data leaves the device by default; embeddings on-device.
+- G5. Prove the **dogfooding loop** on one real matter end to end.
+
+**Non-goals (this increment)** — deferred, not rejected
+- Replacing email, calendar, billing, docketing, CRM, or the USPTO as systems of record.
+- Autonomous legal advice or filings.
+- Real privileged data in the repository (synthetic fixtures only in-repo).
+- Multi-machine sync.
+- The full reasoner, full GraphRAG, and full FalkorDB projection (GA, see §10).
+
+## 4. Target user
+
+**Tom — solo IP attorney, 25 years in.** Existing email/calendar/document/billing tools; a
+mixed archive of prior work product; a preference to slow down without losing leverage;
+limited appetite for IT. (Per `goals/agentic-professional-runtime/docs/product-vision-law-practice.md`.)
+He is the first user *and* the corpus source *and* the standard of quality.
+
+## 5. The MVP slice — chat app → document portal
+
+Today `apps/professional-desktop` (v0.0.3) is a local chat app (Tauri + React + Bun sidecar,
+PGlite persistence, `ChatRpcs`, `AnthropicTurnKernel`/`FixtureTurnKernel`). The MVP turns it
+into the document portal by walking the **same runtime data loop** already locked as the
+first proof (`docs/runtime-data-loop.md`) — only the input changes from a normalized email
+to a matter document:
+
+```
+seed matter/client context
+  └─► ingest a document, with stable source spans
+  └─► run extraction (deterministic fixture first, real model behind the same contract later)
+  └─► produce candidate claims + tasks + (optional) draft, each with evidence spans + provenance
+  └─► render in the Lexical editor; hover-card artifact-ref links into the subgraph
+  └─► attorney reviews → approves/rejects (strict gate)
+  └─► accepted claims persist to the local epistemic store with provenance
+  └─► expose an evidence-bounded context packet via the SDK
+```
+
+This honors the SPEC's non-negotiables: **candidate-only writes**, **evidence by stable span
+ID** (not whole-artifact, not byte offsets), **claim+evidence+provenance+lifecycle as
+authority**, **graph/search as projections**, and **SDK-first**.
+
+## 6. User stories & acceptance criteria
+
+**US-1 — Ingest & ground.** *As Tom, I drop a document in and the system extracts claims tied
+to the exact text.*
+- AC-1.1 A supported document (`.md`/`.docx`/`.pdf` via `@beep/md` + `@beep/pandoc-ast`) ingests without leaving the device.
+- AC-1.2 At least one **candidate claim** is produced with a valid `Evidence` span that resolves to real characters in the source (`@beep/langextract` `GroundedExtraction.span`).
+- AC-1.3 Clicking a claim highlights its source span in the document.
+
+**US-2 — Portal.** *As Tom, I read a document and see what each part links to.*
+- AC-2.1 An `artifact-ref` link renders a hover card with the linked artifact (e.g. a figure → CAD locator) (`@beep/lexical-schema`).
+- AC-2.2 The card shows the target's identity and a way to open/trace it.
+
+**US-3 — Approve.** *As Tom, nothing becomes a fact until I sign.*
+- AC-3.1 Candidate claims appear in a review surface with their evidence; none are authoritative pre-approval.
+- AC-3.2 Approve/reject is recorded as an `Activity` with reviewer + timestamp (`@beep/epistemic-domain`).
+- AC-3.3 Accepted claims persist to local PGlite via `@beep/epistemic-tables` and survive restart.
+
+**US-4 — Local & walled.** *As Tom, my client data stays mine.*
+- AC-4.1 With no backup backend configured, zero network egress of document content (verifiable).
+- AC-4.2 Claims are scoped to a matter; a matter's substantive content is not readable across the wall.
+
+## 7. Functional requirements
+
+- FR-1 Document ingest pipeline: file → canonical model (`@beep/md`/`@beep/pandoc-ast`) → NLP offsets (`@beep/nlp-mcp`) → span-grounded extraction (`@beep/langextract`).
+- FR-2 Candidate production: `CandidateClaim` + `Evidence` (span IDs) + `Activity` provenance.
+- FR-3 Portal editor: Lexical state with `ArtifactRefNode` hover cards over the matter subgraph.
+- FR-4 Review & approval surface: list candidates, show evidence, approve/reject, record lifecycle.
+- FR-5 Local persistence: PGlite via `@beep/epistemic-tables`; rebuildable read models.
+- FR-6 SDK context packet: evidence-bounded read surface (`@beep/agents-use-cases/public`).
+- FR-7 Extraction is swappable: deterministic fixture agent first, real model behind the same candidate-write contract.
+
+## 8. Non-functional requirements
+
+- NFR-1 **Local-first:** on-device by default; no client content egress without an explicit backend choice; embeddings computed locally.
+- NFR-2 **Provenance-complete:** 100% of accepted claims carry a resolvable evidence span; the validator rejects a claim whose span doesn't exist in the source.
+- NFR-3 **Walled matters:** matter = named subgraph = confidentiality boundary; joinable for conflict checks, sealed for substantive reads.
+- NFR-4 **Storage-neutral domain:** PGlite is the first adapter; domain language must not depend on it.
+- NFR-5 **Determinism for tests:** fixture path produces snapshot-stable output independent of model nondeterminism.
+- NFR-6 **Effect-native & typed:** schema-first, typed errors, slice isolation per `standards/ARCHITECTURE.md`.
+
+## 9. Out of scope for v1
+
+Raw `.eml` parsing; real email/calendar connectors; external sending; multi-machine sync; full
+package scaffolding for every slice; autonomous legal/financial advice; production compliance
+certification. (Mirrors `SPEC.md` and `runtime-data-loop.md` non-goals.)
+
+## 10. Phased roadmap
+
+| Phase | Theme | Outcome |
+|---|---|---|
+| **P0 — loop (done/spec)** | Runtime data loop on email fixtures | Candidate claims/tasks/draft + approval + SDK packet, deterministic |
+| **P1 — document portal (this PRD)** | Extend loop to documents; editor portal | Real matter docs → grounded candidates → approve → local proven store |
+| **P2 — librarian** | Ingest the corpus | AI librarian organizes `oppold-corpus` output into candidate claims at scale |
+| **P3 — graph & ask** | Projection + retrieval | FalkorDB projection, GraphRAG ask-and-check, cross-matter conflict checks |
+| **P4 — reason & wall** | Logic family | OWL 2 EL/RL reasoner over the TBox; enforced matter walls; bitemporal store |
+| **P5 — sync & scale** | DMS completeness | Sync engine (FS ↔ Box/S3/local), Box Events → ingest |
+
+## 11. Success metrics
+
+- **Grounding coverage:** 100% of accepted claims have a resolvable evidence span (hard gate).
+- **Time-to-first-grounded-claim:** from document drop to first reviewable candidate.
+- **Approval throughput:** candidates Tom can review per session; reject rate trend (a learning signal).
+- **Data egress:** zero client-content network egress in the default local configuration.
+- **Dogfood traction:** number of real matters Tom runs through the loop; claims he keeps.
+- **Style fidelity (qualitative):** Tom's edit distance on first drafts trending down over time.
+
+## 12. Differentiation & competitive context
+
+| Product | One-liner | Cloud/local | Grounds to source? | Audience |
+|---|---|---|---|---|
+| iManage / NetDocuments | Legal DMS (NetDocs cloud-only; Worldox discontinued) | Cloud (iManage also hybrid) | Search/clause AI emerging | BigLaw → small [4][5] |
+| Harvey / CoCounsel / Robin AI | Legal AI assistants | Cloud (some private-cloud) | **Yes**, strong inline citations | BigLaw / enterprise [1][2][3] |
+| Rowan / PatentPal / Patlytics / Solve | Patent drafting & prosecution AI | Cloud SaaS | Uneven; strongest in search/analysis | Patent practitioners [7][8][9] |
+| Elephas / GPT4All | Local/offline AI | **Local** | Weak; not legal-grade | Privacy-minded solos [6] |
+| **Prose-to-Proof** | Local IP workbench | **Local-first** | **Yes — every assertion, by hard guarantee** | **Solo IP practice** |
+
+**Wedge:** none of the above occupy *local + every-assertion-grounded + IP-specialized*. The
+UX bar for "click a claim → jump to the highlighted source span" is set by Hebbia and Glean;
+Gemini's grounding model and Perplexity's inline citations are the consumer reference points. [10][11][12]
+
+## 13. Risks & open questions
+
+- **Real-model grounding fidelity.** Span alignment must stay deterministic and verifiable; risk of model-invented offsets is mitigated by `@beep/langextract`'s alignment (exact → fuzzy) rejecting unaligned text.
+- **Ontology depth for IP.** FOLIO is shallow on patent/trademark specifics; the IP layer needs the `ip-law-knowledge-graph` 7-source set. FOLIO governance (SALI/SOLI fork) is unsettled — cite carefully. [13]
+- **Which first workflow.** Office-action review vs. intake vs. drafting vs. contract review — highest trust/value ratio is an open product question (`product-vision-law-practice.md`).
+- **Corpus export constraints.** What of Tom's prior-firm history can be exported, under what confidentiality terms (the corpus stays outside the repo regardless).
+- **Approval language.** How to distinguish "assistant draft" from "attorney work product" in the UI.
+
+## 14. References
+
+Internal: `goals/agentic-professional-runtime/{SPEC.md, docs/product-vision-law-practice.md,
+docs/runtime-data-loop.md, docs/approval-and-autonomy-policy.md}` · `goals/ip-law-knowledge-graph/SPEC.md`
+· `goals/oppold-corpus-pipeline/SPEC.md` · `docs/BEEPGRAPH_ARCHITECTURE.md` · the
+[Architecture Map](../PROSE_TO_PROOF_ARCHITECTURE_MAP.md).
+
+External (market context):
+[1] harvey.ai/platform · [2] legal.thomsonreuters.com/.../cocounsel-legal · [3] robinai.com (Word add-in)
+· [4] lexworkplace.com/imanage-vs-netdocuments · [5] sbnonline.com — NetDocuments/Worldox acquisition
+· [6] elephas.app/resources/best-private-ai-tools-for-lawyers · [7] clarivate.com — Rowan Patents
+· [8] patlytics.ai/office-action · [9] blog.patentext.com — Solve vs Patlytics · [10] hebbia.com — document analysis citations
+· [11] docs.glean.com — citations · [12] ai.google.dev/gemini-api/docs — grounding · [13] openlegalstandard.org — FOLIO/SALI.
+
+*Competitive claims are point-in-time (researched 2026-06-15) and should be re-verified before external use.*

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -31,3 +31,13 @@ reason = "protobufjs 7.5.8 advisory; fixed in 7.6.3. protobufjs is a transitive 
 id = "GHSA-h67p-54hq-rp68"
 ignoreUntil = 2026-09-13T00:00:00Z
 reason = "js-yaml advisory affecting 3.14.2 and 4.1.1; fixed in 4.2.0. js-yaml is a transitive dependency (the 3.14.2 line is pulled by a legacy dependent that has not adopted the 4.x major). Newly published advisory, not introduced by the current PR (identical versions present on main); tracked for a repo-wide bump to >=4.2.0. Revisit when dependents widen their ranges."
+
+[[IgnoredVulns]]
+id = "GHSA-8988-4f7v-96qf"
+ignoreUntil = 2026-09-15T00:00:00Z
+reason = "@opentelemetry/core advisory affecting versions <2.8.0 (1.30.1, 2.1.0, 2.5.0, 2.7.0, 2.7.1 present in the tree); fixed in 2.8.0. @opentelemetry/core is a transitive dependency of the OpenTelemetry SDK/exporter stack, not a direct workspace dependency; the workspace already pins the otel SDK packages at 2.8.0 while the older core copies are pulled by transitive otel dependents that have not adopted 2.8.0. Newly published advisory, not introduced by the current PR (identical versions present on main); tracked for a repo-wide bump to >=2.8.0. Revisit when dependents widen their ranges."
+
+[[IgnoredVulns]]
+id = "GHSA-6v5v-wf23-fmfq"
+ignoreUntil = 2026-09-15T00:00:00Z
+reason = "markdown-it advisory affecting 14.1.1; fixed in 14.2.0. markdown-it is a transitive dependency (markdown rendering/tooling stack), not a direct workspace dependency. Newly published advisory, not introduced by the current PR (identical version present on main); tracked for a repo-wide bump to >=14.2.0. Revisit when dependents widen their ranges."

--- a/packages/agents/domain/.beep/repo-exports/catalog.shard.jsonc
+++ b/packages/agents/domain/.beep/repo-exports/catalog.shard.jsonc
@@ -13,7 +13,7 @@
   },
   "fingerprint": {
     "algorithm": "sha256",
-    "digest": "d22183d582bfdd56f4ba4b3fc517a98de02b0624fdd43b7c925e8714e32842f6",
+    "digest": "41999821ac81ba117c022d6e5e5a60e00fb89ad03e8a0671693b9db49d2c4a8b",
     "inputs": [
       {
         "path": "generator:repo-exports-catalog",
@@ -62,8 +62,8 @@
       },
       {
         "path": "packages/agents/domain/src/turn/index.ts",
-        "sha256": "b83e4d3ab3d6d6cbaef28894e6b3107deda217359d5e87404515a28158e72b7d",
-        "bytes": 1078
+        "sha256": "324d27b60504989196cedc5a10f51b147c37f74c2c014f707114ca6468b8b906",
+        "bytes": 1386
       },
       {
         "path": "packages/agents/domain/src/values/AssistantContent/AssistantContent.behavior.ts",

--- a/packages/agents/domain/package.json
+++ b/packages/agents/domain/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@beep/test-utils": "workspace:^",
+    "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:"
   }

--- a/packages/agents/domain/test/AgentsDomain.test.ts
+++ b/packages/agents/domain/test/AgentsDomain.test.ts
@@ -23,7 +23,13 @@ const AgentModeArbitrary = S.toArbitrary(AgentMode);
 const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
 const assistantContentSchemaId = (schema: {
   readonly ast: { readonly annotations: Record<string, unknown> | undefined };
-}) => String(schema.ast.annotations?.schemaId);
+}): symbol => {
+  const schemaId = schema.ast.annotations?.schemaId;
+  if (typeof schemaId !== "symbol") {
+    throw new Error("expected an interned schemaId annotation symbol");
+  }
+  return schemaId;
+};
 const turnCompatibilityBarrelImportPattern =
   /^\s*import\s+(?:type\s+)?[\s\S]*?\s+from\s+["']@beep\/agents-domain(?:\/turn)?["'];?/gmu;
 const assistantContentSymbolPattern = /\b(?:AssistantBlock|AssistantContent)\b/u;

--- a/packages/agents/domain/test/AgentsDomain.test.ts
+++ b/packages/agents/domain/test/AgentsDomain.test.ts
@@ -1,5 +1,3 @@
-import { readdirSync, readFileSync } from "node:fs";
-import * as Path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Agent, AgentMode, assistantContentToDocument, TableBlock, Turn, YouTubeBlock } from "@beep/agents-domain";
 import * as TurnSubpath from "@beep/agents-domain/turn";
@@ -11,43 +9,28 @@ import {
 } from "@beep/agents-domain/values/AssistantContent";
 import * as Md from "@beep/md/Md.model";
 import * as Agents from "@beep/shared-domain/identity/Agents";
-import { baseEntityFixtureInput } from "@beep/test-utils";
+import { baseEntityFixtureInput, provideScopedLayer } from "@beep/test-utils";
+import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Path } from "effect";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import { FastCheck as fc } from "effect/testing";
+import type { PlatformError } from "effect";
 
 const AgentModeArbitrary = S.toArbitrary(AgentMode);
 
 const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
-const assistantContentSchemaId = (schema: { readonly ast: { readonly annotations: Record<string, unknown> } }) =>
-  String(schema.ast.annotations.schemaId);
-const readRepoFile = (relativePath: string) => readFileSync(Path.join(repoRoot, relativePath), "utf8");
-const repoRelativePath = (absolutePath: string) => Path.relative(repoRoot, absolutePath).split(Path.sep).join("/");
-const collectAgentsSourceFiles = (directory: string): ReadonlyArray<string> => {
-  const sourceFiles: Array<string> = [];
-
-  for (const entry of readdirSync(directory, { withFileTypes: true })) {
-    if (entry.name === "dist" || entry.name === "docs" || entry.name === "node_modules" || entry.name.startsWith(".")) {
-      continue;
-    }
-
-    const entryPath = Path.join(directory, entry.name);
-    if (entry.isDirectory()) {
-      sourceFiles.push(...collectAgentsSourceFiles(entryPath));
-      continue;
-    }
-
-    if (entry.isFile() && entryPath.endsWith(".ts") && entryPath.includes(`${Path.sep}src${Path.sep}`)) {
-      sourceFiles.push(entryPath);
-    }
-  }
-
-  return sourceFiles.sort();
-};
+const assistantContentSchemaId = (schema: {
+  readonly ast: { readonly annotations: Record<string, unknown> | undefined };
+}) => String(schema.ast.annotations?.schemaId);
 const turnCompatibilityBarrelImportPattern =
   /^\s*import\s+(?:type\s+)?[\s\S]*?\s+from\s+["']@beep\/agents-domain(?:\/turn)?["'];?/gmu;
 const assistantContentSymbolPattern = /\b(?:AssistantBlock|AssistantContent)\b/u;
+const ignoredAgentsDirEntries = new Set(["dist", "docs", "node_modules"]);
+const isIgnoredAgentsDirEntry = (entry: string): boolean => ignoredAgentsDirEntries.has(entry) || entry.startsWith(".");
+const isAgentsSourceFile = (entryPath: string, sep: string): boolean =>
+  entryPath.endsWith(".ts") && entryPath.includes(`${sep}src${sep}`);
 
 describe("@beep/agents-domain", () => {
   it("exports value schemas from the package identity", () => {
@@ -120,21 +103,53 @@ describe("@beep/agents-domain", () => {
     expect(decoded).toStrictEqual(ParagraphBlock.make({ children: [TextInline.make({ text: "hello" })] }));
   });
 
-  it("keeps agents source code off assistant content compatibility barrel imports", () => {
-    const violations = collectAgentsSourceFiles(Path.join(repoRoot, "packages/agents")).flatMap((sourcePath) => {
-      const sourceText = readRepoFile(repoRelativePath(sourcePath));
-      const forbiddenImports = [...sourceText.matchAll(turnCompatibilityBarrelImportPattern)]
-        .map((match) => match[0])
-        .filter((importDeclaration) => assistantContentSymbolPattern.test(importDeclaration));
+  it.effect("keeps agents source code off assistant content compatibility barrel imports", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
 
-      return forbiddenImports.map((importDeclaration) => ({
-        importDeclaration,
-        sourcePath: repoRelativePath(sourcePath),
-      }));
-    });
+      const repoRelativePath = (absolutePath: string): string =>
+        path.relative(repoRoot, absolutePath).split(path.sep).join("/");
 
-    expect(violations).toEqual([]);
-  });
+      const collectAgentsSourceFiles = (
+        directory: string
+      ): Effect.Effect<ReadonlyArray<string>, PlatformError.PlatformError> =>
+        Effect.gen(function* () {
+          const sourceFiles: Array<string> = [];
+
+          for (const entry of yield* fs.readDirectory(directory)) {
+            if (isIgnoredAgentsDirEntry(entry)) {
+              continue;
+            }
+
+            const entryPath = path.join(directory, entry);
+            const info = yield* fs.stat(entryPath);
+            if (info.type === "Directory") {
+              sourceFiles.push(...(yield* collectAgentsSourceFiles(entryPath)));
+            } else if (isAgentsSourceFile(entryPath, path.sep)) {
+              sourceFiles.push(entryPath);
+            }
+          }
+
+          return sourceFiles.sort();
+        });
+
+      const sourceFiles = yield* collectAgentsSourceFiles(path.join(repoRoot, "packages/agents"));
+      const violations: Array<{ readonly importDeclaration: string; readonly sourcePath: string }> = [];
+
+      for (const sourcePath of sourceFiles) {
+        const sourceText = yield* fs.readFileString(sourcePath);
+        for (const match of sourceText.matchAll(turnCompatibilityBarrelImportPattern)) {
+          const importDeclaration = match[0];
+          if (assistantContentSymbolPattern.test(importDeclaration)) {
+            violations.push({ importDeclaration, sourcePath: repoRelativePath(sourcePath) });
+          }
+        }
+      }
+
+      expect(violations).toEqual([]);
+    }).pipe(provideScopedLayer(NodeServices.layer))
+  );
 
   it("lifts rich assistant blocks into canonical Md nodes", () => {
     const document = assistantContentToDocument([

--- a/packages/foundation/modeling/md/.beep/repo-exports/catalog.shard.jsonc
+++ b/packages/foundation/modeling/md/.beep/repo-exports/catalog.shard.jsonc
@@ -13,7 +13,7 @@
   },
   "fingerprint": {
     "algorithm": "sha256",
-    "digest": "5c350d73ccb47ca8a873e574447130f36c262aff624898a391543c6b87ea6384",
+    "digest": "c018dd98bc74500ef9c2db5ad711ae729eec3169de86f693377790902c2d1993",
     "inputs": [
       {
         "path": "generator:repo-exports-catalog",
@@ -37,8 +37,8 @@
       },
       {
         "path": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sha256": "07d081eee69047ac64f0b920133a206f04677d58e630215654b9946c0727348c",
-        "bytes": 26784
+        "sha256": "758cb2cf60cd772c40fceb5935b524db2b0488e68c3dbcad1f7ec45d0d1e0c05",
+        "bytes": 26761
       },
       {
         "path": "packages/foundation/modeling/md/src/Md.ts",
@@ -735,7 +735,7 @@
         "symbolName": "DocumentToHtmlFragment",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 853,
+        "sourceLine": 851,
         "summary": "Schema transformation from a document AST to a branded HTML fragment.",
         "categories": [
           "validation"
@@ -760,7 +760,7 @@
         "symbolName": "DocumentToHtmlFragment",
         "exportKind": "type",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 877,
+        "sourceLine": 875,
         "summary": "Type for {@link DocumentToHtmlFragment}.",
         "categories": [
           "models"
@@ -785,7 +785,7 @@
         "symbolName": "DocumentToMarkdown",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 811,
+        "sourceLine": 809,
         "summary": "Schema transformation from a document AST to branded Markdown text.",
         "categories": [
           "validation"
@@ -810,7 +810,7 @@
         "symbolName": "DocumentToMarkdown",
         "exportKind": "type",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 835,
+        "sourceLine": 833,
         "summary": "Type for {@link DocumentToMarkdown}.",
         "categories": [
           "models"
@@ -1527,7 +1527,7 @@
         "symbolName": "HtmlFragmentAdapter",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 706,
+        "sourceLine": 704,
         "summary": "Built-in HTML fragment render adapter.",
         "categories": [
           "utilities"
@@ -2044,7 +2044,7 @@
         "symbolName": "MarkdownAdapter",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 684,
+        "sourceLine": 682,
         "summary": "Built-in Markdown render adapter.",
         "categories": [
           "utilities"
@@ -2539,7 +2539,7 @@
         "symbolName": "render",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 761,
+        "sourceLine": 759,
         "summary": "Renders a document through the Markdown adapter.",
         "categories": [
           "utilities"
@@ -2564,7 +2564,7 @@
         "symbolName": "renderEffectWith",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 646,
+        "sourceLine": 644,
         "summary": "Starts an effectful render adapter with synchronous adapter failures captured.",
         "categories": [
           "utilities"
@@ -2589,7 +2589,7 @@
         "symbolName": "renderEffectWithUnsafe",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 607,
+        "sourceLine": 605,
         "summary": "Starts an effectful render adapter and returns its effect directly.",
         "categories": [
           "utilities"
@@ -2664,7 +2664,7 @@
         "symbolName": "renderHtml",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 783,
+        "sourceLine": 781,
         "summary": "Renders a document through the HTML fragment adapter.",
         "categories": [
           "utilities"
@@ -2689,7 +2689,7 @@
         "symbolName": "renderHtmlBlock",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 464,
+        "sourceLine": 462,
         "summary": "Renders a block node as an HTML fragment.",
         "categories": [
           "utilities"
@@ -2714,7 +2714,7 @@
         "symbolName": "renderHtmlBlocks",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 520,
+        "sourceLine": 518,
         "summary": "Renders block nodes as an HTML fragment body.",
         "categories": [
           "utilities"
@@ -2739,7 +2739,7 @@
         "symbolName": "renderHtmlInline",
         "exportKind": "function",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 390,
+        "sourceLine": 388,
         "summary": "Renders an inline node as an HTML fragment.",
         "categories": [
           "utilities"
@@ -2764,7 +2764,7 @@
         "symbolName": "renderHtmlUnsafe",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 560,
+        "sourceLine": 558,
         "summary": "Renders a document through the HTML fragment adapter and returns the output directly.",
         "categories": [
           "utilities"
@@ -2814,7 +2814,7 @@
         "symbolName": "renderMarkdownBlock",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 408,
+        "sourceLine": 406,
         "summary": "Renders a block node as Markdown.",
         "categories": [
           "utilities"
@@ -2839,7 +2839,7 @@
         "symbolName": "renderMarkdownBlocks",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 501,
+        "sourceLine": 499,
         "summary": "Renders block nodes as a Markdown document body.",
         "categories": [
           "utilities"
@@ -2864,7 +2864,7 @@
         "symbolName": "renderMarkdownInline",
         "exportKind": "function",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 343,
+        "sourceLine": 341,
         "summary": "Renders an inline node as Markdown.",
         "categories": [
           "utilities"
@@ -2889,7 +2889,7 @@
         "symbolName": "renderUnsafe",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 542,
+        "sourceLine": 540,
         "summary": "Renders a document through the Markdown adapter and returns the output directly.",
         "categories": [
           "utilities"
@@ -2914,7 +2914,7 @@
         "symbolName": "renderWith",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 730,
+        "sourceLine": 728,
         "summary": "Renders a document with a custom pure adapter.",
         "categories": [
           "utilities"
@@ -2939,7 +2939,7 @@
         "symbolName": "renderWithUnsafe",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 579,
+        "sourceLine": 577,
         "summary": "Renders a document with a custom pure adapter and returns the output directly.",
         "categories": [
           "utilities"
@@ -6686,7 +6686,7 @@
         "symbolName": "DocumentToHtmlFragment",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 853,
+        "sourceLine": 851,
         "summary": "Schema transformation from a document AST to a branded HTML fragment.",
         "categories": [
           "validation"
@@ -6711,7 +6711,7 @@
         "symbolName": "DocumentToHtmlFragment",
         "exportKind": "type",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 877,
+        "sourceLine": 875,
         "summary": "Type for {@link DocumentToHtmlFragment}.",
         "categories": [
           "models"
@@ -6736,7 +6736,7 @@
         "symbolName": "DocumentToMarkdown",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 811,
+        "sourceLine": 809,
         "summary": "Schema transformation from a document AST to branded Markdown text.",
         "categories": [
           "validation"
@@ -6761,7 +6761,7 @@
         "symbolName": "DocumentToMarkdown",
         "exportKind": "type",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 835,
+        "sourceLine": 833,
         "summary": "Type for {@link DocumentToMarkdown}.",
         "categories": [
           "models"
@@ -6811,7 +6811,7 @@
         "symbolName": "HtmlFragmentAdapter",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 706,
+        "sourceLine": 704,
         "summary": "Built-in HTML fragment render adapter.",
         "categories": [
           "utilities"
@@ -6836,7 +6836,7 @@
         "symbolName": "MarkdownAdapter",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 684,
+        "sourceLine": 682,
         "summary": "Built-in Markdown render adapter.",
         "categories": [
           "utilities"
@@ -6886,7 +6886,7 @@
         "symbolName": "render",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 761,
+        "sourceLine": 759,
         "summary": "Renders a document through the Markdown adapter.",
         "categories": [
           "utilities"
@@ -6911,7 +6911,7 @@
         "symbolName": "renderEffectWith",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 646,
+        "sourceLine": 644,
         "summary": "Starts an effectful render adapter with synchronous adapter failures captured.",
         "categories": [
           "utilities"
@@ -6936,7 +6936,7 @@
         "symbolName": "renderEffectWithUnsafe",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 607,
+        "sourceLine": 605,
         "summary": "Starts an effectful render adapter and returns its effect directly.",
         "categories": [
           "utilities"
@@ -6986,7 +6986,7 @@
         "symbolName": "renderHtml",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 783,
+        "sourceLine": 781,
         "summary": "Renders a document through the HTML fragment adapter.",
         "categories": [
           "utilities"
@@ -7011,7 +7011,7 @@
         "symbolName": "renderHtmlBlock",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 464,
+        "sourceLine": 462,
         "summary": "Renders a block node as an HTML fragment.",
         "categories": [
           "utilities"
@@ -7036,7 +7036,7 @@
         "symbolName": "renderHtmlBlocks",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 520,
+        "sourceLine": 518,
         "summary": "Renders block nodes as an HTML fragment body.",
         "categories": [
           "utilities"
@@ -7061,7 +7061,7 @@
         "symbolName": "renderHtmlInline",
         "exportKind": "function",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 390,
+        "sourceLine": 388,
         "summary": "Renders an inline node as an HTML fragment.",
         "categories": [
           "utilities"
@@ -7086,7 +7086,7 @@
         "symbolName": "renderHtmlUnsafe",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 560,
+        "sourceLine": 558,
         "summary": "Renders a document through the HTML fragment adapter and returns the output directly.",
         "categories": [
           "utilities"
@@ -7111,7 +7111,7 @@
         "symbolName": "renderMarkdownBlock",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 408,
+        "sourceLine": 406,
         "summary": "Renders a block node as Markdown.",
         "categories": [
           "utilities"
@@ -7136,7 +7136,7 @@
         "symbolName": "renderMarkdownBlocks",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 501,
+        "sourceLine": 499,
         "summary": "Renders block nodes as a Markdown document body.",
         "categories": [
           "utilities"
@@ -7161,7 +7161,7 @@
         "symbolName": "renderMarkdownInline",
         "exportKind": "function",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 343,
+        "sourceLine": 341,
         "summary": "Renders an inline node as Markdown.",
         "categories": [
           "utilities"
@@ -7186,7 +7186,7 @@
         "symbolName": "renderUnsafe",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 542,
+        "sourceLine": 540,
         "summary": "Renders a document through the Markdown adapter and returns the output directly.",
         "categories": [
           "utilities"
@@ -7211,7 +7211,7 @@
         "symbolName": "renderWith",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 730,
+        "sourceLine": 728,
         "summary": "Renders a document with a custom pure adapter.",
         "categories": [
           "utilities"
@@ -7236,7 +7236,7 @@
         "symbolName": "renderWithUnsafe",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/md/src/Md.render.ts",
-        "sourceLine": 579,
+        "sourceLine": 577,
         "summary": "Renders a document with a custom pure adapter and returns the output directly.",
         "categories": [
           "utilities"

--- a/packages/foundation/modeling/pandoc-ast/.beep/repo-exports/catalog.shard.jsonc
+++ b/packages/foundation/modeling/pandoc-ast/.beep/repo-exports/catalog.shard.jsonc
@@ -13,7 +13,7 @@
   },
   "fingerprint": {
     "algorithm": "sha256",
-    "digest": "e3e14fcc06da14cdc35bf8a99a59f208c723694b8a1b0f6456fecdf605bde665",
+    "digest": "bace12c2e6fba01e6eab937ad5829f236b7a1c28018790612771cc1e25afb191",
     "inputs": [
       {
         "path": "generator:repo-exports-catalog",
@@ -37,8 +37,8 @@
       },
       {
         "path": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sha256": "475f69938c5c9182df1a1aa6148b6ede2a21f45887d7b2593d4dbd479a38f730",
-        "bytes": 32268
+        "sha256": "6b86aa2f6fbcd319e4500ba29b55df97aaa0fdc7eefd3eccd00431def1355a0b",
+        "bytes": 33940
       },
       {
         "path": "packages/foundation/modeling/pandoc-ast/src/Pandoc.model.ts",
@@ -385,7 +385,7 @@
         "symbolName": "documentToPandoc",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 953,
+        "sourceLine": 1006,
         "summary": "Maps the canonical `@beep/md` AST into a Pandoc document with a structured",
         "categories": [
           "mapping"
@@ -410,7 +410,7 @@
         "symbolName": "DocumentToPandocResult",
         "exportKind": "class",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 871,
+        "sourceLine": 924,
         "summary": "Result of mapping an `@beep/md` document to Pandoc.",
         "categories": [
           "models"
@@ -434,7 +434,7 @@
         "symbolName": "DocumentToPandocResult",
         "exportKind": "namespace",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 891,
+        "sourceLine": 944,
         "summary": "Companion namespace for {@link DocumentToPandocResult}.",
         "categories": [
           "models"
@@ -2227,7 +2227,7 @@
         "symbolName": "pandocToDocument",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 926,
+        "sourceLine": 979,
         "summary": "Maps a Pandoc document into the canonical `@beep/md` AST with a structured",
         "categories": [
           "mapping"
@@ -2252,7 +2252,7 @@
         "symbolName": "PandocToDocumentResult",
         "exportKind": "class",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 827,
+        "sourceLine": 880,
         "summary": "Result of mapping a Pandoc document to `@beep/md`.",
         "categories": [
           "models"
@@ -2276,7 +2276,7 @@
         "symbolName": "PandocToDocumentResult",
         "exportKind": "namespace",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 847,
+        "sourceLine": 900,
         "summary": "Companion namespace for {@link PandocToDocumentResult}.",
         "categories": [
           "models"
@@ -3123,7 +3123,7 @@
         "symbolName": "documentToPandoc",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 953,
+        "sourceLine": 1006,
         "summary": "Maps the canonical `@beep/md` AST into a Pandoc document with a structured",
         "categories": [
           "mapping"
@@ -3148,7 +3148,7 @@
         "symbolName": "DocumentToPandocResult",
         "exportKind": "class",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 871,
+        "sourceLine": 924,
         "summary": "Result of mapping an `@beep/md` document to Pandoc.",
         "categories": [
           "models"
@@ -3172,7 +3172,7 @@
         "symbolName": "DocumentToPandocResult",
         "exportKind": "namespace",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 891,
+        "sourceLine": 944,
         "summary": "Companion namespace for {@link DocumentToPandocResult}.",
         "categories": [
           "models"
@@ -3196,7 +3196,7 @@
         "symbolName": "pandocToDocument",
         "exportKind": "const",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 926,
+        "sourceLine": 979,
         "summary": "Maps a Pandoc document into the canonical `@beep/md` AST with a structured",
         "categories": [
           "mapping"
@@ -3221,7 +3221,7 @@
         "symbolName": "PandocToDocumentResult",
         "exportKind": "class",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 827,
+        "sourceLine": 880,
         "summary": "Result of mapping a Pandoc document to `@beep/md`.",
         "categories": [
           "models"
@@ -3245,7 +3245,7 @@
         "symbolName": "PandocToDocumentResult",
         "exportKind": "namespace",
         "sourcePath": "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
-        "sourceLine": 847,
+        "sourceLine": 900,
         "summary": "Companion namespace for {@link PandocToDocumentResult}.",
         "categories": [
           "models"

--- a/packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts
+++ b/packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts
@@ -451,6 +451,19 @@ const mdListText = (items: ReadonlyArray<Md.Li | Md.TaskItem>): string =>
     "\n"
   );
 
+const youtubeWatchUrl = (videoId: string): string => `https://www.youtube.com/watch?v=${videoId}`;
+
+const mdTableText = (block: Md.Table): string =>
+  A.join(
+    A.map(block.children, (row) =>
+      A.join(
+        A.map(row.children, (cell) => mdInlinesText(cell.children)),
+        " | "
+      )
+    ),
+    "\n"
+  );
+
 const mdBlockText: (block: Md.Block) => string = Match.type<Md.Block>().pipe(
   Match.tagsExhaustive({
     h1: (block) => mdInlinesText(block.children),
@@ -466,6 +479,8 @@ const mdBlockText: (block: Md.Block) => string = Match.type<Md.Block>().pipe(
     ol: (block) => mdListText(block.children),
     li: (block) => mdInlinesText(block.children),
     taskList: (block) => mdListText(block.children),
+    table: (block) => mdTableText(block),
+    youtube: (block) => youtubeWatchUrl(block.videoId),
     hr: () => "",
   })
 );
@@ -814,6 +829,44 @@ const mdBlockToPandoc = (block: Md.Block, path: JsonPath): Effect.Effect<Project
             items: value,
           }),
         })),
+      table: (node) => {
+        const text = mdTableText(node);
+        return Effect.succeed({
+          issues: [
+            issue({
+              construct: "Table",
+              direction: "md-to-pandoc",
+              message: "Md tables are outside the v1 Pandoc-core profile and are emitted as plain paragraph text.",
+              path,
+              severity: "lossy",
+            }),
+          ],
+          value: Para.make({ children: [Str.make({ text: text.length === 0 ? "[table]" : text })] }),
+        });
+      },
+      youtube: (node) => {
+        const url = youtubeWatchUrl(node.videoId);
+        return Effect.succeed({
+          issues: [
+            issue({
+              construct: "YouTube",
+              direction: "md-to-pandoc",
+              message: "Md YouTube embeds have no Pandoc-core equivalent and are emitted as a plain link.",
+              path,
+              severity: "lossy",
+            }),
+          ],
+          value: Para.make({
+            children: [
+              Link.make({
+                attr: PandocAttr.empty,
+                children: [Str.make({ text: url })],
+                target: PandocTarget.make({ title: "", url }),
+              }),
+            ],
+          }),
+        });
+      },
       hr: () => Effect.succeed(emptyProjection(HorizontalRule.make({}))),
     })
   );

--- a/packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts
+++ b/packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts
@@ -451,7 +451,7 @@ const mdListText = (items: ReadonlyArray<Md.Li | Md.TaskItem>): string =>
     "\n"
   );
 
-const youtubeWatchUrl = (videoId: string): string => `https://www.youtube.com/watch?v=${videoId}`;
+const youtubeWatchUrl = (videoId: string): string => `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`;
 
 const mdTableText = (block: Md.Table): string =>
   A.join(

--- a/packages/foundation/modeling/pandoc-ast/test/Pandoc.mapping.test.ts
+++ b/packages/foundation/modeling/pandoc-ast/test/Pandoc.mapping.test.ts
@@ -75,6 +75,30 @@ const expectPlain = (block: Pandoc.PandocBlock | undefined): Pandoc.Plain => {
   return block;
 };
 
+const expectPara = (block: Pandoc.PandocBlock | undefined): Pandoc.Para => {
+  expect(block?._tag).toBe("para");
+  if (block?._tag !== "para") {
+    throw new Error("expected Pandoc para block");
+  }
+  return block;
+};
+
+const expectStr = (inline: Pandoc.PandocInline.Type | undefined): Pandoc.Str => {
+  expect(inline?._tag).toBe("str");
+  if (inline?._tag !== "str") {
+    throw new Error("expected Pandoc str inline");
+  }
+  return inline;
+};
+
+const expectLink = (inline: Pandoc.PandocInline.Type | undefined): Pandoc.Link => {
+  expect(inline?._tag).toBe("link");
+  if (inline?._tag !== "link") {
+    throw new Error("expected Pandoc link inline");
+  }
+  return inline;
+};
+
 const expectParagraphText = (block: Md.Block | undefined, value: string): void => {
   expect(block?._tag).toBe("p");
   if (block?._tag !== "p") {
@@ -150,6 +174,66 @@ describe("Pandoc.mapping", () => {
         expect(result.report.profile).toBe("gap");
         expect(A.map(result.report.issues, (entry) => entry.construct)).toEqual(
           expect.arrayContaining(["rawMarkdown", "TaskList"])
+        );
+      })
+    ));
+
+  it("degrades @beep/md tables and YouTube embeds to Pandoc with recorded lossiness", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const document = Md.Document.make({
+          children: [
+            Md.Table.make({
+              headerRow: true,
+              children: [
+                Md.TableRow.make({
+                  children: [
+                    Md.TableCell.make({ children: [text("Name")] }),
+                    Md.TableCell.make({ children: [text("Value")] }),
+                  ],
+                }),
+                Md.TableRow.make({
+                  children: [
+                    Md.TableCell.make({ children: [text("Rich")] }),
+                    Md.TableCell.make({ children: [text("Ready")] }),
+                  ],
+                }),
+              ],
+            }),
+            Md.YouTube.make({ videoId: "dQw4w9WgXcQ" }),
+          ],
+        });
+
+        const result = yield* documentToPandoc(document);
+
+        expect(result.pandoc.blocks.map((block) => block._tag)).toEqual(["para", "para"]);
+        expect(A.map(result.report.issues, (entry) => entry.construct)).toEqual(
+          expect.arrayContaining(["Table", "YouTube"])
+        );
+
+        const tableText = expectStr(expectPara(result.pandoc.blocks[0]).children[0]);
+        expect(tableText.text).toBe("Name | Value\nRich | Ready");
+
+        const youtubeLink = expectLink(expectPara(result.pandoc.blocks[1]).children[0]);
+        expect(youtubeLink.target.url).toBe("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+      })
+    ));
+
+  it("encodes reserved characters in YouTube watch URLs and placeholders empty tables", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const document = Md.Document.make({
+          children: [Md.Table.make({ headerRow: false, children: [] }), Md.YouTube.make({ videoId: "a b&c" })],
+        });
+
+        const result = yield* documentToPandoc(document);
+
+        expect(A.map(result.report.issues, (entry) => entry.construct)).toEqual(
+          expect.arrayContaining(["Table", "YouTube"])
+        );
+        expect(expectStr(expectPara(result.pandoc.blocks[0]).children[0]).text).toBe("[table]");
+        expect(expectLink(expectPara(result.pandoc.blocks[1]).children[0]).target.url).toBe(
+          "https://www.youtube.com/watch?v=a%20b%26c"
         );
       })
     ));

--- a/packages/tooling/tool/cli/.beep/repo-exports/catalog.shard.jsonc
+++ b/packages/tooling/tool/cli/.beep/repo-exports/catalog.shard.jsonc
@@ -13,7 +13,7 @@
   },
   "fingerprint": {
     "algorithm": "sha256",
-    "digest": "57d69ec7c5b9608bb234e1ecea3f31a52aa461619d0b9fd84bb4e1a139ceca3d",
+    "digest": "4c920228d07b0b741c8f342d60d217d54a60ae73c71cfb393df5d53743d2b950",
     "inputs": [
       {
         "path": "generator:repo-exports-catalog",
@@ -52,8 +52,8 @@
       },
       {
         "path": "packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts",
-        "sha256": "663d61354d8798db9558a72cbb6ddd66d9c700ae1c902eefeff7e350b80f2b37",
-        "bytes": 114718
+        "sha256": "0903b60b3590fcbe12b98fc4685c9ce94f7aa67a618899660e5171fc6c75c313",
+        "bytes": 116391
       },
       {
         "path": "packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.errors.ts",
@@ -1685,7 +1685,7 @@
         "symbolName": "aiMetricsCommand",
         "exportKind": "const",
         "sourcePath": "packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts",
-        "sourceLine": 3580,
+        "sourceLine": 3600,
         "summary": "AI metrics root command.",
         "categories": [
           "commands"
@@ -1760,7 +1760,7 @@
         "symbolName": "aiMetricsCommand",
         "exportKind": "const",
         "sourcePath": "packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts",
-        "sourceLine": 3580,
+        "sourceLine": 3600,
         "summary": "AI metrics root command.",
         "categories": [
           "commands"
@@ -1835,7 +1835,7 @@
         "symbolName": "aiMetricsCommand",
         "exportKind": "const",
         "sourcePath": "packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts",
-        "sourceLine": 3580,
+        "sourceLine": 3600,
         "summary": "AI metrics root command.",
         "categories": [
           "commands"


### PR DESCRIPTION
## Summary

Restores the full repository quality proof (`bun run beep yeet verify` / the
hosted pre-push gate) to **end-to-end green**. The `main` branch had several red
gates left behind by an incompletely-landed `table` / `youtube` rich-block
feature that spans `@beep/md`, `@beep/agents-domain`, and `@beep/pandoc-ast`,
plus two newly-published transitive-dependency security advisories.

Each gate was fixed at its root (no check was weakened or suppressed except the
two documented, reviewed OSV ignores).

## Changes

### Build / type-check
- **`@beep/pandoc-ast`** (`Pandoc.mapping.ts`): complete the Md→Pandoc
  compatibility mapping for the new `table` and `youtube` Md block variants. Md
  tables degrade to a paragraph capture (the v1 Pandoc-core profile records
  tables as gap nodes) and YouTube embeds project to a plain Pandoc link — both
  with recorded compatibility issues — and both render in plain-text extraction.
  This restores the package build.
- **`@beep/agents-domain`** (`AgentsDomain.test.ts`): replace `node:fs` /
  `node:path` with Effect `FileSystem` / `Path` (satisfies the
  `effect(nodeBuiltinImport)` law), provide the layer via `provideScopedLayer`
  (satisfies `effect(strictEffectProvide)`), and fix an annotation-type helper.

### Policy / lint
- **schema-first (`SFV4-arbitrary-tests`)**: the chat contract test crossed the
  3-codec threshold once `TurnHistoryItem` encode/decode landed, so it now
  carries schema-derived property coverage via
  `assertSchemaArbitraryDecodesToSelf(TurnHistoryItem)`.
- **fallow audit (complexity)**: extracted two predicate helpers from the
  agents-domain test directory walker, dropping its cyclomatic complexity from
  10 to 5 (a real reduction, not a `fallow-ignore` suppression).
- **cspell**: exclude `osv-scanner.toml` from spell-checking (opaque GHSA
  identifiers), consistent with how `bun.lock`, `_typos.toml`, and the
  openapi/swagger files are handled.

### Security
- **`osv-scanner.toml`**: ignore two newly-published advisories on **transitive**
  dependencies, following the file's existing convention (reason + revisit date):
  - `GHSA-8988-4f7v-96qf` — `@opentelemetry/core` <2.8.0 (fixed 2.8.0)
  - `GHSA-6v5v-wf23-fmfq` — `markdown-it` 14.1.1 (fixed 14.2.0)

  Both are pulled transitively (no direct workspace dependency), are present on
  `main` unchanged by this branch, and are tracked for a repo-wide bump.

### Release metadata / generated
- **changeset**: `@beep/pandoc-ast` patch for the mapping completion.
- regenerated repo-export catalog shards + `standards/repo-exports.catalog.md`
  for the feature's new exports.

### Docs
- **`docs/BEEPGRAPH_ARCHITECTURE.md`**: BeepGraph architecture decision document,
  bundled into this PR by request.

## Verification

Full local pre-push proof is green (build, check, lint, test, repo-exports,
docgen, cspell, typos, changeset, secrets/gitleaks, SAST, OSV security, Nix,
fallow audit, schema-first, and all repo-law lanes):

```
$ bun run beep yeet verify
outcome: success
  advisory:01-fallow-feedback -> passed
  full:01-pre-push           -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Markdown→Pandoc rendering for new `table` and `youtube` blocks with explicit lossy-compatibility reporting and correct plain-text extraction.
* **Documentation**
  * Added/updated Prose-to-Proof product and architecture docs, plus new visualization HTML pages.
* **Configuration**
  * Updated spell-check rules and added vulnerability suppressions.
* **Tests**
  * Extended contract, Pandoc mapping, and agents-domain checks (including schema and lossy behavior round-trips).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->