### PR TITLE
feat(scratchpad): bubbles shrinkwrap demo page and geometry loop-close docs

### DIFF
--- a/explorations/computable-workspace-geometry/README.md
+++ b/explorations/computable-workspace-geometry/README.md
@@ -25,10 +25,12 @@ beep-effect6 write lane before opening the thread-virtualization packet
 merged 2026-07-14 and
 [`goals/pretext-driver/`](../../goals/pretext-driver/README.md) is
 completed-retained with reflection. Dock-adapter title-minima wiring MERGED
-2026-07-14 (PR #396, squash `dc95033709`; exploration-tracked, no packet).
-Next slice in flight: bubble shrinkwrap — `measureLineStats` /
-`walkLineRanges` pure driver-root wrappers + a `scratchpad/bubbles` proof
-(also burns Q2 v2 residue). Q2 v2 residue grows inside the driver package.
+2026-07-14 (PR #396) with a demo harness + live clamp proof (#397); bubble
+shrinkwrap MERGED 2026-07-14 (PR #399: `lineRanges`/`lineStats` pure root
+helpers + `scratchpad/bubbles` proof + live demo page). Remaining ungated
+candidates: layout-as-unit-tests doctrine (MAP), kernel residue (max
+constraints, LayoutPriority, snap-to-collapse). Q2 v2 residue grows inside
+the driver package.
 
 ## Read This First
 
@@ -38,7 +40,24 @@ Next slice in flight: bubble shrinkwrap — `measureLineStats` /
 
 ## Trail
 
-- 2026-07-14 (latest: demo harness + clamp proven in a live browser): the
+- 2026-07-14 (latest: bubble shrinkwrap LANDED — third consumer, surface
+  grew): PR #399 merged (squash `00be3efd41`). `@beep/pretext` root gained
+  the shrinkwrap primitives as pure word-granularity mirrors of upstream's
+  line APIs: `LineRange`/`lineRanges` (one greedy fold, `lineCount`-identical
+  break semantics, half-open word indices) and `LineStats`/`lineStats`
+  (derived; field names mirror upstream). Proofs pin `lineStats.lineCount ==
+  lineCount` and `maxLineWidth == naturalWidth` at unbounded width, plus
+  exact fixture arithmetic (driver 23+1). `scratchpad/bubbles` proves the
+  consumer: schema-first `ChatMessage`/`BubbleConstraints` → pure
+  `bubbleBox` (width = min(maxWidth, maxLineWidth)+2·padding, height =
+  lines×lineHeight; unmeasured → None), 5 bun tests. Greptile's one nit was
+  real (undeclared `@beep/pretext` workspace dep) and taught the lesson:
+  a scratchpad dep addition must resync tsconfig references AND fallow
+  boundaries or repo-sanity fails. The demo harness gained `/bubbles.html`
+  rendering `bubbleBox` live — the border is the math, the text just fits.
+  Codex (gpt-5.6-sol medium) wrote the driver+proof lane in an isolated
+  worktree; Fable reviewed, fixed the nit, and wrote the demo page.
+- 2026-07-14 (demo harness + clamp proven in a live browser): the
   deferred smoke target landed as `scratchpad/dockview-demo` — a vite page
   (port 5199, no install: workspace symlinks resolve `@beep/*` to source)
   hosting the dock adapter with a seeded workspace (nested splits, floating

--- a/goals/pretext-driver/README.md
+++ b/goals/pretext-driver/README.md
@@ -19,6 +19,11 @@ merge (crispen `f9598694f8`, panel fixes `35b9710c95`, round-2 clean).
 Reflection:
 [`history/reflections/2026-07-14-claude.md`](./history/reflections/2026-07-14-claude.md).
 
+Surface grew post-close (2026-07-14, PR #399): pure root gained
+`LineRange`/`lineRanges` and `LineStats`/`lineStats` shrinkwrap helpers
+(exploration-tracked in `explorations/computable-workspace-geometry`; packet
+stays completed-retained).
+
 ## Mission
 
 Wrap `@chenglou/pretext` as the repo driver `@beep/pretext`: text

--- a/scratchpad/dockview-demo/README.md
+++ b/scratchpad/dockview-demo/README.md
@@ -34,8 +34,13 @@ bunx tsgo -p scratchpad/dockview-demo/tsconfig.json --pretty false
 The page itself is non-gating demo surface; the gating suites live in
 `scratchpad/dockview` (bun test) and `scratchpad/dockview-react` (vitest).
 
-## Seams
+## Pages
 
-- Second demo page (bubble shrinkwrap): add `bubbles.html` next to
-  `index.html` — vite treats extra `.html` files as additional entries; give
-  it its own `src/bubbles.tsx` and reuse `demo.css`.
+- `/` — dock adapter with live title-minima clamps.
+- `/bubbles.html` — bubble shrinkwrap: `scratchpad/bubbles` `bubbleBox`
+  boxes computed from live-captured word advances; the border is the math,
+  the text just has to fit (`overflow: hidden` makes any mismatch visible).
+
+Further pages: add another `.html` next to `index.html` (vite treats extra
+`.html` files as additional entries) with its own `src/*.tsx`, reuse
+`demo.css`.

--- a/scratchpad/dockview-demo/bubbles.html
+++ b/scratchpad/dockview-demo/bubbles.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bubble shrinkwrap — computable workspace geometry</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/bubbles.tsx"></script>
+  </body>
+</html>

--- a/scratchpad/dockview-demo/src/bubbles.tsx
+++ b/scratchpad/dockview-demo/src/bubbles.tsx
@@ -4,6 +4,7 @@ import { PretextCapture, PretextCaptureRequest } from "@beep/pretext";
 import { PretextCaptureLive } from "@beep/pretext/browser";
 import { Effect } from "effect";
 import * as A from "effect/Array";
+import * as Cause from "effect/Cause";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as Str from "effect/String";
@@ -70,14 +71,37 @@ const App = ({ metrics }: { readonly metrics: FontMetrics }) => (
   </main>
 );
 
+const MeasurementUnavailable = ({ detail }: { readonly detail: string }) => (
+  <main className="demo-shell">
+    <header className="demo-header">
+      <h1>Bubble shrinkwrap — measurement unavailable</h1>
+      <p>
+        Live font capture failed in this browser, so there is nothing honest to render. <a href="/">Dock demo</a>
+      </p>
+      <p className="bubble-caption">{detail}</p>
+    </header>
+  </main>
+);
+
+const mountNode = Effect.suspend(() => {
+  const host = document.getElementById("root");
+  return P.isNull(host) ? Effect.die(new Error("Missing #root mount node")) : Effect.succeed(host);
+});
+
 const boot = Effect.gen(function* () {
   const capture = yield* PretextCapture;
   const snapshot = yield* capture.captureFontMetrics(
     PretextCaptureRequest.make({ font, lineHeight, words: distinctWords })
   );
-  const host = document.getElementById("root");
-  if (P.isNull(host)) return yield* Effect.die(new Error("Missing #root mount node"));
+  const host = yield* mountNode;
   createRoot(host).render(<App metrics={snapshot.metrics} />);
 });
 
-void Effect.runPromise(boot.pipe(Effect.provide(PretextCaptureLive)));
+void Effect.runPromise(
+  boot.pipe(
+    Effect.provide(PretextCaptureLive),
+    Effect.catchCause((cause) =>
+      Effect.map(mountNode, (host) => createRoot(host).render(<MeasurementUnavailable detail={Cause.pretty(cause)} />))
+    )
+  )
+);

--- a/scratchpad/dockview-demo/src/bubbles.tsx
+++ b/scratchpad/dockview-demo/src/bubbles.tsx
@@ -1,0 +1,83 @@
+/** @effect-diagnostics strictEffectProvide:skip-file */
+import type { FontMetrics } from "@beep/pretext";
+import { PretextCapture, PretextCaptureRequest } from "@beep/pretext";
+import { PretextCaptureLive } from "@beep/pretext/browser";
+import { Effect } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as P from "effect/Predicate";
+import * as Str from "effect/String";
+import { createRoot } from "react-dom/client";
+import { BubbleConstraints, bubbleBox, ChatMessage } from "../../bubbles/Bubble.ts";
+import "./demo.css";
+
+const font = "16px Arial";
+const lineHeight = 20;
+const constraints = BubbleConstraints.make({ maxWidth: 320, padding: 10 });
+
+const messages: ReadonlyArray<ChatMessage> = [
+  ChatMessage.make({ id: "m1", author: "user", text: "How wide should this bubble be?" }),
+  ChatMessage.make({ id: "m2", author: "agent", text: "Exactly as wide as its widest measured line, plus padding." }),
+  ChatMessage.make({ id: "m3", author: "user", text: "Short one." }),
+  ChatMessage.make({
+    id: "m4",
+    author: "agent",
+    text: "Long messages clamp at the maximum content width and grow downward instead, one measured line at a time, with no DOM oracle involved anywhere.",
+  }),
+  ChatMessage.make({ id: "m5", author: "user", text: "So the box is pure arithmetic?" }),
+  ChatMessage.make({
+    id: "m6",
+    author: "agent",
+    text: "Pure arithmetic over cached word advances. Agents can see it.",
+  }),
+];
+
+const distinctWords = A.dedupe(A.flatMap(messages, (message) => Str.split(message.text, " ")));
+
+const Bubble = ({ message, metrics }: { readonly message: ChatMessage; readonly metrics: FontMetrics }) =>
+  O.match(bubbleBox(metrics, message, constraints), {
+    onNone: () => <p className="bubble-caption">unmeasured: {message.text}</p>,
+    onSome: (box) => (
+      <div className={`bubble-row bubble-row-${message.author}`}>
+        <div
+          className={`bubble bubble-${message.author}`}
+          style={{ width: box.width, height: box.height, padding: constraints.padding }}
+        >
+          {message.text}
+        </div>
+        <p className="bubble-caption">
+          {box.width}×{box.height}
+        </p>
+      </div>
+    ),
+  });
+
+const App = ({ metrics }: { readonly metrics: FontMetrics }) => (
+  <main className="demo-shell">
+    <header className="demo-header">
+      <h1>Bubble shrinkwrap — computable workspace geometry</h1>
+      <p>
+        Every bubble box below is computed headlessly: <code>lineStats</code> over live-captured word advances, width =
+        min(maxWidth, widest line) + padding, height = lines × line-height. The border is the math; the text just has to
+        fit. <a href="/">Dock demo</a>
+      </p>
+    </header>
+    <section className="bubbles-stage">
+      {A.map(messages, (message) => (
+        <Bubble key={message.id} message={message} metrics={metrics} />
+      ))}
+    </section>
+  </main>
+);
+
+const boot = Effect.gen(function* () {
+  const capture = yield* PretextCapture;
+  const snapshot = yield* capture.captureFontMetrics(
+    PretextCaptureRequest.make({ font, lineHeight, words: distinctWords })
+  );
+  const host = document.getElementById("root");
+  if (P.isNull(host)) return yield* Effect.die(new Error("Missing #root mount node"));
+  createRoot(host).render(<App metrics={snapshot.metrics} />);
+});
+
+void Effect.runPromise(boot.pipe(Effect.provide(PretextCaptureLive)));

--- a/scratchpad/dockview-demo/src/demo.css
+++ b/scratchpad/dockview-demo/src/demo.css
@@ -140,6 +140,49 @@ section[data-group-id] {
   border-radius: 3px;
 }
 
+.bubbles-stage {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bubble-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.bubble-row-user {
+  align-items: flex-end;
+}
+
+.bubble {
+  box-sizing: border-box;
+  font:
+    16px Arial,
+    sans-serif;
+  line-height: 20px;
+  overflow: hidden;
+  border-radius: 10px;
+  background: #26436e;
+  color: #eef2f8;
+}
+
+.bubble-agent {
+  background: #2b3038;
+  color: #e6e6e6;
+}
+
+.bubble-caption {
+  margin: 4px 2px 0;
+  font-size: 11px;
+  color: #6d7683;
+}
+
 .demo-notes h2 {
   margin: 0 0 8px;
   font-size: 14px;

--- a/scratchpad/dockview-demo/src/main.tsx
+++ b/scratchpad/dockview-demo/src/main.tsx
@@ -97,7 +97,7 @@ const App = ({ graph }: { readonly graph: DockAtomGraph }) => (
       <h1>Dockview — computable workspace geometry</h1>
       <p>
         Kernel geometry is pure schema math; group width floors come from real text measurement via{" "}
-        <code>options.titleMinima</code>.
+        <code>options.titleMinima</code>. <a href="/bubbles.html">Bubble shrinkwrap demo</a>
       </p>
     </header>
     <section className="demo-stage">


### PR DESCRIPTION
## feat(scratchpad): bubbles shrinkwrap demo page and geometry loop-close docs

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_dockview-bubbles-demo-601c516342cf/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786619143&installation_id=141092090&pr_number=403&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F403&signature=2177d6f9fa19e23565106846ca39c0fe065c1a0e184a7b48fe34755f7551826e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->