### PR TITLE
docs(one-round-loop): p0 closeout — row-2 proven, ledger final

### DIFF
--- a/goals/one-round-loop/history/p0-parity-evidence.md
+++ b/goals/one-round-loop/history/p0-parity-evidence.md
@@ -127,7 +127,40 @@ fixture branch itself):
   structural identity (the local lane runs the byte-identical CI
   command, per the D9 echo evidence) with expected PASS/PASS.
 
-Round-3 verdict table: _pending (local battery + CI on ab19e4979c)_.
+**Round-3/4 same-SHA verdict table.** PR A's merge to main made the
+fixture PR CONFLICTING → GitHub cannot build refs/pull/N/merge →
+pull_request runs silently stop triggering (a distinct S4-adjacent
+class: the "stuck queue" was an unbuildable merge ref). Fixture branch
+rebased onto main (injections verified intact) → final SHA
+`025473601b`; local battery re-run on that SHA and CI run on the same
+SHA (PR #322):
+
+| Lane | Local verdict | CI verdict | Match |
+|---|---|---|---|
+| commitlint | FAIL | FAIL | ✔ |
+| repo-sanity | FAIL | FAIL | ✔ |
+| lint-policy | FAIL | FAIL | ✔ |
+| lint | FAIL | FAIL | ✔ |
+| check | FAIL | FAIL | ✔ |
+| codegen | FAIL | FAIL | ✔ |
+| knip | FAIL | FAIL | ✔ |
+| jsdoc-ratchet | FAIL | FAIL | ✔ |
+| secrets | FAIL | FAIL | ✔ (approximate row) |
+| sast | PASS | PASS | ✔ (no-constructible-fixture row; structural identity) |
+| security | FAIL | FAIL | ✔ (approximate row) |
+| build | FAIL | skipped (push-only) | ✔ per table note (local battery is the verdict source) |
+| test-unit | FAIL | FAIL | ✔ |
+| test-integration | FAIL | FAIL | ✔ |
+| docgen | FAIL | FAIL | ✔ |
+| coverage | FAIL | FAIL | ✔ |
+| desktop-ipc | FAIL | FAIL | ✔ |
+| fallow | FAIL | FAIL | ✔ |
+| nix | FAIL | FAIL | ✔ |
+
+**Row 2 verdict: PROVEN.** Every row's local verdict matches CI's on
+the same SHA; every seeded lane fails on both sides; the one PASS/PASS
+row is the documented SAST coverage-gap disposition. Fixture PR #322
+closed unmerged; branch and worktree deleted.
 
 ## 3. Lane inventory single-sourcing (matrix row 3)
 
@@ -135,15 +168,15 @@ Round-3 verdict table: _pending (local battery + CI on ab19e4979c)_.
   pr-size + dependency-review) with class/replay/flags — verified by
   `packages/tooling/tool/cli/test/ci-lane.test.ts` (descriptor suite:
   21 entries, unique ids, frozen 17 required-context set).
-- check.yml body thinning (orl-003, PR B): every cli-runnable /
-  workflow-gated body now dispatches `bun run beep ci lane <id>` (16
-  dispatch sites); the remaining case block carries only event-shape
-  flags; ci-native jobs (pr-size, secrets, security) untouched; all 20
-  context names unchanged (fence 2); the temporary shadow workflow is
-  removed with the proof recorded above. Workflow-side environment
-  addition: the Nix job now runs setup-monorepo-ci on PR events too
-  (the lane dispatch needs bun; the nix commands themselves are
-  unchanged).
+- check.yml body thinning (orl-003): MERGED to main as
+  [#324](https://github.com/beep-effect/beep-effect/pull/324)
+  (2026-07-08T01:27Z). Every cli-runnable / workflow-gated body
+  dispatches `bun run beep ci lane <id>` (16 sites); ci-native jobs
+  untouched; all 20 context names unchanged (fence 2); the temporary
+  shadow workflow removed. The thinned check.yml ran LIVE on PR #324
+  itself: all checks green (round 2; round 1 failed on the stale
+  fallow contract test, §7). Nix job now runs setup-monorepo-ci on PR
+  events (dispatch needs bun; commands unchanged).
 
 ## 4. Dogfood ledger (D4) — P0 PR
 
@@ -266,3 +299,15 @@ declare `.github/workflows/**` in the relevant turbo task `inputs` (or
 globalDependencies), or move workflow-contract tests behind a
 non-cached lane. Until then: workflow-touching PRs should run the
 affected test lane with `--force` locally.
+
+## 8. P0 exit summary
+
+- Matrix row 1 (D9 same-SHA shadow): PROVEN (§1).
+- Matrix row 2 (local-verdict fixtures): PROVEN (§2, same-SHA table).
+- Matrix row 3 (lane inventory single-sourced + thinning): DONE (§3;
+  check.yml contains no raw cli-runnable lane bodies).
+- Dogfood (D4): every packet PR ran the battery from its branch before
+  push; PR #324 needed 2 CI rounds — root-caused (stale contract test
+  green under a turbo cache hit; cache-input gap, §7) with the local
+  catch demonstrated (uncached test run reproduces the failure) — DoD.2
+  satisfied for the >1-round PR.

--- a/goals/one-round-loop/ops/progress.json
+++ b/goals/one-round-loop/ops/progress.json
@@ -6,7 +6,7 @@
     "wontFixRule": "Stretch items only; requires a rationale string."
   },
   "phases": {
-    "P0_ci_inversion": "in_progress",
+    "P0_ci_inversion": "done",
     "P1_property_lane": "pending",
     "P2_medium_tier": "pending",
     "P3_stretch": "pending",
@@ -14,7 +14,7 @@
   },
   "coreItems": {
     "C1_ci_lane_inversion": {
-      "status": "in_progress"
+      "status": "done"
     },
     "C2_property_law_lane": {
       "status": "pending"
@@ -77,9 +77,9 @@
       {
         "pr": 324,
         "title": "ci: p0 thinning to main (PR C)",
-        "ciRounds": null,
+        "ciRounds": 2,
         "localProof": "same content as PR 323 (16/16)",
-        "outcome": "open"
+        "outcome": "merged; round 1 failed on stale fallow contract test (turbo cache-input gap, evidence \u00a77); round 2 green"
       }
     ]
   }

--- a/goals/one-round-loop/tasks/tasks.jsonc
+++ b/goals/one-round-loop/tasks/tasks.jsonc
@@ -27,7 +27,7 @@
       "id": "orl-003",
       "rank": 3,
       "phase": "P0",
-      "status": "in_progress",
+      "status": "done",
       "blockedBy": ["orl-001", "orl-002"],
       "title": "Thin check.yml to lane dispatch",
       "detail": "Blocked on BOTH the lane definitions and `beep ci local` — thinning never precedes the faithful local battery. Matrix case-block and cli-runnable standalone jobs become `bun run beep ci lane <id> [flags]`; workflow-gated orchestration stays in YAML; ci-native jobs (gitleaks image, OSV action, dependency-review) keep workflow bodies, marked CI-native in --list. FENCE: 17 required-check context names unchanged (ruleset 10240248) or same-change gh api update. Parity proof per D9: temporary workflow_dispatch shadow workflow dispatching every lane via `beep ci lane` on the SAME head SHA as the unmodified check.yml run; lane set + CLI-echoed commands + verdicts must match; run IDs recorded in history/ BEFORE the thinning commit replaces check.yml bodies. This PR itself dogfoods: `beep ci local` from its own branch before push (D4)."


### PR DESCRIPTION
## Summary

P0 closeout bookkeeping (docs-only): the row-2 same-SHA verdict table (every lane FAIL/FAIL, sast PASS/PASS per its documented SAST-coverage-gap disposition), orl-003 marked done (merged as #324, thinned check.yml live-proven green on its own PR), P0 phase → done, dogfood ledger finalized (incl. #324's 2-round root-cause per DoD.2: stale contract test green under a turbo cache hit — cache-input gap documented in evidence §7).

Also records the conflicting-PR CI-blackout class (unbuildable merge ref → pull_request runs silently never start) discovered during the fixture proof.

## Dogfood proof

Docs-only diff (D8): `beep ci local --fast --affected` from this branch — **16/16 lanes green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786067055&installation_id=141092090&pr_number=325&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F325&signature=d95946414f56bc353040b9373bf365e3d155de3a2bb3a77f0677ef4b4afb1da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->