### PR TITLE
ci(trunk): restore green main and durable Check completion

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "../scripts/changeset-changelog.cjs",
     { "repo": "beep-effect/beep-effect" }
   ],
   "commit": false,

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -34,10 +34,12 @@
     // the stories glob in apps/storybook/.storybook/main.ts.
     "packages/foundation/ui-system/*/stories/**/*.stories.tsx",
     // Tool-loaded roots: syncpack auto-loads its config, eslint.config.mjs is
-    // profile-selected by the Lint command, and global-cleanup.ts is the
-    // vitest globalSetup for @beep/repo-cli.
+    // profile-selected by the Lint command, Changesets loads its changelog
+    // module from config, and global-cleanup.ts is the vitest globalSetup for
+    // @beep/repo-cli.
     "syncpack.config.ts",
     "eslint.config.mjs",
+    "scripts/changeset-changelog.cjs",
     "packages/tooling/tool/cli/test/global-cleanup.ts"
   ],
   // Approximates dead-code path suppression; Knip remains authoritative for unmigrated workspace/binary policy.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,9 @@ Ship reliable code with effect-first and schema-first patterns.
   `... verify`, `... publish --message "..."`, `... monitor` for End-to-End
   Green (repair, proof, commit, push, PR checks, closeout, merge readiness).
   Keep repo quality commands green.
+- `main` is PR-only. Do not commit saving/wip/tmp checkpoints to shared
+  branches; publish from a feature branch through Yeet and let hosted required
+  checks gate the merge.
 - Fast-plus-monitor is opt-in only (`publish --fast --monitor`, PR-branch
   guarded). Default to plain `publish --message`. Keep
   `bun run audit:github pre-push` as the explicit full local fallback for

--- a/README.md
+++ b/README.md
@@ -246,11 +246,24 @@ See [`standards/effect-first-development.md`](standards/effect-first-development
 All changes must keep the repo quality commands green and follow the non-negotiable habits below:
 
 - Use `bun run beep architecture` and `bun run beep create-package` for new slice or package work.
-- Search the repo export catalog (`bun run repo-exports:catalog:check`) before introducing new symbols.
+- Search live source and package barrels before introducing new shared symbols.
 - Prefer `bun run docgen:local` for documentation work.
-- Run the quality gates (`bun run lint`, `bun run check`, `bun run test`,
-  `bun run audit`, targeted `bun run beep quality <subcommand>`, etc.) and keep
-  them green.
+- Publish through Yeet: feature branch, reviewed staged changes,
+  `bun run beep yeet publish --message "type(scope): summary"`, PR, green
+  required checks, merge.
+- Never commit `saving`, `wip`, or temporary checkpoint work to shared branches.
+  `main` is PR-only and protected by required hosted checks.
+- Run the quality gates (`bun run beep yeet verify`, targeted
+  `bun run beep ci lane <name>`, etc.) and keep them green.
+- Treat hosted PR checks as the final merge gate. Local
+  `bun run beep yeet verify` replays the full pre-push collector:
+  aggregate build/check/lint/test/docgen quality, Knip, JSDoc Ratchet, Repo
+  Sanity plus changeset status, promoted Fallow, Secret Scanning, Security,
+  SAST, and Nix. The remaining hosted-only residue is event-shaped:
+  Commitlint's pushed range, Security's GitHub dependency-review sub-gate, and
+  path-gated desktop IPC setup. Replay those with `bun run beep ci lane
+  commitlint ...`, `bun run beep ci lane desktop-ipc`, or the PR checks when
+  they are relevant.
 - Follow the rules in [`AGENTS.md`](AGENTS.md) and [`CLAUDE.md`](CLAUDE.md).
 
 ---

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
@@ -603,6 +603,7 @@ const runGitOutput = Effect.fn("Yeet.runGitOutput")(function* (
 });
 
 const blockedMonitorBranches: ReadonlyArray<string> = ["main", "master", "HEAD"];
+const protectedPublishBranches: ReadonlyArray<string> = ["main", "master", "HEAD"];
 const shouldMonitorChecks = (options: YeetRunOptions): boolean =>
   options.monitor || options.mode === "monitor" || options.mode === "closeout";
 
@@ -619,6 +620,31 @@ const validateMonitorBranch = (context: RepoRunContext): Effect.Effect<void, Yee
     })
   );
 };
+
+const validatePublishBranch = (
+  context: RepoRunContext,
+  options: YeetRunOptions
+): Effect.Effect<void, YeetCommandError> => {
+  if (options.mode !== "publish" || !A.contains(protectedPublishBranches, context.branch)) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    YeetCommandError.make({
+      message: `yeet publish is PR-branch-only; refusing to publish directly from "${context.branch}". Create a feature branch from ${context.base}, then rerun yeet publish.`,
+      command: `git switch -c <feature-branch> ${context.base}`,
+      exitCode: 1,
+    })
+  );
+};
+
+/**
+ * Expose the protected-branch publish guard for focused tests.
+ *
+ * @category testing
+ * @since 0.0.0
+ */
+export const validatePublishBranchForTesting = validatePublishBranch;
 
 const runGhPullRequestView = Effect.fn("Yeet.runGhPullRequestView")(function* (
   context: RepoRunContext
@@ -2779,6 +2805,7 @@ export const runYeet = Effect.fn("Yeet.runYeet")(function* (
 > {
   const message = yield* validateRequiredMessage(options);
   const context = yield* hydrateYeetRunContext(options);
+  yield* validatePublishBranch(context, options);
   yield* validateMonitorGuards(context, options);
   const forceTurbo =
     options.mode === "repair" || options.mode === "verify" || options.mode === "publish"

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -52,6 +52,7 @@ import {
   TurboPlanSnapshot,
   TurboPlanTask,
   TurboWorkspacePackage,
+  validatePublishBranchForTesting,
   YeetCommandError,
   YeetExecutedStep,
   YeetProofLockStateForTesting,
@@ -1557,6 +1558,18 @@ describe("yeet status helpers", () => {
 });
 
 describe("yeet publish scope helpers", () => {
+  it("refuses publish on main before any publish plan can push", () =>
+    Effect.gen(function* () {
+      const mainContext = RepoRunContext.make({ ...context, branch: "main" });
+      const error = yield* validatePublishBranchForTesting(
+        mainContext,
+        defaultYeetRunOptions({ message: "ci(trunk): guard main publish" })
+      ).pipe(Effect.flip);
+
+      expect(error.message).toContain('yeet publish is PR-branch-only; refusing to publish directly from "main"');
+      expect(error.command).toBe("git switch -c <feature-branch> origin/main");
+    }));
+
   it("summarizes refused paths with counts, top-level entries, and capped examples", () => {
     const paths = pipe(
       A.makeBy(14, (index) => `generated/wiki/page-${Str.padStart(2, "0")(`${index}`)}.md`),

--- a/scripts/changeset-changelog.cjs
+++ b/scripts/changeset-changelog.cjs
@@ -1,0 +1,44 @@
+const githubModule = require("@changesets/changelog-github");
+const fallbackModule = require("@changesets/cli/changelog");
+
+const githubChangelog = githubModule.default ?? githubModule;
+const fallbackChangelog = fallbackModule.default ?? fallbackModule;
+
+const transientGitHubError = (error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Timeout on validation of query") ||
+    message.includes("An error occurred when fetching data from GitHub") ||
+    message.includes("Failed to parse data from GitHub") ||
+    message.includes("GITHUB_TOKEN")
+  );
+};
+
+const fallbackWithWarning = async (operation, error, fallback) => {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!transientGitHubError(error)) {
+    throw error;
+  }
+  process.stderr.write(
+    `[changeset-changelog] GitHub changelog enrichment failed during ${operation}; using plain changelog fallback.\n${message}\n`
+  );
+  return fallback();
+};
+
+exports.getReleaseLine = async (changeset, type, options) =>
+  githubChangelog
+    .getReleaseLine(changeset, type, options)
+    .catch((error) =>
+      fallbackWithWarning("release line generation", error, () =>
+        fallbackChangelog.getReleaseLine(changeset, type, options)
+      )
+    );
+
+exports.getDependencyReleaseLine = async (changesets, dependenciesUpdated, options) =>
+  githubChangelog
+    .getDependencyReleaseLine(changesets, dependenciesUpdated, options)
+    .catch((error) =>
+      fallbackWithWarning("dependency release line generation", error, () =>
+        fallbackChangelog.getDependencyReleaseLine(changesets, dependenciesUpdated, options)
+      )
+    );

--- a/scripts/changeset-changelog.cjs
+++ b/scripts/changeset-changelog.cjs
@@ -4,18 +4,22 @@ const fallbackModule = require("@changesets/cli/changelog");
 const githubChangelog = githubModule.default ?? githubModule;
 const fallbackChangelog = fallbackModule.default ?? fallbackModule;
 
+const transientGitHubErrorMessages = [
+  "Timeout on validation of query",
+  "An error occurred when fetching data from GitHub",
+  "Failed to parse data from GitHub",
+  "GITHUB_TOKEN",
+];
+
+const errorMessage = (error) => (error instanceof Error ? error.message : String(error));
+
 const transientGitHubError = (error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes("Timeout on validation of query") ||
-    message.includes("An error occurred when fetching data from GitHub") ||
-    message.includes("Failed to parse data from GitHub") ||
-    message.includes("GITHUB_TOKEN")
-  );
+  const message = errorMessage(error);
+  return transientGitHubErrorMessages.some((transientMessage) => message.includes(transientMessage));
 };
 
 const fallbackWithWarning = async (operation, error, fallback) => {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = errorMessage(error);
   if (!transientGitHubError(error)) {
     throw error;
   }


### PR DESCRIPTION
## ci(trunk): restore green main and durable Check completion

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/codex_green-main-protection-059a67ca576d/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786134787&installation_id=141092090&pr_number=342&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F342&signature=71776835d1823b53be1bc9e56076e24220d43d6b02cb90e4c439af28a34bff46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->