### PR TITLE
fix(ui): wait for calendar popover grid in date-picker story

### DIFF
--- a/.changeset/date-picker-story-flake.md
+++ b/.changeset/date-picker-story-flake.md
@@ -1,0 +1,7 @@
+---
+"@beep/ui": patch
+---
+
+Deflake the date-picker Default story: wait for the calendar popover grid to
+become visible after the trigger click instead of asserting immediately —
+the popover-open animation raced the assertion in the Storybook browser lane.

--- a/packages/foundation/ui-system/ui/stories/components/date-picker.stories.tsx
+++ b/packages/foundation/ui-system/ui/stories/components/date-picker.stories.tsx
@@ -62,7 +62,9 @@ export const Default: Story = {
     expect(trigger).toBeVisible();
     return userEvent.click(trigger).then(() => {
       const popover = within(document.body);
-      expect(popover.getByRole("grid")).toBeVisible();
+      return waitFor(() => {
+        expect(popover.getByRole("grid")).toBeVisible();
+      });
     });
   },
 };


### PR DESCRIPTION
## fix(ui): wait for calendar popover grid in date-picker story

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit:amend: passed
- full:pre-push: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_date-picker-story-flake-1d3e543dc11a/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787653918&installation_model_id=424656&pr_number=461&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F461&signature=90ed6773fd2c2e92c37884d682f45071c9a854ecc40358c480cd35dd91839b51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->