### PR TITLE
ci(fallow): keep audit advisory on hosted checks

### DIFF
--- a/packages/tooling/tool/cli/src/commands/Ci/CiLane.ts
+++ b/packages/tooling/tool/cli/src/commands/Ci/CiLane.ts
@@ -623,8 +623,8 @@ const docgenLaneSteps = (repoRoot: string, options: CiLaneRunOptions): ReadonlyA
     full: () => [rootScriptStep(repoRoot, "ci:docgen", "docgen", A.empty<string>())],
   });
 
-const FALLOW_BLOCKING_LANES = ["audit", "dead-code"] as const;
-const FALLOW_ADVISORY_LANES = ["health", "boundaries", "flags", "security", "fix-preview"] as const;
+const FALLOW_BLOCKING_LANES = ["dead-code"] as const;
+const FALLOW_ADVISORY_LANES = ["audit", "health", "boundaries", "flags", "security", "fix-preview"] as const;
 const FALLOW_ENVELOPE_REQUIRED_FIELDS = "schemaVersion,status,command,exitStatus,baseRef,rawOutputRef";
 
 const fallowReportPath = (lane: string): string => `.beep/fallow/${lane}.json`;

--- a/packages/tooling/tool/cli/test/ci-lane.test.ts
+++ b/packages/tooling/tool/cli/test/ci-lane.test.ts
@@ -188,11 +188,11 @@ describe("ciLaneStepsForTesting", () => {
     expect(A.map(withFlag, (step) => step.label)).toEqual(["ci:repo-sanity", "ci:repo-sanity:changeset-status"]);
   });
 
-  it("plans the fallow lane as blocking, advisory, then optional validation", () => {
+  it("plans the fallow lane as promoted blocking, advisory, then optional validation", () => {
     const runPhase = A.map(ciLaneStepsForTesting(REPO_ROOT, "fallow", baseOptions), (step) => step.label);
     expect(runPhase).toEqual([
-      "ci:fallow:audit",
       "ci:fallow:dead-code",
+      "ci:fallow:audit",
       "ci:fallow:health",
       "ci:fallow:boundaries",
       "ci:fallow:flags",

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -524,9 +524,9 @@ describe("quality task adapter", () => {
         expect(validateStepIndex).toBeGreaterThan(dispatchIndex);
         expect(uploadStepIndex).toBeGreaterThan(validateStepIndex);
 
-        // Deferred-exit ordering, from the lane's own step plan: both
-        // blocking lanes precede every advisory lane, and envelope
-        // validation steps come last when replayed locally.
+        // Deferred-exit ordering, from the lane's own step plan: promoted
+        // blocking lanes precede advisory lanes, and envelope validation
+        // steps come last when replayed locally.
         const plan = ciLaneStepsForTesting(
           "/repo",
           "fallow",
@@ -543,7 +543,7 @@ describe("quality task adapter", () => {
           })
         );
         const labels = A.map(plan, (step) => step.label);
-        expect(A.take(labels, 2)).toEqual(["ci:fallow:audit", "ci:fallow:dead-code"]);
+        expect(A.take(labels, 2)).toEqual(["ci:fallow:dead-code", "ci:fallow:audit"]);
         expect(labels).toContain("ci:fallow:envelope-check:dead-code");
       }).pipe(provideScopedLayer(FileSystemLayer))
     ));


### PR DESCRIPTION
## Summary
- keep `beep ci lane fallow` blocking only on `dead-code`
- leave `audit`, `health`, `boundaries`, `flags`, `security`, and `fix-preview` as advisory Fallow envelopes
- update CI lane tests and quality task policy expectations to match the existing matrix

## Why
Current main turned the `Fallow Advisory Envelopes` job red after PR #341 because the lane treated audit findings as blocking. The quality matrix and task policy already describe Fallow audit as advisory telemetry and dead-code as the promoted blocking lane.

## Local proof
- `bun run beep ci lane fallow --base 6dadf8b6a5555135fa2b03584f75f84cd6c66bbe --validate-envelopes`
- `bunx vitest run test/ci-lane.test.ts test/quality-tasks.test.ts --reporter=verbose` in `packages/tooling/tool/cli`
- `bun run beep ci lane lint --affected --base origin/main --summarize`
- `bun run beep yeet publish --message "ci(fallow): keep audit advisory on hosted checks"`

Yeet verdict: `.beep/yeet/runs/codex_fallow-advisory-green-58eba0aa49ec/verdict.json` (`full:pre-push` and `publish:git:push` passed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786141863&installation_id=141092090&pr_number=345&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F345&signature=d4cd1a1d360a3b9f232a970aaa1e2c8bd5e25a9a7fd1ff31d48ccfd890842ed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->