### PR TITLE
fix(ontology): preserve portable canonical containment

### DIFF
--- a/.changeset/portable-taxonomy-containment.md
+++ b/.changeset/portable-taxonomy-containment.md
@@ -1,0 +1,5 @@
+---
+"@beep/ontology": patch
+---
+
+Preserve vendor taxonomy containment checks for canonical Windows paths.

--- a/packages/foundation/modeling/ontology/src/TaxonomyLoader.ts
+++ b/packages/foundation/modeling/ontology/src/TaxonomyLoader.ts
@@ -215,7 +215,10 @@ const readSlice = Effect.fn("TaxonomyLoader.readSlice")(function* (entry: Vendor
       const path = yield* fs
         .realPath(candidatePath)
         .pipe(Effect.mapError(() => VendorSliceReadError.make({ id: entry.id, path: candidatePath })));
-      const rootedPrefix = `${canonicalVendorRoot}/`;
+      const separator = Str.includes("\\")(canonicalVendorRoot) && !Str.includes("/")(canonicalVendorRoot) ? "\\" : "/";
+      const rootedPrefix = Str.endsWith(separator)(canonicalVendorRoot)
+        ? canonicalVendorRoot
+        : `${canonicalVendorRoot}${separator}`;
       if (!Str.startsWith(rootedPrefix)(path)) {
         return yield* VendorSlicePathEscape.make({ id: entry.id, path, vendorRoot: canonicalVendorRoot });
       }

--- a/packages/foundation/modeling/ontology/test/SemanticFoundation.test.ts
+++ b/packages/foundation/modeling/ontology/test/SemanticFoundation.test.ts
@@ -193,6 +193,43 @@ layer(TaxonomyLoader.layer)("semantic foundation", (it) => {
   );
 
   it.effect(
+    "accepts a canonical Windows vendor root with a trailing separator",
+    Effect.fnUntraced(function* () {
+      const loader = yield* TaxonomyLoader;
+      const canonicalRoot = "C:\\vendor\\";
+      const canonicalSlice = `${canonicalRoot}fixture-slice.jsonld`;
+      const manifest = yield* encodeEntry(
+        VendorManifestEntry.make({
+          format: "jsonld",
+          id: "windows-slice",
+          loadStatus: "VETTED",
+          path: "fixture-slice.jsonld",
+        })
+      );
+      const slice = yield* encodeSeed(
+        TaxonomySeed.make({
+          concepts: [],
+          filingRoots: [],
+          pathTemplateSegments: ["root", "client", "matter", "taxonomy-concept", "document-class", "file-name"],
+          schemeIri: IRIReference.make("https://ns.beep.sh/ontology/semantic-foundation/taxonomy/windows"),
+          title: "Windows vendor slice",
+        })
+      );
+      const loaded = yield* loader.load(manifestPath, vendorRoot).pipe(
+        Effect.provideService(
+          FileSystem.FileSystem,
+          FileSystem.makeNoop({
+            readFileString: (path) => Effect.succeed(path === manifestPath ? manifest : slice),
+            realPath: (path) => Effect.succeed(path === vendorRoot ? canonicalRoot : canonicalSlice),
+          })
+        )
+      );
+
+      expect(loaded.concepts).toHaveLength(SemanticFoundationSeed.concepts.length);
+    })
+  );
+
+  it.effect(
     "maps a missing vendor root realpath to a typed slice read error",
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;


### PR DESCRIPTION
## fix(ontology): preserve portable canonical containment

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit:amend: passed
- full:pre-push: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_portable-taxonomy-containment-d14c984a47b8/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787584872&installation_model_id=424656&pr_number=447&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F447&signature=973a6bb6ab4b65ad5fe4023954b7e333cd67881f3fcc4beaed406bee2201d25a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->