### PR TITLE
docs(roadmap): reconcile post-consolidation + roadmap-refs anti-rot lint + board sync

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,8 @@
 # Roadmap
 
-Freshness: 2026-07-11. Synthesized from `goals/`, `explorations/`, `standards/`,
-and `docs/` in a grilled interview session; supersedes the *frame* of
+Freshness: 2026-07-14. Reconciled after the goals portfolio consolidation
+(PR #401) and agent-effectiveness-pulse wave 1 (PR #400); priorities unchanged.
+This file supersedes the *frame* of
 [`docs/mirror/2026-07-08-roadmap.md`](./mirror/2026-07-08-roadmap.md) (which
 remains a dated personal snapshot). Where the two disagree, this file wins.
 
@@ -42,18 +43,22 @@ when its last packet closes, not one slot per packet.
 ### Lane 1 — Product
 
 [`legal-document-intake`](../goals/legal-document-intake/README.md), portal
-phases P3–P6 in PLAN order, each phase its own PR under the yeet completion
+phases P4–P6 in PLAN order, each phase its own PR under the yeet completion
 gate (P7 Close follows as packet closeout, outside the portal path):
 
-1. **P3 Box sync** — the first-user moment: filed docs mirror to the real
-   Box account (`@beep/box` write surface already exists; the full
-   `box-driver` packet stays paused).
-2. **P4 Extraction → KG loop** — grounded candidates through the ClaimGate;
-   KG rows are schema-first Postgres/PGlite tables per intake decision D6
-   (graph DB deferred behind the port; benchmarks reopen it, not preference).
-3. **P5 Retrieval + viewer** — NL query → span-highlighted document. Gate
+1. **P4 Extraction → KG loop** — the live front: grounded candidates through
+   the ClaimGate; KG rows are schema-first Postgres/PGlite tables per intake
+   decision D6 (graph DB deferred behind the port; benchmarks reopen it, not
+   preference).
+2. **P5 Retrieval + viewer** — NL query → span-highlighted document. Gate
    for the NEXT horizon.
-4. **P6 M365 write + dual DMS.**
+3. **P6 M365 write + dual DMS.**
+
+P3 Box sync shipped in PR #386; the live-Box/OAuth deferral is recorded in
+the intake packet as a tracked exception. The
+[`professional-desktop-adversarial-qa`](../goals/professional-desktop-adversarial-qa/README.md)
+campaign is standing product-quality work until two consecutive rounds are
+clean; it does not consume a lane slot.
 
 ### Lane 2 — Product support
 
@@ -61,21 +66,21 @@ Only packets that directly feed Lane 1:
 
 - [`file-processing-capability`](../goals/file-processing-capability/README.md) (3/7)
 - [`agentic-professional-runtime`](../goals/agentic-professional-runtime/README.md) (3/5)
-- [`semantic-foundation`](../goals/semantic-foundation/README.md) — scoped to
+- [`semantic-foundation`](../goals/semantic-foundation/README.md) (0/6) — scoped to
   **M1 Intake-Serving Semantic Seed** and **M4 ClaimGate Shapes** (feeds
-  intake P4). M2/M3 queue in NEXT.
+  intake P4). Feeder research phases are now R1–R4; M2/M3 queue in NEXT.
 
-### Lane 3 — Finish, then retire
+### Lane 3 — Harness & metrics
 
-Near-done actives driven to close; the lane retires when empty:
+Harness observability, hygiene, and the v1-blocking metrics durability gate:
 
-- [`codex-security-findings-2026-07-08`](../goals/codex-security-findings-2026-07-08/README.md) (8/10)
-- [`ai-metrics-stack`](../goals/ai-metrics-stack/README.md) (6/8)
-- [`gov-legal-data-driver-codegen`](../goals/gov-legal-data-driver-codegen/README.md)
-  (3/4) — closing it does **not** auto-start `gov-legal-data-driver-delivery`.
-- [`ontology-agent-surface`](../goals/ontology-agent-surface/README.md) —
-  land the in-flight P1 toolkit branch, then park P2–P4 (resumes when the
-  product path needs agent-driven ontology edits).
+- [`harness-otel-adoption`](../goals/harness-otel-adoption/README.md) (0/4)
+- [`harness-hygiene-mechanical`](../goals/harness-hygiene-mechanical/README.md) (0/4)
+- [`ai-metrics-stack`](../goals/ai-metrics-stack/README.md) (6/8), **P7f
+  Forwarder Durability** — v1-blocking and gates P7e; evidence is recorded in
+  the [packet manifest](../goals/ai-metrics-stack/ops/manifest.json).
+
+The previous finish-then-retire members all closed during 2026-07-11–14.
 
 ### Maintenance rule (always allowed, any packet, any lane state)
 
@@ -94,13 +99,15 @@ ratchets hold at zero — keep-green only, no new clicks past zero.
   [`citation-grounding-hallucination-guard`](../explorations/citation-grounding-hallucination-guard/).
 - **`semantic-foundation` M2** (classification schemes) and **M3**
   (docketing and party roles).
-- **`gov-legal-data-driver-delivery`** — resumes per named-driver pull when
-  a product feature needs a specific driver, never as a batch.
+- **`gov-legal-data-driver-delivery`** — a fresh packet citing the closed
+  [`gov-legal-data-driver-delivery`](../goals/gov-legal-data-driver-delivery/README.md)
+  packet's evidence/specs, opened per named-driver pull when a product feature
+  needs a specific driver, never as a batch.
 - **Platform re-entries** as slots free:
   [`domain-kernel-hardening`](../goals/domain-kernel-hardening/README.md)
   (before KG tables scale) and
-  [`one-round-loop`](../goals/one-round-loop/README.md) (when CI round-trips
-  bottleneck a lane).
+  a fresh packet citing [`one-round-loop`](../goals/one-round-loop/README.md)'s
+  evidence/specs (when CI round-trips bottleneck a lane).
 
 ## LATER — gate: librarian + graph-&-ask shipped
 
@@ -109,8 +116,10 @@ ratchets hold at zero — keep-green only, no new clicks past zero.
   [`agent-memory-tiers-bitemporal-edges`](../explorations/agent-memory-tiers-bitemporal-edges/)
   exploration feeds this).
 - **PRD P5 sync & scale** — sync engine, Box Events → ingest;
-  `stack-installer` revival (second-user distribution); `oip-web` revival
-  (brand/intake surface).
+  [`stack-installer`](../explorations/stack-installer/) revival (second-user
+  distribution); `oip-web` revival (brand/intake surface) follows the completed
+  [`oip-web-production-hardening` launch
+  runbook](../goals/oip-web-production-hardening/history/outputs/launch-runbook.md).
 - **Generalization verticals** (Todox, wealth management) on the proven
   runtime.
 - **Platform programs** — crispening wave continuation,
@@ -119,28 +128,18 @@ ratchets hold at zero — keep-green only, no new clicks past zero.
 
 ## Parked packets — resume conditions
 
-Newly parked in this synthesis (lifecycle `paused`, executed via
-`set-status`). Packets already paused before this synthesis stay paused
-under their existing notes.
-
 | Packet | Resumes when |
 | --- | --- |
-| [`agent-reflection-loop`](../goals/agent-reflection-loop/README.md) | A packet closes without usable reflections (enforcement gap recurs). |
-| [`one-round-loop`](../goals/one-round-loop/README.md) | CI round-trips bottleneck a lane (median PR needs >1 round). |
-| [`lint-advisory-hardening`](../goals/lint-advisory-hardening/README.md) | Advisory noise measurably slows lane agents, or the post-P5 platform window opens. |
-| [`fallow-advisory-ratchets`](../goals/fallow-advisory-ratchets/README.md) | A Fallow advisory lane regresses, or the post-P5 platform window opens. |
-| [`fallow-debt-burndown`](../goals/fallow-debt-burndown/README.md) | With `fallow-advisory-ratchets` (same program). |
-| [`repo-codegraph`](../goals/repo-codegraph/README.md) | Symbol-discovery friction demonstrably blocks lane work. |
-| [`knowledge-workspace`](../goals/knowledge-workspace/README.md) | After portal P5, once the epistemic store holds real user data. |
 | [`domain-kernel-hardening`](../goals/domain-kernel-hardening/README.md) | Before KG tables scale — opens with PRD P2 librarian. |
-| [`schema-first-v4-capabilities`](../goals/schema-first-v4-capabilities/README.md) | A schema-heavy wave (e.g. intake P4 KG schemas) hits a v4-feature gap. |
-| [`unified-ai-toolchain`](../goals/unified-ai-toolchain/README.md) | Agent-config drift next causes a real incident. |
-| [`project-intelligence`](../goals/project-intelligence/README.md) | Research-on-cron delegation is worth a lane slot (earliest: post portal P5). |
-| [`stack-installer`](../goals/stack-installer/README.md) | Distribution phase opens (LATER: sync & scale; a second non-technical user). |
-| [`gov-legal-data-driver-delivery`](../goals/gov-legal-data-driver-delivery/README.md) | A product feature pulls a named gov driver (per-driver, not batch). |
 
-Status flips in the same synthesis: `beep-schema-topology` and `canvas` are
-phase-complete and move to `completed-retained`.
+Completed packets record their own reopening triggers; deleted packets' living
+visions were re-captured under `explorations/`:
+[`agent-governance-control-plane`](../explorations/agent-governance-control-plane/),
+[`knowledge-workspace`](../explorations/knowledge-workspace/),
+[`project-intelligence`](../explorations/project-intelligence/),
+[`stack-installer`](../explorations/stack-installer/), and the
+[`legal-ontology-landscape` survey note](../explorations/legal-ontology-landscape/);
+everything else remains in git history.
 
 ## Exploration funnel policy
 
@@ -161,5 +160,3 @@ a derived view, synced manually when this file changes; this file is truth.
 ## Parked ideas (about this roadmap itself)
 
 - Board-sync automation (`ROADMAP.md` → GitHub Projects).
-- A `beep` lint that checks every packet slug named here still resolves and
-  its lifecycle matches what this file implies.

--- a/packages/tooling/tool/cli/src/bin-main.ts
+++ b/packages/tooling/tool/cli/src/bin-main.ts
@@ -14,6 +14,7 @@ const LINT_POLICY_SUBCOMMANDS: ReadonlyArray<string> = [
   "deprecated-apis",
   "package-test-imports",
   "reflection-artifacts",
+  "roadmap-refs",
   "schema-catalog",
   "schema-first",
   "schema-topology",

--- a/packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts
@@ -23,6 +23,7 @@ import { lintIdentityRegistryCommand } from "./IdentityRegistry.js";
 import { LintCircularAnalysisError, LintFileDiscoveryError } from "./Lint.errors.js";
 import { lintPackageTestImportsCommand } from "./PackageTestImports.js";
 import { lintReflectionArtifactsCommand } from "./ReflectionArtifact.ts";
+import { lintRoadmapRefsCommand } from "./RoadmapRefs.ts";
 import { lintSchemaCatalogCommand } from "./SchemaCatalog.ts";
 import { lintSchemaFirstCommand } from "./SchemaFirst.ts";
 import { lintSchemaTopologyCommand } from "./SchemaTopology.ts";
@@ -595,6 +596,7 @@ export const lintCommand = Command.make("lint", {}, () =>
     "- bun run beep lint package-test-imports",
     "- bun run beep lint policy",
     "- bun run beep lint reflection-artifacts",
+    "- bun run beep lint roadmap-refs",
     "- bun run beep lint schema-catalog",
     "- bun run beep lint schema-first",
     "- bun run beep lint schema-topology",
@@ -610,6 +612,7 @@ export const lintCommand = Command.make("lint", {}, () =>
     lintPackageTestImportsCommand,
     lintPolicyCommand,
     lintReflectionArtifactsCommand,
+    lintRoadmapRefsCommand,
     lintSchemaCatalogCommand,
     lintSchemaFirstCommand,
     lintSchemaTopologyCommand,

--- a/packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts
+++ b/packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts
@@ -13,8 +13,8 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { decodeYamlTextAs, LiteralKit } from "@beep/schema";
-import { A, thunkEmptyStr } from "@beep/utils";
-import { Console, Effect, FileSystem, Path, pipe, SchemaGetter } from "effect";
+import { A } from "@beep/utils";
+import { Console, Effect, FileSystem, Path, pipe } from "effect";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
@@ -23,6 +23,7 @@ import { Command } from "effect/unstable/cli";
 import { parse } from "jsonc-parser";
 import { failWithReportedExit } from "../../internal/cli/ExitCodeError.js";
 import { optionalProp } from "../../internal/cli/OptionRecord.js";
+import { makePolicyFindingLogger } from "../../internal/cli/PolicyFindingLogger.js";
 import { GoalStatus } from "../Goals/Goals.schemas.js";
 
 const $I = $RepoCliId.create("commands/Lint/ReflectionArtifact");
@@ -35,8 +36,6 @@ const REFLECTION_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}-.+\.md$/;
 // `completed-retained` gates reflections; `superseded` packets are exempt and
 // get a doctor advisory when they carry no supersession pointer.
 const COMPLETED_STATUS_TOKENS: ReadonlyArray<string> = [GoalStatus.Enum["completed-retained"]];
-
-const stringifyJsonLine = SchemaGetter.stringifyJson({ space: 0 });
 
 const ReflectionConfidence = LiteralKit(["high", "medium", "low"]).pipe(
   $I.annoteSchema("ReflectionConfidence", {
@@ -142,17 +141,11 @@ class ReflectionPolicyFinding extends S.Class<ReflectionPolicyFinding>($I`Reflec
 
 const encodePolicyFinding = S.encodeUnknownEffect(ReflectionPolicyFinding);
 
-const renderPolicyFindingLine = Effect.fn("renderReflectionFindingLine")(function* (finding: ReflectionPolicyFinding) {
-  const encoded = yield* encodePolicyFinding(finding);
-  const rendered = yield* stringifyJsonLine.run(O.some(encoded), {});
-  return `[reflection:issue] ${O.getOrElse(rendered, thunkEmptyStr)}`;
-});
-
-const logPolicyFinding = Effect.fn("logReflectionFinding")(function* (finding: ReflectionPolicyFinding) {
-  yield* Console.error(
-    `- ${finding.goal}${finding.file !== undefined ? ` :: ${finding.file}` : ""} [${finding.severity}] ${finding.message}`
-  );
-  yield* Console.error(yield* renderPolicyFindingLine(finding));
+const { log: logPolicyFinding } = makePolicyFindingLogger({
+  issuePrefix: "[reflection:issue] ",
+  encode: encodePolicyFinding,
+  renderSummary: (finding: ReflectionPolicyFinding) =>
+    `- ${finding.goal}${finding.file !== undefined ? ` :: ${finding.file}` : ""} [${finding.severity}] ${finding.message}`,
 });
 
 const decodeFrontmatter = decodeYamlTextAs(ReflectionFrontmatter);

--- a/packages/tooling/tool/cli/src/commands/Lint/RoadmapRefs.ts
+++ b/packages/tooling/tool/cli/src/commands/Lint/RoadmapRefs.ts
@@ -1,0 +1,270 @@
+/**
+ * Roadmap-reference inventory and enforcement command.
+ *
+ * Verifies that goal and exploration links in `docs/ROADMAP.md` resolve to
+ * existing files or directories. Goal phase snapshots are compared with the
+ * linked packet manifest when phase data is available, but drift is advisory.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { findRepoRoot } from "@beep/repo-utils/Root";
+import { LiteralKit } from "@beep/schema";
+import { A, thunkEmptyStr } from "@beep/utils";
+import { Console, Effect, FileSystem, flow, Number as N, Path, pipe } from "effect";
+import * as O from "effect/Option";
+import * as P from "effect/Predicate";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { Command } from "effect/unstable/cli";
+import { failWithReportedExit } from "../../internal/cli/ExitCodeError.js";
+import { makePolicyFindingLogger } from "../../internal/cli/PolicyFindingLogger.js";
+import { decodeGoalManifest, GoalPhaseStatus } from "../Goals/Goals.schemas.js";
+import { goalManifestPhases, parseGoalManifestText } from "../Goals/Inventory.js";
+
+const $I = $RepoCliId.create("commands/Lint/RoadmapRefs");
+
+const ROADMAP_PATH = "docs/ROADMAP.md";
+const ROADMAP_LINK_PATTERN = /\[[^\]]*\]\(((?:\.\.\/|\.\/)(?:goals|explorations)\/[^)\s]+)\)(?:\s*\((\d+)\/(\d+)\))?/g;
+const ROADMAP_LINK_DEFINITION_PATTERN = /^\s*\[[^\]]+\]:\s+((?:\.\.\/|\.\/)(?:goals|explorations)\/\S+)\s*$/gm;
+
+class RoadmapReference extends S.Class<RoadmapReference>($I`RoadmapReference`)(
+  {
+    target: S.String,
+    phaseDone: S.optionalKey(S.Finite),
+    phaseTotal: S.optionalKey(S.Finite),
+  },
+  $I.annote("RoadmapReference", {
+    description: "One goal or exploration Markdown link parsed from the repository roadmap.",
+  })
+) {}
+
+const RoadmapPolicySeverity = LiteralKit(["warning", "error"]).pipe(
+  $I.annoteSchema("RoadmapPolicySeverity", {
+    description: "Severity emitted by roadmap-reference lint findings.",
+  })
+);
+
+class RoadmapPolicyFinding extends S.Class<RoadmapPolicyFinding>($I`RoadmapPolicyFinding`)(
+  {
+    category: S.Literal("roadmap-policy"),
+    ruleId: S.Literal("roadmap-ref"),
+    severity: RoadmapPolicySeverity,
+    target: S.String,
+    file: S.String,
+    message: S.String,
+    remediation: S.String,
+  },
+  $I.annote("RoadmapPolicyFinding", {
+    description: "Machine-readable roadmap-reference lint finding consumed by repository quality tooling.",
+  })
+) {}
+
+const encodePolicyFinding = S.encodeUnknownEffect(RoadmapPolicyFinding);
+
+const { log: logPolicyFinding } = makePolicyFindingLogger({
+  issuePrefix: "[roadmap:issue] ",
+  encode: encodePolicyFinding,
+  renderSummary: (finding: RoadmapPolicyFinding) =>
+    `- ${finding.target} :: ${finding.file} [${finding.severity}] ${finding.message}`,
+});
+
+const parseRoadmapReferences = (raw: string): ReadonlyArray<RoadmapReference> => {
+  let references = A.empty<RoadmapReference>();
+
+  for (const match of Str.matchAll(ROADMAP_LINK_PATTERN)(raw)) {
+    const target = match[1];
+    if (!P.isString(target)) {
+      continue;
+    }
+    const phaseSnapshot = pipe(
+      O.all([O.fromUndefinedOr(match[2]), O.fromUndefinedOr(match[3])]),
+      O.flatMap(([done, total]) => O.all([N.parse(done), N.parse(total)]))
+    );
+    references = A.append(
+      references,
+      RoadmapReference.make({
+        target,
+        ...pipe(
+          phaseSnapshot,
+          O.map(([done, total]) => ({ phaseDone: done, phaseTotal: total })),
+          O.getOrElse(() => ({}))
+        ),
+      })
+    );
+  }
+
+  for (const match of Str.matchAll(ROADMAP_LINK_DEFINITION_PATTERN)(raw)) {
+    const target = match[1];
+    if (P.isString(target)) {
+      references = A.append(references, RoadmapReference.make({ target }));
+    }
+  }
+
+  return references;
+};
+
+const targetPath: (target: string) => string = flow(Str.split(/[?#]/), A.head, O.getOrElse(thunkEmptyStr));
+
+const makeFinding = (
+  severity: "warning" | "error",
+  target: string,
+  message: string,
+  remediation: string
+): RoadmapPolicyFinding =>
+  RoadmapPolicyFinding.make({
+    category: "roadmap-policy",
+    ruleId: "roadmap-ref",
+    severity,
+    target,
+    file: ROADMAP_PATH,
+    message,
+    remediation,
+  });
+
+const isGoalPhaseSnapshot = (reference: RoadmapReference): boolean =>
+  reference.phaseDone !== undefined &&
+  reference.phaseTotal !== undefined &&
+  (Str.startsWith("../goals/")(reference.target) || Str.startsWith("./goals/")(reference.target));
+
+const readManifestPhaseCounts = Effect.fn("RoadmapRefs.readManifestPhaseCounts")(function* (
+  reference: RoadmapReference,
+  roadmapPath: string
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const goalPath = pipe(targetPath(reference.target), Str.split("/"), A.take(3), A.join("/"));
+  const manifestPath = path.join(path.dirname(roadmapPath), goalPath, "ops", "manifest.json");
+  const manifestText = yield* fs
+    .readFileString(manifestPath)
+    .pipe(Effect.map(O.some), Effect.orElseSucceed(O.none<string>));
+  const parsedManifest = O.flatMap(manifestText, parseGoalManifestText);
+  if (O.isNone(parsedManifest)) {
+    return O.none<{ readonly done: number; readonly total: number }>();
+  }
+  const manifest = yield* decodeGoalManifest(parsedManifest.value).pipe(
+    Effect.map(O.some),
+    Effect.orElseSucceed(O.none)
+  );
+  if (O.isNone(manifest) || manifest.value.phases === undefined) {
+    return O.none<{ readonly done: number; readonly total: number }>();
+  }
+  const phases = goalManifestPhases(manifest.value);
+  return O.some({
+    done: A.length(A.filter(phases, (phase) => GoalPhaseStatus.is.complete(phase.status))),
+    total: A.length(phases),
+  });
+});
+
+const phaseSnapshotFinding = Effect.fn("RoadmapRefs.phaseSnapshotFinding")(function* (
+  reference: RoadmapReference,
+  roadmapPath: string,
+  resolvedTarget: string
+) {
+  if (!isGoalPhaseSnapshot(reference)) {
+    return O.none<RoadmapPolicyFinding>();
+  }
+
+  const counts = yield* readManifestPhaseCounts(reference, roadmapPath);
+  if (O.isNone(counts)) {
+    return O.none<RoadmapPolicyFinding>();
+  }
+
+  const { done, total } = counts.value;
+  const matches =
+    reference.phaseDone !== undefined &&
+    reference.phaseTotal !== undefined &&
+    N.Equivalence(reference.phaseDone, done) &&
+    N.Equivalence(reference.phaseTotal, total);
+  if (matches) {
+    return O.none<RoadmapPolicyFinding>();
+  }
+
+  return O.some(
+    makeFinding(
+      "warning",
+      reference.target,
+      `Roadmap phase snapshot (${reference.phaseDone}/${reference.phaseTotal}) disagrees with manifest phases (${done}/${total}).`,
+      `Update the phase snapshot adjacent to the link for ${resolvedTarget}.`
+    )
+  );
+});
+
+/**
+ * Verifies roadmap packet links exist and reports goal phase-count drift.
+ *
+ * @example
+ * ```ts
+ * import { runRoadmapRefsLint } from "@beep/repo-cli/commands/Lint/RoadmapRefs"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(runRoadmapRefsLint))
+ * ```
+ * @category commands
+ * @since 0.0.0
+ */
+export const runRoadmapRefsLint = Effect.fn(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const repoRoot = yield* findRepoRoot();
+  const roadmapPath = path.join(repoRoot, ROADMAP_PATH);
+  const raw = yield* fs.readFileString(roadmapPath);
+  const blocking = A.empty<RoadmapPolicyFinding>();
+  const advisories = A.empty<RoadmapPolicyFinding>();
+
+  for (const reference of parseRoadmapReferences(raw)) {
+    const resolvedTarget = path.resolve(path.dirname(roadmapPath), targetPath(reference.target));
+    if (!(yield* fs.exists(resolvedTarget))) {
+      blocking.push(
+        makeFinding(
+          "error",
+          reference.target,
+          `Roadmap link target does not exist: ${resolvedTarget}.`,
+          "Restore the referenced packet path or update the roadmap link to an existing target."
+        )
+      );
+      continue;
+    }
+
+    const advisory = yield* phaseSnapshotFinding(reference, roadmapPath, resolvedTarget);
+    if (O.isSome(advisory)) {
+      advisories.push(advisory.value);
+    }
+  }
+
+  yield* Console.log(`[roadmap] blocking_findings=${A.length(blocking)}`);
+  yield* Console.log(`[roadmap] advisory_findings=${A.length(advisories)}`);
+
+  if (A.isReadonlyArrayNonEmpty(advisories)) {
+    yield* Console.error("[roadmap] advisories (non-fatal):");
+    for (const finding of advisories) {
+      yield* logPolicyFinding(finding);
+    }
+  }
+
+  if (A.isReadonlyArrayNonEmpty(blocking)) {
+    yield* Console.error("[roadmap] blocking findings:");
+    for (const finding of blocking) {
+      yield* logPolicyFinding(finding);
+    }
+    return yield* failWithReportedExit("roadmap: referenced goal or exploration target is missing.");
+  }
+});
+
+/**
+ * `bun run beep lint roadmap-refs` — enforce roadmap packet links.
+ *
+ * @example
+ * ```ts
+ * import { lintRoadmapRefsCommand } from "@beep/repo-cli/commands/Lint/RoadmapRefs"
+ *
+ * console.log(lintRoadmapRefsCommand.name)
+ * ```
+ * @category commands
+ * @since 0.0.0
+ */
+export const lintRoadmapRefsCommand = Command.make("roadmap-refs", {}, runRoadmapRefsLint).pipe(
+  Command.withDescription("Verify roadmap goal and exploration links resolve to existing targets")
+);

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.schemas.ts
@@ -108,6 +108,7 @@ export const LintPolicySubcommand = LiteralKit([
   "package-test-imports",
   "policy",
   "reflection-artifacts",
+  "roadmap-refs",
   "schema-first",
   "schema-topology",
   "tooling-schema-first",

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -1043,6 +1043,7 @@ const rootRepoLintPolicySteps = (repoRoot: string): ReadonlyArray<QualityTaskSte
   repoCliStep(repoRoot, "lint:identity-registry", ["lint", "identity-registry"]),
   repoCliStep(repoRoot, "lint:package-test-imports", ["lint", "package-test-imports"]),
   repoCliStep(repoRoot, "lint:reflection-artifacts", ["lint", "reflection-artifacts"]),
+  repoCliStep(repoRoot, "lint:roadmap-refs", ["lint", "roadmap-refs"]),
   repoCliStep(repoRoot, "goals:doctor", ["goals", "doctor"]),
   repoCliStep(repoRoot, "goals:index-check", ["goals", "index", "--check"]),
   repoCliStep(repoRoot, "lint:schema-first", ["lint", "schema-first"]),

--- a/packages/tooling/tool/cli/src/internal/cli/PolicyFindingLogger.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/PolicyFindingLogger.ts
@@ -1,0 +1,41 @@
+import { thunkEmptyStr } from "@beep/utils";
+import { Console, Effect, SchemaGetter } from "effect";
+import * as O from "effect/Option";
+
+const stringifyJsonLine = SchemaGetter.stringifyJson({ space: 0 });
+
+/**
+ * Builds the shared human-readable and machine-readable logger used by policy lints.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect"
+ *
+ * const logger = makePolicyFindingLogger({
+ *   issuePrefix: "[example:issue] ",
+ *   encode: (finding: { readonly message: string }) => Effect.succeed(finding),
+ *   renderSummary: (finding) => finding.message,
+ * })
+ * console.log(Effect.isEffect(logger.render({ message: "example" })))
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+export const makePolicyFindingLogger = <Finding, EncodeError, EncodeRequirements>(options: {
+  readonly issuePrefix: string;
+  readonly encode: (finding: Finding) => Effect.Effect<unknown, EncodeError, EncodeRequirements>;
+  readonly renderSummary: (finding: Finding) => string;
+}) => {
+  const render = Effect.fn("PolicyFindingLogger.render")(function* (finding: Finding) {
+    const encoded = yield* options.encode(finding);
+    const rendered = yield* stringifyJsonLine.run(O.some(encoded), {});
+    return `${options.issuePrefix}${O.getOrElse(rendered, thunkEmptyStr)}`;
+  });
+
+  const log = Effect.fn("PolicyFindingLogger.log")(function* (finding: Finding) {
+    yield* Console.error(options.renderSummary(finding));
+    yield* Console.error(yield* render(finding));
+  });
+
+  return { log, render } as const;
+};

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -946,6 +946,7 @@ describe("quality task adapter", () => {
       "lint:identity-registry",
       "lint:package-test-imports",
       "lint:reflection-artifacts",
+      "lint:roadmap-refs",
       "goals:doctor",
       "goals:index-check",
       "lint:schema-first",
@@ -976,6 +977,7 @@ describe("quality task adapter", () => {
       "lint:identity-registry",
       "lint:package-test-imports",
       "lint:reflection-artifacts",
+      "lint:roadmap-refs",
       "goals:doctor",
       "goals:index-check",
       "lint:schema-first",
@@ -1018,7 +1020,7 @@ describe("quality task adapter", () => {
           expect(Exit.isSuccess(exit)).toBe(true);
 
           const logText = A.join(A.filter(yield* TestConsole.logLines, isString), "\n");
-          expect(logText).toContain("[beep-cli] lint:policy: running 22 step(s) with concurrency 3");
+          expect(logText).toContain("[beep-cli] lint:policy: running 23 step(s) with concurrency 3");
         })
       )
     ));
@@ -1456,11 +1458,12 @@ describe("quality task adapter", () => {
           // still executes after the aggregate lint step fails.
           expect(commandLog).toContain("bunx turbo run lint");
           expect(commandLog).toContain("bun run beep laws effect-imports --check");
+          expect(commandLog).toContain("bun run beep lint roadmap-refs");
           expect(commandLog).toContain("bun run beep docgen check --reuse-proof-manifest");
           expect(commandLog).toContain("bunx typos");
 
           const logText = A.join(A.filter(yield* TestConsole.logLines, isString), "\n");
-          expect(logText).toContain("[beep-cli] lint: running 23 step(s) with concurrency 3");
+          expect(logText).toContain("[beep-cli] lint: running 24 step(s) with concurrency 3");
         })
       )
     ));

--- a/packages/tooling/tool/cli/test/roadmap-refs.fixture.md
+++ b/packages/tooling/tool/cli/test/roadmap-refs.fixture.md
@@ -1,0 +1,8 @@
+# Roadmap reference lint fixture
+
+- [Resolving goal](../goals/resolving/README.md) (0/2)
+- [Resolving exploration](../explorations/resolving/README.md)
+- [Dead goal](../goals/dead/README.md)
+- [Reference-style dead goal][dead-ref]
+
+[dead-ref]: ../goals/dead-ref/README.md

--- a/packages/tooling/tool/cli/test/roadmap-refs.test.ts
+++ b/packages/tooling/tool/cli/test/roadmap-refs.test.ts
@@ -1,0 +1,95 @@
+import { lintCommand } from "@beep/repo-cli";
+import { FsUtilsLive } from "@beep/repo-utils/FsUtils";
+import { findRepoRoot } from "@beep/repo-utils/Root";
+import { provideScopedLayer } from "@beep/test-utils";
+import { A } from "@beep/utils";
+import { NodeServices } from "@effect/platform-node";
+import { Effect, Exit, FileSystem, Layer, Path, pipe } from "effect";
+import * as P from "effect/Predicate";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import * as TestConsole from "effect/testing/TestConsole";
+import { Command } from "effect/unstable/cli";
+import { describe, expect, it } from "vitest";
+import { expectReportedExit, withTempWorkingDirectory } from "./support/CommandTest.js";
+
+const FIXTURE_PATH = "packages/tooling/tool/cli/test/roadmap-refs.fixture.md";
+const runLintCommand = Command.runWith(lintCommand, { version: "0.0.0" });
+const encodeJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
+
+const testLayer = Layer.mergeAll(
+  NodeServices.layer,
+  TestConsole.layer,
+  FsUtilsLive.pipe(Layer.provide(NodeServices.layer))
+);
+
+const writeFixture = Effect.fn("RoadmapRefsTest.writeFixture")(function* (roadmap: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  yield* fs.writeFileString("bun.lock", "");
+  yield* fs.makeDirectory(path.join("docs"), { recursive: true });
+  yield* fs.makeDirectory(path.join("goals", "resolving", "ops"), { recursive: true });
+  yield* fs.makeDirectory(path.join("explorations", "resolving"), { recursive: true });
+  yield* fs.writeFileString(path.join("docs", "ROADMAP.md"), roadmap);
+  yield* fs.writeFileString(path.join("goals", "resolving", "README.md"), "# Resolving goal\n");
+  yield* fs.writeFileString(path.join("explorations", "resolving", "README.md"), "# Resolving exploration\n");
+  yield* fs.writeFileString(
+    path.join("goals", "resolving", "ops", "manifest.json"),
+    yield* encodeJson({
+      schemaVersion: "initiative-manifest/v2",
+      initiative: { id: "resolving", status: "active" },
+      completionGate: {
+        operator: "yeet",
+        requiresPullRequest: true,
+        requiresMergeable: true,
+        statement: "Ship via yeet.",
+        grandfathered: false,
+      },
+      phases: [
+        { id: "P0", status: "complete" },
+        { id: "P1", status: "pending" },
+      ],
+    })
+  );
+});
+
+describe("roadmap-refs lint command", { concurrent: false }, () => {
+  it(
+    "blocks only the dead link and reports phase drift as advisory",
+    () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const repoRoot = yield* findRepoRoot();
+          const roadmap = yield* fs.readFileString(path.join(repoRoot, FIXTURE_PATH));
+
+          yield* withTempWorkingDirectory(
+            Effect.gen(function* () {
+              yield* writeFixture(roadmap);
+              const exit = yield* Effect.exit(runLintCommand(["roadmap-refs"]));
+              expectReportedExit(exit);
+              expect(Exit.isFailure(exit)).toBe(true);
+
+              const issueLines = pipe(
+                yield* TestConsole.errorLines,
+                A.filter(P.isString),
+                A.filter(Str.startsWith("[roadmap:issue]"))
+              );
+              const blocking = A.filter(issueLines, Str.includes('"severity":"error"'));
+              const advisories = A.filter(issueLines, Str.includes('"severity":"warning"'));
+
+              expect(blocking).toHaveLength(2);
+              expect(A.some(blocking, Str.includes("../goals/dead/README.md"))).toBe(true);
+              expect(A.some(blocking, Str.includes("../goals/dead-ref/README.md"))).toBe(true);
+              expect(A.some(blocking, Str.includes("../goals/resolving/README.md"))).toBe(false);
+              expect(advisories).toHaveLength(1);
+              expect(A.some(advisories, Str.includes("(0/2) disagrees with manifest phases (1/2)"))).toBe(true);
+            })
+          );
+        }).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+});


### PR DESCRIPTION
Roadmap refresh after the goals portfolio consolidation (PR #401) and pulse wave 1 (PR #400).

## docs/ROADMAP.md reconciled (freshness 2026-07-14, priorities unchanged)

- Lane 1 fronts intake P4 (P3 Box sync shipped in PR #386, live-Box/OAuth deferral tracked in
  the packet); professional-desktop-adversarial-qa recorded as a standing product-quality
  campaign (runs to two consecutive clean rounds; not a lane-slot consumer).
- Lane 3 renamed "Harness & metrics": harness-otel-adoption, harness-hygiene-mechanical,
  ai-metrics-stack P7f forwarder durability (v1-blocking, gates P7e). Prior members all
  closed 2026-07-11..14.
- Parked-packets table shrunk 13 rows -> 1 (domain-kernel-hardening); completed packets
  carry their own reopening triggers, deleted packets' visions live under explorations/.
- All packet links verified; zero references to deleted packet directories remain.

## New: beep lint roadmap-refs (the roadmap's own parked anti-rot idea)

- Blocking: every ../goals and ../explorations markdown link in docs/ROADMAP.md must
  resolve on disk. Advisory: goal phase-count snapshots that drift from packet manifests.
- Wired into lint policy + quality tasks beside reflection-artifacts; repo-root-anchored
  (cwd-independent); shared finding logger extracted to internal/cli/PolicyFindingLogger
  and adopted by both roadmap-refs and reflection-artifacts (fallow dedup clean).

## GitHub Projects board ("beep-effect roadmap") synced manually

Shipped items marked Done (intake P3, codex-security close, gov-codegen close,
ontology-agent-surface); ai-metrics card retitled to P7f; Lane 3 option renamed to
"Lane 3 - Harness"; cards added for adversarial-QA and the two harness packets;
re-entry cards reworded to fresh-packet form. Board remains a derived view; the file
is truth.

Note: phase-count snapshots will drift again when open PRs (#404 harness-otel P0-P1,
#405 exploration graduations) merge — the new lint reports that as advisory, links
stay blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
