### PR TITLE
docs(epistemic): replace fact-language with typed-verdict vocabulary

### DIFF
--- a/docs/product/prose-to-proof.md
+++ b/docs/product/prose-to-proof.md
@@ -89,7 +89,8 @@ seed matter/client context
 
 This honors the SPEC's non-negotiables: **candidate-only writes**, **evidence by stable span
 ID** (not whole-artifact, not byte offsets), **claim+evidence+provenance+lifecycle as
-authority**, **graph/search as projections**, and **SDK-first**.
+authority** (authoritative about what was asserted, evidenced, and decided — not about the
+propositions' truth), **graph/search as projections**, and **SDK-first**.
 
 ## 6. User stories & acceptance criteria
 
@@ -103,10 +104,11 @@ to the exact text.*
 - AC-2.1 An `artifact-ref` link renders a hover card with the linked artifact (e.g. a figure → CAD locator) (`@beep/lexical-schema`).
 - AC-2.2 The card shows the target's identity and a way to open/trace it.
 
-**US-3 — Approve.** *As Tom, nothing becomes a fact until I sign.*
-- AC-3.1 Candidate claims appear in a review surface with their evidence; none are authoritative pre-approval.
+**US-3 — Approve.** *As Tom, nothing is accepted for use in my matter until I sign — and my signature records my decision, not the claim's truth.*
+- AC-3.1 Candidate claims appear in a review surface with their evidence; none enter accepted state pre-approval.
 - AC-3.2 Approve/reject is recorded as an `Activity` with reviewer + timestamp (`@beep/epistemic-domain`).
 - AC-3.3 Accepted claims persist to local PGlite via `@beep/epistemic-tables` and survive restart.
+- Note: approval is a scoped human disposition — one of seven independent typed verdicts (shape validity, anchor fidelity, semantic stance, source authority/currentness, human disposition, action authorization, release). None of them converts a contestable proposition into source truth; "accepted" is repository state, not epistemic status.
 
 **US-4 — Local & walled.** *As Tom, my client data stays mine.*
 - AC-4.1 With no backup backend configured, zero network egress of document content (verifiable).

--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -40,23 +40,6 @@ The lego pieces already built. Authoritative inventories (link, never copy):
 
 ### Active
 
-- [`academia-corpus-mining`](./academia-corpus-mining/README.md) —
-  align-stage: 443 canonical Academia.edu papers mined through a tiered
-  pipeline (T1 triage of all 443, 185 Sol-max T2 deep-reads — 42 gold /
-  125 silver / 15 bronze / 3 dross — 7 cluster reports + a repo-grounded
-  master synthesis with a 36-route table and 13 align questions). Align
-  closed nine decisions 2026-07-25: all 15 high-priority routes dispatched
-  as bounded notes into 11 target packets + 2 new capture packets
-  (`agent-execution-sandbox`, `model-artifact-admission`);
-  prose-to-proof's "becomes a fact" language will be replaced with
-  typed-verdict vocabulary (separate binding-doc PR); belief views compose
-  first over the bitemporal core; argumentation follows semantic-foundation
-  M1. Adopts the June-29 prior synthesis (snippets errata-flagged) as
-  [`research/prior-synthesis-legal-ontologies.md`](./academia-corpus-mining/research/prior-synthesis-legal-ontologies.md);
-  normalized corpus lives externally (`~/YeeBois/research/academia-2026-07/`,
-  public-repo copyright discipline). Parks after the binding-doc PR;
-  revival trigger: wave 2 over the June-29 backlog (97 legal-NLP papers
-  first).
 - [`agent-effectiveness-pulse`](./agent-effectiveness-pulse/README.md) — a
   data-driven pulse on repo agent friendliness/effectiveness (stage
   `graduate`, opened 2026-07-14, still active for wave 2): which skills are
@@ -274,6 +257,21 @@ The lego pieces already built. Authoritative inventories (link, never copy):
 
 ### Parked
 
+- [`academia-corpus-mining`](./academia-corpus-mining/README.md) — parked
+  2026-07-25 at align-complete with all 15 high-priority routes dispatched:
+  443 canonical Academia.edu papers mined in tiers (T1 triage of all 443,
+  185 Sol-max T2 deep-reads — 42 gold / 125 silver / 15 bronze / 3 dross —
+  7 cluster reports + a repo-grounded master synthesis with a 36-route
+  table). Nine align decisions landed 2026-07-25: 11 bounded dispatch notes
+  into target packets, 2 new capture packets (`agent-execution-sandbox`,
+  `model-artifact-admission`), prose-to-proof/approval-policy fact language
+  replaced with typed-verdict vocabulary, memory-layer-taxonomy
+  episodic/projection split, belief views first over the bitemporal core,
+  argumentation after semantic-foundation M1. Medium/low routes stay
+  recorded in the master table; the June-29 prior synthesis stays adopted
+  (snippets errata-flagged); the normalized corpus lives externally
+  (`~/YeeBois/research/academia-2026-07/`). Revival trigger: the approved
+  wave-2 backlog run (97 legal-NLP/extraction papers first).
 - [`effect-ontology-harvest`](./effect-ontology-harvest/README.md) — parked
   2026-07-14 at align-complete: harvest-not-port complete with zero goals by
   design; demand gates and reference routes are recorded, and every item must

--- a/explorations/academia-corpus-mining/README.md
+++ b/explorations/academia-corpus-mining/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 Stage: `align`
-Status: `active`
+Status: `parked`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -38,6 +38,11 @@ entries in [`DECISIONS.md`](./DECISIONS.md).
 
 ## Trail
 
+- 2026-07-25 (park): binding-doc PR landed the typed-verdict replacement
+  (`docs/product/prose-to-proof.md`, the approval policy) and the
+  memory-layer-taxonomy episodic/projection split — the last dispatched
+  route. Status → `parked`; revival trigger: the approved wave-2 backlog
+  run (97 legal-NLP papers first).
 - 2026-07-25 (align): interview closed nine decisions (see DECISIONS.md
   align entries) — dispatch all 15 high-priority routes as bounded notes +
   2 new capture packets (`agent-execution-sandbox`,

--- a/explorations/academia-corpus-mining/ops/manifest.json
+++ b/explorations/academia-corpus-mining/ops/manifest.json
@@ -3,7 +3,7 @@
   "exploration": {
     "slug": "academia-corpus-mining",
     "title": "Academia Corpus Mining",
-    "status": "active",
+    "status": "parked",
     "stage": "align",
     "openQuestions": [
       "Deferred (parked revival trigger): run the approved wave-2 mining pass over the June-29 backlog — starting with the 97 legal-NLP/extraction papers — once the 15-route dispatch has fully landed (align decision, 2026-07-25).",

--- a/goals/agentic-professional-runtime/SPEC.md
+++ b/goals/agentic-professional-runtime/SPEC.md
@@ -204,8 +204,9 @@ active topology and should not be restored wholesale.
 
 The storage model is:
 
-- versioned or immutable entity rows for current runtime truth
-- append-only `Activity` and provenance records for why and how truth changed
+- versioned or immutable entity rows for current runtime-accepted state
+- append-only `Activity` and provenance records for why and how that state
+  changed
 - evidence records that preserve source spans and source artifacts
 - rebuildable read models for graph, search, timeline, inbox, compliance, and
   work queues

--- a/goals/agentic-professional-runtime/SPEC.md
+++ b/goals/agentic-professional-runtime/SPEC.md
@@ -42,20 +42,22 @@ not two separate platforms.
   2. Wealth cash request before a payment deadline.
 - Product fixture IDs are readable and stable. Evidence uses stable source span
   IDs, not whole-artifact-only citations or byte offsets.
-- The v1 proof produces candidate runtime truth only:
+- The v1 proof produces candidate records only:
   1. candidate claims;
   2. candidate tasks;
   3. candidate draft artifacts;
   4. attach evidence and provenance;
   5. pending approval gates;
   6. evidence-bounded context packets.
-- Claim plus evidence plus provenance plus lifecycle is the authoritative memory
-  primitive. Search, graph views, retrieval packets, summaries, and MCP outputs
-  are projections.
+- Claim plus evidence plus provenance plus lifecycle is the authoritative record
+  of what was asserted, evidenced, and decided — not of whether the underlying
+  proposition is true. Search, graph views, retrieval packets, summaries, and
+  MCP outputs are projections.
 - The internal Effect/TypeScript SDK is the canonical integration contract.
   MCP, Claude Desktop, OpenClaw, and other clients wrap or consume that contract.
 - Agents may read runtime context and propose candidate writes. Human or policy
-  acceptance promotes candidate records into authoritative state.
+  acceptance records a scoped disposition that makes candidate records eligible
+  for scoped runtime use; it does not make their propositions true.
 - Existing professional systems stay systems of record for their own data. This
   runtime connects to them and records its own claims, tasks, artifacts,
   approvals, activities, and usage.

--- a/goals/agentic-professional-runtime/docs/approval-and-autonomy-policy.md
+++ b/goals/agentic-professional-runtime/docs/approval-and-autonomy-policy.md
@@ -4,7 +4,7 @@
 
 The first runtime proof must be useful without pretending agents are licensed
 professionals. This document defines the v1 policy boundary between candidate
-agent work and authoritative runtime truth.
+agent work and runtime-accepted state.
 
 ## V1 Default
 
@@ -28,8 +28,14 @@ The initial lifecycle vocabulary is:
 - `revision_requested`
 - `superseded`
 
-`accepted` state means the runtime records the item as authoritative runtime
-truth. It does not mean an external system of record has accepted it.
+`accepted` state records a scoped human disposition: the item becomes eligible
+for scoped runtime use under this policy. It does not make the underlying
+proposition true, it does not by itself place the item in any preferred
+working view, and it does not mean an external system of record has accepted
+it. Acceptance records the human-disposition verdict — one of seven
+independent typed verdicts (shape validity, anchor fidelity, semantic stance,
+source authority/currentness, human disposition, action authorization,
+release); none implies another.
 
 ## Approval Gate Requirements
 
@@ -78,5 +84,5 @@ Rejected or revised candidate work remains useful evidence. The runtime should
 preserve the activity trail instead of deleting the candidate output silently.
 
 Future package tests should prove that rejected candidates do not appear in
-current authoritative views while still appearing in audit, activity, or review
+current accepted views while still appearing in audit, activity, or review
 history.

--- a/goals/agentic-professional-runtime/docs/runtime-data-loop.md
+++ b/goals/agentic-professional-runtime/docs/runtime-data-loop.md
@@ -49,8 +49,10 @@ Every agent-produced output remains candidate state in v1:
 - approval gates record the reviewer, requested actions, and evidence context
 - context packets expose bounded work context to SDK clients
 
-Accepted truth is outside the first deterministic fixture. The fixture proves
-that proposed truth is shaped, evidenced, and reviewable before promotion.
+Acceptance decisions are outside the first deterministic fixture. The fixture
+proves that candidate assertions are shaped, evidenced, and reviewable before
+any acceptance decision — and acceptance, when it arrives, records a scoped
+human disposition rather than converting a candidate into truth.
 
 ## Evidence Rules
 

--- a/standards/memory-architecture/01-memory-layer-taxonomy.md
+++ b/standards/memory-architecture/01-memory-layer-taxonomy.md
@@ -52,9 +52,9 @@ This document defines the four memory layers required by the project's agent mem
 
 **What gets it wrong:** Naive Graphiti usage where everything is stored forever and the graph grows without bounds. This is exactly what the user experienced -- degradation at scale.
 
-**Concrete implementation:** Graphiti is acceptable HERE (not for long-term) IF:
+**Concrete implementation:** a Graphiti-style projection store is acceptable HERE (not for long-term) — note Graphiti itself is write-frozen pending decommission after the bitemporal port, so this contract binds its successor store — IF:
 
-1. Graphiti holds only the projection store, never the exact episodic records.
+1. The projection store holds only projections, never the exact episodic records.
 2. Temporal windows are enforced (projection entries older than N days are pruned or compressed; exact records are governed by retention policy, not interference management).
 3. A consolidation pipeline promotes high-signal facts to Layer 1 (durable).
 4. Competitor density is monitored.

--- a/standards/memory-architecture/01-memory-layer-taxonomy.md
+++ b/standards/memory-architecture/01-memory-layer-taxonomy.md
@@ -35,9 +35,16 @@ This document defines the four memory layers required by the project's agent mem
 - Graphiti's bi-temporal model has the right shape: facts with validity windows, auto-invalidation.
 - BUT: must implement interference management -- this layer WILL degrade if left unmanaged.
 
-**Theorem status:** INSIDE for semantic retrieval, but manageable through:
+**Split (2026-07-25, academia corpus dispatch):** this layer is two stores, not one:
 
-- Aggressive temporal pruning (old sessions drop off).
+- **Exact episodic records** -- append-only, immutable session/event records. OUTSIDE the theorem (exact records, no semantic retrieval); pruned only by explicit retention policy, never to manage interference.
+- **Prunable semantic/session projections** -- consolidated, clustered, compressed views derived from those records. INSIDE the theorem; every pruning, windowing, and compression lever below applies to these projections. They stay rebuildable only while their source records are retained; when retention policy removes source records, dependent projections must expire with them rather than persist as memory whose provenance no longer exists.
+
+"Old sessions drop off" means the projections drop off; the exact records that produced them are governed by retention policy alone. Evidence: the memory-bitemporal cluster of `explorations/academia-corpus-mining` ([`research/t3-memory-bitemporal.md`](../../explorations/academia-corpus-mining/research/t3-memory-bitemporal.md)) and the dispatch note in `goals/epistemic-bitemporal-edge-core/research/`.
+
+**Theorem status:** INSIDE for semantic retrieval (the projection store), but manageable through:
+
+- Aggressive temporal pruning (old session projections drop off; the exact episodic records follow retention policy).
 - Competitor density management (don't let the graph grow unbounded).
 - Compression via clustering (the paper's best Pareto point: ~2,500 clusters).
 
@@ -47,10 +54,11 @@ This document defines the four memory layers required by the project's agent mem
 
 **Concrete implementation:** Graphiti is acceptable HERE (not for long-term) IF:
 
-1. Temporal windows are enforced (sessions older than N days are pruned or compressed).
-2. A consolidation pipeline promotes high-signal facts to Layer 1 (durable).
-3. Competitor density is monitored.
-4. The graph is periodically compressed (clustering).
+1. Graphiti holds only the projection store, never the exact episodic records.
+2. Temporal windows are enforced (projection entries older than N days are pruned or compressed; exact records are governed by retention policy, not interference management).
+3. A consolidation pipeline promotes high-signal facts to Layer 1 (durable).
+4. Competitor density is monitored.
+5. The graph is periodically compressed (clustering).
 
 **Consolidation strategy:** Automated with human-in-the-loop for promotion to Layer 1. OpenClaw's six-signal weighted scoring is a good starting model: relevance (0.30), frequency (0.24), query diversity (0.15), recency (0.15), consolidation (0.10), conceptual richness (0.06).
 
@@ -102,7 +110,7 @@ This document defines the four memory layers required by the project's agent mem
 
 **What gets it right:** TrustGraph's multi-store architecture (graph + vector + row + object stores) with provenance tracing. Graphiti's bi-temporal fact tracking with auto-invalidation. FalkorDB's raw performance for graph+vector hybrid queries.
 
-**Concrete implementation:** BeepGraph is **specced, not shipped** -- see [`../../docs/BEEPGRAPH_ARCHITECTURE.md`](../../docs/BEEPGRAPH_ARCHITECTURE.md) (the spine exemplar is *effect-ontology*, not a raw TrustGraph rewrite; TrustGraph contributes the projection **shell**). The **authority spine** is largely built (`@beep/epistemic-domain`, `@beep/semantic-web` PROV-O + bounded SHACL, `@beep/rdf`); the projection/retrieval shell and the extraction kernel are the net-new work. Port what enables verification and trust scoring.
+**Concrete implementation:** BeepGraph is **specced, not shipped** -- see [`../../docs/BEEPGRAPH_ARCHITECTURE.md`](../../docs/BEEPGRAPH_ARCHITECTURE.md) (the spine exemplar is _effect-ontology_, not a raw TrustGraph rewrite; TrustGraph contributes the projection **shell**). The **authority spine** is largely built (`@beep/epistemic-domain`, `@beep/semantic-web` PROV-O + bounded SHACL, `@beep/rdf`); the projection/retrieval shell and the extraction kernel are the net-new work. Port what enables verification and trust scoring.
 
 **Consolidation strategy:** Automated compression with provenance-based verification. Facts without traceable provenance should decay faster. Trust scores should weight consolidation decisions.
 
@@ -125,8 +133,8 @@ This document defines the four memory layers required by the project's agent mem
 |  INSIDE theorem -- managed degradation            |
 +---------------------------------------------------+
 |  Layer 2: Short-Term (Session/Ephemeral)          |
-|  Episodic log with temporal windowing             |
-|  INSIDE theorem -- aggressive consolidation       |
+|  Exact episodic records -- OUTSIDE (retention)    |
+|  Semantic projections -- INSIDE (consolidation)   |
 +---------------------------------------------------+
 
 Promotion flow: Layer 2 --> (consolidation) --> Layer 1 or Layer 4


### PR DESCRIPTION
## docs(epistemic): replace fact-language with typed-verdict vocabulary

Implements the academia-corpus-mining align decisions (2026-07-25) whose
routes target binding prose; adversarially reviewed by codex (initial
BLOCK, 5 findings fixed, re-review SHIP).

- docs/product/prose-to-proof.md: US-3 no longer says approval makes a
  fact; approval = scoped human disposition, one of seven independent
  typed verdicts; authority language scoped to what was asserted,
  evidenced, and decided.
- goals/agentic-professional-runtime: SPEC + approval policy +
  runtime-data-loop drop 'candidate/accepted runtime truth' — acceptance
  records eligibility for scoped runtime use, never truth conversion;
  the seven verdicts are enumerated once, exactly.
- standards/memory-architecture/01-memory-layer-taxonomy.md: Layer 2
  split into exact episodic records (OUTSIDE the theorem,
  retention-governed) vs prunable semantic projections (INSIDE; all
  pruning/compression scoped there); rebuildability conditional on
  retained sources; diagram + Graphiti rules updated; one pre-existing
  MD049 emphasis fixed in passing.
- academia-corpus-mining packet parked (stage align, dispatch
  discharged); ATLAS entry moved Active -> Parked; revival trigger:
  approved wave-2 backlog run (97 legal-NLP papers first).

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_typed-verdict-prose-9d39b24f71c7/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787593690&installation_model_id=424656&pr_number=451&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F451&signature=72d0e67d591d9034a86ee0510bbfa861a78ae6b23451fd252ae3672f2e4c5f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->