### PR TITLE
feat(explorations): resolve ontology-agent-surface align and draft brief

### DIFF
--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -40,7 +40,7 @@ The lego pieces already built. Authoritative inventories (link, never copy):
 
 ### Active
 - [`ontology-agent-surface`](./ontology-agent-surface/README.md) — agent/MCP
-  tool surface for the ontology workbench (stage `align`): the named
+  tool surface for the ontology workbench (stage `shape`): the named
   follow-up from [`goals/ontology-workbench`](../goals/ontology-workbench/README.md)
   (completed-retained). Thin-adapter thesis over the SPEC 13-16 agent-ready
   plumbing (partitioned session graphs, schema-typed protocol, real batch

--- a/explorations/ontology-agent-surface/BRIEF.md
+++ b/explorations/ontology-agent-surface/BRIEF.md
@@ -9,25 +9,92 @@ this file matches the picture in their head.
 
 ## Problem
 
-<The raw idea, the use case, the thing we keep hitting. Why now.>
+The ontology workbench (goals/ontology-workbench, completed-retained) gives a
+human everything: open/edit/save Turtle with typed undoable change ops, SPARQL
+with safeguards, bounded inference, SHACL validation with verified repairs,
+PROV-O journaling. Agents get none of it. The repo's ontology-flavored agent
+work (legal-document-intake taxonomies, schema-derived ontologies, future
+authoring loops) either shells out to external CLIs or hand-rolls Turtle —
+losing the typed edit model, the verified-repair loop, and provenance. The
+workbench's SPEC 13–16 plumbing (partitioned graphs, schema-typed protocol,
+real batch deltas, query safeguards) was built precisely for this consumer and
+has none. Meanwhile the community is converging on agentic ontology tooling
+(open-ontologies, owl-mcp) without our differentiators: files-as-truth, typed
+undoable change ops shared with a human UI, verified repairs, per-edit
+provenance.
 
 ## Appetite
 
-<How much time/scope this deserves — and how that bound constrains the
-solution. An appetite is a budget, not an estimate.>
+One goal packet on the scale of a mid-size workbench phase (P4-ish): roughly
+one focused execution arc, phased P0→P3, landing as a handful of stacked PRs.
+Not a multi-packet program — the thin-adapter thesis is the point; if the
+surface starts demanding a session-repository refactor or a second transport,
+that is out-of-appetite and gets deferred.
 
 ## Solution Sketch
 
-<The elements of the solution at fat-marker fidelity: flows, surfaces,
-boundaries. Diagrams and screenshots welcome (assets/).>
+**A curated ~10-tool MCP surface, served from the existing desktop sidecar,
+wrapping the ontology use-cases directly.**
+
+- **Transport/placement** (DECISIONS 2026-07-10): streamable-HTTP `/mcp`
+  endpoint mounted beside `/rpc/` on the sidecar's loopback server; reuses
+  `RpcSessionAuth`; Origin-validated, 127.0.0.1-bound. stdio launcher is a
+  possible follow-up, not v1.
+- **Session model** (DECISIONS): v1 tools are stateless over saved files.
+  Open server-side → apply typed change-op batch → save guarded by an
+  rdfc-1.0 canonize-fingerprint compare-and-swap. Unsaved webview state is
+  out of scope; `sessionHandle` reserved in schemas for a stateful v2.
+- **Tool vocabulary** (DECISIONS): ~10 task-oriented tools wrapping
+  use-cases (not RPC 1:1): open/inspect, snapshot/describe, search,
+  sparql-query, propose-change-batch (returns real deltas), validate,
+  repair (verified proposals), export-provenance, capability-metadata.
+  Toolkit definition lives with the ontology slice; the MCP driver hosts it
+  (m365-mcp template: schema tools → thin handlers → sanitized server; the
+  first end-to-end HTTP MCP protocol test in the repo).
+- **Write safety** (DECISIONS): TierGate fail-closed on every mutating tool;
+  actor identity threaded into the PROV-O journal (`prov:Agent` per caller);
+  static budgets (max quads/batch, max results/query); reasoner drift-cap
+  surfaced as a typed tool error.
+- **Hardening folded into early phases** (DECISIONS): repair-strategy
+  registry beyond `sh:hasValue` (the repair tool depends on it), base-prefix
+  codec fidelity (agents rewrite files), ROBOT host validation of interop
+  fixtures. Architecture consolidations (single partition-ingestion
+  classifier, worker-safe entrypoints, shared action-state helper) adopted
+  opportunistically where phases touch those files.
+- **Proof style** (workbench lesson): every tool proven against the real
+  engine stack (oxigraph/shacl/n3 layers) in tests, plus a live proof driving
+  the MCP endpoint end-to-end from an actual agent client; no fakes-only
+  coverage; no silent no-op guards — every refusal is a typed tool error.
 
 ## Rabbit Holes
 
-<Known traps: technical unknowns, unsolved design problems, misunderstood
-interdependencies. Each one either gets patched here or becomes an explicit
-risk the goal packet inherits.>
+- **CAS semantics under prefix/formatting churn**: the fingerprint is
+  canonical (rdfc-1.0), so a byte-different but semantically-equal file passes
+  CAS — decide early whether that is the intended precondition (semantic
+  equality) or whether saves also need a byte-hash guard.
+- **Tool-call latency vs. per-call open/parse**: stateless means re-parsing
+  the file each call; fine for pizza-scale, unknown at 100k-element scale.
+  Budget a benchmark before declaring the model final; do not silently cache
+  (that recreates the session-ownership problem).
+- **TierGate wiring precedent**: no production driver wires it today —
+  the first wiring defines the pattern; review it as a standard-setting
+  change, not a local detail.
+- **Actor identity source**: what identifies "the agent" at the HTTP boundary
+  (bearer token claims? client-declared name?) — must be decided before the
+  PROV attribution is meaningful rather than decorative.
+- **Concurrent human edits**: CAS rejects the write, but the agent needs a
+  recoverable error contract (current fingerprint + refetch guidance), not
+  just failure.
 
 ## No-Gos
 
-<What this exploration deliberately excludes. These become non-goals in
-graduated SPEC.md files.>
+- No sidecar session repository / revisioned two-writer contract in v1
+  (reserved for v2; `sessionHandle` placeholder only).
+- No stdio transport in v1.
+- No OWL 2 DL reasoning (t2/t3 competency deferral stands; capability-metadata
+  tool advertises what inference exists).
+- No broad tool vocabulary (25+) before usage data.
+- No registry fetch (OLS/BioPortal), multi-format import/export, or
+  server-backed workspaces (inherited from the workbench GOAL out-list).
+- No unguarded mutations: a tool that cannot be gated, attributed, and
+  budgeted does not ship.

--- a/explorations/ontology-agent-surface/DECISIONS.md
+++ b/explorations/ontology-agent-surface/DECISIONS.md
@@ -7,11 +7,103 @@ until they land here. Deferred questions get an entry too, marked DEFERRED
 with the reason.
 -->
 
-## YYYY-MM-DD — <short question slug>
+## 2026-07-10 — MCP transport & placement
 
-**Question:** <the branch-closing question>
+**Question:** How should agents reach the ontology tool surface — streamable
+HTTP mounted on the existing sidecar, a stdio headless launcher (m365-mcp
+pattern), both, or defer?
 
-**Answer:** <what was decided>
+**Answer:** Streamable HTTP `/mcp` endpoint mounted on the existing sidecar
+loopback server, beside `/rpc/`, reusing `RpcSessionAuth` for the MCP spec's
+local-server auth requirement. A stdio headless launcher is an explicit
+possible follow-up for CLI-only agent clients, not part of v1.
 
-**Rationale:** <why — including the options rejected and the recommendation
-that was given>
+**Rationale:** The sidecar already serves loopback HTTP with bearer auth, so
+this is the minimal-delta option satisfying the MCP spec's local-HTTP security
+requirements (Origin validation, 127.0.0.1 binding, authentication). Sidecar
+stdio is occupied by Effect RPC framing (`IpcStdoutGuard` — RESEARCH in-repo
+inventory), ruling out same-process stdio. Rejected: stdio headless launcher
+as v1 (duplicates runtime boot; permanently blind to running-app state);
+both-transports-day-one (double the test/parity surface before the tool
+vocabulary is proven); defer (this fork gates the P0/P1 slice shape).
+
+## 2026-07-10 — Agent session model (v1)
+
+**Question:** The live editing session is owned by the webview atom registry —
+not the sidecar — with no revision/two-writer contract. What session model do
+v1 agent tools get?
+
+**Answer:** Stateless on saved files with a fingerprint compare-and-swap:
+each tool call opens the Turtle file server-side, applies typed change-op
+batches, and saves atomically guarded by an rdfc-1.0 canonize-fingerprint
+precondition. Agents see last-saved state; the human's unsaved webview session
+is explicitly out of v1 scope. Tool schemas reserve a `sessionHandle` field
+for a future stateful v2.
+
+**Rationale:** Matches the files-as-truth doctrine and reuses the existing
+canonize fingerprint machinery for conflict safety without building a
+revisioned session repository. Agent edits stay typed change-op batches
+(applied via the server-side session use-cases), so verified repairs and
+PROV attribution still work. Rejected: sidecar session repository now (the
+right long-term shape but a client-atom refactor that would dominate the
+packet); agent-exclusive live sessions with human-file locking (adds lock
+lifecycle complexity without solving stale-read semantics); defer (the choice
+drives every tool contract schema, so deferring weakens decompose).
+
+## 2026-07-10 — Mutation safety scope (v1)
+
+**Question:** First write-capable MCP surface in the repo; no production
+driver wires mcp-kit's TierGate today. Which safety mechanisms are
+launch-blocking?
+
+**Answer:** All three, in minimal forms: (1) TierGate wired fail-closed on
+every mutating tool; (2) per-change actor attribution threaded into the
+PROV-O journal (`prov:Agent` per caller identity crossing the tool boundary);
+(3) simple static budgets — max quads per change-op batch, max results per
+query — with the reasoner drift-cap surfaced as a typed tool error rather
+than a silent full recompute.
+
+**Rationale:** This surface sets the write-precedent for every future MCP
+driver; shipping it gated, attributed, and bounded is the point of having
+mcp-kit. Minimal forms keep the lift small (static caps, existing PROV
+plumbing, existing TierGate). Rejected: TierGate+attribution without budgets
+(pathological batch sizes stay possible); budgets-only (ungated writes
+contradict mcp-kit's fail-closed design); read-only v1 (abandons the packet's
+differentiator — typed undoable agent edits and verified repairs).
+
+## 2026-07-10 — Tool vocabulary (v1)
+
+**Question:** Expose the 9 wire-ready RPCs 1:1, or curate an agent-first tool
+set?
+
+**Answer:** Curated agent-first set of roughly 10 task-oriented tools wrapping
+the use-cases directly (not RPC 1:1): open/inspect, snapshot/describe, search,
+sparql-query, propose-change-batch (delta-returning), validate, repair
+(verified proposals), export-provenance, capability-metadata. Grow toward
+open-ontologies-style breadth only as usage proves need.
+
+**Rationale:** The RPC shapes were designed for the workbench UI — most send a
+complete `Session`, which the stateless+CAS file model replaces anyway — and
+undo/redo/search have no RPC to mirror (client-local). Wrapping use-cases
+directly gives agent-shaped contracts without disturbing the UI RPC surface.
+Rejected: 1:1 RPC mirror (UI-shaped payloads, missing tools); 25+ tools day
+one (schema/test surface ahead of usage data); minimal read+propose pair
+(leaves the flagship validate→repair loop out of the first slice).
+
+## 2026-07-10 — Packet scope: hardening pre-work folded in
+
+**Question:** Fold the workbench retrospective's hardening pre-work into this
+packet's early phases, or keep a pure MCP-surface packet?
+
+**Answer:** Fold into P0/P1: repair-strategy registry (per-constraint-component
+strategies beyond `sh:hasValue`), base-prefix codec fidelity, and ROBOT host
+validation. The three architecture consolidations (single partition-ingestion
+classifier, worker-safe entrypoint convention, shared surfaced-action-state
+helper) ride along opportunistically where phases already touch those files.
+
+**Rationale:** The repair tool is a flagship v1 tool and ships hollow if it
+only repairs `sh:hasValue`; agents rewriting files make codec fidelity
+first-contact; ROBOT validation is cheap and upgrades interop evidence.
+Matches the user-approved retrospective plan. Rejected: pure MCP packet
+(serial packets churning the same files); repairs-only fold (defers the
+fidelity issue agents hit first).

--- a/explorations/ontology-agent-surface/README.md
+++ b/explorations/ontology-agent-surface/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Stage: `align`
+Stage: `shape`
 Status: `active`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
@@ -17,10 +17,9 @@ workbench retrospective's hardening pre-work and architecture consolidations.
 
 ## Next Open Question
 
-Transport/placement (first of 5 in the manifest queue): streamable-HTTP `/mcp`
-endpoint on the existing sidecar vs a stdio headless launcher — research found
-sidecar stdio is already occupied by Effect RPC framing, and a separate process
-cannot see unsaved UI session state.
+BRIEF.md is drafted from the five resolved decisions — does it match the
+picture in the user's head? (Shape-stage exit gate: user sign-off, then
+decompose.)
 
 ## Read This First
 
@@ -33,6 +32,11 @@ cannot see unsaved UI session state.
 
 ## Trail
 
+- 2026-07-10: align completed — all 5 queued questions resolved in one
+  grilling pass (HTTP-on-sidecar transport; stateless+fingerprint-CAS session
+  model; TierGate+attribution+budgets launch-blocking; curated ~10-tool
+  vocabulary; hardening folded into P0/P1). BRIEF.md drafted; manifest
+  advanced to `shape`. Stopped awaiting brief sign-off.
 - 2026-07-10: research stage completed both halves — codex in-repo inventory
   (9 wire-ready RPCs; m365-mcp as MCP template; TierGate in mcp-kit; gaps: no
   two-writer session contract, no mutation budgets/attribution, no mountable

--- a/explorations/ontology-agent-surface/ops/manifest.json
+++ b/explorations/ontology-agent-surface/ops/manifest.json
@@ -4,14 +4,8 @@
     "slug": "ontology-agent-surface",
     "title": "Ontology Agent Surface",
     "status": "active",
-    "stage": "align",
-    "openQuestions": [
-      "Transport/placement: streamable-HTTP /mcp endpoint on the existing sidecar vs stdio headless launcher (sidecar stdio is occupied by Effect RPC; a separate process cannot see unsaved UI state)?",
-      "Session ownership: introduce a sidecar session repository with revisions and a two-writer contract, or v1 agent tools operate stateless on saved files only?",
-      "Mutation safety scope for v1: TierGate wiring, mutation budgets, and per-change actor attribution \u2014 which are launch-blocking vs follow-up?",
-      "Tool vocabulary: expose the 9 wire-ready RPCs as-is, or curate an agent-first tool set (open-ontologies' 70+ tools as breadth reference)?",
-      "Confirm folding the retrospective hardening pre-work (repair strategy registry, ROBOT validation, base-prefix codec fidelity) into this packet's P0/P1."
-    ],
+    "stage": "shape",
+    "openQuestions": [],
     "sources": ["research/SOURCES.md"],
     "links": {
       "goals": [],


### PR DESCRIPTION
## Summary
- Completes the align stage of explorations/ontology-agent-surface (follow-up to #363,
  rebased onto the security-hardening commit): all 5 queued questions resolved and logged
  in DECISIONS.md —
  streamable-HTTP /mcp on the existing sidecar (stdio deferred); v1 agent sessions are
  stateless over saved files with canonize-fingerprint compare-and-swap; TierGate +
  PROV actor attribution + static budgets all launch-blocking; curated ~10-tool
  agent-first vocabulary; retrospective hardening pre-work folded into P0/P1.
- Drafts BRIEF.md (problem / appetite / solution sketch / 5 rabbit holes / 6 no-gos).
- Manifest advanced to stage `shape` with an empty question queue; README trail and
  ATLAS synced.

## Test plan
- bun run beep yeet verify: all lanes passed (docs-only change).
- jq validates ops/manifest.json; git diff --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786338214&installation_id=141092090&pr_number=364&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F364&signature=4050783286ee1fbcb143e068b952b68b2277f4432459fbb14a118083b6db9a33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->