### PR TITLE
test(professional-desktop): cover blockquote + task-list plain-text projection (#269 follow-up)

### DIFF
--- a/.changeset/chat-contract-plaintext-coverage.md
+++ b/.changeset/chat-contract-plaintext-coverage.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: extend the professional-desktop chat-contract test to assert blockquote recursion and task-list item text in `documentToPlainText`. No package releases required.

--- a/apps/professional-desktop/test/chat-contract.test.ts
+++ b/apps/professional-desktop/test/chat-contract.test.ts
@@ -197,7 +197,7 @@ describe("@beep/professional-desktop chat contract", () => {
     }).pipe(provideScopedLayer(StackLayer))
   );
 
-  it("projects table cells and youtube embeds into turn-history plain text", () => {
+  it("projects table cells, youtube embeds, blockquotes, and task lists into turn-history plain text", () => {
     const content = Md.Document.make({
       children: [
         Md.Table.make({
@@ -218,14 +218,23 @@ describe("@beep/professional-desktop chat contract", () => {
           ],
         }),
         Md.YouTube.make({ videoId: "dQw4w9WgXcQ" }),
+        Md.BlockQuote.make({ children: [Md.P.make({ children: [Md.Text.make({ value: "Quoted note" })] })] }),
+        Md.TaskList.make({
+          children: [Md.TaskItem.make({ checked: false, children: [Md.Text.make({ value: "Ship docs" })] })],
+        }),
       ],
     });
 
     const text = documentToPlainText(content);
 
+    // Structured nodes are projected by the canonical @beep/md plain-text
+    // renderer (not a bespoke walker): tables stay tab-separated, youtube embeds
+    // surface their watch URL, blockquotes recurse, and task items keep their text.
     expect(text).toContain("Feature\tStatus");
     expect(text).toContain("Rich blocks\tReady");
     expect(text).toContain("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    expect(text).toContain("Quoted note");
+    expect(text).toContain("Ship docs");
   });
 
   it.effect("cancel leaves no partial assistant row and appends no usage record", () =>


### PR DESCRIPTION
Follow-up to the #269 review feedback.

## What this does
Extends the `documentToPlainText` contract test (`apps/professional-desktop/test/chat-contract.test.ts`) to assert **blockquote recursion** and **task-list item text** — completing structured-node coverage for derived thread titles and agent turn history. Table cells (`→ tab-separated`) and youtube embeds (`→ watch URL`) were already asserted; this closes the remaining gap from the reviewer's nit (which also listed blockquote + taskList).

## On the other #269 review nits (investigated → no change needed)
- **libpff Crypto requirement** — already documented in `makePffexportFileProcessingEngine`'s `@effects` JSDoc.
- **libpff test `provideScopedLayer`** — the repo's standard `@beep/test-utils` helper (used throughout this very chat-contract test and `FileProcessing.test.ts`); refactoring would create inconsistency, and it passes checks.
- **ChatOrchestrator renderer change** — verified non-regressive: the canonical `@beep/md` plain-text renderer handles youtube→watch-URL, tables, blockquotes, and task lists (the old bespoke walker's cases).

## Verification
- `chat-contract` test: 11/11 pass (including the extended assertions)
- Global `bun run check` + `bun run lint`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784622070&installation_id=141092090&pr_number=271&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F271&signature=31d6680e70470f3dd497b422929ead05f8bfd6f018f9e7a68964ef80e1570ca1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded the chat contract test to validate plain-text projection correctly handles blockquotes and task lists, alongside existing coverage for other markdown elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->