### PR TITLE
docs(memory): apply 2026-07-08 memory-stack research as doctrine

### DIFF
--- a/.claude/skills/mcp-graphiti-memory/SKILL.md
+++ b/.claude/skills/mcp-graphiti-memory/SKILL.md
@@ -11,8 +11,12 @@ description: "DEPRECATED (2026-07-08 memory decision): Graphiti is write-frozen,
 > use Cognee for durable dev-memory.
 
 ## Use When
-- You need cross-session memory lookup or writeback.
+- You need READ-ONLY historical lookup of pre-freeze Graphiti memory.
 - You see Graphiti MCP startup or handshake failures.
+
+Never select this skill for memory WRITEBACK: the write path is frozen
+(2026-07-08 decision). Route new durable memory to Cognee
+(`cognee-memory:cognee-remember`).
 
 ## Quick Smoke
 1. Call `mcp__graphiti-memory__get_status`.
@@ -21,7 +25,7 @@ description: "DEPRECATED (2026-07-08 memory decision): Graphiti is write-frozen,
 ## Representative Calls
 - Read status: `get_status`.
 - Recall facts: `search_memory_facts`.
-- Save findings: `add_memory`.
+- Save findings: FROZEN — do not call `add_memory`; use Cognee instead.
 
 ## Common Failures
 - `group_ids` type error.

--- a/.claude/skills/mcp-graphiti-memory/SKILL.md
+++ b/.claude/skills/mcp-graphiti-memory/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: mcp-graphiti-memory
-description: "Use for Graphiti MCP memory workflows including startup checks, fact search, episode logging, and handshake diagnosis."
+description: "DEPRECATED (2026-07-08 memory decision): Graphiti is write-frozen, read-only for historical context until the epistemic-tables bitemporal port lands. Use only for read workflows: startup checks, fact search, handshake diagnosis. New durable memory goes to Cognee."
 ---
 
 # MCP Graphiti Memory
+
+> **DEPRECATED** — per `standards/memory-architecture/04-decision-log.md`
+> (2026-07-08): graphiti-memory is write-frozen and read-available only until
+> the `@beep/epistemic-tables` bitemporal port lands. Do not log new episodes;
+> use Cognee for durable dev-memory.
 
 ## Use When
 - You need cross-session memory lookup or writeback.

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -352,3 +352,4 @@ wkcbdgqqo
 Wyner
 yeet
 zazuko
+uncited

--- a/.cspell/third-party.txt
+++ b/.cspell/third-party.txt
@@ -93,3 +93,5 @@ wplnls
 Xenova
 yunet
 YuNet
+memify
+TRAC

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,10 +77,13 @@ Ship reliable code with effect-first and schema-first patterns.
 
 - Cognee (`beepintir` MCP + cognee-memory plugin hooks/skills) is the sole
   always-on durable dev-memory (2026-07-08 decision,
-  `standards/memory-architecture/04-decision-log.md`). Bounded use only:
-  embedded/local or all-Postgres profile; semantic memory is a managed cache
-  (TTL, pruning, consolidation, node-set scoping) — never source of truth.
-  No uncited LLM output crosses the authority boundary.
+  `standards/memory-architecture/04-decision-log.md`). It is OPERATOR-LEVEL
+  config (user plugin + user MCP settings), not provisioned by this repo's
+  `.mcp.json` — checkouts without it fall back to file memory and repo docs,
+  by design. Bounded use only: embedded/local or all-Postgres profile;
+  semantic memory is a managed cache (TTL, pruning, consolidation, node-set
+  scoping) — never source of truth. No uncited LLM output crosses the
+  authority boundary.
 - File memory (this file via the `CLAUDE.md` symlink, auto-memory
   `MEMORY.md`) remains Layer 1 for durable curated knowledge.
 - `graphiti-memory` is DEPRECATED: write-frozen, read-available for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,22 +73,29 @@ Ship reliable code with effect-first and schema-first patterns.
   `/explore` skill; crystallized work graduates into `goals/` packets and
   `docs/product/` prose.
 
-## Graphiti Memory
+## Agent Memory
 
-- `graphiti-memory` is the primary durable repo knowledge base. MCP clients
-  use the queue proxy `http://localhost:8123/mcp` (`:8000` is the backing
-  upstream). Helpers: `bun run graphiti:proxy`, `bun run graphiti:proxy:ensure`.
-- If unavailable in-session, fall back to repo-local docs, code search, and
-  this file.
-- Prefer `get_status`, narrow `get_episodes`, and scoped
-  `search_memory_facts` with small limits over broad startup searches.
-- Startup gotcha: the server expects `group_ids` as a list — if the wrapper
-  types it `string`, pass a JSON array literal containing `beep_dev`.
+- Cognee (`beepintir` MCP + cognee-memory plugin hooks/skills) is the sole
+  always-on durable dev-memory (2026-07-08 decision,
+  `standards/memory-architecture/04-decision-log.md`). Bounded use only:
+  embedded/local or all-Postgres profile; semantic memory is a managed cache
+  (TTL, pruning, consolidation, node-set scoping) — never source of truth.
+  No uncited LLM output crosses the authority boundary.
+- File memory (this file via the `CLAUDE.md` symlink, auto-memory
+  `MEMORY.md`) remains Layer 1 for durable curated knowledge.
+- `graphiti-memory` is DEPRECATED: write-frozen, read-available for
+  historical context only until the `@beep/epistemic-tables` bitemporal port
+  lands, then decommissioned. Read helpers until then:
+  `bun run graphiti:proxy`, `bun run graphiti:proxy:ensure`; `group_ids`
+  must be a JSON array containing `beep_dev`.
+- If memory is unavailable in-session, fall back to repo-local docs, code
+  search, and this file.
 
 ## Tool Routing
 
 - effect v3↔v4 differences: prefer the `effect-v4-imports` skill; reach for
-  `graphiti-memory` only for historical context.
+  Cognee recall (or read-frozen `graphiti-memory`) only for historical
+  context.
 - shadcn: editor app = app workspace, shared UI package = shared base; prefer
   the shadcn skill + shadcn MCP for registry discovery and installs.
 - MUI: prefer `mui-mcp` — `useMuiDocs` first, then `fetchDocs` only with URLs
@@ -100,7 +107,7 @@ Ship reliable code with effect-first and schema-first patterns.
   enabled tools before working, not mid-task.
 - Always-loaded files (this file, skill frontmatter, settings) are the prompt
   cache prefix: batch edits to them, keep them lean; durable cross-session
-  knowledge belongs in file-memory or Graphiti, not here.
+  knowledge belongs in file-memory or Cognee, not here.
 - Front-load stable context; let volatile per-task detail arrive later in the
   conversation.
 - Continue related follow-ups on an existing subagent (SendMessage) instead

--- a/explorations/agent-memory-tiers-bitemporal-edges/DECISIONS.md
+++ b/explorations/agent-memory-tiers-bitemporal-edges/DECISIONS.md
@@ -9,6 +9,34 @@ are grounded in RESEARCH.md (cited inline) — starting positions to grill, not
 settled decisions. Do not over-specify; these forks shape the goal, not the code.
 -->
 
+## Research input (2026-07-08 run, recorded 2026-07-11) — forks remain open
+
+The 13-lane memory-stack research
+([`docs/agent-memory-infra/00-recommendation.md`](../../docs/agent-memory-infra/00-recommendation.md))
+bears directly on four forks below; its findings strengthen the recommended
+answers but do NOT close them — resolve via `/grill-with-docs` as designed:
+
+- **Q1 (sourcing/licensing):** borrow shapes from Apache-2.0 Graphiti only
+  (file-level citations in `graphiti-clone.md`: `edges.py:263-285`,
+  `nodes.py:318-351`, `edge_operations.py:538-847`); no SSPL code paths —
+  FalkorDB is SSPLv1, and Graphiti-with-FalkorDB bundles inherit the flag.
+- **Q2 (own vs consume/defer):** unchanged; FalkorDB/GraphRAG stay deferred to
+  `goals/trustgraph-port`; NEW consume-idea — Cognee's relational rollback
+  ledger for projection rebuild/undo.
+- **Q4 (durable truth):** reaffirmed by all thirteen lanes — Postgres
+  repo-native via `@beep/epistemic-tables` + `@beep/drizzle`; no external
+  graph vendor in the authority path.
+- **Q6 (CONTRADICTS edge):** adopt Graphiti's invalidate-don't-delete
+  semantics as the reference shape; add the Oracle's review-state enum
+  (`candidate`/`machine-extracted`/`human-reviewed`/`authoritative`) to the
+  edge lifecycle schema.
+
+Also note: this packet's port is now load-bearing for dev tooling — Graphiti's
+deployment is write-frozen and decommissions only after this port lands
+(`standards/memory-architecture/04-decision-log.md`, 2026-07-08 entry).
+
+---
+
 ## Q1: How do we source the borrowed memory primitives — port-with-attribution, reference-only, or clean-room?
 
 **Recommended:** Reimplement everything in Effect-Schema and take **no runtime

--- a/explorations/agent-memory-tiers-bitemporal-edges/README.md
+++ b/explorations/agent-memory-tiers-bitemporal-edges/README.md
@@ -48,5 +48,6 @@ see [`explorations/_gold-intake`](../_gold-intake/).
 
 ## Trail
 
+- 2026-07-11: 2026-07-08 memory-stack research input recorded in DECISIONS.md (Q1/Q2/Q4/Q6 strengthened, forks stay open); packet's bitemporal port is now the gate for graphiti-memory decommission.
 - 2026-06-29: research-complete — RESEARCH.md synthesized, codex gate-1 folded, DECISIONS pre-drafted.
 - 2026-06-29: packet opened from gold-intake cluster 'Four-tier agent-memory schema w/ confidence + conflict edges' (15 nuggets).

--- a/standards/memory-architecture/03-saas-landscape-assessment.md
+++ b/standards/memory-architecture/03-saas-landscape-assessment.md
@@ -21,6 +21,13 @@
 
 **What to take:** Bi-temporal validity windows and auto-invalidation are the right primitives for managing Layer 2 (session memory). The four-primitive model (Entity, Fact, Episode, CustomType) is a clean abstraction. The specific implementation will degrade, but the temporal management pattern should be adopted.
 
+> **Narrowed (2026-07-08):** "bi-temporal" overstates it — Graphiti provides
+> valid-time fields plus system timestamps plus episode lineage, not a
+> transaction ledger with claim lifecycle. Deployment status: retiring to
+> donor after the `@beep/epistemic-tables` bitemporal port lands
+> (write-freeze until then). See 05's Graphiti note and
+> `docs/agent-memory-infra/graphiti-clone.md`.
+
 ---
 
 ## Supermemory
@@ -38,6 +45,12 @@
 **Verdict:** IGNORE
 
 **What to take:** Nothing. The connector ecosystem is immature and the architectural internals are opaque. The project has no need for another degrading memory backend with reliability issues.
+
+> **Superseded in part (2026-07-08):** "nothing to take" is refuted — the
+> document/chunk/memory schema split, `updates`/`extends`/`derives` version
+> relations, container-tag namespace isolation, and retrieval-mode split are
+> real, source-observed donor patterns. IGNORE **as foundation** is confirmed
+> (engine opaque, hosted-API-backed). See the Supermemory entry added to 05.
 
 ---
 
@@ -74,6 +87,12 @@
 **Verdict:** USE — Already chosen as the graph engine.
 
 **What to take:** Already selected for repo-memory v0 and BeepGraph. The right choice for local-first deployment. Continue using it. The performance characteristics make interference management strategies (compression, clustering, pruning) practical at interactive latency.
+
+> **Superseded in part (2026-07-08):** calling FalkorDB "open-source" is wrong
+> for shipping decisions — it is **SSPLv1, non-OSI** (live LICENSE.txt fetch,
+> confirmed by two lanes). USE survives only for local projection/read-model
+> roles with the license accepted consciously; anything shipped must pick a
+> gate-passing backend. See `docs/agent-memory-infra/00-recommendation.md`.
 
 ---
 

--- a/standards/memory-architecture/04-decision-log.md
+++ b/standards/memory-architecture/04-decision-log.md
@@ -4,6 +4,61 @@ Dated decision log for the memory architecture standard. Records decisions as th
 
 ---
 
+## 2026-07-08: External Memory Stack — Donor Portfolio Confirmed; Cognee Is the Sole Dev-Memory Incumbent; Doctrine Phrasing Sharpened
+
+**Context:** Six products (OriginTrail DKG, TrustGraph, Graphiti/Zep, Cognee,
+Supermemory, Mem0) were evaluated at clone+docs depth across 12 codex research
+lanes plus a GPT-5.5 Pro adversarial oracle lane; synthesis with per-claim
+citations and spot-checks lives in
+[`docs/agent-memory-infra/`](../../docs/agent-memory-infra/00-recommendation.md).
+That run corrected several claims in this standard (see 03/05 supersession
+annotations) and its drafted durable records were applied on 2026-07-11.
+
+**Decision:**
+
+- **(A) Product runtime:** no external memory service enters the product
+  runtime's authority path or default deployment. Durable truth stays
+  repo-native (claim + evidence + provenance + lifecycle in Postgres). The
+  donor portfolio is ported behind `drivers/*`: Graphiti bitemporal edge
+  contract, TrustGraph provenance/explainability shell, Cognee
+  projection/rollback-ledger ergonomics, Mem0 ADD-only extraction discipline,
+  plus Supermemory/OriginTrail minor donors.
+- **(B) Dev-tooling memory:** Cognee (bounded: embedded/local or all-Postgres
+  profile, never the full compose stack) is the sole always-on dev-memory
+  incumbent. graphiti-memory is decommissioned only AFTER the
+  `@beep/epistemic-tables` bitemporal port lands; until then it is
+  read-available but no longer written to. A 2–4 week recall bakeoff gate
+  applies; the fallback on failure is Layer-1 file memory alone, not a return
+  to Graphiti. File memory (CLAUDE.md / MEMORY.md) remains Layer 1.
+- **(C) Doctrine phrasing:** deterministic-first survives adversarial review;
+  the operative rule is sharpened to **"no uncited LLM output may cross the
+  authority boundary"**, with explicit review states
+  (`candidate` / `machine-extracted` / `human-reviewed` / `authoritative`) and
+  four separately governed memory classes (authoritative facts+quoted sources /
+  derived semantic graph / operational agent state / opinions+work product).
+
+**Rationale:** All thirteen lanes converged on the authority boundary (every
+candidate stores LLM-derived content without evidence spans or acceptance
+lifecycle). The Role B reversal from Graphiti to Cognee rests on the
+redundancy argument (Graphiti's sole decisive differentiator — its temporal
+edge model — is exactly what the repo is porting natively), first-party
+degradation history, operational direction of travel, and ontology alignment.
+
+**Consequences:**
+
+- 03/05 in this standard carry dated supersession annotations (FalkorDB is
+  SSPLv1, not OSI open-source; Supermemory "nothing to take" refuted; Mem0
+  upgraded to donor; Graphiti "bi-temporal" narrowed; Cognee/OriginTrail
+  entries added to 05).
+- `AGENTS.md`/`CLAUDE.md` name Cognee (bounded) as the durable dev-memory;
+  Graphiti demoted to read-only donor pending the port milestone.
+- `.mcp.json` keeps graphiti-memory until the port lands (write-freeze only).
+- `explorations/agent-memory-tiers-bitemporal-edges` receives the research
+  input for its open forks (Apache-2.0 Graphiti shapes only; Postgres-native
+  reaffirmed; invalidate-don't-delete; review-state enum).
+
+---
+
 ## 2026-06-17: Reframe — Code-Intelligence Was the Learning Vehicle; Product Is the IP-Law Flywheel
 
 **Context:** The `atlas-synthesis` exploration (2026-06-17, formerly

--- a/standards/memory-architecture/04-decision-log.md
+++ b/standards/memory-architecture/04-decision-log.md
@@ -52,7 +52,10 @@ degradation history, operational direction of travel, and ontology alignment.
   entries added to 05).
 - `AGENTS.md`/`CLAUDE.md` name Cognee (bounded) as the durable dev-memory;
   Graphiti demoted to read-only donor pending the port milestone.
-- `.mcp.json` keeps graphiti-memory until the port lands (write-freeze only).
+- Both memory servers are operator-level MCP config, not repo `.mcp.json`
+  (which carries no memory server). The operator's config keeps
+  graphiti-memory read-available until the port lands (write-freeze only);
+  Cognee likewise runs from the operator's plugin/user settings.
 - `explorations/agent-memory-tiers-bitemporal-edges` receives the research
   input for its open forks (Apache-2.0 Graphiti shapes only; Postgres-native
   reaffirmed; invalidate-don't-delete; review-state enum).

--- a/standards/memory-architecture/05-context-graph-capability-assessment.md
+++ b/standards/memory-architecture/05-context-graph-capability-assessment.md
@@ -3,6 +3,17 @@
 Status: doctrine addendum.
 Assessed: 2026-05-12.
 
+> **Refresh (2026-07-08, applied 2026-07-11):** the clone+docs research run in
+> [`docs/agent-memory-infra/`](../../docs/agent-memory-infra/00-recommendation.md)
+> supersedes several entries below (see the dated notes in each affected
+> section and the 2026-07-08 entry in [`04-decision-log.md`](./04-decision-log.md)):
+> FalkorDB is **SSPLv1, not OSI open-source**; Mem0 is upgraded from
+> benchmark-only to donor; Graphiti's "bi-temporal" wording is narrowed and its
+> deployment retires post-port; Cognee is the sole (bounded) dev-tooling
+> memory incumbent; Supermemory and OriginTrail DKG entries are added at the
+> end of the candidate list. The authority model above is unchanged — the run
+> **confirmed** it across all thirteen lanes.
+
 This addendum reopens the external landscape only for feature and capability
 selection. It does not reopen the question of what owns durable memory truth in
 this repository.
@@ -175,6 +186,17 @@ Sources: [llms.txt](https://www.cognee.ai/llms.txt),
 Cognee should influence UX, ontology workflows, and cache ergonomics. It should
 not own accepted claims, professional approvals, or durable legal facts.
 
+> **Role update (2026-07-08):** Cognee is now the **sole always-on dev-tooling
+> memory incumbent** (Role B), conditional on: running the embedded/local or
+> all-Postgres profile (never the full compose stack — its own compose
+> reserves 4CPU/8GB + 2CPU/4GB); bounding the semantic cache per `01`
+> (TTL/pruning/consolidation via its memify/improve loop, node-set scoping);
+> and a 2–4 week recall bakeoff whose fallback is Layer-1 file memory alone.
+> Its authority-boundary limits above are unchanged. Also a **projection
+> donor** for Role A: DataPoint metadata, pipeline provenance stamping with a
+> relational rollback ledger, and the all-Postgres deployment shape. See
+> `docs/agent-memory-infra/cognee-clone.md`.
+
 ### Graphiti / Zep
 
 Sources: [Graphiti GitHub](https://github.com/getzep/graphiti),
@@ -203,6 +225,15 @@ Sources: [Graphiti GitHub](https://github.com/getzep/graphiti),
 
 Use the temporal model, not the unbounded memory practice. Any Graphiti-like
 cache must have TTL, pruning, consolidation, and provenance-gated promotion.
+
+> **Superseded in part (2026-07-08):** "bi-temporal" overstates the model —
+> Graphiti provides valid-time fields plus system timestamps plus episode
+> lineage (`valid_at`/`invalid_at`/`expired_at`/`reference_time`,
+> `episodes[]`), not a transaction ledger with claim lifecycle. Its MCP server
+> is labeled experimental upstream, and the FalkorDB backend option carries
+> the SSPLv1 flag. Verdict update: **primary bitemporal port donor; deployment
+> retires after the `@beep/epistemic-tables` port lands** (write-freeze until
+> then). See `docs/agent-memory-infra/graphiti-clone.md`.
 
 ### GraphZep
 
@@ -280,6 +311,12 @@ Sources: [FalkorDB docs](https://docs.falkordb.com/),
 FalkorDB can be foundational infrastructure, but only as a rebuildable
 projection/read model over authoritative events and evidence.
 
+> **License correction (2026-07-08):** FalkorDB is **SSPLv1 — not an OSI
+> license** (confirmed by two lanes incl. a live LICENSE.txt fetch). Any
+> shipping decision that bundles it (directly or via Graphiti's FalkorDB
+> backend) must choose a gate-passing backend or accept SSPL consciously.
+> The "USE — already chosen" verdict in 03 predates this flag.
+
 ### LangGraph / LangMem
 
 Sources: [LangChain JS long-term memory docs](https://docs.langchain.com/oss/javascript/langchain/long-term-memory),
@@ -354,6 +391,17 @@ Sources: [mem0 docs index](https://docs.mem0.ai/llms.txt),
 **Tradeoff**
 
 Do not invest unless a narrow benchmark or integration comparison requires it.
+
+> **Upgraded (2026-07-08):** "benchmark/reference only" is too narrow — Mem0
+> ships a real TS OSS SDK (`mem0ai/oss`), a pgvector-default self-host server,
+> and the strongest Claude/Codex plugin/lifecycle-hook story of the six.
+> Verdict update: **donor** for ADD-only automatic extraction (no LLM-decided
+> UPDATE/DELETE), UUID masking before LLM calls, hash-dedup, entity-sidecar
+> linking, and hybrid scoring over pgvector; its lifecycle-hook *pattern*
+> (recall-before-prompt, store-on-stop, pre-compact summary) is the reference
+> shape for tuning Cognee's hooks. Still nowhere near authority-grade (no
+> evidence spans, no acceptance lifecycle). See
+> `docs/agent-memory-infra/mem0-clone.md`.
 
 ### LlamaIndex PropertyGraphIndex
 
@@ -466,6 +514,58 @@ Source: [Hindsight GitHub](https://github.com/vectorize-io/hindsight).
 
 Track as an external benchmark. Do not let benchmark claims override authority
 requirements.
+
+### Supermemory (added 2026-07-08)
+
+Sources: `docs/agent-memory-infra/supermemory-clone.md`,
+`docs/agent-memory-infra/supermemory-docs.md`.
+
+**Use as:** schema-pattern donor only; never foundation.
+
+**Pros**
+
+- Real, source-observed donor patterns: document/chunk/memory schema split;
+  typed version relations (`updates`/`extends`/`derives`); container-tag
+  namespace isolation; profile/query/full retrieval-mode split.
+
+**Cons**
+
+- Engine is not source-buildable from the OSS repo; the repo's own dev path
+  points at the hosted API — fails auditable self-host.
+- 03's "nothing to take" is refuted, but its IGNORE-as-foundation verdict is
+  confirmed.
+
+**Tradeoff**
+
+LEARN (schemas, version relations, container tags, retrieval modes); the
+engine stays opaque and hosted-API-backed.
+
+### OriginTrail DKG (added 2026-07-08)
+
+Sources: `docs/agent-memory-infra/origintrail-clone.md`,
+`docs/agent-memory-infra/origintrail-docs.md`.
+
+**Use as:** verifiable-provenance packaging donor; watchlist.
+
+**Pros**
+
+- The only TS-native candidate of the six (Node 22+ monorepo, HTTP daemon,
+  29-tool MCP); Apache-2.0 root license (clone-verified).
+- Strongest verifiable-provenance packaging ideas found: knowledge-asset
+  lifecycle envelopes (create→finalize→share→publish), Merkle commitments
+  over public/private partitions, author attestations, fail-closed
+  private-graph gates, explicit WM/SWM/VM trust-tier labels.
+- Tokenless local mode covers WM/SWM/query.
+
+**Cons**
+
+- Release-candidate; its own README says avoid production. VM finality needs
+  TRAC/gas (chain dependency).
+
+**Tradeoff**
+
+Watchlist for the legal verifiability story once V10 exits release-candidate;
+port packaging ideas, do not deploy.
 
 ### ArangoDB, LanceDB, SurrealDB
 


### PR DESCRIPTION
Applies the drafted-but-unapplied durable records from docs/agent-memory-infra/00-recommendation.md
(13-lane clone+docs research run, 2026-07-08):

- standards/memory-architecture/04-decision-log.md: new 2026-07-08 entry (Role A: no external
  memory in the product authority path, donor portfolio ported repo-native; Role B: Cognee sole
  bounded dev-memory incumbent, Graphiti write-frozen until the epistemic-tables bitemporal port;
  sharpened rule: no uncited LLM output crosses the authority boundary).
- 05-context-graph-capability-assessment.md: refresh banner + dated deltas (FalkorDB SSPLv1,
  mem0 upgraded to donor, Graphiti narrowed/retiring, Cognee incumbent conditions) and new
  Supermemory + OriginTrail DKG entries.
- 03-saas-landscape-assessment.md: dated supersession annotations on three stale verdicts.
- AGENTS.md: Graphiti Memory section replaced by Agent Memory (Cognee primary, file memory
  Layer 1, Graphiti deprecated read-only).
- explorations/agent-memory-tiers-bitemporal-edges: research input recorded; forks remain open.
- mcp-graphiti-memory skill marked deprecated; cspell dictionary additions (uncited, memify, TRAC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWdxBCfnH7183Eq61wNDRj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786374737&installation_id=141092090&pr_number=378&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F378&signature=49d9e45047163139913349e6af0c411382e27b6746580e81a2a4c485efdf70f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->