### PR TITLE
fix(security): close 3 Codex findings — SSRF mapped-IPv6 + gitleaks config trust

### DIFF
--- a/.changeset/security-codex-followup-2026-06-18.md
+++ b/.changeset/security-codex-followup-2026-06-18.md
@@ -1,0 +1,11 @@
+---
+"@beep/schema": patch
+"@beep/box": patch
+"@beep/nlp-mcp": patch
+---
+
+Harden the SSRF guards against IPv4-mapped IPv6 bypass (follow-up to the PR #254 security work).
+
+- `@beep/schema` `SafeRemoteHost`: decode the IPv4 embedded in IPv4-mapped IPv6 hosts (`new URL().hostname` normalizes them to compressed hex, e.g. `::ffff:c0a8:101`) and classify it through the shared `isInternalIpv4` checks, closing a bypass where mapped RFC1918 addresses (`http://[::ffff:c0a8:101]/` → 192.168.1.1) reached internal space. Also add the opt-in `resolve` hook to `assertAllowedRemoteUrl` so callers can resolve DNS (the module `@remarks` already documented it).
+- `@beep/box`: wire the by-URL SSRF guard with a fail-closed `node:dns` resolver so a hostname resolving to internal space is rejected before the SDK connects.
+- `@beep/nlp-mcp`: apply the same IPv4-mapped IPv6 decode to the dataset-loader's duplicated SSRF guard.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -485,8 +485,28 @@ jobs:
           set -euo pipefail
 
           log_opts="-1"
+          config_path=".gitleaks.toml"
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             log_opts="origin/${GITHUB_BASE_REF:-main}..HEAD"
+
+            # The secret-scanning gate must NOT trust a PR-controlled scanner
+            # config: a PR could broaden the allowlist (or add .gitleaksignore
+            # fingerprints) in the SAME change to hide a planted secret and still
+            # pass the required check. For pull_request runs, scan with the base
+            # branch's already-reviewed config + ignore file instead of the PR's.
+            base_ref="origin/${GITHUB_BASE_REF:-main}"
+            if git cat-file -e "${base_ref}:.gitleaks.toml" 2>/dev/null; then
+              git show "${base_ref}:.gitleaks.toml" > .gitleaks.base.toml
+              config_path=".gitleaks.base.toml"
+            fi
+            # Pin .gitleaksignore to the base too (gitleaks auto-reads it from the
+            # source root): use the base version, or none if the base has none, so
+            # a PR cannot add suppression fingerprints to its own scan.
+            if git cat-file -e "${base_ref}:.gitleaksignore" 2>/dev/null; then
+              git show "${base_ref}:.gitleaksignore" > .gitleaksignore
+            else
+              rm -f .gitleaksignore
+            fi
           elif [[ -n "${BEFORE_SHA:-}" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then
             log_opts="${BEFORE_SHA}..HEAD"
           fi
@@ -495,7 +515,7 @@ jobs:
             -v "$PWD:/repo" \
             -w /repo \
             zricethezav/gitleaks@sha256:5d0147dc25c78f8cc2b9861ff8f5c9b4a41419ed60a9ce2217de5a215270b42b \
-            detect --source=/repo --config=/repo/.gitleaks.toml --log-opts="$log_opts" --redact --no-banner
+            detect --source=/repo --config="/repo/${config_path}" --log-opts="$log_opts" --redact --no-banner
 
   security:
     name: Security

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,8 +14,8 @@ regexes = [
 ]
 
 [[allowlists]]
-description = "CauseRedaction is a secret-redaction helper; its JSDoc @example blocks and tests intentionally contain placeholder secret-shaped strings (sk-/token=/API_KEY=) to demonstrate redaction. These are not real secrets."
+description = "CauseRedaction is a secret-redaction helper; its JSDoc @example blocks and tests intentionally contain placeholder secret-shaped strings (sk-/token=/API_KEY=) to demonstrate redaction. These are not real secrets. Anchored at the repo root (with an optional /repo/ CI-mount prefix) so a nested attacker-controlled path like evil/packages/.../CauseRedaction.ts cannot inherit the allowlist."
 paths = [
-  '''(^|/)packages/foundation/capability/observability/src/CauseRedaction\.ts$''',
-  '''(^|/)packages/foundation/capability/observability/test/CauseRedaction\.test\.ts$''',
+  '''^(?:/repo/)?packages/foundation/capability/observability/src/CauseRedaction\.ts$''',
+  '''^(?:/repo/)?packages/foundation/capability/observability/test/CauseRedaction\.test\.ts$''',
 ]

--- a/packages/drivers/box/src/Box.streaming.ts
+++ b/packages/drivers/box/src/Box.streaming.ts
@@ -6,17 +6,19 @@
  */
 
 import { Buffer } from "node:buffer";
+import * as dns from "node:dns";
 import { Readable } from "node:stream";
 import { $BoxId } from "@beep/identity";
-import { assertAllowedRemoteUrl } from "@beep/schema";
+import { assertAllowedRemoteUrl, BlockedHostError } from "@beep/schema";
 import { Cause, Effect, Exit, Queue, Result, Stream } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
 import * as M from "./_generated/Box.models.gen.ts";
 import { BoxError } from "./Box.errors.ts";
 import { BOX_SDK_VERSION } from "./internal/Box.constants.ts";
 import { decodeWith, logDriverFailure } from "./internal/Box.runtime.ts";
-import type { BlockedHostError } from "@beep/schema";
 import type { BoxMethodName } from "./_generated/Box.models.gen.ts";
 
 const $I = $BoxId.create("Box.streaming");
@@ -631,18 +633,41 @@ const mergeCancellation = <A>(
 };
 
 /**
+ * Fail-closed DNS resolver injected into the SSRF guard so a by-URL target whose
+ * hostname resolves to internal space is rejected before the SDK connects. Uses
+ * the OS resolver (`getaddrinfo` via `dns.lookup`) to match what the SDK's own
+ * connection will resolve. A resolution failure surfaces a `BlockedHostError` so
+ * the guard never proceeds on a name it could not evaluate.
+ */
+const resolveRemoteHost = (hostname: string): Effect.Effect<ReadonlyArray<string>, BlockedHostError> =>
+  Effect.tryPromise({
+    try: () => dns.promises.lookup(hostname, { all: true }),
+    catch: (cause) =>
+      BlockedHostError.make({
+        host: hostname,
+        url: O.none(),
+        message: `Refusing to reach ${hostname}: DNS resolution failed`,
+        cause: O.some(cause),
+      }),
+  }).pipe(Effect.map((records) => A.map(records, (record) => record.address)));
+
+/**
  * Fail-closed SSRF guard for caller-supplied Box by-URL parameters.
  *
  * The `chunkedUploads.uploadFilePartByUrl` and `zipDownloads.getZipDownloadContent`
  * operations forward a full URL string straight to the Box SDK, turning the
  * driver into an SSRF/readable-SSRF primitive if attacker-influenced. This guard
  * parses the URL and rejects loopback, link-local, RFC1918/ULA private, and
- * cloud-metadata destinations before any outbound request is issued, translating
- * the typed `BlockedHostError` into a redacted `BoxError` so the failure stays on
- * the driver's `BoxError` channel.
+ * cloud-metadata destinations (including IPv4-mapped IPv6 forms) before any
+ * outbound request is issued. It additionally resolves the hostname through
+ * {@link resolveRemoteHost} and rejects any name that resolves to internal space,
+ * translating the typed `BlockedHostError` into a redacted `BoxError` so the
+ * failure stays on the driver's `BoxError` channel. The residual DNS-rebinding
+ * TOCTOU window (resolve public, connect internal) is documented on the
+ * `@beep/schema` `SafeRemoteHost` guard.
  */
 const assertBoxUrlAllowed = (method: BoxMethodName, url: string): Effect.Effect<void, BoxError> =>
-  assertAllowedRemoteUrl(url).pipe(
+  assertAllowedRemoteUrl(url, { resolve: resolveRemoteHost }).pipe(
     Effect.mapError((error: BlockedHostError) =>
       BoxError.fromReason("transport", {
         cause: error.message,

--- a/packages/drivers/nlp-mcp/src/Streaming/DatasetLoader.ts
+++ b/packages/drivers/nlp-mcp/src/Streaming/DatasetLoader.ts
@@ -279,11 +279,36 @@ const isPrivate172 = (host: string): boolean =>
     O.exists((n) => n >= 16 && n <= 31)
   );
 
+const isInternalIpv4 = (host: string): boolean =>
+  Str.startsWith("127.")(host) ||
+  Str.startsWith("169.254.")(host) ||
+  Str.startsWith("10.")(host) ||
+  Str.startsWith("192.168.")(host) ||
+  isPrivate172(host);
+
+// Decode the IPv4 embedded in an IPv4-mapped IPv6 host. `new URL(...).hostname`
+// normalizes mapped addresses to compressed hex (::ffff:c0a8:101), so the dotted
+// prefixes never fire for URL input; decode hex and dotted suffixes back to IPv4
+// so mapped private ranges classify like their bare form. None for non-mapped.
+const extractMappedIpv4 = (host: string): O.Option<string> =>
+  pipe(
+    Str.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)(host),
+    O.flatMap((groups) => O.all([A.get(groups, 1), A.get(groups, 2)])),
+    O.map(([hi, lo]) => {
+      const high = Number.parseInt(hi, 16);
+      const low = Number.parseInt(lo, 16);
+      return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+    }),
+    O.orElse(() => pipe(Str.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)(host), O.flatMap(A.get(1))))
+  );
+
 const isBlockedRemoteHost = (hostname: string): boolean => {
   const host = pipe(Str.toLowerCase(hostname), Str.replace(/^\[|\]$/g, ""));
   // SSRF guard duplicated with @beep/schema SafeRemoteHost.isInternalHost by
   // design: each slice owns a self-contained, independently auditable blocklist
   // rather than coupling this driver to a foundation schema's internals.
+  // IPv4-mapped IPv6 is decoded back to its IPv4 form so mapped private ranges
+  // classify through the same isInternalIpv4 checks.
   // fallow-ignore-next-line code-duplication
   return (
     host === "localhost" ||
@@ -291,18 +316,11 @@ const isBlockedRemoteHost = (hostname: string): boolean => {
     host === "0.0.0.0" ||
     host === "::" ||
     host === "::1" ||
-    Str.startsWith("127.")(host) ||
-    Str.startsWith("::ffff:127.")(host) ||
-    Str.startsWith("::ffff:7f")(host) ||
-    Str.startsWith("169.254.")(host) ||
-    Str.startsWith("::ffff:169.254.")(host) ||
-    Str.startsWith("::ffff:a9fe:")(host) ||
     Str.startsWith("fe80:")(host) ||
     Str.startsWith("fc")(host) ||
     Str.startsWith("fd")(host) ||
-    Str.startsWith("10.")(host) ||
-    Str.startsWith("192.168.")(host) ||
-    isPrivate172(host)
+    isInternalIpv4(host) ||
+    O.exists(extractMappedIpv4(host), isInternalIpv4)
   );
 };
 

--- a/packages/foundation/modeling/schema/src/SafeRemoteHost.ts
+++ b/packages/foundation/modeling/schema/src/SafeRemoteHost.ts
@@ -121,12 +121,50 @@ const isAllowlisted = (host: string, allowlist: ReadonlyArray<string> | undefine
   );
 
 /**
+ * Classify a bare IPv4 dotted-quad host as loopback, link-local, RFC1918
+ * private, or cloud-metadata space. Shared by the direct-IPv4 path and by the
+ * IPv4 embedded in an IPv4-mapped IPv6 address (see {@link extractMappedIpv4}),
+ * so a mapped address can never reach a range that its bare form would block.
+ */
+const isInternalIpv4 = (host: string): boolean =>
+  Str.startsWith("127.")(host) ||
+  Str.startsWith("169.254.")(host) ||
+  Str.startsWith("10.")(host) ||
+  Str.startsWith("192.168.")(host) ||
+  isPrivate172(host);
+
+/**
+ * Decode the IPv4 embedded in an IPv4-mapped IPv6 host into dotted-decimal form.
+ *
+ * `new URL(...).hostname` normalizes IPv4-mapped IPv6 to compressed *hex*
+ * (`::ffff:192.168.1.1` becomes `::ffff:c0a8:101`), so a dotted-prefix check
+ * never fires for URL-parsed input — that gap let `http://[::ffff:c0a8:101]/`
+ * reach `192.168.1.1`. Both the hex suffix (`::ffff:hhhh:hhhh`) and the dotted
+ * suffix (`::ffff:a.b.c.d`, reachable for raw-host callers) are decoded so mapped
+ * RFC1918/loopback/link-local space classifies identically to its bare IPv4
+ * form. Returns none for non-mapped hosts.
+ */
+const extractMappedIpv4 = (host: string): O.Option<string> =>
+  pipe(
+    Str.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)(host),
+    O.flatMap((groups) => O.all([A.get(groups, 1), A.get(groups, 2)])),
+    O.map(([hi, lo]) => {
+      const high = Number.parseInt(hi, 16);
+      const low = Number.parseInt(lo, 16);
+      return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+    }),
+    O.orElse(() => pipe(Str.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)(host), O.flatMap(A.get(1))))
+  );
+
+/**
  * Core blocked-host classifier mirroring the loopback, link-local,
  * RFC1918/ULA private, and cloud-metadata ranges blocked by the dataset loader.
  */
 // SSRF host classifier: the explicit loopback/link-local/RFC1918/ULA/metadata
 // range checks are intentionally exhaustive and flat for auditability; folding
-// them behind abstraction would obscure which ranges are blocked.
+// them behind abstraction would obscure which ranges are blocked. IPv4-mapped
+// IPv6 is decoded back to its IPv4 form (extractMappedIpv4) so mapped private
+// ranges classify through the same isInternalIpv4 checks.
 // fallow-ignore-next-line complexity
 const isInternalHost = (host: string): boolean =>
   // SSRF guard duplicated with @beep/nlp-mcp DatasetLoader.isBlockedRemoteHost by
@@ -138,18 +176,11 @@ const isInternalHost = (host: string): boolean =>
   host === "0.0.0.0" ||
   host === "::" ||
   host === "::1" ||
-  Str.startsWith("127.")(host) ||
-  Str.startsWith("::ffff:127.")(host) ||
-  Str.startsWith("::ffff:7f")(host) ||
-  Str.startsWith("169.254.")(host) ||
-  Str.startsWith("::ffff:169.254.")(host) ||
-  Str.startsWith("::ffff:a9fe:")(host) ||
   Str.startsWith("fe80:")(host) ||
   Str.startsWith("fc")(host) ||
   Str.startsWith("fd")(host) ||
-  Str.startsWith("10.")(host) ||
-  Str.startsWith("192.168.")(host) ||
-  isPrivate172(host);
+  isInternalIpv4(host) ||
+  O.exists(extractMappedIpv4(host), isInternalIpv4);
 
 /**
  * RFC1918 `172.16.0.0/12` covers `172.16.` through `172.31.`; check the second
@@ -309,6 +340,13 @@ export const assertAllowedRemoteHost: {
  * with a typed {@link BlockedHostError} carrying the parse defect, so callers
  * never proceed on a URL the guard could not evaluate.
  *
+ * When `options.resolve` is supplied, the parsed hostname is additionally
+ * resolved to its A/AAAA addresses and the request is rejected if **any**
+ * resolved address classifies as internal — catching public DNS names that point
+ * at internal IPs. Resolution is opt-in (drivers inject a resolver) and skipped
+ * when no resolver is supplied or the literal host is allowlisted; see the module
+ * `@remarks` for the residual DNS-rebinding TOCTOU limitation.
+ *
  * @example
  * ```ts
  * import { assertAllowedRemoteUrl } from "@beep/schema"
@@ -328,16 +366,23 @@ export const assertAllowedRemoteHost: {
 export const assertAllowedRemoteUrl: {
   (options?: {
     readonly allowlist?: ReadonlyArray<string> | undefined;
+    readonly resolve?: RemoteHostResolver | undefined;
   }): (url: string) => Effect.Effect<void, BlockedHostError>;
   (
     url: string,
-    options?: { readonly allowlist?: ReadonlyArray<string> | undefined }
+    options?: {
+      readonly allowlist?: ReadonlyArray<string> | undefined;
+      readonly resolve?: RemoteHostResolver | undefined;
+    }
   ): Effect.Effect<void, BlockedHostError>;
 } = dual(
   (args) => P.isString(args[0]),
   Effect.fn("SafeRemoteHost.assertAllowedRemoteUrl")(function* (
     url: string,
-    options: { readonly allowlist?: ReadonlyArray<string> | undefined } = {}
+    options: {
+      readonly allowlist?: ReadonlyArray<string> | undefined;
+      readonly resolve?: RemoteHostResolver | undefined;
+    } = {}
   ) {
     const parsed = Result.try({
       try: () => new URL(url).hostname,
@@ -367,5 +412,6 @@ export const assertAllowedRemoteUrl: {
         cause: O.none(),
       });
     }
+    yield* assertResolvedAddressesAllowed(hostname, O.some(url), options);
   })
 );

--- a/packages/foundation/modeling/schema/test/SafeRemoteHost.test.ts
+++ b/packages/foundation/modeling/schema/test/SafeRemoteHost.test.ts
@@ -1,4 +1,4 @@
-import { assertAllowedRemoteHost, isBlockedRemoteHost } from "@beep/schema";
+import { assertAllowedRemoteHost, assertAllowedRemoteUrl, isBlockedRemoteHost } from "@beep/schema";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
@@ -41,6 +41,46 @@ describe("SafeRemoteHost", () => {
       const blocked = yield* Effect.exit(assertAllowedRemoteHost("169.254.169.254"));
       expect(blocked._tag).toBe("Failure");
       const allowed = yield* Effect.exit(assertAllowedRemoteHost("example.com"));
+      expect(allowed._tag).toBe("Success");
+    })
+  );
+
+  it("blocks IPv4-mapped IPv6 RFC1918/loopback/link-local forms (CSF-SSRF mapped-v6 bypass)", () => {
+    // Hex form as produced by `new URL(...).hostname` normalization.
+    expect(isBlockedRemoteHost("::ffff:c0a8:101")).toBe(true); // 192.168.1.1
+    expect(isBlockedRemoteHost("::ffff:a00:1")).toBe(true); // 10.0.0.1
+    expect(isBlockedRemoteHost("::ffff:ac10:1")).toBe(true); // 172.16.0.1
+    expect(isBlockedRemoteHost("::ffff:7f00:1")).toBe(true); // 127.0.0.1
+    expect(isBlockedRemoteHost("::ffff:a9fe:a9fe")).toBe(true); // 169.254.169.254
+    expect(isBlockedRemoteHost("[::ffff:c0a8:101]")).toBe(true); // bracketed
+    // Dotted-suffix mapped form (reachable for raw-host callers).
+    expect(isBlockedRemoteHost("::ffff:192.168.1.1")).toBe(true);
+    expect(isBlockedRemoteHost("::ffff:10.0.0.1")).toBe(true);
+    // Public mapped addresses stay allowed (no over-blocking).
+    expect(isBlockedRemoteHost("::ffff:101:101")).toBe(false); // 1.1.1.1
+    expect(isBlockedRemoteHost("::ffff:ac20:1")).toBe(false); // 172.32.0.1 (outside the /12)
+  });
+
+  it.effect(
+    "assertAllowedRemoteUrl blocks an IPv4-mapped IPv6 URL host (::ffff:c0a8:101 -> 192.168.1.1)",
+    Effect.fnUntraced(function* () {
+      const exit = yield* Effect.exit(assertAllowedRemoteUrl("http://[::ffff:c0a8:101]/file"));
+      expect(exit._tag).toBe("Failure");
+    })
+  );
+
+  it.effect(
+    "assertAllowedRemoteUrl resolves the host and blocks names resolving to internal space",
+    Effect.fnUntraced(function* () {
+      const blocked = yield* Effect.exit(
+        assertAllowedRemoteUrl("https://internal.example.com/x", {
+          resolve: () => Effect.succeed(["10.0.0.5"]),
+        })
+      );
+      expect(blocked._tag).toBe("Failure");
+      const allowed = yield* Effect.exit(
+        assertAllowedRemoteUrl("https://example.com/x", { resolve: () => Effect.succeed(["93.184.216.34"]) })
+      );
       expect(allowed._tag).toBe("Success");
     })
   );


### PR DESCRIPTION
Follow-up to PR #254 — closes gaps the security work itself introduced. Four Codex Cloud Security findings; 3 are code fixes here, the 4th is a repo/org setting.

## Findings

### 1 — SSRF via IPv4-mapped IPv6 (HIGH)
`new URL().hostname` normalizes IPv4-mapped IPv6 to compressed **hex** (`::ffff:c0a8:101`), which the dotted `::ffff:10.`/`::ffff:192.168.` checks never matched — so `http://[::ffff:c0a8:101]/` reached `192.168.1.1`.
- Decode the embedded IPv4 (hex **and** dotted suffix forms) and classify it through a shared `isInternalIpv4`, in **both** `@beep/schema` `SafeRemoteHost` and the duplicated `@beep/nlp-mcp` `DatasetLoader` guard.
- Add the opt-in `resolve` hook to `assertAllowedRemoteUrl` (the module `@remarks` already documented it) and wire the Box by-URL guard with a **fail-closed `node:dns`** resolver, so a hostname resolving to internal space is rejected before the SDK connects. (Residual DNS-rebinding TOCTOU is documented on the schema guard.)

### 2 — gitleaks allowlist too loose (MEDIUM)
The CauseRedaction path regexes used `(^|/)packages/…$`, which also matched `evil/packages/…/CauseRedaction.ts` — letting a nested file inherit the allowlist. Anchored to `^(?:/repo/)?packages/…$`.

### 4 — gitleaks trusts PR-controlled config (MEDIUM)
The CI secret-scan trusted the PR's `/repo/.gitleaks.toml` (+ `.gitleaksignore`), so a PR could weaken its own gate in the same change. For `pull_request` runs the scan now uses the **base branch's** reviewed config + ignore file.

### 3 — dependency-review availability (MEDIUM, no code change)
Resolved by enabling **GitHub Dependency Graph** on the org repo (Settings → Security & analysis) — the workflow already activates the dependency-review gate once the graph is enabled. To be done during the org migration.

## Verification
- `@beep/schema` SafeRemoteHost tests: +1 unit case (mapped-IPv6 hex/dotted, public-mapped still allowed) + 2 effect tests (URL guard + resolver).
- Typecheck (incl. effect-LSP) + lint clean for `@beep/schema`, `@beep/box`, `@beep/nlp-mcp`.
- nlp-mcp integration SSRF assertions (`::ffff:127.0.0.1`, `::ffff:169.254.169.254`) still blocked.
- Patch changeset for the three packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)