### PR TITLE
feat(goals): fold ontosphere research into ontology-workbench packet

### DIFF
--- a/goals/ontology-workbench/GOAL.md
+++ b/goals/ontology-workbench/GOAL.md
@@ -7,8 +7,9 @@ below are repo-relative.
 Outcome: `apps/professional-desktop` gains a fully featured ontology explorer,
 editor, and visualizer backed by a new `ontology` vertical slice — open a
 Turtle document, explore it (tree, search, GPU-scale graph), edit it
-structurally with undo/redo, query it with SPARQL, see bounded inference, and
-save Protégé/ROBOT-parseable Turtle.
+structurally with undo/redo, query it with SPARQL, validate it with SHACL and
+apply verified repairs, see bounded inference, and save Protégé/ROBOT-parseable
+Turtle.
 
 This is a compact `/goal` launcher. Treat the packet files as the detailed
 contract:
@@ -24,12 +25,13 @@ Read those first, then `AGENTS.md`, `CLAUDE.md`, and the standards named by
 Scope:
 
 - In: `packages/ontology/{domain,use-cases,server,client,ui}` (new slice);
-  `packages/drivers/{n3,cosmos,oxigraph}` (new drivers);
+  `packages/drivers/{n3,cosmos,oxigraph,shacl}` (new drivers);
   `apps/professional-desktop` (navigation shell + runtime/RPC wiring only);
   disambiguation notes in the two ontology README files named by `SPEC.md`.
 - Out: multi-format import/export, registry fetch (OLS/BioPortal), full OWL 2
-  DL reasoning, server-backed workspaces, chat-feature refactors, changes to
-  `@beep/ontology` foundation models or the identity-as-iri surface.
+  DL reasoning, server-backed workspaces, agent/MCP tool surface (follow-up
+  packet), chat-feature refactors, changes to `@beep/ontology` foundation
+  models or the identity-as-iri surface.
 
 Hard constraints (details in `SPEC.md`):
 
@@ -40,18 +42,22 @@ Hard constraints (details in `SPEC.md`):
   baseline dependency (Tauri Linux webview).
 - SPARQL via Oxigraph WASM implementing the existing `@beep/semantic-web`
   contract; reasoning is domain-native structural inference.
+- SHACL via the existing `@beep/semantic-web` contract; repairs are verified,
+  undoable change ops.
+- Agent-ready ops (SPEC 13–16): real batch deltas, query safeguards,
+  schema-typed worker protocol, partitioned session indexes.
 - Slice `ui` package owns screens; scaffold via `bun run beep architecture`.
 
 Workflow:
 
 1. Inspect referenced files and current repo state.
-2. Execute `PLAN.md` phases in order (P0→P5); make the smallest change that
+2. Execute `PLAN.md` phases in order (P0→P6); make the smallest change that
    satisfies `SPEC.md` at each step.
 3. Preserve unrelated user/worktree changes.
 4. Keep decisions tied to evidence from files, tests, docs, or command output.
 5. Update packet evidence/status as phases complete; land each phase through
    `bun run beep yeet` (repair → verify → publish → monitor).
-6. At P5 Close, write a closeout reflection to
+6. At P6 Close, write a closeout reflection to
    `history/reflections/<YYYY-MM-DD>-<agent>.md` via the `/reflect` skill;
    `bun run beep lint reflection-artifacts` must pass.
 

--- a/goals/ontology-workbench/PLAN.md
+++ b/goals/ontology-workbench/PLAN.md
@@ -9,17 +9,18 @@ Status: `pending`
 | Phase | Status | Goal | Exit criteria |
 | --- | --- | --- | --- |
 | P0 Bootstrap | pending | Branch from fresh `origin/main`; confirm packet sources, re-read SPEC constraints, verify `@beep/rdf` / `@beep/semantic-web` / `@beep/rdf-canonize` surfaces still match `research/beep-repo-capability-report.md`. | Facts confirmed or drift recorded; scope re-affirmed. |
-| P1 Foundation | pending | Scaffold `ontology` slice (minimum legal set: domain + use-cases + server via `bun run beep architecture`). Schema-first domain on `@beep/rdf` values; typed change-op tagged unions; session = base + change log. `packages/drivers/n3` Turtle codec. Ports: OntologyFileStore (Effect `FileSystem`, sidecar-side), TurtleCodec. | Fixture ontologies round-trip by canonize fingerprint; slice tests green in isolation. |
-| P2 Explorer + Editor | pending | Add `client` (OntologyRpcs per the `agents` ChatRpcs pattern, atoms via `@effect/atom-react`) and `ui` packages. Workspace shell, MUI X Tree View hierarchy explorer, inspector/form editing, search, Turtle source view (`@beep/editor`), undo/redo, dirty state, open/save. App wiring: navigation shell (chat ⇄ workbench), RuntimeLive + sidecar RPC registration. | Author-edit-save loop works in the running desktop app; undo/redo + change log render. |
-| P3 Visualizer | pending | `packages/drivers/cosmos` wrapping `@cosmos.gl/graph` (browser-safe entrypoint). Worker-side projection: model → typed-array node/link buffers with incremental diffs. Focus-neighborhood, progressive disclosure, label LOD, light editing (select-to-edit, drag-between-nodes → change op). sigma.js fallback behind capability detection. Early spike: cosmos.gl on webkitgtk before deep integration (SPEC stop condition). | Synthetic 100k-element ontology interactive on webkitgtk; benchmark note in `history/`. |
-| P4 SPARQL + Reasoning | pending | `packages/drivers/oxigraph` implementing the `@beep/semantic-web` SPARQL contract; query panel UI (SELECT/CONSTRUCT). Domain-native structural inference (closure, domain/range propagation, disjointness) incremental over the change log; inferred-view toggle; reasoner port. | SPARQL + inferred-view acceptance criteria pass. |
-| P5 Harden + Close | pending | Protégé/ROBOT interop validation against real ontologies (record evidence), performance pass, disambiguation README notes, docs. Yeet closeout + reflection. | All SPEC acceptance criteria checked; PR(s) mergeable; closeout reflection exists. |
+| P1 Foundation | pending | Scaffold `ontology` slice (minimum legal set: domain + use-cases + server via `bun run beep architecture`). Schema-first domain on `@beep/rdf` values; typed change-op tagged unions; session = base + change log, partitioned into derived named graphs (asserted/ontologies/inferred/shapes/provenance) with one shared exclusion rule (SPEC 13). `packages/drivers/n3` Turtle codec. Ports: OntologyFileStore (Effect `FileSystem`, sidecar-side), TurtleCodec. Effect-Schema-typed worker protocol for parse/diff workers (SPEC 14). Port ontoauthor-mat + pizza/FOAF fixtures (Apache-2.0 attribution). | Fixture ontologies round-trip by canonize fingerprint; slice tests green in isolation. |
+| P2 Explorer + Editor | pending | Add `client` (OntologyRpcs per the `agents` ChatRpcs pattern, atoms via `@effect/atom-react`; batch ops return real deltas, SPEC 16) and `ui` packages. Workspace shell, MUI X Tree View hierarchy explorer, ABox/TBox view modes (one classification rule shared with search, SPEC acceptance), inspector/form editing, search, Turtle source view (`@beep/editor`), undo/redo, dirty state, open/save, worker-computed metrics/quality panel. App wiring: navigation shell (chat ⇄ workbench), RuntimeLive + sidecar RPC registration. E2E authoring script = ported pizza tutorial. | Author-edit-save loop works in the running desktop app; undo/redo + change log render; ABox/TBox toggle consistent. |
+| P3 Visualizer | pending | `packages/drivers/cosmos` wrapping `@cosmos.gl/graph` (browser-safe entrypoint). Worker-side projection: model → typed-array node/link buffers with incremental diffs. Focus-neighborhood, progressive disclosure, label LOD, fold levels L0–L3 (annotation collapse, structural folding BEFORE community clustering, worker-computed, auto-cluster above threshold), ABox/TBox viewport filter, halo light-editing gestures → typed change ops (connect/delete/expand + predicate autocomplete), pinned-node layout preservation, drag-type-to-instantiate. sigma.js fallback behind capability detection. Early spike: cosmos.gl on webkitgtk before deep integration (SPEC stop condition). | Synthetic 100k-element ontology interactive on webkitgtk (folds active); benchmark note in `history/`. |
+| P4 SPARQL + Reasoning | pending | `packages/drivers/oxigraph` implementing the `@beep/semantic-web` SPARQL contract; query panel UI (SELECT/CONSTRUCT) with prefix-aware defaults, example library, Ctrl/Cmd+Enter run, LIMIT injection, result truncation (SPEC 16). Domain-native structural inference (closure, domain/range propagation, disjointness) incremental over the change log with the SPEC 15 invalidation discipline (changed signatures, module-scoped recompute, drift-cap fail-closed full pass); inferred-view toggle; reasoner port. | SPARQL + inferred-view acceptance criteria pass. |
+| P5 Validation + Provenance | pending | `packages/drivers/shacl` implementing the `@beep/semantic-web` SHACL contract (SPEC 17); validation panel (focus-node navigation, validates asserted + inferred). Verified repair suggestions offered as undoable typed change-op proposals. PROV-O journal export derived from the change log; VoID/DCAT dataset description at export; metrics panel hardening. | SHACL violation → verified repair → undo acceptance passes; PROV-O + VoID/DCAT exports produced. |
+| P6 Harden + Close | pending | Protégé/ROBOT interop validation against real ontologies (record evidence), ontoauthor-mat competency pass (t1–t6), performance pass, disambiguation README notes, docs. Yeet closeout + reflection. | All SPEC acceptance criteria checked; PR(s) mergeable; closeout reflection exists. |
 
 Each phase lands as one or more PRs driven through
 `bun run beep yeet` (repair → verify → publish → monitor); the packet is not
-complete until P5's PR is mergeable.
+complete until P6's PR is mergeable.
 
-## P5 Closeout Checklist
+## P6 Closeout Checklist
 
 Before marking the packet closed (`status` → `completed-retained` / `complete`):
 
@@ -35,8 +36,9 @@ Before marking the packet closed (`status` → `completed-retained` / `complete`
 
 - Preserve unrelated worktree changes.
 - Keep `SPEC.md` normative; update it only when the contract changes.
-- Ontology-Playground ports carry MIT attribution (see
-  `research/SOURCES.md` port discipline table).
+- Ontology-Playground ports carry MIT attribution; ontosphere ports
+  (fixtures, patterns) carry Apache-2.0 attribution (see
+  `research/SOURCES.md` port discipline tables).
 - The `explorations/identity-as-iri` lineage owns repo-internal
   schema-derived ontologies; this slice edits user ontology documents. Keep
   the boundary crisp — shared needs route through `@beep/rdf` /

--- a/goals/ontology-workbench/README.md
+++ b/goals/ontology-workbench/README.md
@@ -11,8 +11,8 @@ Source: [`ops/manifest.json`](./ops/manifest.json)
 Ship a fully featured ontology explorer, editor, and visualizer in
 `apps/professional-desktop`, delivered as a new `ontology` vertical slice with
 files-as-truth Turtle persistence, a typed change-operation edit model,
-GPU-scale graph exploration (cosmos.gl), SPARQL querying (Oxigraph), and
-bounded domain-native inference.
+GPU-scale graph exploration (cosmos.gl), SPARQL querying (Oxigraph), bounded
+domain-native inference, and a SHACL validation lane with verified repairs.
 
 ## Launch
 
@@ -27,10 +27,10 @@ Use this command for execution-capable sessions:
 ## Read This First
 
 1. [`GOAL.md`](./GOAL.md) - compact `/goal` launcher.
-2. [`SPEC.md`](./SPEC.md) - normative source of truth (13 locked decisions).
-3. [`PLAN.md`](./PLAN.md) - phased execution plan (P0 Bootstrap → P5 Close).
+2. [`SPEC.md`](./SPEC.md) - normative source of truth (18 locked constraints).
+3. [`PLAN.md`](./PLAN.md) - phased execution plan (P0 Bootstrap → P6 Close).
 4. [`ops/manifest.json`](./ops/manifest.json) - machine-readable routing.
-5. [`research/`](./research/) - three research reports + provenance ledger.
+5. [`research/`](./research/) - five research reports + provenance ledger.
 6. [`history/`](./history/) - evidence and closeouts, if present.
 
 ## Current Phase
@@ -49,6 +49,13 @@ Not started.
 - Decisions were locked in a `/grill-with-docs` interview on 2026-07-08
   (13 branches; recorded as SPEC constraints). Research was performed by
   Codex agents; reports are verbatim under `research/`.
+- A same-day round-2 interview (9 branches) folded in the ontosphere
+  reference repo (Apache-2.0, ISWC 2026): SHACL + verified repairs, session
+  graph partitions, typed worker protocol, ABox/TBox view modes, fold
+  levels/clustering, agent-ready ops, PROV-O + VoID/DCAT exports, and the
+  ontoauthor-mat fixtures — recorded as SPEC Constraints 13–18; phases became
+  P0–P6. The agent/MCP tool surface is deliberately deferred to a named
+  follow-up packet (`ontology-agent-tools`).
 - Naming: the slice is `ontology` (`@beep/ontology-domain`, …); the existing
   foundation package `@beep/ontology` (FOLIO models,
   `packages/foundation/modeling/ontology`) is a different artifact. P5 adds

--- a/goals/ontology-workbench/SPEC.md
+++ b/goals/ontology-workbench/SPEC.md
@@ -19,6 +19,13 @@ deterministic Turtle that Protégé and ROBOT parse.
 - Full OWL 2 DL reasoning (HermiT-class). Reasoning is bounded to
   domain-native structural inference (see Constraints).
 - Server-backed or multi-user workspaces. Files on disk are the only truth.
+- An MCP/agent tool surface for the workbench. The slice must be agent-ready
+  by construction (Constraint 16), but exposing tools to agents is a named
+  follow-up packet (`ontology-agent-tools`; blueprint: ontosphere's 43-tool
+  MCP manifest — see `research/SOURCES.md`).
+- Term-reuse search before IRI minting and namespace legend / guarded bulk
+  URI rename — evaluated against ontosphere and deferred
+  (see `research/SOURCES.md` evaluated-and-deferred ledger).
 - Fixing the existing chat feature's app-local UI drift.
 - Replacing or extending `@beep/ontology` (foundation FOLIO models) or the
   `identity-as-iri` authoring surface — this workbench edits **user ontology
@@ -45,6 +52,9 @@ Higher sources outrank lower sources when they conflict.
 - `packages/drivers/cosmos` (new: `@cosmos.gl/graph` wrapper, browser-safe).
 - `packages/drivers/oxigraph` (new: Oxigraph WASM implementing the existing
   `@beep/semantic-web` SPARQL contract).
+- `packages/drivers/shacl` (new: SHACL validation engine implementing the
+  existing `@beep/semantic-web` SHACL contract; engine chosen at P5 —
+  candidates `rdf-validate-shacl`, `shacl-engine`).
 - `apps/professional-desktop` (navigation shell, RuntimeLive additions,
   sidecar RPC registration only).
 - `packages/foundation/modeling/ontology/README.md` +
@@ -92,6 +102,37 @@ Higher sources outrank lower sources when they conflict.
     validation script); its data model and hand-rolled parser are explicitly
     not templates.
 
+Constraints 13–18 were locked in a second grilling round (2026-07-08,
+9 decisions) after exploring ontosphere (Apache-2.0 reference implementation;
+see `research/SOURCES.md`):
+
+13. Session dataset partitions: the in-memory session is partitioned into
+    derived named graphs (asserted data / loaded ontologies / inferred /
+    shapes / provenance) with ONE shared exclusion rule consumed by reasoning,
+    SPARQL projection, exports, and viz. Partitions are rebuildable indexes;
+    Turtle files + the typed change log remain the only truth (Constraint 2).
+14. Typed worker protocol: every worker boundary (parse, diff, search index,
+    layout, cluster) uses Effect Schema-validated command payloads.
+15. Inference invalidation discipline: incremental structural inference tracks
+    the full changed signature (subjects + predicate/object), recomputes
+    module-scoped, and fails closed to a full recompute after a bounded drift
+    cap or on any inconsistency. The reasoner port stays open; Konclude-WASM
+    (SharedArrayBuffer/COOP/COEP caveat) and eyereasoner are recorded
+    candidate drivers.
+16. Agent-ready by construction: batch operations return real added/removed
+    deltas; SPARQL execution applies safeguards (prefix normalization, parse
+    validation, LIMIT injection when absent, result truncation); every
+    mutation flows through typed change operations. No agent/MCP tool surface
+    ships in this packet (see Non-Goals).
+17. SHACL validation implements the existing `@beep/semantic-web` SHACL
+    contract via a driver; validation covers asserted + inferred data. Repair
+    suggestions are verified against the session before being offered and are
+    applied as undoable typed change operations.
+18. ontosphere (Apache-2.0) may be ported from with attribution: the
+    ontoauthor-mat benchmark fixtures, demo ontologies (pizza/FOAF), and the
+    named patterns in `research/SOURCES.md`. Its Reactodia renderer, Comunica
+    engine, and Konclude-baseline reasoning are explicitly not templates.
+
 ## Acceptance Criteria
 
 - [ ] A real BFO-aligned knowledge-graph ontology can be authored end-to-end
@@ -108,6 +149,17 @@ Higher sources outrank lower sources when they conflict.
 - [ ] SPARQL panel executes SELECT and CONSTRUCT over the loaded ontology.
 - [ ] Inferred-view toggle shows derived hierarchy/types and flags
       disjointness violations.
+- [ ] ABox/TBox view modes stay consistent across explorer, search, and
+      viewport (one shared classification rule).
+- [ ] SHACL loop: loading shapes renders violations with focus-node
+      navigation; applying a suggested (verified) repair resolves the
+      violation; undo restores the prior state.
+- [ ] The six ported ontoauthor-mat competency tasks pass in slice tests:
+      each `cq.sparql` returns the expected result over its reference
+      ontology and its shapes validate.
+- [ ] PROV-O journal export derives from the typed change log; VoID/DCAT
+      dataset description is produced at export.
+- [ ] Metrics panel renders worker-computed counts and quality heuristics.
 - [ ] Slice tests run with only its own Layers + shared test-kit + driver
       test Layers (no app runtime boot).
 - [ ] No unrelated refactors or formatting churn.
@@ -123,6 +175,8 @@ Higher sources outrank lower sources when they conflict.
 | Slice tests | slice + driver test suites (exact filter recorded in PLAN as they land) | Green |
 | Round-trip proof | fixture-ontology round-trip test (P1) + external check: fixture opens in Protégé / `robot --input` without error (recorded in `history/`) | Passes |
 | Scale benchmark | synthetic 100k-element benchmark note under `history/` (P3) | Interactive per acceptance |
+| Competency fixtures | ontoauthor-mat t1–t6 (ported, Apache-2.0 attribution) run in slice tests (P6) | Green |
+| SHACL loop | violation → verified repair → undo test (P5) | Green |
 
 ## Stop Conditions
 

--- a/goals/ontology-workbench/ops/manifest.json
+++ b/goals/ontology-workbench/ops/manifest.json
@@ -15,13 +15,13 @@
   "provenance": {
     "exploration": null,
     "authoredDirectly": true,
-    "note": "Authored directly from a /grill-with-docs interview (2026-07-08, 13 locked decisions) plus three Codex research reports (Ontology-Playground survey, beep repo capability inventory, graph rendering performance landscape) saved verbatim under research/."
+    "note": "Authored directly from a /grill-with-docs interview (2026-07-08, 13 locked decisions) plus three Codex research reports (Ontology-Playground survey, beep repo capability inventory, graph rendering performance landscape) saved verbatim under research/. Amended same day after a second grilling round (9 locked decisions) informed by two Codex reports on the ontosphere reference repo (Apache-2.0): SHACL+verified repairs, session graph partitions, typed worker protocol, ABox/TBox view modes, fold levels/clustering, agent-ready ops, PROV-O + VoID/DCAT exports, ontoauthor-mat fixtures; phases restructured P0-P6."
   },
   "completionGate": {
     "operator": "yeet",
     "requiresPullRequest": true,
     "requiresMergeable": true,
-    "statement": "Not achieved until this goal's work ships as PRs driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --pr -> monitor); each phase lands through yeet and P5's PR must be mergeable.",
+    "statement": "Not achieved until this goal's work ships as PRs driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --pr -> monitor); each phase lands through yeet and P6's PR must be mergeable.",
     "grandfathered": false
   },
   "currentSourceOfTruth": [
@@ -37,7 +37,9 @@
     "research/SOURCES.md",
     "research/ontology-playground-report.md",
     "research/beep-repo-capability-report.md",
-    "research/graph-performance-report.md"
+    "research/graph-performance-report.md",
+    "research/ontosphere-survey-report.md",
+    "research/ontosphere-delta-report.md"
   ],
   "agentLaunchers": [
     {
@@ -59,31 +61,37 @@
       "id": "P1",
       "name": "Foundation",
       "status": "pending",
-      "exit": "ontology slice (domain+use-cases+server) and drivers/n3 land; fixture ontologies round-trip by rdf-canonize fingerprint; slice tests green in isolation."
+      "exit": "ontology slice (domain+use-cases+server) and drivers/n3 land with partitioned session design and Effect-Schema worker protocol; ontoauthor-mat + pizza/FOAF fixtures ported; fixture ontologies round-trip by rdf-canonize fingerprint; slice tests green in isolation."
     },
     {
       "id": "P2",
       "name": "Explorer + Editor",
       "status": "pending",
-      "exit": "client + ui packages land; author-edit-save loop works in the running desktop app with undo/redo and change log."
+      "exit": "client + ui packages land; author-edit-save loop works in the running desktop app with undo/redo, change log, ABox/TBox view modes, and metrics panel."
     },
     {
       "id": "P3",
       "name": "Visualizer",
       "status": "pending",
-      "exit": "drivers/cosmos viewport with worker projection, focus-neighborhood, light editing; synthetic 100k-element ontology interactive on webkitgtk with benchmark note in history/."
+      "exit": "drivers/cosmos viewport with worker projection, focus-neighborhood, fold levels L0-L3 with clustering, halo light-editing gestures, pinned-node layouts; synthetic 100k-element ontology interactive on webkitgtk with benchmark note in history/."
     },
     {
       "id": "P4",
       "name": "SPARQL + Reasoning",
       "status": "pending",
-      "exit": "drivers/oxigraph implements the @beep/semantic-web SPARQL contract; query panel executes SELECT/CONSTRUCT; inferred-view toggle shows closure/type/disjointness signals."
+      "exit": "drivers/oxigraph implements the @beep/semantic-web SPARQL contract; query panel executes SELECT/CONSTRUCT with safeguards UX; inferred-view toggle shows closure/type/disjointness signals under the invalidation discipline."
     },
     {
       "id": "P5",
+      "name": "Validation + Provenance",
+      "status": "pending",
+      "exit": "drivers/shacl implements the @beep/semantic-web SHACL contract; SHACL violation -> verified repair -> undo acceptance passes; PROV-O journal and VoID/DCAT exports produced from the change log."
+    },
+    {
+      "id": "P6",
       "name": "Harden + Close",
       "status": "pending",
-      "exit": "Protege/ROBOT interop evidence recorded; all SPEC acceptance criteria pass; disambiguation notes added; closeout reflection exists; final PR mergeable."
+      "exit": "Protege/ROBOT interop evidence recorded; ontoauthor-mat competency tasks t1-t6 pass; all SPEC acceptance criteria pass; disambiguation notes added; closeout reflection exists; final PR mergeable."
     }
   ],
   "verificationCommands": [

--- a/goals/ontology-workbench/research/SOURCES.md
+++ b/goals/ontology-workbench/research/SOURCES.md
@@ -4,8 +4,12 @@
   interview (2026-07-08). The align/shape/decompose work normally done in an
   exploration packet happened in that session; its 13 locked decisions are
   recorded as `SPEC.md` Constraints.
-- **Provenance:** three Codex research reports saved verbatim in this
-  directory (each ends with its Codex session ID):
+- **Round 2 (same day, post-ship):** a second `/grill-with-docs` round
+  (9 locked decisions, recorded as `SPEC.md` Constraints 13–18 + scope
+  changes) after exploring the ontosphere reference repo; phases were
+  restructured P0–P6.
+- **Provenance:** five Codex research reports saved verbatim in this
+  directory (each ends with its Codex session/thread ID):
   - [`ontology-playground-report.md`](./ontology-playground-report.md) —
     survey of the reference repo `Ontology-Playground`.
   - [`beep-repo-capability-report.md`](./beep-repo-capability-report.md) —
@@ -13,6 +17,12 @@
     reusable substrate, packet format).
   - [`graph-performance-report.md`](./graph-performance-report.md) —
     large-graph web rendering landscape and Tauri WebGPU reality check.
+  - [`ontosphere-survey-report.md`](./ontosphere-survey-report.md) — deep
+    survey of the ontosphere reference repo (stack, architecture, features,
+    patterns, anti-patterns, docs/benchmark inventory).
+  - [`ontosphere-delta-report.md`](./ontosphere-delta-report.md) —
+    prioritized delta analysis of ontosphere against this packet's locked
+    decisions (15 opportunities + validations).
 
 ## 1. Mined source corpus
 
@@ -23,17 +33,46 @@
 | `op-panels` | Inspector, stats, path finder (BFS), search/filter side panels | Ontology-Playground | `src/components/InspectorPanel.tsx`, `src/lib/pathFinder.ts`, `src/components/SearchFilter.tsx` | explorer UX | port-with-attribution |
 | `op-roundtrip` | Build-time catalogue compile + RDF parse/serialize round-trip validation | Ontology-Playground | `scripts/compile-catalogue.ts`, `scripts/validate-rdf.ts` | round-trip proof discipline | port-with-attribution (idea feeds the P1 fixture round-trip test) |
 | `op-parser` | Hand-rolled RDF/XML DOMParser parser/serializer | Ontology-Playground | `src/lib/rdf/parser.ts`, `src/lib/rdf/serializer.ts` | anti-template | reference only (cautionary; we wrap N3.js instead) |
+| `os-partitions` | Derived named-graph session partitions (data/ontologies/inferred/shapes/provenance) with ONE shared reasoning-exclusion rule | ontosphere | `src/workers/rdfManager.runtime.ts` (`EXCLUDED_FROM_REASONING`), `src/mcp/manifest.ts` | session architecture | port-with-attribution (as derived indexes; files+change-log stay truth) |
+| `os-worker-protocol` | Typed worker protocol with runtime-validated command payloads | ontosphere | `src/utils/rdfManager.workerProtocol.ts` | worker boundary discipline | port-with-attribution (re-expressed as Effect Schema) |
+| `os-abox-tbox` | ABox/TBox view classification as ONE rule shared by canvas + search; drag-type-to-instantiate | ontosphere | `src/providers/N3DataProvider.ts` (`classifyEntityView`), `src/components/Canvas/ReactodiaCanvas.tsx` | explorer/editor semantics | port-with-attribution |
+| `os-folding` | Fold levels L0–L3; structural grouping BEFORE community clustering; auto-cluster threshold; worker layouts with phantom fixed-node substitution | ontosphere | `src/components/Canvas/core/ClusterLevelManager.ts`, `structuralGroups.ts`, `clusterAlgorithms/*`, `layout/*` | visualizer LOD | port-with-attribution (renderer differs — cosmos.gl) |
+| `os-repairs` | Ranked repair suggestions verified against the store, applied as one undoable operation | ontosphere | `src/components/Canvas/RepairSuggestions.tsx`, `src/mcp/tools/computeRepairs.ts` | validation → change-op proposals | port-with-attribution (proposals become typed change ops) |
+| `os-shacl` | SHACL shapes graph, validation over asserted+inferred, panel with focus-node navigation | ontosphere | `src/utils/shaclShapeLoader.ts`, `src/components/Canvas/ShaclShapesPanel.tsx` | validation lane | port-with-attribution (engine behind `@beep/semantic-web` contract) |
+| `os-sparql-ux` | SPARQL panel UX: prefix-aware defaults, examples, Ctrl/Cmd+Enter, LIMIT injection, result truncation | ontosphere | `src/components/Canvas/SparqlPanel.tsx`, `src/mcp/tools/graph.ts` | query UX + safeguards | port-with-attribution (engine stays Oxigraph) |
+| `os-invalidation` | Incremental reasoning: changed-signature accumulation, module-scoped recompute, drift-cap fail-closed full pass | ontosphere | `src/workers/rdfManager.runtime.ts`, `rdfManager.workerProtocol.ts` | inference invalidation | port-with-attribution (technique only; our inference stays domain-native) |
+| `os-provenance` | PROV-O edit journal with real added/removed deltas and batch revert (volatile in ontosphere — cautionary) | ontosphere | `src/mcp/provenance.ts` | provenance export | port-with-attribution (derived from our durable change log instead) |
+| `os-metrics` | Worker-computed metrics + OQuaRE-flavored quality heuristics panel | ontosphere | `src/components/Canvas/MetricsPanel.tsx` | observability panel | port-with-attribution |
+| `os-benchmarks` | ontoauthor-mat competency tasks t1–t6 (task.md + cq.sparql + reference.ttl + shapes.ttl) + pizza/FOAF demo ontologies + stepwise pizza tutorial | ontosphere | `benchmarks/ontoauthor-mat/**`, `docs/mcp-demo/**` | canonical test fixtures + E2E script | port-with-attribution (Apache-2.0) |
+| `os-mcp` | 43-tool MCP surface with manifest-as-doctrine (graph roles, batching rules, workflows) | ontosphere | `src/mcp/manifest.ts`, `ontosphereMcpServer.ts`, `tools/*` | agent surface blueprint | reference only (blueprint for the `ontology-agent-tools` follow-up packet) |
+| `os-runtime` | 6,222-line worker runtime module; volatile persistence; Konclude SharedArrayBuffer/COOP/COEP hosting constraint | ontosphere | `src/workers/rdfManager.runtime.ts`, `src/mcp/provenance.ts` | anti-template | reference only (cautionary: keep boundaries small, persistence durable) |
 
 **How these inform implementation:** the playground's UI composition and
 history/validation discipline transfer; its semantics do not (no axioms, no
 individuals editing, no SPARQL/reasoning, RDF/XML-only). Our stack replaces
-every semantic layer with real libraries behind drivers.
+every semantic layer with real libraries behind drivers. ontosphere is the
+inverse: semantically deep (OWL DL reasoning, SHACL, repairs, MCP) but built
+on a renderer/engine stack we rejected — we port its disciplines and fixtures,
+not its stack.
+
+### Evaluated and deferred (round-2 interview, 2026-07-08)
+
+| Item | ontosphere evidence | Decision |
+|------|---------------------|----------|
+| Term-reuse search before IRI minting | `rdfManager.runtime.ts` ranked label/localname search | Not adopted (interview Q3); revisit post-packet |
+| Namespace legend + guarded bulk URI rename | `rdfManager.workerProtocol.ts` `RenameNamespaceUriPayload` | Not adopted (interview Q3); revisit post-packet |
+| Comunica as SPARQL engine | `package.json` `@comunica/query-sparql-rdfjs` | Rejected — Oxigraph contract stays locked; panel UX adopted |
+| Reactodia as renderer | `package.json` `@reactodia/workspace`, `docs/reactodia-vs-reactflow-analysis.md` | Rejected — cosmos.gl stays locked; interaction semantics adopted |
+| EL fast path / Konclude OWL 2 DL baseline | `rdfManager.runtime.ts` EL + Konclude WASM | Rejected as baseline (interview Q6); recorded as reasoner-port candidates (SharedArrayBuffer/COOP/COEP caveat) |
+| Multi-format + remote loading (`rdf-parse`) | `rdfManager.impl.ts` import paths | Stays a non-goal (future packet) |
+| MCP/agent tool surface | `src/mcp/**` (43 tools) | Deferred to named follow-up packet `ontology-agent-tools`; this packet is agent-ready by construction (SPEC 16) |
 
 ## 2. Upstream repositories & licenses
 
 | Repo | License | Port discipline | What we take |
 |------|---------|-----------------|--------------|
 | Ontology-Playground (local checkout: `/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/Ontology-Playground`) | MIT (`LICENSE`) | port-with-attribution | UI patterns per corpus table above |
+| ontosphere (local checkout: `/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere`; citable — `CITATION.cff`, ISWC 2026 paper in-repo) | Apache-2.0 (`LICENSE`) | port-with-attribution | Session/worker/validation disciplines, fixtures, and panel UX per `os-*` corpus rows; renderer/engine stack explicitly not taken. Its own `ACKNOWLEDGEMENTS.md` credits Konclude, Reactodia, N3.js, SHACL, ELK/Dagre, Comunica |
 | cosmos.gl `@cosmos.gl/graph` (https://github.com/cosmosgl/graph) | MIT | dependency (wrapped in `packages/drivers/cosmos`) | WebGL2 GPU force sim + rendering |
 | sigma.js + graphology (https://www.sigmajs.org/) | MIT | dependency (fallback path) | WebGL renderer + worker layouts |
 | N3.js | MIT | dependency (wrapped in `packages/drivers/n3`) | Turtle parse/serialize |
@@ -57,7 +96,7 @@ d3-force-webgpu.
 | Capability | Package path | Use |
 |------------|--------------|-----|
 | RDF value models (IRI, CURIE, named node, literal, quad, dataset, JSON-LD) | `packages/foundation/modeling/rdf` (`@beep/rdf`) | reuse — slice domain builds on these |
-| SPARQL / SHACL / canonicalization service contracts | `packages/foundation/capability/semantic-web` (`@beep/semantic-web`) | reuse — Oxigraph driver implements the SPARQL contract |
+| SPARQL / SHACL / canonicalization service contracts | `packages/foundation/capability/semantic-web` (`@beep/semantic-web`) | reuse — Oxigraph driver implements the SPARQL contract; SHACL driver implements the SHACL contract |
 | RDF canonicalization driver | `packages/drivers/rdf-canonize` (`@beep/rdf-canonize`) | reuse — round-trip fingerprint proof |
 | FOLIO-oriented OWL models | `packages/foundation/modeling/ontology` (`@beep/ontology`) | adjacent only — disambiguate, do not extend |
 | UI system (shadcn, Tailwind v4, MUI X Tree View, D3 knowledge-graph) | `packages/foundation/ui-system/ui` (`@beep/ui`) | reuse — tree explorer, panels; knowledge-graph component NOT the main viewport |
@@ -67,6 +106,7 @@ d3-force-webgpu.
 | Turtle codec driver | `packages/drivers/n3` | NET-NEW |
 | Graph viewport driver | `packages/drivers/cosmos` | NET-NEW |
 | SPARQL engine driver | `packages/drivers/oxigraph` | NET-NEW |
+| SHACL validation driver | `packages/drivers/shacl` | NET-NEW |
 | Ontology slice | `packages/ontology/{domain,use-cases,server,client,ui}` | NET-NEW |
 
 ## 5. Cross-links & provenance
@@ -78,6 +118,9 @@ d3-force-webgpu.
 - Repo-internal schema-derived ontology authoring belongs to
   [`explorations/identity-as-iri`](../../../explorations/identity-as-iri);
   boundary noted in `SPEC.md` Non-Goals.
-- Decision log: `SPEC.md` Constraints (13 items) — locked during the
-  2026-07-08 grilling interview; the viz decision (cosmos.gl over Cytoscape)
-  superseded an interim choice after the performance research landed.
+- Decision log: `SPEC.md` Constraints — 1–12 locked during the 2026-07-08
+  grilling interview (the viz decision, cosmos.gl over Cytoscape, superseded
+  an interim choice after the performance research landed); 13–18 locked in
+  the same-day round-2 interview (9 decisions) after the ontosphere
+  exploration, which also restructured the phases to P0–P6 and named the
+  `ontology-agent-tools` follow-up packet.

--- a/goals/ontology-workbench/research/ontosphere-delta-report.md
+++ b/goals/ontology-workbench/research/ontosphere-delta-report.md
@@ -1,0 +1,92 @@
+Read-only check completed. I did not modify, create, or delete files. Paths below are relative to `.../ontology_repos/ontosphere`.
+
+**Prioritized Opportunities**
+
+1. **Add SHACL validation as a P4/P5 validation lane**
+   Evidence: `README.md:121-123` lists “SHACL validation” plus focus/path/severity reporting; `src/components/Canvas/ShaclShapesPanel.tsx:165-172` gives a “No shapes loaded” state and `?shaclShapes=` hook; `docs/demo-scripts/feat-shacl.md:40-49` shows reasoning changing validation targets.
+   Packet surface: `SPEC` acceptance criterion, `PLAN` P4/P5.
+   Recommendation: **Adapt**. SHACL complements structural inference without violating the “not a full OWL reasoner” decision.
+
+2. **Add repair suggestions as typed change-operation proposals**
+   Evidence: `README.md:117-119` describes ranked verified fixes; `src/components/Canvas/RepairSuggestions.tsx:187-229` computes and verifies repairs; `RepairSuggestions.tsx:276-403` applies one undoable fix.
+   Packet surface: `SPEC` Constraint 3, `PLAN` P4.
+   Recommendation: **Adapt**. Keep KGCL-style tagged unions as the edit model, but let diagnostics propose verified operations.
+
+3. **Add explicit ABox/TBox view modes and type-drag instantiation**
+   Evidence: `src/providers/N3DataProvider.ts:17` defines `ViewMode = 'abox' | 'tbox'`; `N3DataProvider.ts:91-114` classifies resources into ABox/TBox/both; `ReactodiaCanvas.tsx:1800-1869` creates a new instance when a class/type IRI is dropped.
+   Packet surface: `SPEC` visualizer/editor constraints, `PLAN` P2/P3.
+   Recommendation: **Adopt**. This fits the MUI Tree + explorer/editor split and clarifies schema versus instance workflows.
+
+4. **Use derived named-graph partitions inside the session**
+   Evidence: `src/workers/rdfManager.runtime.ts:302-306` separates data, ontologies, inferred, shapes, workflows, provenance; `rdfManager.runtime.ts:315-320` excludes derived/meta graphs from reasoning.
+   Packet surface: `SPEC` Constraints 2 and 7, `PLAN` P1/P4.
+   Recommendation: **Adapt**. Use partitions as derived in-memory indexes only; Turtle files and typed change logs remain authoritative truth.
+
+5. **Add term-reuse search before minting new IRIs**
+   Evidence: `rdfManager.workerProtocol.ts:167-171` says search should help reuse existing IRIs; `rdfManager.runtime.ts:2516-2520` searches labels/local names across all graphs; `rdfManager.runtime.ts:2582-2611` ranks exact label, startsWith, substring, and local-name matches.
+   Packet surface: `PLAN` P2 editor/search acceptance.
+   Recommendation: **Adopt**. This is small, high-value, and prevents accidental vocabulary duplication.
+
+6. **Add namespace registry, legend, and guarded URI rename**
+   Evidence: `README.md:111` names live namespace URI renaming; `README.md:269` says legend renames propagate across stored triples; `rdfManager.workerProtocol.ts:75-79` has a typed `RenameNamespaceUriPayload`.
+   Packet surface: `PLAN` P2, maybe `SPEC` edit operation coverage.
+   Recommendation: **Adapt**. Make rename a previewable bulk typed change op with undo, not a silent store mutation.
+
+7. **Strengthen visualizer progressive disclosure with fold levels and clustering**
+   Evidence: `README.md:110` documents L1/L2 folding and community clustering; `TopBar.tsx:59-107` exposes fold controls and algorithms; `docs/demo-scripts/feat-clustering.md:3-5` demos L1 annotation collapse, L2 structural fold, L3 Louvain.
+   Packet surface: `SPEC` Constraint 4, `PLAN` P3 100k-scale criteria.
+   Recommendation: **Adapt**. Keep cosmos.gl/sigma, but copy the fold taxonomy and worker-computed cluster overlays.
+
+8. **Add an ontology metrics and quality heuristics panel**
+   Evidence: `MetricsPanel.tsx:1-12` describes counts and OQuaRE-flavored heuristics; `MetricsPanel.tsx:168-268` renders triples, subjects, classes, properties, namespace breakdown, and ratios.
+   Packet surface: `PLAN` P5 hardening or P2 sidebar.
+   Recommendation: **Adopt**. Low-risk observability for users and test fixtures.
+
+9. **Add FAIR metadata export later, not as core editing**
+   Evidence: `metadataTools.ts:56-60` generates VoID + DCAT metadata; `voidGenerator.ts:253-320` emits a pure Turtle description; `README.md:138` includes `generateDatasetMetadata`.
+   Packet surface: `PLAN` P5, `research/SOURCES.md`.
+   Recommendation: **Adapt**. Useful provenance/export sidecar, but keep Turtle authoring and round-trip as the primary contract.
+
+10. **Reject Comunica as the SPARQL engine, but copy panel UX**
+    Evidence: `package.json:71` uses `@comunica/query-sparql-rdfjs`; `rdfManager.runtime.ts:5086-5150` handles SELECT/CONSTRUCT/UPDATE/ASK; `SparqlPanel.tsx:37-50` builds prefix-aware default queries and `SparqlPanel.tsx:160-168` supports Ctrl/Cmd+Enter.
+    Packet surface: `SPEC` Constraint 6, `PLAN` P4.
+    Recommendation: **Reject replacement**. Oxigraph WASM stays locked, but prefix insertion, examples, keyboard run, and result truncation are worth adopting.
+
+11. **Reject Reactodia as primary renderer, but copy interaction semantics**
+    Evidence: `package.json:101` uses `@reactodia/workspace`; `README.md:108` highlights halo authoring and autocomplete; `docs/reactodia-vs-reactflow-analysis.md:20-32` documents rendering-pipeline techniques.
+    Packet surface: `SPEC` Constraints 4 and 5, `PLAN` P3.
+    Recommendation: **Reject replacement**. Reactodia is strong for thousands and rich authoring, but cosmos.gl/sigma better matches the locked 100k WebGL2 requirement.
+
+12. **Incremental reasoning should track full changed signatures**
+    Evidence: `rdfManager.workerProtocol.ts:209-226` describes module-scoped incremental reasoning; `ReactodiaCanvas.tsx:1543-1549` accumulates subjects plus predicate/object signature; `rdfManager.runtime.ts:350-357` forces full revalidation after 20 incremental steps.
+    Packet surface: `SPEC` Constraint 7, `PLAN` P4.
+    Recommendation: **Adapt**. Use the technique for structural closure invalidation, while rejecting full Konclude as baseline.
+
+13. **Add agent/edit provenance as a derived view over the packet change log**
+    Evidence: `README.md:122-123` mentions PROV-O edit provenance and reversal; `src/mcp/provenance.ts:4-10` stores agent edits in `urn:vg:provenance`; `provenance.ts:30-34` admits the journal is volatile.
+    Packet surface: `SPEC` Constraint 3, `PLAN` P2/P5.
+    Recommendation: **Adapt**. Generate PROV-O from durable typed change operations; do not make a volatile provenance graph authoritative.
+
+14. **Reject multi-format/remote loading for this packet, cite as future work**
+    Evidence: `README.md:103-105` supports RDF/XML, JSON-LD, N-Quads, TriG and canonical hashes; `package.json:121-123` uses `rdf-canonize`, `rdf-parse`, and Konclude; `README.md:407-438` has URL/import autoload.
+    Packet surface: `SPEC` Non-goals, `research/SOURCES.md`.
+    Recommendation: **Reject now**. Turtle files-as-truth and N3 driver are locked; multi-format and remote endpoint loading belong in a later packet.
+
+15. **Add Ontosphere provenance entries to `research/SOURCES.md`**
+    Evidence: `CITATION.cff:3-14` gives title, version, abstract; `CITATION.cff:25-28` gives repo, URL, license, release date; `ACKNOWLEDGEMENTS.md:7-35` lists Konclude, Reactodia, N3.js, SHACL, ELK/Dagre, Comunica.
+    Packet surface: `research/SOURCES.md`.
+    Recommendation: **Adopt**. Cite Ontosphere as an Apache-2.0 reference implementation/pattern source, not as code to port wholesale.
+
+**Validates Locked Decisions**
+
+- N3/RDFJS substrate: Ontosphere uses `n3` and RDF/JS heavily, validating the N3.js driver direction.
+- Derived inferred graph: `urn:vg:inferred` is separate and clearable, validating asserted-versus-inferred separation.
+- Worker-heavy architecture: RDF parsing, querying, reasoning, and layout are pushed off the main thread, validating packet worker requirements.
+- Canonicalization: `src/utils/rdfCanonicalize.ts` validates the packet’s round-trip/canonical proof instinct.
+- No WebGPU baseline needed: Ontosphere’s browser client uses Web Workers/WASM and conventional rendering, not WebGPU.
+- Structural/incremental reasoning discipline: locality modules, changed signatures, and periodic full recompute validate bounded inference plus explicit invalidation.
+- UI slice ownership: Ontosphere’s canvas/sidebar/panels own product workflows, matching the packet’s “slice UI owns screens” decision.
+- Oxigraph remains defensible: Ontosphere’s Comunica path works, but nothing found genuinely dislodges the locked `@beep/semantic-web` + Oxigraph WASM contract.
+
+---
+Codex thread: 019f4477-44b8-7ae3-ae85-5b6a2cc5e6af (read-only delta analysis vs goals/ontology-workbench, 2026-07-08)

--- a/goals/ontology-workbench/research/ontosphere-survey-report.md
+++ b/goals/ontology-workbench/research/ontosphere-survey-report.md
@@ -1,0 +1,319 @@
+Root inspected: `/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere`. I kept this read-only and did not run build/test commands because they may create caches or generated output.
+
+## 1. Project Purpose, Maturity, License
+
+Ontosphere is a browser-only ontology/RDF workbench: a React/TypeScript app for loading RDF/OWL graphs, visually editing nodes and triples, running OWL reasoning, validating with SHACL, querying with SPARQL, exporting graph/data artifacts, and exposing the whole surface through MCP tools for AI agents. The package description says it is a “Browser-based interactive RDF/ontology knowledge graph editor” with OWL 2 DL reasoning, clustering, layout, and MCP support, running entirely client-side in [package.json](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:2). The README’s overview says all computation runs in-browser against an in-memory RDF store backed by Web Workers, with no backend required in [README.md](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/README.md:64).
+
+Maturity signals are strong for a research/demo-grade but serious workbench: version `1.5.2`, public package metadata, Apache-2.0 license, DOI/paper links, a large README, release notes, demo videos, Playwright e2e specs, Vitest coverage, benchmark fixtures, patches for upstream packages, and dedicated scripts for MCP generation and demo recording. There is some version drift: the README badge still says `1.5.0`, while `package.json` says `1.5.2`.
+
+License: `Apache-2.0` in [package.json](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:4), with the full Apache License 2.0 text and copyright attribution to Thomas Hanke and Fraunhofer IWM in [LICENSE](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/LICENSE:1).
+
+## 2. Tech Stack And Notable Libraries
+
+Only root JS/TS package manifests were present: `package.json`, `package-lock.json`, and `bun.lockb`. I did not find `Cargo.toml`, `pyproject.toml`, or root `requirements*.txt`.
+
+| Area | Libraries / Versions | Evidence | Role |
+|---|---:|---|---|
+| App/runtime | React `19.2.0`, React DOM `19.2.0`, Vite `^7.1.12`, TypeScript `^5.9.3` | [package.json:124](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:124) | Browser SPA and build toolchain. |
+| Graph editor/rendering | `@reactodia/workspace` `0.34.1` | [package.json:101](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:101) | Main canvas, visual authoring, layout worker integration, templates. |
+| RDF parsing/store | `n3` `1.26.0`, `rdf-parse` `4.0.0`, `@rdfjs/data-model` `^2.1.1`, `@rdfjs/dataset` `^2.0.2` | [package.json:99](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:99) | RDF terms, store, streaming parser, SHACL dataset conversion. |
+| RDF canonicalization | `rdf-canonize` `^5.0.0` | [package.json:121](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:121) | W3C RDFC-1.0 canonical N-Quads and hash. |
+| SPARQL | `@comunica/query-sparql-rdfjs` `^5.2.1`, `sparqljs` `^3.7.4` | [package.json:71](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:71) | Worker-side SPARQL engine plus query parsing/rewriting. |
+| OWL reasoning | `rdf-reasoner-konclude` `^0.3.2`; N3 reasoner fallback | [package.json:123](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:123) | Konclude WASM OWL DL reasoning, plus N3 rulesets. |
+| SHACL | `shacl-engine` `^1.1.0` | [package.json:131](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:131) | Data+inferred validation against shapes graph. |
+| Layout engines | `dagre` `0.8.5`, `elkjs` `0.11.0`, Reactodia default layout worker | [package.json:107](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:107) | Horizontal/vertical Dagre; ELK layered/force/stress/radial surfaces. |
+| Clustering / graph algorithms | `ml-kmeans` `7.0.0`, `ngraph.graph` `20.1.1`, `ngraph.louvain` `2.0.0`, `ngraph.coarsen` `1.5.0`, `ngraph.slpa` `0.1.0` | [package.json:114](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:114) | Community detection and large graph folding. |
+| State | `zustand` `5.0.8`, `@tanstack/react-query` `5.90.6` | [package.json:102](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:102) | Config, settings, ontology and workflow state. |
+| UI/components | Radix UI packages, `lucide-react` `0.552.0`, `sonner` `2.0.7`, `cmdk` `1.1.1`, `react-resizable-panels` `3.0.6`, `recharts` `3.3.0` | [package.json:72](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:72) | shadcn/Radix-style controls, icons, toasts, panels, metrics. |
+| Workers/WASM | RDF manager worker, Dagre worker, ELK worker, Reactodia layout worker, Konclude WASM worker, Pyodide workflow worker | [ReactodiaCanvas.tsx:59](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/ReactodiaCanvas.tsx:59), [pyodide.runtime.ts:28](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/pyodide.runtime.ts:28) | Off-main-thread parse/query/reason/layout/workflow execution. |
+| Server/dev glue | `express` `5.1.0`, `socket.io` `4.8.3`, `coi-serviceworker` `^0.1.7` | [package.json:110](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:110) | Local/static serving, relay demos, COOP/COEP support. |
+| Testing | Vitest `^4.0.6`, Playwright `^1.59.1`, Testing Library React `^16.3.2`, jsdom `^27.1.0` | [package.json:141](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:141) | Unit, integration, browser/e2e. |
+
+Editors: no Monaco/Codemirror dependency. Editing is Reactodia visual authoring plus custom property panels and a plain textarea SPARQL editor.
+
+## 3. Architecture Map
+
+High-level flow:
+
+1. `src/main.tsx` initializes theme/config/debug flags, registers MCP, and mounts the React app.
+2. `src/App.tsx` wraps routing, React Query, tooltips, and deferred workflow catalog loading.
+3. `src/pages/Index.tsx` renders the main `ReactodiaCanvas`.
+4. `ReactodiaCanvas` wires Reactodia, app config, search, layout, authoring, inferred graph display, view switching, undo/redo, file load, export, and reasoning.
+5. `rdfManager` is a main-thread facade over `rdfManager.workerClient`, which talks to `src/workers/rdfManager.worker.ts` and `src/workers/rdfManager.runtime.ts`.
+6. The worker owns the N3 store, RDF parse/import/export, SPARQL, SHACL, OWL reasoning, incremental reasoning, module extraction, namespaces, and subject-change events.
+7. `N3DataProvider` adapts RDF quads to Reactodia models and indexes subjects, types, inferred markings, graph names, ABox/TBox membership, structural groups, and community clusters.
+8. MCP tools call the same RDF manager and workspace context, so agent edits flow through the same store/canvas/reasoning pipeline as UI edits.
+
+Key module boundaries:
+
+| Boundary | Files | Responsibility |
+|---|---|---|
+| Rendering/editing | `src/components/Canvas/ReactodiaCanvas.tsx`, templates under `src/templates/`, `NodePropertyEditor.tsx`, `rdfPropertyEditor.tsx` | Reactodia canvas, authoring, visual templates, property editing, keyboard undo/redo. |
+| RDF facade | `src/utils/rdfManager.ts`, `src/utils/rdfManager.impl.ts`, `src/utils/rdfManager.workerClient.ts` | Main-thread API and worker RPC wrapper. |
+| Worker protocol | `src/utils/rdfManager.workerProtocol.ts`, `src/utils/rdfSerialization.ts` | Typed commands/payload validation for worker calls. |
+| RDF/runtime | `src/workers/rdfManager.runtime.ts` | Store, import/export, SPARQL, SHACL, Konclude/N3 reasoning, incremental reasoning, modules. |
+| Canvas adapter/index | `src/providers/N3DataProvider.ts` | Reactodia data provider, search/type/class indexes, inferred metadata, clustering inputs. |
+| Layout | `src/components/Canvas/layout/*` | Dagre/ELK workers, fixed-node phantom substitution, silent layout. |
+| Large graph folding | `src/components/Canvas/core/ClusterLevelManager.ts`, `structuralGroups.ts`, `clusterAlgorithms/*` | L0-L3 fold levels, structural groups, community clustering. |
+| State/persistence | `src/stores/appConfigStore.ts`, `settingsStore.ts`, `ontologyStore.ts`, `stateStorage.ts` | Zustand stores, browser `localStorage`, loaded ontology metadata/config. |
+| MCP/AI | `src/mcp/manifest.ts`, `ontosphereMcpServer.ts`, `workspaceContext.ts`, `tools/*`, `relayBridge.ts` | 43-tool MCP surface, relay bridge, provenance, graph/navigation/reasoning/edit tools. |
+| Workflows/Pyodide | `src/workers/pyodide.*`, workflow stores/utils/components | Offthread Python workflow execution and workflow template catalog. |
+
+Named graph/persistence model:
+
+| Graph | Purpose |
+|---|---|
+| `urn:vg:data` | Asserted user/data triples; most mutations write here. |
+| `urn:vg:ontologies` | Loaded ontology/schema triples. |
+| `urn:vg:inferred` | OWL/N3 inferred triples; can be cleared independently. |
+| `urn:vg:shapes` | SHACL shapes. |
+| `urn:vg:workflows` | Workflow/catalog data. |
+| `urn:vg:provenance` | PROV-O agent edit journal sidecar. |
+
+The graph partition is explicitly documented in the MCP server description in [manifest.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/mcp/manifest.ts:16). The RDF runtime centralizes reasoner exclusions, with the important excerpt `EXCLUDED_FROM_REASONING` covering workflows, inferred, shapes, and provenance in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:315). Dataset-faithful exports collect `urn:vg:data`, `urn:vg:inferred`, `urn:vg:shapes`, `urn:vg:ontologies`, and `urn:vg:workflows` in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:3761).
+
+Persistence is deliberately browser-local and mostly volatile. App/settings live in `localStorage` via Zustand persist keys such as `ontology-painter-config` in [appConfigStore.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/stores/appConfigStore.ts:95). The RDF store and provenance journal are in-memory; provenance comments explicitly say reload clears both data and provenance in [provenance.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/mcp/provenance.ts:30).
+
+Offthread boundaries:
+
+| Worker/offthread path | Role |
+|---|---|
+| `src/workers/rdfManager.worker.ts` / `rdfManager.runtime.ts` | RDF parse/import/export, store mutation, SPARQL, SHACL, reasoning. |
+| `public/rdf-reasoner-konclude/worker.js` expected by runtime | Konclude WASM worker copied by `postinstall`. |
+| `src/components/Canvas/layout/dagre.worker.ts` | Dagre layout. |
+| `src/components/Canvas/layout/elk.worker.ts` | ELK layout worker. |
+| Reactodia layout worker | Default Reactodia/cola-style layout. |
+| `src/workers/pyodide.worker.ts` / `pyodide.runtime.ts` | Python workflow execution, stdout/stderr/input events. |
+
+## 4. Feature Inventory
+
+Explorer/navigation:
+- ABox/TBox view switching, each with its own saved layout/imported diagram state in `ReactodiaCanvas`.
+- Search by label/IRI, class tree/entity sections, match counter, keyboard cycling.
+- Pan/zoom/minimap/fit/focus through Reactodia plus MCP `focusNode` and `fitCanvas`.
+- Namespace legend and color palette with namespace URI rename support.
+- `getNeighbors` and `findPath` MCP navigation tools.
+
+Import/loading:
+- Local RDF file load with `.ttl`, `.owl`, `.rdf`, `.n3`, `.nt`, `.jsonld`, `.trig`, `.nq`, `.xml` accepted in [ReactodiaCanvas.tsx](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/ReactodiaCanvas.tsx:1731).
+- Remote URL loading, CORS proxy fallback, SPARQL endpoint CONSTRUCT loading in [rdfManager.impl.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/utils/rdfManager.impl.ts:1213).
+- Streaming RDF parse through `rdf-parse`; import chunks of `5000` quads with progress events in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:4036).
+- `owl:imports` discovery and well-known ontology registry in `ontologyStore` / `wellKnownOntologies`.
+
+Editing:
+- Reactodia always-on authoring: add nodes, link halo, relation changes, entity deletions.
+- Custom node property editor that avoids RDF reads at render time and writes minimal RDF on save; its own comment calls this a “streamlined” editor in [NodePropertyEditor.tsx](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/NodePropertyEditor.tsx:3).
+- Undo/redo delegates to Reactodia model history; excerpts are `model.history.undo()` and `model.history.redo()` in [ReactodiaCanvas.tsx](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/ReactodiaCanvas.tsx:1707).
+- MCP mutation tools: `loadRdf`, `addNode`, `updateNode`, `removeNode`, `addTriple`, `removeLink`, namespace tools.
+
+Visualization modes:
+- Reactodia canvas with custom RDF element/link templates.
+- ABox/TBox split using `classifyEntityView`, where unknown resources default to ABox in [N3DataProvider.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/providers/N3DataProvider.ts:91).
+- Fold levels L0-L3: annotation hiding, structural grouping, community clusters.
+- Layouts: Dagre LR/TB, ELK layered/force/stress/radial surfaces, Reactodia default.
+- Export canvas as PNG/SVG/print.
+
+Search/query:
+- Search index from `N3DataProvider`, with data/inferred graph allowlist.
+- SPARQL panel with prefix insertion, examples, Ctrl/Cmd+Enter, SELECT/CONSTRUCT/ASK/UPDATE rendering in [SparqlPanel.tsx](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/SparqlPanel.tsx:25).
+- MCP `queryGraph` injects prefixes, parses with `sparqljs`, and injects LIMIT when missing in [graph.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/mcp/tools/graph.ts:315).
+- Worker-side Comunica uses `unionDefaultGraph: true` in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:5092).
+
+Reasoning/inference:
+- Konclude OWL 2 DL path with consistency check, reasoning, MIPS inconsistency explanations, and inferred graph replacement in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:5480).
+- N3 backend fallback with public rulesets under `public/reasoning-rules`.
+- Incremental reasoning using locality modules and subject-local inferred graph splicing in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:2696).
+- EL fast path guarded by conformance/fallback-to-Konclude logic in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:2828).
+- Entailment explanation, module extraction, OWL profile checks, repair suggestions.
+
+Validation:
+- SHACL shapes loaded into `urn:vg:shapes`; direct URL and GitHub folder support in [shaclShapeLoader.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/utils/shaclShapeLoader.ts:75).
+- SHACL validates asserted data plus inferred graph in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:2283).
+- SHACL panel groups shapes, constraints, validation messages, and can navigate to focus nodes in [ShaclShapesPanel.tsx](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/ShaclShapesPanel.tsx:29).
+
+Import/export formats:
+- Import: Turtle, N3, N-Triples, N-Quads, TriG, JSON-LD, RDF/XML/OWL/XML through `rdf-parse` and file/MIME hints.
+- Export: Turtle, JSON-LD, RDF/XML, N-Quads, TriG in [rdfManager.impl.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/utils/rdfManager.impl.ts:1605).
+- RDFC-1.0 canonical N-Quads and hash in [rdfManager.impl.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/utils/rdfManager.impl.ts:1674).
+- Metadata generation: VoID/DCAT via `src/utils/voidGenerator.ts` and `src/mcp/tools/metadataTools.ts`.
+
+Collaboration/AI:
+- Browser MCP server with 43 tools in README and manifest.
+- `window.__mcpTools` built even when `navigator.modelContext` is missing, for relay/browser automation in [ontosphereMcpServer.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/mcp/ontosphereMcpServer.ts:55).
+- Relay bridge/bookmarklet docs and components.
+- PROV-O edit provenance and one-click batch reversal.
+
+## 5. Standout Patterns Worth Porting
+
+1. Named graph partition as the central contract.
+   The repo has a clean split between asserted data, ontologies, inferred triples, SHACL, workflows, and provenance. The strongest part is that the reasoner and module extractor share a single exclusion definition instead of scattered filters. Port this pattern wholesale.
+
+2. Typed worker protocol with runtime validation.
+   `RDFWorkerCommandPayloads` defines every command, including `runReasoning`, `importSerialized`, `sparqlQuery`, `verifyRepair`, `searchTerms`, `extractModule`, and `reasonIncremental` in [rdfManager.workerProtocol.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/utils/rdfManager.workerProtocol.ts:104). Validators start around [rdfManager.workerProtocol.ts:287](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/utils/rdfManager.workerProtocol.ts:287). This is a good pattern for worker-heavy ontology tools.
+
+3. RDF store as source of truth; canvas as projection.
+   Reactodia authoring is flushed into RDF batches, and then subject-change events re-project into the canvas. Brief excerpt: `Flush all staged authoring state` in [ReactodiaCanvas.tsx](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/ReactodiaCanvas.tsx:78). This avoids divergent graph/editor state.
+
+4. Batch operations return real deltas.
+   `applyBatch` returns actual added/removed counts after dedupe/match resolution in [rdfManager.impl.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/utils/rdfManager.impl.ts:1465). That makes provenance, undo, and partial failure reporting honest.
+
+5. Provenance as sidecar graph plus in-memory reversible journal.
+   Every mutating MCP edit records exact added/removed triples into `urn:vg:provenance`, excluded from reasoning/export, with datatype/language metadata for faithful revert in [provenance.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/mcp/provenance.ts:4). This is a practical change-operation model for agent-driven editors.
+
+6. ABox/TBox classification centralized in the data provider.
+   `classifyEntityView` is the single rule used by both view filtering and search indexing in [N3DataProvider.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/providers/N3DataProvider.ts:91). This avoids the common bug where search and canvas disagree.
+
+7. Large graph LOD/folding stack.
+   `ClusterLevelManager` owns levels L0-L3, preserves membership across group/ungroup, and consumes precomputed positions from silent layout in [ClusterLevelManager.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/core/ClusterLevelManager.ts:1). Initial load auto-clusters above threshold and precomputes L1/L2 in the background in [ReactodiaCanvas.tsx](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/ReactodiaCanvas.tsx:487).
+
+8. Structural grouping before community detection.
+   `N3DataProvider` contracts L2 structural groups into super-nodes before clustering, then expands assignments back to original IRIs in [N3DataProvider.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/providers/N3DataProvider.ts:431). This is a useful technique for ontology graphs with long subclass chains and OWL list structures.
+
+9. Layout workers with fixed-node preservation.
+   Dagre and ELK use workers and a phantom substitution strategy for fixed nodes in [layouts.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/layout/layouts.ts:11). This is worth porting if users can pin nodes.
+
+10. Import chunking with progress and blank-node skolemization.
+    The worker buffers parsed quads, skolemizes, inserts in chunks, and emits import progress; excerpt `IMPORT_CHUNK_SIZE = 5000` in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:4149). This is a good baseline for browser RDF ingestion.
+
+11. Reasoning safety over speed.
+    Incremental reasoning falls back to full Konclude when the baseline is missing, inconsistent, empty, or drift-capped in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:3378). The EL fast path is explicitly fail-closed to Konclude in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:2874).
+
+12. Query safeguards.
+    MCP query handling normalizes prefixes, validates parse, caps result sizes, and injects LIMIT if absent in [graph.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/mcp/tools/graph.ts:331). That is exactly the right shape for agent-facing SPARQL.
+
+13. Dataset-faithful export plus canonical hash.
+    N-Quads/TriG preserve named graphs; canonicalization can exclude inferred triples by default and hash asserted content in [rdfManager.impl.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/utils/rdfManager.impl.ts:1641). This is useful for snapshots, reproducible demos, and diffing.
+
+14. MCP manifest as operational doctrine.
+    The manifest includes graph architecture, batching rules, workflow guidance, and tool schemas in [manifest.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/mcp/manifest.ts:4). This is better than exposing raw functions to agents without behavioral rules.
+
+## 6. Cautionary Anti-Patterns To Avoid
+
+- Several modules are too large and too central: `rdfManager.runtime.ts` is 6,222 lines, `ReactodiaCanvas.tsx` 2,204 lines, `rdfManager.impl.ts` 1,736 lines, `N3DataProvider.ts` 777 lines, and `mcp/manifest.ts` 662 lines. They contain good ideas, but port the ideas into smaller boundaries.
+- The repo has some rename residue: several comments and identifiers still say `VG` / `VocabGraph` while the product is Ontosphere. That can confuse future contributors.
+- Docs/package drift exists: README version badge says `1.5.0`; package version is `1.5.2`.
+- Persistence is mostly volatile. RDF data and provenance disappear on reload unless exported; this is correct for the zero-backend design, but not enough for a collaborative/durable ontology workbench.
+- Konclude deployment requires `SharedArrayBuffer`, HTTPS/localhost, and COOP/COEP headers. The runtime throws a specific fallback warning in [rdfManager.runtime.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/workers/rdfManager.runtime.ts:5481), but this remains a real hosting constraint.
+- `structuralGroups.ts` explicitly still has `TODO: extend subclass grouping to rdfs:subPropertyOf` in [structuralGroups.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/core/structuralGroups.ts:34).
+- Layout API drift: `ELK_ALGORITHM_IDS` includes `radial`, and MCP exposes `elk-radial`, but `createElkLayout` is typed only as `layered | force | stress` in [layouts.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/components/Canvas/layout/layouts.ts:85), while [layout.ts](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/src/mcp/tools/layout.ts:122) calls it with `radial`.
+- Some safety knowledge lives in long comments inside giant files. The comments are valuable, but important invariants should eventually become smaller modules plus tests/docs.
+
+## 7. Tests, Build Scripts, Tooling
+
+Scripts of note in [package.json](/home/elpresidank/YeeBois/research/ontology_research/ontology_repos/ontosphere/package.json:31):
+
+| Script | Purpose |
+|---|---|
+| `npm run dev` / `dev:https` | Vite dev server with debug flag. |
+| `npm run build` | `prebuild` generates MCP JSON, then Vite build. |
+| `npm run test` | Vitest. |
+| `npm run typecheck` | TypeScript no-emit. |
+| `npm run typecheck:ratchet` | Baseline/ratchet typecheck script. |
+| `npm run lint` | ESLint. |
+| `npm run check:mcp` | Validate generated MCP JSON. |
+| `npm run test:e2e` | Playwright. |
+| `npm run demo:*` | MCP/demo scenario generation and video workflows. |
+| `npm run ui-overview*` | Generate UI overview assets. |
+
+Tooling files:
+- `vite.config.ts`, `vitest.config.ts`, `eslint.config.js`, `tsconfig*.json`, `components.json`, `tailwind.config.ts`.
+- `playwright.config.ts`, `playwright.demo.config.ts`, `playwright.openwebui.config.ts`.
+- Custom Vite plugins: `vite-plugin-worker-comunica.ts`, `vite-plugin-mcp-manifest.ts`, `vite-plugin-bookmarklet.ts`.
+- `patch-package` used in `postinstall`, plus `scripts/copy-konclude-assets.mjs`.
+
+Test surface:
+- Component tests for autocomplete, canvas autoload/preserve, property editor, reasoning modal, repair suggestions, SHACL/SPARQL panels, metrics, workflow dialogs.
+- Store/RDF tests for import formats, dataset export, chunked import, namespace subscriptions, mutations, inferred graph persistence, OWL imports, ontology removal.
+- Worker tests for SHACL, EL reasoner, locality module, incremental reasoning conformance/repro/EL fast path, diagnostics, repair verification.
+- MCP tests for graph, nodes, links, layout, reasoning, navigation, SHACL, provenance, metadata, search terms, axiom weakening, compute repairs.
+- E2E specs cover feature demos, FOAF, pizza, scene ontology, reasoning inconsistency/named restrictions, relay bookmarklet flows, Open WebUI, SPARQL worker.
+
+## 8. Documentation, Research Notes, Papers, Reference Material Inside Repo
+
+Top-level:
+- `README.md` — main product, architecture, feature, MCP, reasoning, SHACL, startup, deployment docs.
+- `LICENSE` — Apache-2.0 license and copyright.
+- `ACKNOWLEDGEMENTS.md` — credits and dependency acknowledgements.
+- `CITATION.cff` — citation metadata.
+- `AGENTS.md` / `CLAUDE.md` — local agent/development rules.
+- `ontosphere-iswc2026-paper.pdf` — ISWC 2026 paper PDF.
+- `public/paper/index.html` — HTML paper.
+- `public/paper/media/architecture.svg` — paper architecture diagram.
+- `public/paper/media/css/acm.css`, `dokieli.css`, `lncs.css` — paper styles.
+- `public/paper/media/fonts/*` and `public/paper/scripts/dokieli.js` — paper rendering assets.
+- `public/ui-overview.svg`, `public/ui-overview.png`, `public/visgraph_ui.png` — UI reference images.
+- `src/clustering_algos.md` — clustering algorithm notes.
+- `src/components/Canvas/core/clusterAlgorithms/README.md` — clustering implementation reference.
+
+Demo scripts and recordings:
+- `docs/demo-scripts/HOWTO.md` — demo recording/run instructions.
+- `docs/demo-scripts/feat-ai-relay.md` — AI relay demo script.
+- `docs/demo-scripts/feat-authoring.md` — visual authoring demo script.
+- `docs/demo-scripts/feat-clustering.md` — clustering/folding demo script.
+- `docs/demo-scripts/feat-exploration.md` — exploration/navigation demo script.
+- `docs/demo-scripts/feat-loading.md` — loading/import demo script.
+- `docs/demo-scripts/feat-reasoning.md` — reasoning demo script.
+- `docs/demo-scripts/feat-shacl.md` — SHACL demo script.
+- `docs/demo-scripts/foaf-social-network.md` — FOAF demo script.
+- `docs/demo-scripts/iswc2026-comprehensive.md` — comprehensive ISWC demo script.
+- `docs/demo-scripts/pizza-ontology.md` — pizza ontology demo script.
+- `docs/demo-scripts/reasoning-demo.md` — reasoning scenario script.
+- `docs/demo-scripts/scene-ontology.md` — scene ontology script.
+- `docs/demo-videos/*.mp4` and `*.video.json` — feature/workflow recordings and metadata.
+
+MCP demo material:
+- `docs/mcp-demo/foaf-social-network.md`, `graph.ttl`, `01-tbox.svg`, `02-before-reasoning.svg`, `03-after-reasoning.svg`, `04-frank-focus.svg` — FOAF tutorial, source graph, snapshots.
+- `docs/mcp-demo/reasoning-demo.md`, `graph.ttl`, `01-tbox.svg`, `02-before-reasoning.svg`, `03-after-reasoning.svg`, `04-dave-focus.svg` — reasoning demo and snapshots.
+- `docs/mcp-demo/scene-ontology.md`, `graph.ttl`, `01-tbox.svg`, `02-abox-full.svg`, `03-after-reasoning.svg`, `04-jake-focus.svg` — scene ontology demo.
+- `docs/mcp-demo/pizza-tutorial.md` plus `01-root-classes-bare.svg` through `20-owa-vegetarian-lesson.svg` — stepwise pizza ontology construction and reasoning sequence.
+- `docs/mcp-demo/seeds/*.md` — seed prompts/scripts for all demo scenarios.
+
+Architecture/research notes:
+- `docs/reactodia-vs-reactflow-analysis.md` — graph renderer/editor comparison.
+- `docs/relay-bridge.md` — AI relay bridge design.
+- `docs/owui-relay-session.md` — Open WebUI relay notes.
+- `docs/release-notes-v1.5.0.md` — feature/release context.
+- `docs/solutions/architecture-patterns/owui-relay-fire-on-idle-dispatch-2026-04-30.md` — relay dispatch architecture note.
+- `docs/solutions/developer-experience/owui-websocket-blocked-playwright.md` — Playwright/WebSocket troubleshooting.
+- `docs/solutions/developer-experience/vitest-jsdom-broken-in-isolation-2026-04-21.md` — Vitest/jsdom issue note.
+- `docs/solutions/logic-errors/konclude-v030-abox-realization-gaps-2026-06-10.md` — Konclude behavior/gap note.
+- `docs/solutions/logic-errors/relay-inline-param-iri-splitting-2026-04-21.md` — relay parsing bug note.
+
+Benchmarks/reference RDF:
+- `benchmarks/ontoauthor-mat/README.md` — benchmark suite overview.
+- `benchmarks/ontoauthor-mat/t1-subsumption/{task.md,cq.sparql,reference.ttl,shapes.ttl}` — subsumption task/query/reference/shapes.
+- `benchmarks/ontoauthor-mat/t2-existential/{task.md,cq.sparql,reference.ttl,shapes.ttl}` — existential restriction task.
+- `benchmarks/ontoauthor-mat/t3-universal/{task.md,cq.sparql,reference.ttl,shapes.ttl}` — universal restriction task.
+- `benchmarks/ontoauthor-mat/t4-disjointness/{task.md,cq.sparql,reference.ttl,shapes.ttl}` — disjointness task.
+- `benchmarks/ontoauthor-mat/t5-sameas/{task.md,cq.sparql,reference.ttl,shapes.ttl}` — sameAs task.
+- `benchmarks/ontoauthor-mat/t6-unsatisfiability/{task.md,cq.sparql,reference.ttl,shapes.ttl}` — unsatisfiability task.
+
+Bundled runtime references:
+- `public/reasoning-rules/best-practice.n3`, `owl-e.n3`, `owl-p.n3`, `owl-rl.n3` — N3 rulesets.
+- `public/shacl-shapes/ontology-quality.shacl.ttl`, `reasoning-demo.shacl.ttl` — bundled SHACL shapes.
+- `public/reasoning-demo.ttl`, `public/reasoning-demo-inconsistent.ttl` — bundled demo graphs.
+- `public/demo-stage.html`, `public/demo-stage-owui.html`, `public/relay.html`, `public/relay-mock-chat.html`, `public/relay-fhgenie-mock.html` — demo/relay harnesses.
+
+## Summary Table
+
+| Item | File path(s) | Why it matters for an ontology explorer/editor/visualizer |
+|---|---|---|
+| Product contract | `README.md`, `package.json`, `LICENSE` | Defines scope: browser RDF/OWL editor, reasoning, SHACL, MCP, Apache-2.0. |
+| Named graph architecture | `src/mcp/manifest.ts`, `src/workers/rdfManager.runtime.ts`, `src/utils/rdfManager.impl.ts` | Clean separation of asserted, inferred, shapes, ontologies, workflows, provenance. |
+| RDF worker pipeline | `src/utils/rdfManager.workerProtocol.ts`, `src/utils/rdfManager.workerClient.ts`, `src/workers/rdfManager.runtime.ts` | Strong model for offthread parsing, SPARQL, reasoning, validation, import/export. |
+| Reactodia canvas/editor | `src/components/Canvas/ReactodiaCanvas.tsx`, `src/providers/N3DataProvider.ts`, `src/templates/*` | Practical visual RDF editing and projection layer. |
+| Large graph LOD | `ClusterLevelManager.ts`, `structuralGroups.ts`, `clusterAlgorithms/*`, `layout/*` | Folding, clustering, worker layouts, fixed-node preservation. |
+| Reasoning/repair | `rdfManager.runtime.ts`, `src/workers/elReasoner.ts`, `localityModule.ts`, `src/mcp/tools/reasoning.ts`, `computeRepairs.ts`, `axiomWeakening.ts` | OWL DL, incremental modules, EL fast path, explanations, verified repairs. |
+| SHACL validation | `src/utils/shaclShapeLoader.ts`, `src/components/Canvas/ShaclShapesPanel.tsx`, `src/mcp/tools/shacl.ts` | Shape loading, validation, focus-node UX. |
+| SPARQL/query | `src/components/Canvas/SparqlPanel.tsx`, `src/mcp/tools/graph.ts`, `rdfManager.runtime.ts` | User and agent query/update path with safeguards. |
+| Agent/MCP surface | `src/mcp/manifest.ts`, `ontosphereMcpServer.ts`, `workspaceContext.ts`, `tools/*`, `provenance.ts` | High-value blueprint for AI-operated ontology tools. |
+| Reversible edits | `src/mcp/provenance.ts`, `AgentEditsPanel.tsx`, mutation tools | Batch diff/revert with typed/language literal fidelity. |
+| Export/canonicalization | `rdfManager.impl.ts`, `rdfCanonicalize.ts`, `voidGenerator.ts`, `metadataTools.ts` | Dataset export, RDFC hash, FAIR metadata. |
+| Persistence model | `appConfigStore.ts`, `settingsStore.ts`, `ontologyStore.ts`, `stateStorage.ts`, `provenance.ts` | Shows what is durable config vs volatile RDF session state. |
+| Documentation/paper/demos | `README.md`, `public/paper/*`, `docs/demo-*`, `docs/mcp-demo/*`, `docs/solutions/*` | Rich material to mine for UX flows, architecture rationale, and demo scenarios. |
+| Benchmarks | `benchmarks/ontoauthor-mat/**` | Ready-made competency tasks, SPARQL checks, references, SHACL shapes. |
+| Test corpus | `src/__tests__/**`, `src/workers/__tests__/**`, `src/mcp/__tests__/**`, `e2e/**` | Regression map for parser, reasoner, editor, MCP, and browser flows. |
+
+
+---
+Codex thread: 019f4475-6037-7fa0-bf52-a604e56f0ec1 (read-only survey, 2026-07-08)


### PR DESCRIPTION
## Summary

Amends the ontology-workbench goal packet (shipped in #348) with decisions from a
second /grill-with-docs round (9 locked decisions) informed by two Codex research
reports on the ontosphere reference repo (Apache-2.0, ISWC 2026).

- SPEC: constraints 13-18 (session graph partitions, typed worker protocol,
  inference invalidation discipline, agent-ready ops, SHACL via the existing
  @beep/semantic-web contract with verified repairs, ontosphere port discipline);
  new acceptance criteria (SHACL loop, ontoauthor-mat competency pass, ABox/TBox
  consistency, PROV-O + VoID/DCAT exports, metrics panel); non-goals name the
  ontology-agent-tools follow-up and the evaluated-and-deferred items.
- PLAN/manifest: phases restructured P0-P6 with a new P5 Validation + Provenance.
- research/: two verbatim Codex reports (ontosphere survey + delta analysis);
  SOURCES.md gains the os-* mined-corpus rows, the Apache-2.0 upstream row, and
  an evaluated-and-deferred ledger.
- GOAL.md launcher updated (3,820 chars, under the 4,000 hard max).

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786157234&installation_id=141092090&pr_number=350&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F350&signature=f08c9f2d8061d686b194051c066bd242dd4c001271985d52475418c8761cb0d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->