### PR TITLE
feat(epistemic): append-only execution ledger tables, port, and adapter

### DIFF
--- a/.changeset/epistemic-execution-ledger.md
+++ b/.changeset/epistemic-execution-ledger.md
@@ -1,0 +1,37 @@
+---
+"@beep/epistemic-tables": patch
+"@beep/epistemic-use-cases": patch
+"@beep/epistemic-server": patch
+"@beep/db-admin": patch
+"@beep/professional-desktop": patch
+---
+
+Add the append-only execution ledger: tables, migration, port, and Drizzle adapter.
+
+Two insert-only tables land — `epistemic_execution_decision` (chained per run by
+`PRIMARY KEY (run_key, seq)`) and `epistemic_execution_outcome` (one outcome per decision
+by `PRIMARY KEY (decision_hash)`, bound to its write-ahead decision by a composite foreign
+key). Both are raw drizzle `pgTable` projections rather than `EntityTable.pgTableFrom`
+over `BaseEntity`, settling the fork the packet recorded: `BaseEntity` bakes in
+`row_version`/`updated_at`/`updated_by_principal`, update vocabulary that would be a lie in
+the schema of rows that must never mutate.
+
+The migration ships the repo's first plpgsql triggers — row-level `BEFORE UPDATE OR
+DELETE` guards plus statement-level `BEFORE TRUNCATE` guards, because a truncated run
+would read back as an empty chain the verifier certifies intact — authored inside the
+statement splitter's narrower rule (no `;` + newline + boundary keyword inside the body)
+and proven through the real `migrate()` path. Bounded CHECKs enforce the nine-member
+denial-reason domain at the table, so free text cannot be smuggled into a no-payload
+ledger even by a writer that bypasses every schema; a second composite foreign key pins
+the settled decision's verdict to `allowed`, so an outcome fabricated for a denied
+decision is unrepresentable rather than merely detectable.
+
+`ExecutionLedger` is the new port in `epistemic/use-cases` (append and read only — no
+update or delete is expressible), with its Drizzle adapter in `epistemic/server` mapping
+constraint rejections to typed errors by name. The derived "decided, outcome unknown"
+predicate is scoped to allowed decisions, so an ordinary denial is never reported as a
+crash. Integration proof: a tampered mid-chain row is detected at its exact index by the
+domain verifier after the owner drops the trigger — tamper-evident, not tamper-proof, as
+documented.
+
+This is PR 3 of goals/agent-execution-authority.

--- a/apps/professional-desktop/docgen.json
+++ b/apps/professional-desktop/docgen.json
@@ -613,6 +613,12 @@
       ],
       "@beep/ontology-config/test": [
         "../../packages/ontology/config/src/test.ts"
+      ],
+      "@beep/epistemic-tables/values": [
+        "../../packages/epistemic/tables/src/values/index.ts"
+      ],
+      "@beep/epistemic-tables/values/ExecutionRecord": [
+        "../../packages/epistemic/tables/src/values/ExecutionRecord/index.ts"
       ]
     }
   }

--- a/apps/professional-desktop/src/runtime/Migrations.gen.ts
+++ b/apps/professional-desktop/src/runtime/Migrations.gen.ts
@@ -541,4 +541,90 @@ CREATE UNIQUE INDEX epistemic_claim_disposition_public_id_unique_idx
   ON epistemic_claim_disposition (public_id);
 `,
   },
+  {
+    name: "20260726210000_epistemic_execution_ledger",
+    sql: `CREATE TABLE epistemic_execution_decision (
+  run_key TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  prev_hash TEXT,
+  hash TEXT NOT NULL,
+  verdict TEXT NOT NULL,
+  reason TEXT,
+  operation_digest TEXT NOT NULL,
+  sink_class TEXT NOT NULL,
+  audience TEXT NOT NULL,
+  destination_digest TEXT NOT NULL,
+  grant_set_digest TEXT NOT NULL,
+  policy_revision TEXT NOT NULL,
+  decided_at BIGINT NOT NULL,
+  CONSTRAINT epistemic_execution_decision_pk PRIMARY KEY (run_key, seq),
+  CONSTRAINT epistemic_execution_decision_hash_unique UNIQUE (hash),
+  CONSTRAINT epistemic_execution_decision_run_hash_unique UNIQUE (run_key, hash),
+  CONSTRAINT epistemic_execution_decision_hash_verdict_unique UNIQUE (hash, verdict),
+  CONSTRAINT epistemic_execution_decision_seq_nonnegative CHECK (seq >= 0),
+  CONSTRAINT epistemic_execution_decision_genesis_prev CHECK ((seq = 0) = (prev_hash IS NULL)),
+  CONSTRAINT epistemic_execution_decision_verdict_bounded CHECK (verdict IN ('allowed', 'denied')),
+  CONSTRAINT epistemic_execution_decision_reason_iff_denied CHECK ((verdict = 'denied') = (reason IS NOT NULL)),
+  CONSTRAINT epistemic_execution_decision_reason_bounded CHECK (
+    reason IS NULL OR reason IN (
+      'no-grant-in-scope',
+      'grant-set-digest-mismatch',
+      'operation-not-granted',
+      'sink-class-not-granted',
+      'audience-not-granted',
+      'destination-not-granted',
+      'grant-expired',
+      'policy-revision-mismatch',
+      'ledger-unavailable'
+    )
+  ),
+  CONSTRAINT epistemic_execution_decision_sink_class_bounded CHECK (sink_class IN ('network-egress', 'mcp-write')),
+  CONSTRAINT epistemic_execution_decision_audience_bounded CHECK (
+    audience IN ('local-workspace', 'external-network')
+  )
+);
+
+CREATE TABLE epistemic_execution_outcome (
+  run_key TEXT NOT NULL,
+  decision_hash TEXT NOT NULL,
+  decision_verdict TEXT NOT NULL DEFAULT 'allowed',
+  settlement TEXT NOT NULL,
+  recorded_at BIGINT NOT NULL,
+  hash TEXT NOT NULL,
+  CONSTRAINT epistemic_execution_outcome_pk PRIMARY KEY (decision_hash),
+  CONSTRAINT epistemic_execution_outcome_decision_fk FOREIGN KEY (run_key, decision_hash)
+    REFERENCES epistemic_execution_decision (run_key, hash),
+  CONSTRAINT epistemic_execution_outcome_decision_verdict_fk FOREIGN KEY (decision_hash, decision_verdict)
+    REFERENCES epistemic_execution_decision (hash, verdict),
+  CONSTRAINT epistemic_execution_outcome_settles_allowed CHECK (decision_verdict = 'allowed'),
+  CONSTRAINT epistemic_execution_outcome_hash_unique UNIQUE (hash),
+  CONSTRAINT epistemic_execution_outcome_settlement_bounded CHECK (
+    settlement IN ('completed', 'failed', 'interrupted')
+  )
+);
+
+CREATE FUNCTION epistemic_execution_ledger_block_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $guard$
+BEGIN
+  RAISE EXCEPTION 'epistemic execution ledger is append-only: % on %', TG_OP, TG_TABLE_NAME;
+END;
+$guard$;
+
+CREATE TRIGGER epistemic_execution_decision_append_only
+  BEFORE UPDATE OR DELETE ON epistemic_execution_decision
+  FOR EACH ROW EXECUTE FUNCTION epistemic_execution_ledger_block_mutation();
+
+CREATE TRIGGER epistemic_execution_outcome_append_only
+  BEFORE UPDATE OR DELETE ON epistemic_execution_outcome
+  FOR EACH ROW EXECUTE FUNCTION epistemic_execution_ledger_block_mutation();
+
+CREATE TRIGGER epistemic_execution_decision_block_truncate
+  BEFORE TRUNCATE ON epistemic_execution_decision
+  FOR EACH STATEMENT EXECUTE FUNCTION epistemic_execution_ledger_block_mutation();
+
+CREATE TRIGGER epistemic_execution_outcome_block_truncate
+  BEFORE TRUNCATE ON epistemic_execution_outcome
+  FOR EACH STATEMENT EXECUTE FUNCTION epistemic_execution_ledger_block_mutation();
+`,
+  },
 ];

--- a/goals/agent-execution-authority/PLAN.md
+++ b/goals/agent-execution-authority/PLAN.md
@@ -4,9 +4,10 @@
 
 Status: `in-progress`
 
-PRs 1 and 2 have landed. PR 1 (#458) shipped the grant and record schemas plus
-the `frozen-grant-set` law; PR 2 shipped `@beep/epistemic-config`, the
-`OntologyMcpConfig` split, and the MCP entrypoint cleanup. PR 3 is next.
+PRs 1–3 have landed. PR 1 (#458) shipped the grant and record schemas plus
+the `frozen-grant-set` law; PR 2 (#463) shipped `@beep/epistemic-config`, the
+`OntologyMcpConfig` split, and the MCP entrypoint cleanup; PR 3 shipped the
+append-only ledger tables, migration, port, and Drizzle adapter. PR 4 is next.
 
 ## Phases
 
@@ -78,18 +79,19 @@ Placement follows `03-driver-boundaries.md:151-153`: port in
 product repository in app code — that is known drift, recorded but not fixed
 here.
 
-**Open fork to settle at PR 3 (noted 2026-07-26):** every table in
-`packages/epistemic` goes through `EntityTable.pgTableFrom(BaseEntity model)` —
-no raw `pgTable` exists in the slice, and the WorkItem raw-table precedent lives
-in architecture-lab, not here. But `BaseEntity` bakes in
-`rowVersion`/`updatedAt`/`updatedByPrincipal`, i.e. update vocabulary the
-insert-only ledger must not have (decision 4 rejected mutable `BaseEntity` rows
-explicitly). Options: (a) raw `pgTable` mapping the PR 1 record schemas —
-foreign to the slice's table idiom but honest about immutability; (b)
-`EntityTable.pgTableFrom` + triggers blocking UPDATE anyway — idiomatic but
-ships three dead mutability columns on a row that must never mutate. Decide
-deliberately at PR 3; the PR 1 record schemas are deliberately plain values so
-either projection works.
+**Fork resolved at PR 3 (2026-07-26): raw `pgTable`.** The SPEC's Persistence
+section was already normative ("Non-`BaseEntity` rows", WorkItem precedent
+named) and decision 4 rejected mutable rows explicitly; option (b) would have
+shipped `row_version`/`updated_at`/`updated_by_principal` as schema lies on rows
+that must never mutate, purely for idiom consistency. A third option surfaced
+during exploration — `EntitySchema.ClassFactory` without `BaseEntity` fed to
+`pgTableFrom`, keeping `.definition` metadata with zero forced columns — and was
+rejected because it has zero product usage anywhere (proven only by a JSDoc
+example), and a one-way door is the wrong place to pioneer machinery. The
+no-payload descriptor walk adapts to drizzle column metadata (exact column set +
+no jsonb/json/bytea + bounded literals), proving the identical property. The PR 1
+record schemas are their own row codecs: encoded form is already the flat wire
+projection, so the converters are `S.encode`/`S.decode` and nothing else.
 
 *Proves:* `.pglite.test.ts`, `{ concurrent: false }` — append N, verify, tamper
 via raw SQL and assert verification fails **at the tampered index**, assert the

--- a/goals/agent-execution-authority/README.md
+++ b/goals/agent-execution-authority/README.md
@@ -37,16 +37,25 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-**P1 Implement.** PRs 1 and 2 have landed. Next concrete action: PR 3 — the
-ledger tables, migration, port, Drizzle adapter, and chain verifier. Settle the
-open fork recorded at `PLAN.md` first: raw `pgTable` versus
-`EntityTable.pgTableFrom`, since `BaseEntity` bakes in `rowVersion`,
-`updatedAt`, and `updatedByPrincipal`, none of which an insert-only ledger may
-carry.
+**P1 Implement.** PRs 1–3 have landed. Next concrete action: PR 4 — add
+`recordOutcome` to `TierGateShape` in `@beep/mcp-kit` (called by
+`dispatchWithTierGate` via `Effect.onExit`, taking a bounded settlement literal,
+never an `Exit`) and `EgressDenied` in `@beep/api-transport`. Mind that docgen
+executes `TierGate.ts`'s `@example` blocks, which construct `TierGateShape`
+values and must gain the new method.
 
 ## Latest Evidence
 
-- **PR 2** (2026-07-26) — `@beep/epistemic-config` owns the destination
+- **PR 3** (2026-07-26) — the append-only ledger: raw-`pgTable` decision/outcome
+  tables (fork resolved against `BaseEntity` — its mutability columns would be
+  schema lies), the repo's first plpgsql triggers authored inside the splitter's
+  boundary-keyword rule and proven through real `migrate()`, the
+  `ExecutionLedger` port and Drizzle adapter with constraint-name error mapping,
+  and the tamper proof: after `DROP TRIGGER` and a raw-SQL mutation of the
+  mid-chain row, `verifyExecutionDecisionChain` reports `chain-broken` at index
+  1 exactly. The derived unknown-outcome predicate is proven blind to ordinary
+  denials.
+- **PR 2** (#463, 2026-07-26) — `@beep/epistemic-config` owns the destination
   allowlist and pinned policy revision; audience is resolved from the
   destination rather than configured. `ONTOLOGY_MCP_MUTATIONS_ENABLED` moved to
   a new `OntologyMcpConfig` service and off the entrypoint's module-top-level

--- a/packages/_internal/db-admin/AGENTS.md
+++ b/packages/_internal/db-admin/AGENTS.md
@@ -11,6 +11,14 @@
   catalog bumps as toolchain changes: rerun `migrations:check` and the desktop
   `codegen:check` immediately. After landing a migration, re-sync the desktop
   bundle: `bun run --cwd apps/professional-desktop codegen`.
+- plpgsql in migration SQL is legal but splitter-constrained: the
+  `LegacyStatementBoundary` splitter is not dollar-quote-aware, so a function
+  body must never contain `;` + newline followed by one of its 12 boundary
+  keywords (ALTER/BEGIN/COMMENT/CREATE/DELETE/DROP/GRANT/INSERT/REVOKE/SET/
+  TRUNCATE/UPDATE/WITH — note `BEGIN` is one). A single-`RAISE` guard body is
+  safe (precedent: `20260726210000_epistemic_execution_ledger`); a body that
+  issues INSERT/UPDATE statements would be split mid-function and fail loudly
+  at migration time. Extend the splitter before writing such a body.
 - Use current `@beep/postgres`, `@beep/drizzle`, and `@beep/test-utils` primitives for live database proof work.
 - Treat older Effect v3 db-admin packages as capability references, not topology templates.
 

--- a/packages/_internal/db-admin/docgen.json
+++ b/packages/_internal/db-admin/docgen.json
@@ -134,6 +134,12 @@
       ],
       "@beep/workspace-tables/entities/Workspace": [
         "../../../packages/workspace/tables/src/entities/Workspace/index.ts"
+      ],
+      "@beep/epistemic-tables/values": [
+        "../../../packages/epistemic/tables/src/values/index.ts"
+      ],
+      "@beep/epistemic-tables/values/ExecutionRecord": [
+        "../../../packages/epistemic/tables/src/values/ExecutionRecord/index.ts"
       ]
     }
   }

--- a/packages/_internal/db-admin/drizzle/20260726210000_epistemic_execution_ledger/migration.sql
+++ b/packages/_internal/db-admin/drizzle/20260726210000_epistemic_execution_ledger/migration.sql
@@ -1,0 +1,82 @@
+CREATE TABLE epistemic_execution_decision (
+  run_key TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  prev_hash TEXT,
+  hash TEXT NOT NULL,
+  verdict TEXT NOT NULL,
+  reason TEXT,
+  operation_digest TEXT NOT NULL,
+  sink_class TEXT NOT NULL,
+  audience TEXT NOT NULL,
+  destination_digest TEXT NOT NULL,
+  grant_set_digest TEXT NOT NULL,
+  policy_revision TEXT NOT NULL,
+  decided_at BIGINT NOT NULL,
+  CONSTRAINT epistemic_execution_decision_pk PRIMARY KEY (run_key, seq),
+  CONSTRAINT epistemic_execution_decision_hash_unique UNIQUE (hash),
+  CONSTRAINT epistemic_execution_decision_run_hash_unique UNIQUE (run_key, hash),
+  CONSTRAINT epistemic_execution_decision_hash_verdict_unique UNIQUE (hash, verdict),
+  CONSTRAINT epistemic_execution_decision_seq_nonnegative CHECK (seq >= 0),
+  CONSTRAINT epistemic_execution_decision_genesis_prev CHECK ((seq = 0) = (prev_hash IS NULL)),
+  CONSTRAINT epistemic_execution_decision_verdict_bounded CHECK (verdict IN ('allowed', 'denied')),
+  CONSTRAINT epistemic_execution_decision_reason_iff_denied CHECK ((verdict = 'denied') = (reason IS NOT NULL)),
+  CONSTRAINT epistemic_execution_decision_reason_bounded CHECK (
+    reason IS NULL OR reason IN (
+      'no-grant-in-scope',
+      'grant-set-digest-mismatch',
+      'operation-not-granted',
+      'sink-class-not-granted',
+      'audience-not-granted',
+      'destination-not-granted',
+      'grant-expired',
+      'policy-revision-mismatch',
+      'ledger-unavailable'
+    )
+  ),
+  CONSTRAINT epistemic_execution_decision_sink_class_bounded CHECK (sink_class IN ('network-egress', 'mcp-write')),
+  CONSTRAINT epistemic_execution_decision_audience_bounded CHECK (
+    audience IN ('local-workspace', 'external-network')
+  )
+);
+
+CREATE TABLE epistemic_execution_outcome (
+  run_key TEXT NOT NULL,
+  decision_hash TEXT NOT NULL,
+  decision_verdict TEXT NOT NULL DEFAULT 'allowed',
+  settlement TEXT NOT NULL,
+  recorded_at BIGINT NOT NULL,
+  hash TEXT NOT NULL,
+  CONSTRAINT epistemic_execution_outcome_pk PRIMARY KEY (decision_hash),
+  CONSTRAINT epistemic_execution_outcome_decision_fk FOREIGN KEY (run_key, decision_hash)
+    REFERENCES epistemic_execution_decision (run_key, hash),
+  CONSTRAINT epistemic_execution_outcome_decision_verdict_fk FOREIGN KEY (decision_hash, decision_verdict)
+    REFERENCES epistemic_execution_decision (hash, verdict),
+  CONSTRAINT epistemic_execution_outcome_settles_allowed CHECK (decision_verdict = 'allowed'),
+  CONSTRAINT epistemic_execution_outcome_hash_unique UNIQUE (hash),
+  CONSTRAINT epistemic_execution_outcome_settlement_bounded CHECK (
+    settlement IN ('completed', 'failed', 'interrupted')
+  )
+);
+
+CREATE FUNCTION epistemic_execution_ledger_block_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $guard$
+BEGIN
+  RAISE EXCEPTION 'epistemic execution ledger is append-only: % on %', TG_OP, TG_TABLE_NAME;
+END;
+$guard$;
+
+CREATE TRIGGER epistemic_execution_decision_append_only
+  BEFORE UPDATE OR DELETE ON epistemic_execution_decision
+  FOR EACH ROW EXECUTE FUNCTION epistemic_execution_ledger_block_mutation();
+
+CREATE TRIGGER epistemic_execution_outcome_append_only
+  BEFORE UPDATE OR DELETE ON epistemic_execution_outcome
+  FOR EACH ROW EXECUTE FUNCTION epistemic_execution_ledger_block_mutation();
+
+CREATE TRIGGER epistemic_execution_decision_block_truncate
+  BEFORE TRUNCATE ON epistemic_execution_decision
+  FOR EACH STATEMENT EXECUTE FUNCTION epistemic_execution_ledger_block_mutation();
+
+CREATE TRIGGER epistemic_execution_outcome_block_truncate
+  BEFORE TRUNCATE ON epistemic_execution_outcome
+  FOR EACH STATEMENT EXECUTE FUNCTION epistemic_execution_ledger_block_mutation();

--- a/packages/_internal/db-admin/src/migrations/EpistemicExecutionLedger.ts
+++ b/packages/_internal/db-admin/src/migrations/EpistemicExecutionLedger.ts
@@ -1,0 +1,44 @@
+/**
+ * Epistemic execution ledger db-admin migration target.
+ *
+ * @packageDocumentation
+ * @category configuration
+ * @since 0.0.0
+ */
+
+import { DbSchema as EpistemicDbSchema } from "@beep/epistemic-tables";
+import {
+  EXECUTION_DECISION_TABLE_NAME,
+  EXECUTION_OUTCOME_TABLE_NAME,
+} from "@beep/epistemic-tables/values/ExecutionRecord";
+import { DbAdminMigrationTarget } from "./ArchitectureLab.ts";
+
+/**
+ * Epistemic execution ledger migration target used to prove the write-ahead
+ * decision chain and post-settlement outcome persistence.
+ *
+ * The append-only invariants these tables rely on — the chain primary key, the
+ * outcome-per-decision primary key, the composite decision foreign key, the
+ * reason-iff-denied CHECK, and the `BEFORE UPDATE`/`BEFORE DELETE` triggers —
+ * are owned by the raw-SQL migration rather than by Drizzle metadata, so this
+ * target publishes the table set while the migration publishes the invariants.
+ *
+ * @example
+ * ```ts
+ * import { EpistemicExecutionLedgerMigrationTarget } from "@beep/db-admin/migrations/EpistemicExecutionLedger"
+ *
+ * console.log(EpistemicExecutionLedgerMigrationTarget.tables)
+ * ```
+ *
+ * @category configuration
+ * @since 0.0.0
+ */
+export const EpistemicExecutionLedgerMigrationTarget: DbAdminMigrationTarget = DbAdminMigrationTarget.make({
+  name: "epistemic-execution-ledger",
+  schemaName: "epistemic",
+  tables: [EXECUTION_DECISION_TABLE_NAME, EXECUTION_OUTCOME_TABLE_NAME],
+  drizzleSchema: {
+    executionDecision: EpistemicDbSchema.executionDecision,
+    executionOutcome: EpistemicDbSchema.executionOutcome,
+  },
+});

--- a/packages/_internal/db-admin/src/targets.ts
+++ b/packages/_internal/db-admin/src/targets.ts
@@ -10,6 +10,7 @@ import { Effect } from "effect";
 import { ArchitectureLabMigrationTarget } from "./migrations/ArchitectureLab.ts";
 import { DocumentsSyncMigrationTarget } from "./migrations/DocumentsSync.ts";
 import { EpistemicEdgeMigrationTarget } from "./migrations/EpistemicEdge.ts";
+import { EpistemicExecutionLedgerMigrationTarget } from "./migrations/EpistemicExecutionLedger.ts";
 import { EpistemicUsageMigrationTarget } from "./migrations/EpistemicUsage.ts";
 import { WorkspaceThreadMigrationTarget } from "./migrations/WorkspaceThread.ts";
 import type { DbAdminMigrationTarget } from "./migrations/ArchitectureLab.ts";
@@ -33,6 +34,12 @@ import type { DbAdminMigrationTarget } from "./migrations/ArchitectureLab.ts";
  * @since 0.0.0
  */
 /**
+ * Epistemic execution ledger migration target export.
+ *
+ * @category configuration
+ * @since 0.0.0
+ */
+/**
  * Epistemic usage migration target export.
  *
  * @category configuration
@@ -48,6 +55,7 @@ export {
   ArchitectureLabMigrationTarget,
   DocumentsSyncMigrationTarget,
   EpistemicEdgeMigrationTarget,
+  EpistemicExecutionLedgerMigrationTarget,
   EpistemicUsageMigrationTarget,
   WorkspaceThreadMigrationTarget,
 };
@@ -60,7 +68,7 @@ export {
  * import { DbAdminMigrationTargets } from "@beep/db-admin/targets"
  *
  * const targetNames = DbAdminMigrationTargets.map((target) => target.name)
- * console.log(targetNames) // ["architecture-lab", "workspace-thread", "epistemic-usage", "documents-sync", "epistemic-edge"]
+ * console.log(targetNames) // ["architecture-lab", "workspace-thread", "epistemic-usage", "documents-sync", "epistemic-edge", "epistemic-execution-ledger"]
  * ```
  *
  * @category configuration
@@ -72,6 +80,7 @@ export const DbAdminMigrationTargets = [
   EpistemicUsageMigrationTarget,
   DocumentsSyncMigrationTarget,
   EpistemicEdgeMigrationTarget,
+  EpistemicExecutionLedgerMigrationTarget,
 ] as const;
 
 /**
@@ -87,7 +96,7 @@ export const DbAdminMigrationTargets = [
  *     Effect.map((targets) => targets.map((target) => target.name))
  *   )
  * )
- * console.log(targetNames) // ["architecture-lab", "workspace-thread", "epistemic-usage", "documents-sync", "epistemic-edge"]
+ * console.log(targetNames) // ["architecture-lab", "workspace-thread", "epistemic-usage", "documents-sync", "epistemic-edge", "epistemic-execution-ledger"]
  * ```
  *
  * @effects

--- a/packages/_internal/db-admin/test/integration/EpistemicExecutionLedgerMigration.pglite.test.ts
+++ b/packages/_internal/db-admin/test/integration/EpistemicExecutionLedgerMigration.pglite.test.ts
@@ -1,0 +1,154 @@
+import { fileURLToPath } from "node:url";
+import { inspect } from "node:util";
+import { DbSchema as EpistemicDbSchema } from "@beep/epistemic-tables";
+import { makeDrizzle, migrate } from "@beep/postgres";
+import { makePgliteIntegrationGate, makePgliteSqlTestLayer, TestDatabaseInfo } from "@beep/test-utils";
+import { A } from "@beep/utils";
+import { describe, expect, layer } from "@effect/vitest";
+import { btree_gist } from "@electric-sql/pglite/contrib/btree_gist";
+import { Effect, Layer, Order, pipe } from "effect";
+import * as O from "effect/Option";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+const { shouldRunPgliteIntegration } = makePgliteIntegrationGate();
+const migrationsFolder = fileURLToPath(new URL("../../drizzle", import.meta.url));
+
+// The drizzle folder contains `CREATE EXTENSION btree_gist` (the epistemic edge
+// migration's gist exclusion constraint), which the shared external
+// pglite-socket lane cannot load. Extension-dependent proofs are pinned to the
+// in-process lane.
+const makeMigrationProofLayer = () =>
+  Layer.fresh(makePgliteSqlTestLayer({ inProcess: { extensions: { btree_gist } }, mode: "in-process" }));
+
+const ledgerTableNames: ReadonlyArray<string> = ["epistemic_execution_decision", "epistemic_execution_outcome"];
+
+// Every name below is load-bearing: the repository maps constraint violations
+// by name, never by message prose, so a silent rename is a silent behavior
+// change.
+const expectedConstraintNames: ReadonlyArray<string> = [
+  "epistemic_execution_decision_audience_bounded",
+  "epistemic_execution_decision_genesis_prev",
+  "epistemic_execution_decision_hash_unique",
+  "epistemic_execution_decision_hash_verdict_unique",
+  "epistemic_execution_decision_pk",
+  "epistemic_execution_decision_reason_bounded",
+  "epistemic_execution_decision_reason_iff_denied",
+  "epistemic_execution_decision_run_hash_unique",
+  "epistemic_execution_decision_seq_nonnegative",
+  "epistemic_execution_decision_sink_class_bounded",
+  "epistemic_execution_decision_verdict_bounded",
+  "epistemic_execution_outcome_decision_fk",
+  "epistemic_execution_outcome_decision_verdict_fk",
+  "epistemic_execution_outcome_hash_unique",
+  "epistemic_execution_outcome_pk",
+  "epistemic_execution_outcome_settlement_bounded",
+  "epistemic_execution_outcome_settles_allowed",
+];
+
+const expectedTriggerNames: ReadonlyArray<string> = [
+  "epistemic_execution_decision_append_only",
+  "epistemic_execution_decision_block_truncate",
+  "epistemic_execution_outcome_append_only",
+  "epistemic_execution_outcome_block_truncate",
+];
+
+const digest = (fill: string): string => fill.repeat(64);
+
+const runKey = digest("a");
+
+const decisionRowFixture = (seq: number, hash: string, prevHash: string | null) => ({
+  audience: "external-network" as const,
+  decidedAt: 1_000 + seq,
+  destinationDigest: digest("d"),
+  grantSetDigest: digest("e"),
+  hash,
+  operationDigest: digest("c"),
+  policyRevision: "1.0.0",
+  prevHash,
+  runKey,
+  seq,
+  sinkClass: "network-egress" as const,
+  verdict: "allowed" as const,
+});
+
+const sortedNames = (names: ReadonlyArray<string>): ReadonlyArray<string> => A.sort(names, Order.String);
+
+if (!shouldRunPgliteIntegration) {
+  describe.skip("db-admin epistemic-execution-ledger migration PgLite integration", () => {});
+} else {
+  describe("db-admin epistemic-execution-ledger migration PgLite integration", { concurrent: false }, () => {
+    layer(makeMigrationProofLayer(), { timeout: "2 minutes" })((it) => {
+      it.effect(
+        "runs the epistemic-execution-ledger migration target SQL",
+        Effect.fnUntraced(function* () {
+          const info = yield* TestDatabaseInfo;
+          const db = yield* makeDrizzle();
+          const migrationsSchema = pipe(
+            info.schema,
+            O.getOrElse(() => "drizzle")
+          );
+
+          yield* migrate(db, { migrationsFolder, migrationsSchema });
+
+          const sql = (yield* SqlClient.SqlClient).withoutTransforms();
+          const constraintRows = yield* sql<{ readonly conname: string; readonly relname: string }>`
+            SELECT constraint_class.conname, table_class.relname
+            FROM pg_constraint AS constraint_class
+            JOIN pg_class AS table_class ON table_class.oid = constraint_class.conrelid
+            WHERE constraint_class.contype IN ('c', 'f', 'p', 'u', 'x')
+          `;
+          const triggerRows = yield* sql<{ readonly tgname: string; readonly relname: string }>`
+            SELECT trigger_class.tgname, table_class.relname
+            FROM pg_trigger AS trigger_class
+            JOIN pg_class AS table_class ON table_class.oid = trigger_class.tgrelid
+            WHERE NOT trigger_class.tgisinternal
+          `;
+
+          const constraintNames = pipe(
+            constraintRows,
+            A.filter((row) => A.contains(ledgerTableNames, row.relname)),
+            A.map((row) => row.conname),
+            sortedNames
+          );
+          const triggerNames = pipe(
+            triggerRows,
+            A.filter((row) => A.contains(ledgerTableNames, row.relname)),
+            A.map((row) => row.tgname),
+            sortedNames
+          );
+
+          expect(constraintNames).toEqual(expectedConstraintNames);
+          expect(triggerNames).toEqual(expectedTriggerNames);
+
+          yield* db.insert(EpistemicDbSchema.executionDecision).values(decisionRowFixture(0, digest("1"), null));
+          yield* db.insert(EpistemicDbSchema.executionDecision).values(decisionRowFixture(1, digest("2"), digest("1")));
+          yield* db.insert(EpistemicDbSchema.executionOutcome).values({
+            decisionHash: digest("1"),
+            hash: digest("f"),
+            recordedAt: 5_000,
+            runKey,
+            settlement: "completed",
+          });
+
+          const decisionRows = yield* db.select().from(EpistemicDbSchema.executionDecision);
+          const outcomeRows = yield* db.select().from(EpistemicDbSchema.executionOutcome);
+
+          expect(decisionRows).toHaveLength(2);
+          expect(outcomeRows).toHaveLength(1);
+          expect(A.map(decisionRows, (row) => row.seq)).toEqual([0, 1]);
+
+          // The adversarial probe stays LAST: implicit-transaction pglite hosts
+          // roll the whole session chain back after an intentional failure, so
+          // no statement may follow it. A direct UPDATE is rejected by the
+          // append-only trigger.
+          const mutation = yield* Effect.flip(sql`
+            UPDATE epistemic_execution_decision SET destination_digest = ${digest("9")} WHERE seq = 0
+          `);
+
+          expect(inspect(mutation, { depth: 10 })).toContain("append-only");
+        }),
+        120_000
+      );
+    });
+  });
+}

--- a/packages/epistemic/server/package.json
+++ b/packages/epistemic/server/package.json
@@ -35,6 +35,7 @@
     "./layer": "./src/Layer.ts",
     "./ClaimDisposition": "./src/ClaimDisposition/index.ts",
     "./EdgeAuthority": "./src/EdgeAuthority/index.ts",
+    "./ExecutionLedger": "./src/ExecutionLedger/index.ts",
     "./internal/*": null,
     "./package.json": "./package.json"
   },

--- a/packages/epistemic/server/src/ExecutionLedger/ExecutionLedger.layer.ts
+++ b/packages/epistemic/server/src/ExecutionLedger/ExecutionLedger.layer.ts
@@ -1,0 +1,36 @@
+/**
+ * Execution ledger repository layers.
+ *
+ * @packageDocumentation
+ * @category layers
+ * @since 0.0.0
+ */
+
+import { ExecutionLedger } from "@beep/epistemic-use-cases/ExecutionLedger";
+import { Layer } from "effect";
+import { makeDrizzleExecutionLedger } from "./ExecutionLedger.repo.ts";
+import type { PostgresDrizzle } from "@beep/postgres";
+
+/**
+ * Drizzle-backed execution ledger repository layer.
+ *
+ * There is no in-memory sibling here, and that is deliberate: the append-only
+ * property this repository sells — the chain primary key, the
+ * outcome-per-decision primary key, the triggers that reject UPDATE and DELETE
+ * — is enforced by the database, so an in-memory stand-in would be proving a
+ * different thing than the one callers depend on.
+ *
+ * @example
+ * ```ts
+ * import { ExecutionLedgerDrizzle } from "@beep/epistemic-server/ExecutionLedger"
+ *
+ * console.log(ExecutionLedgerDrizzle)
+ * ```
+ *
+ * @category layers
+ * @since 0.0.0
+ */
+export const ExecutionLedgerDrizzle: Layer.Layer<ExecutionLedger, never, PostgresDrizzle> = Layer.effect(
+  ExecutionLedger,
+  makeDrizzleExecutionLedger()
+);

--- a/packages/epistemic/server/src/ExecutionLedger/ExecutionLedger.repo.ts
+++ b/packages/epistemic/server/src/ExecutionLedger/ExecutionLedger.repo.ts
@@ -1,0 +1,134 @@
+/**
+ * Execution ledger repository adapter.
+ *
+ * Every method here is an append or a read — the adapter has no vocabulary for
+ * update or delete, and the tables would reject both by trigger if it did. What
+ * the database rejects it rejects by NAME — the chain primary key, the
+ * outcome-per-decision primary key, the composite decision foreign key — and
+ * those names are mapped to typed errors here rather than parsed out of driver
+ * message prose.
+ *
+ * @packageDocumentation
+ * @category repositories
+ * @since 0.0.0
+ */
+
+import { DbSchema } from "@beep/epistemic-tables";
+import {
+  fromExecutionDecisionRow,
+  fromExecutionOutcomeRow,
+  toExecutionDecisionInsert,
+  toExecutionOutcomeInsert,
+} from "@beep/epistemic-tables/values/ExecutionRecord";
+import {
+  ExecutionLedger,
+  ExecutionLedgerConstraintViolation,
+  ExecutionLedgerUnavailable,
+} from "@beep/epistemic-use-cases/ExecutionLedger";
+import { PostgresDrizzle, PostgresError } from "@beep/postgres";
+import { A, O } from "@beep/utils";
+import { and, asc, eq, isNull } from "drizzle-orm";
+import { Effect, pipe } from "effect";
+import type { ExecutionLedgerError, ExecutionLedgerOperation } from "@beep/epistemic-use-cases/ExecutionLedger";
+
+const decisionTable = DbSchema.executionDecision;
+const outcomeTable = DbSchema.executionOutcome;
+
+const DECISION_TABLE_NAME = "epistemic_execution_decision" as const;
+const OUTCOME_TABLE_NAME = "epistemic_execution_outcome" as const;
+
+const constraintNameOf = (operation: ExecutionLedgerOperation, cause: unknown): O.Option<string> =>
+  PostgresError.fromUnknown(operation, cause).constraintName;
+
+const writeFailure =
+  (operation: ExecutionLedgerOperation, tableName: string) =>
+  <A2, E, R>(effect: Effect.Effect<A2, E, R>): Effect.Effect<A2, ExecutionLedgerError, R> =>
+    Effect.mapError(effect, (cause) =>
+      pipe(
+        constraintNameOf(operation, cause),
+        O.match({
+          onNone: () => ExecutionLedgerUnavailable.during(operation, `${operation} failed against ${tableName}`, cause),
+          onSome: (constraintName) => ExecutionLedgerConstraintViolation.on(operation, constraintName),
+        })
+      )
+    );
+
+const readUnavailable =
+  (operation: ExecutionLedgerOperation, tableName: string) =>
+  <A2, E, R>(effect: Effect.Effect<A2, E, R>): Effect.Effect<A2, ExecutionLedgerUnavailable, R> =>
+    effect.pipe(
+      Effect.tapError((cause) =>
+        Effect.logDebug("Epistemic ExecutionLedger repository dropped driver failure").pipe(
+          Effect.annotateLogs({ cause, operation, table: tableName })
+        )
+      ),
+      Effect.mapError((cause) =>
+        ExecutionLedgerUnavailable.during(operation, `${operation} failed against ${tableName}`, cause)
+      )
+    );
+
+/**
+ * Build the Drizzle-backed execution ledger repository.
+ *
+ * @example
+ * ```ts
+ * import { makeDrizzleExecutionLedger } from "@beep/epistemic-server/ExecutionLedger"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(makeDrizzleExecutionLedger()))
+ * ```
+ *
+ * @category repositories
+ * @since 0.0.0
+ */
+export const makeDrizzleExecutionLedger = Effect.fn("Epistemic.ExecutionLedger.makeDrizzle")(function* () {
+  const db = yield* PostgresDrizzle;
+
+  return ExecutionLedger.of({
+    appendDecision: Effect.fn("Epistemic.ExecutionLedger.appendDecision")(function* (record) {
+      yield* db
+        .insert(decisionTable)
+        .values(toExecutionDecisionInsert(record))
+        .pipe(writeFailure("appendDecision", DECISION_TABLE_NAME));
+    }),
+    appendOutcome: Effect.fn("Epistemic.ExecutionLedger.appendOutcome")(function* (record) {
+      yield* db
+        .insert(outcomeTable)
+        .values(toExecutionOutcomeInsert(record))
+        .pipe(writeFailure("appendOutcome", OUTCOME_TABLE_NAME));
+    }),
+    readDecisions: Effect.fn("Epistemic.ExecutionLedger.readDecisions")(function* (runKey) {
+      const rows = yield* db
+        .select()
+        .from(decisionTable)
+        .where(eq(decisionTable.runKey, runKey))
+        .orderBy(asc(decisionTable.seq))
+        .pipe(readUnavailable("readDecisions", DECISION_TABLE_NAME));
+      return A.map(rows, fromExecutionDecisionRow);
+    }),
+    readOutcomes: Effect.fn("Epistemic.ExecutionLedger.readOutcomes")(function* (runKey) {
+      const rows = yield* db
+        .select()
+        .from(outcomeTable)
+        .where(eq(outcomeTable.runKey, runKey))
+        .orderBy(asc(outcomeTable.recordedAt))
+        .pipe(readUnavailable("readOutcomes", OUTCOME_TABLE_NAME));
+      return A.map(rows, fromExecutionOutcomeRow);
+    }),
+    readUnsettledAllowed: Effect.fn("Epistemic.ExecutionLedger.readUnsettledAllowed")(function* (runKey) {
+      // Scoped to allowed decisions on purpose: a refused dispatch legitimately
+      // has no outcome row, and an unscoped LEFT JOIN would report every
+      // ordinary denial as "outcome unknown".
+      const rows = yield* db
+        .select({ decision: decisionTable })
+        .from(decisionTable)
+        .leftJoin(outcomeTable, eq(outcomeTable.decisionHash, decisionTable.hash))
+        .where(
+          and(eq(decisionTable.runKey, runKey), eq(decisionTable.verdict, "allowed"), isNull(outcomeTable.decisionHash))
+        )
+        .orderBy(asc(decisionTable.seq))
+        .pipe(readUnavailable("readUnsettledAllowed", DECISION_TABLE_NAME));
+      return A.map(rows, (row) => fromExecutionDecisionRow(row.decision));
+    }),
+  });
+});

--- a/packages/epistemic/server/src/ExecutionLedger/index.ts
+++ b/packages/epistemic/server/src/ExecutionLedger/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Package entrypoint.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+/**
+ * Execution ledger repository layer exports.
+ *
+ * @category layers
+ * @since 0.0.0
+ */
+export * from "./ExecutionLedger.layer.ts";
+/**
+ * Execution ledger repository adapter exports.
+ *
+ * @category repositories
+ * @since 0.0.0
+ */
+export * from "./ExecutionLedger.repo.ts";

--- a/packages/epistemic/server/src/Layer.ts
+++ b/packages/epistemic/server/src/Layer.ts
@@ -32,7 +32,9 @@ import { ShaclValidationService } from "@beep/semantic-web/services/shacl-valida
 import { Effect, Layer } from "effect";
 import { ClaimDispositionRepositoryDrizzle, ClaimDispositionRepositoryInMemory } from "./ClaimDisposition/index.ts";
 import { EdgeAuthorityRepositoryDrizzle } from "./EdgeAuthority/index.ts";
+import { ExecutionLedgerDrizzle } from "./ExecutionLedger/index.ts";
 import type { EdgeAuthorityRepository } from "@beep/epistemic-use-cases/EdgeAuthority";
+import type { ExecutionLedger } from "@beep/epistemic-use-cases/ExecutionLedger";
 import type { PostgresDrizzle } from "@beep/postgres";
 
 const ClaimGateLayer = Layer.effect(
@@ -77,7 +79,8 @@ export const EpistemicServerLive: Layer.Layer<
 
 /**
  * Drizzle-backed epistemic server layer: the live surface plus the bitemporal
- * edge authority, with dispositions persisted rather than held in memory.
+ * edge authority and the append-only execution ledger, with dispositions
+ * persisted rather than held in memory.
  *
  * @example
  * ```ts
@@ -90,7 +93,12 @@ export const EpistemicServerLive: Layer.Layer<
  * @since 0.0.0
  */
 export const EpistemicServerDrizzleLive: Layer.Layer<
-  ClaimDispositionRepository | ClaimGate | ClaimGateOutcomeResolver | ClaimTransition | EdgeAuthorityRepository,
+  | ClaimDispositionRepository
+  | ClaimGate
+  | ClaimGateOutcomeResolver
+  | ClaimTransition
+  | EdgeAuthorityRepository
+  | ExecutionLedger,
   never,
   PostgresDrizzle
 > = Layer.mergeAll(
@@ -98,6 +106,7 @@ export const EpistemicServerDrizzleLive: Layer.Layer<
   ClaimTransitionLayer,
   ClaimDispositionRepositoryDrizzle,
   EdgeAuthorityRepositoryDrizzle,
+  ExecutionLedgerDrizzle,
   ClaimGateOutcomeResolverLayer.pipe(
     Layer.provide(Layer.merge(ClaimTransitionLayer, ClaimDispositionRepositoryDrizzle))
   )

--- a/packages/epistemic/server/src/index.ts
+++ b/packages/epistemic/server/src/index.ts
@@ -36,6 +36,13 @@ export * from "./ClaimDisposition/index.ts";
  */
 export * from "./EdgeAuthority/index.ts";
 /**
+ * Execution ledger server adapter exports.
+ *
+ * @category repositories
+ * @since 0.0.0
+ */
+export * from "./ExecutionLedger/index.ts";
+/**
  * Epistemic server layer exports.
  *
  * @category layers

--- a/packages/epistemic/server/test/integration/ExecutionLedger.pglite.test.ts
+++ b/packages/epistemic/server/test/integration/ExecutionLedger.pglite.test.ts
@@ -1,0 +1,570 @@
+import { fileURLToPath } from "node:url";
+import { inspect } from "node:util";
+import { PolicyRevision } from "@beep/epistemic-domain/values/ExecutionGrant";
+import {
+  DecisionRecordHash,
+  ExecutionRunKey,
+  GrantOperationDigest,
+  SinkDestinationDigest,
+  sealExecutionDecision,
+  sealExecutionOutcome,
+  verifyExecutionDecisionChain,
+  verifyOutcomeBinding,
+} from "@beep/epistemic-domain/values/ExecutionRecord";
+import { DenialReason } from "@beep/epistemic-domain/values/ExecutionVerdict";
+import { GrantSetDigest } from "@beep/epistemic-domain/values/GrantSet";
+import { EpistemicServerDrizzleLive } from "@beep/epistemic-server/layer";
+import { ExecutionLedger, ExecutionLedgerConstraintViolation } from "@beep/epistemic-use-cases/ExecutionLedger";
+import { makeDrizzle, makeDrizzleLayer, migrate } from "@beep/postgres";
+import { NonNegativeInt } from "@beep/schema";
+import { makePgliteIntegrationGate, makePgliteSqlTestLayer, TestDatabaseInfo } from "@beep/test-utils";
+import { A } from "@beep/utils";
+import { describe, expect, layer } from "@effect/vitest";
+import { btree_gist } from "@electric-sql/pglite/contrib/btree_gist";
+import { DateTime, Effect, Layer, pipe } from "effect";
+import * as O from "effect/Option";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import type {
+  DecisionRecordHash as DecisionRecordHashType,
+  ExecutionDecisionRecord,
+} from "@beep/epistemic-domain/values/ExecutionRecord";
+
+const migrationsFolder = fileURLToPath(new URL("../../../../_internal/db-admin/drizzle", import.meta.url));
+const { shouldRunPgliteIntegration, pgliteIntegrationTimeoutMillis } = makePgliteIntegrationGate();
+
+// The db-admin drizzle folder creates `btree_gist` for the edge exclusion
+// constraint, which the shared external pglite-socket lane cannot load, so this
+// suite is pinned to the in-process driver with the bundled extension.
+const makeMigrationCapableLayer = () =>
+  Layer.fresh(makePgliteSqlTestLayer({ inProcess: { extensions: { btree_gist } }, mode: "in-process" }));
+
+const ExecutionLedgerTestLayer = EpistemicServerDrizzleLive.pipe(
+  Layer.provideMerge(makeDrizzleLayer()),
+  Layer.provideMerge(makeMigrationCapableLayer())
+);
+
+const migrateLedger = Effect.fnUntraced(function* () {
+  const info = yield* TestDatabaseInfo;
+  const db = yield* makeDrizzle();
+  const migrationsSchema = pipe(
+    info.schema,
+    O.getOrElse(() => "drizzle")
+  );
+
+  yield* migrate(db, { migrationsFolder, migrationsSchema });
+});
+
+const revision = PolicyRevision.fromUnknown("1.0.0");
+
+const decisionContent = (input: {
+  readonly runKey: string;
+  readonly seq: number;
+  readonly prevHash: O.Option<DecisionRecordHashType>;
+  readonly verdict?: "allowed" | "denied";
+}) => {
+  const common = {
+    audience: "external-network",
+    decidedAt: DateTime.makeUnsafe(input.seq + 1_000),
+    destinationDigest: SinkDestinationDigest.make("d".repeat(64)),
+    grantSetDigest: GrantSetDigest.make("e".repeat(64)),
+    operationDigest: GrantOperationDigest.make("c".repeat(64)),
+    policyRevision: revision,
+    prevHash: input.prevHash,
+    runKey: ExecutionRunKey.make(input.runKey),
+    seq: NonNegativeInt.make(input.seq),
+    sinkClass: "network-egress",
+  } as const;
+  return input.verdict === "denied"
+    ? ({ ...common, reason: DenialReason.Enum["destination-not-granted"], verdict: "denied" } as const)
+    : ({ ...common, verdict: "allowed" } as const);
+};
+
+// Chains a run of sealed decisions: seq 0 allowed, seq 1 denied, seq 2 allowed.
+const sealedRun = (runKey: string): ReadonlyArray<ExecutionDecisionRecord> => {
+  const first = sealExecutionDecision(decisionContent({ prevHash: O.none(), runKey, seq: 0 }));
+  const second = sealExecutionDecision(
+    decisionContent({ prevHash: O.some(first.hash), runKey, seq: 1, verdict: "denied" })
+  );
+  const third = sealExecutionDecision(decisionContent({ prevHash: O.some(second.hash), runKey, seq: 2 }));
+  return [first, second, third];
+};
+
+const rawSql = Effect.map(Effect.service(SqlClient.SqlClient), (client) => client.withoutTransforms());
+
+if (!shouldRunPgliteIntegration) {
+  describe.skip("Epistemic ExecutionLedger repository PgLite integration", () => {});
+} else {
+  describe("Epistemic ExecutionLedger repository PgLite integration", { concurrent: false }, () => {
+    layer(ExecutionLedgerTestLayer, { timeout: "5 minutes" })((it) => {
+      it.effect(
+        "appends a chained run, reads it back intact, and settles the allowed decisions",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("1".repeat(64));
+          const [first, second, third] = sealedRun(runKey);
+
+          for (const decision of [first, second, third]) {
+            yield* ledger.appendDecision(decision);
+          }
+
+          // A denied decision never settles: dispatch refuses before the effect
+          // runs, so only the two allowed decisions get outcome rows — the
+          // first here, the second later, to exercise the unsettled predicate.
+          const firstOutcome = sealExecutionOutcome({
+            decisionHash: first.hash,
+            recordedAt: DateTime.makeUnsafe(2_000),
+            runKey,
+            settlement: "completed",
+          });
+          yield* ledger.appendOutcome(firstOutcome);
+
+          const decisions = yield* ledger.readDecisions(runKey);
+          expect(decisions).toHaveLength(3);
+          expect(A.map(decisions, (record) => record.seq)).toEqual([0, 1, 2]);
+          expect(verifyExecutionDecisionChain(decisions, runKey).result).toBe("chain-intact");
+
+          const outcomes = yield* ledger.readOutcomes(runKey);
+          expect(outcomes).toHaveLength(1);
+          const settled = yield* pipe(
+            A.head(outcomes),
+            O.match({
+              onNone: () => Effect.die("expected the settled outcome to read back"),
+              onSome: Effect.succeed,
+            })
+          );
+          expect(verifyOutcomeBinding(settled, first)).toBe(true);
+
+          // The unsettled predicate is scoped to allowed decisions: the denied
+          // seq-1 decision has no outcome row and must NOT be reported.
+          const unsettled = yield* ledger.readUnsettledAllowed(runKey);
+          expect(A.map(unsettled, (record) => record.seq)).toEqual([2]);
+
+          const thirdOutcome = sealExecutionOutcome({
+            decisionHash: third.hash,
+            recordedAt: DateTime.makeUnsafe(3_000),
+            runKey,
+            settlement: "failed",
+          });
+          yield* ledger.appendOutcome(thirdOutcome);
+
+          expect(yield* ledger.readUnsettledAllowed(runKey)).toHaveLength(0);
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects a chain collision by the named chain primary key",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("2".repeat(64));
+          const [first] = sealedRun(runKey);
+
+          yield* ledger.appendDecision(first);
+
+          // The rejection probe stays LAST in its effect: a failed statement
+          // aborts the surrounding pglite transaction chain.
+          const violation = yield* Effect.flip(ledger.appendDecision(first));
+
+          expect(ExecutionLedgerConstraintViolation.is(violation)).toBe(true);
+          if (ExecutionLedgerConstraintViolation.is(violation)) {
+            expect(violation.constraintName).toBe("epistemic_execution_decision_pk");
+          }
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects an outcome whose decision was never written, by the composite foreign key",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("3".repeat(64));
+
+          const orphan = sealExecutionOutcome({
+            decisionHash: DecisionRecordHash.make("b".repeat(64)),
+            recordedAt: DateTime.makeUnsafe(2_000),
+            runKey,
+            settlement: "completed",
+          });
+
+          const violation = yield* Effect.flip(ledger.appendOutcome(orphan));
+
+          expect(ExecutionLedgerConstraintViolation.is(violation)).toBe(true);
+          if (ExecutionLedgerConstraintViolation.is(violation)) {
+            expect(violation.constraintName).toBe("epistemic_execution_outcome_decision_fk");
+          }
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects a second outcome for one decision, by the outcome primary key",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("4".repeat(64));
+          const [first] = sealedRun(runKey);
+          yield* ledger.appendDecision(first);
+
+          const outcome = sealExecutionOutcome({
+            decisionHash: first.hash,
+            recordedAt: DateTime.makeUnsafe(2_000),
+            runKey,
+            settlement: "completed",
+          });
+          yield* ledger.appendOutcome(outcome);
+
+          const duplicate = sealExecutionOutcome({
+            decisionHash: first.hash,
+            recordedAt: DateTime.makeUnsafe(3_000),
+            runKey,
+            settlement: "interrupted",
+          });
+          const violation = yield* Effect.flip(ledger.appendOutcome(duplicate));
+
+          expect(ExecutionLedgerConstraintViolation.is(violation)).toBe(true);
+          if (ExecutionLedgerConstraintViolation.is(violation)) {
+            expect(violation.constraintName).toBe("epistemic_execution_outcome_pk");
+          }
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects a free-text denial reason at the table, not just in the schema",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const sql = yield* rawSql;
+          const runKey = "5".repeat(64);
+          const digest = "d".repeat(64);
+
+          // Raw SQL bypasses every domain codec on purpose: the bounded-reason
+          // CHECK is the last line against a compromised writer smuggling
+          // payload text into a no-payload ledger.
+          const violation = yield* Effect.flip(sql`
+            INSERT INTO epistemic_execution_decision (
+              run_key, seq, prev_hash, hash, verdict, reason, operation_digest,
+              sink_class, audience, destination_digest, grant_set_digest,
+              policy_revision, decided_at
+            ) VALUES (
+              ${runKey}, 0, NULL, ${digest}, 'denied', 'exfiltrated: SSN 000-00-0000',
+              ${digest}, 'network-egress', 'external-network', ${digest}, ${digest},
+              '1.0.0', 1000
+            )
+          `);
+
+          expect(inspect(violation, { depth: 10 })).toContain("epistemic_execution_decision_reason_bounded");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects an outcome settling a denied decision, by the verdict foreign key",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("b".repeat(64));
+          const [first, second] = sealedRun(runKey);
+          yield* ledger.appendDecision(first);
+          yield* ledger.appendDecision(second);
+
+          // seq 1 is the DENIED decision: dispatch never ran an effect for it,
+          // so an outcome bound to its hash is a fabrication. The table shape
+          // rejects it — the outcome's constant decision_verdict column can
+          // only reference an (hash, verdict) pair whose verdict is allowed.
+          const fabricated = sealExecutionOutcome({
+            decisionHash: second.hash,
+            recordedAt: DateTime.makeUnsafe(2_000),
+            runKey,
+            settlement: "completed",
+          });
+          const violation = yield* Effect.flip(ledger.appendOutcome(fabricated));
+
+          expect(ExecutionLedgerConstraintViolation.is(violation)).toBe(true);
+          if (ExecutionLedgerConstraintViolation.is(violation)) {
+            expect(violation.constraintName).toBe("epistemic_execution_outcome_decision_verdict_fk");
+          }
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects a direct UPDATE on the outcome table by its append-only trigger",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("c".repeat(64));
+          const [first] = sealedRun(runKey);
+          yield* ledger.appendDecision(first);
+          yield* ledger.appendOutcome(
+            sealExecutionOutcome({
+              decisionHash: first.hash,
+              recordedAt: DateTime.makeUnsafe(2_000),
+              runKey,
+              settlement: "failed",
+            })
+          );
+
+          const sql = yield* rawSql;
+          const mutation = yield* Effect.flip(sql`
+            UPDATE epistemic_execution_outcome SET settlement = 'completed' WHERE run_key = ${runKey}
+          `);
+
+          expect(inspect(mutation, { depth: 10 })).toContain("append-only");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects a direct DELETE on the outcome table by its append-only trigger",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("d".repeat(64));
+          const [first] = sealedRun(runKey);
+          yield* ledger.appendDecision(first);
+          yield* ledger.appendOutcome(
+            sealExecutionOutcome({
+              decisionHash: first.hash,
+              recordedAt: DateTime.makeUnsafe(2_000),
+              runKey,
+              settlement: "completed",
+            })
+          );
+
+          const sql = yield* rawSql;
+          const deletion = yield* Effect.flip(sql`
+            DELETE FROM epistemic_execution_outcome WHERE run_key = ${runKey}
+          `);
+
+          expect(inspect(deletion, { depth: 10 })).toContain("append-only");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects TRUNCATE of the whole ledger by the statement-level triggers",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const sql = yield* rawSql;
+
+          // Row-level triggers never fire on TRUNCATE, and a truncated run
+          // would read back as an EMPTY chain the verifier certifies intact —
+          // the one wipe that would not even be tamper-evident. The
+          // statement-level triggers exist for exactly this hole.
+          const truncation = yield* Effect.flip(sql`
+            TRUNCATE epistemic_execution_decision, epistemic_execution_outcome
+          `);
+
+          expect(inspect(truncation, { depth: 10 })).toContain("append-only");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects a genesis row that claims a predecessor, by the genesis CHECK",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const sql = yield* rawSql;
+          const digest = "d".repeat(64);
+
+          const violation = yield* Effect.flip(sql`
+            INSERT INTO epistemic_execution_decision (
+              run_key, seq, prev_hash, hash, verdict, reason, operation_digest,
+              sink_class, audience, destination_digest, grant_set_digest,
+              policy_revision, decided_at
+            ) VALUES (
+              ${"e".repeat(64)}, 1, NULL, ${digest}, 'allowed', NULL,
+              ${digest}, 'network-egress', 'external-network', ${digest}, ${digest},
+              '1.0.0', 1000
+            )
+          `);
+
+          expect(inspect(violation, { depth: 10 })).toContain("epistemic_execution_decision_genesis_prev");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects an allowed row carrying a reason, by the reason-iff-denied CHECK",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const sql = yield* rawSql;
+          const digest = "d".repeat(64);
+
+          // The reason itself is in the bounded list, so the only constraint
+          // this row can violate is the presence rule — pinning the CHECK body,
+          // not just its name.
+          const violation = yield* Effect.flip(sql`
+            INSERT INTO epistemic_execution_decision (
+              run_key, seq, prev_hash, hash, verdict, reason, operation_digest,
+              sink_class, audience, destination_digest, grant_set_digest,
+              policy_revision, decided_at
+            ) VALUES (
+              ${"f".repeat(64)}, 0, NULL, ${digest}, 'allowed', 'grant-expired',
+              ${digest}, 'network-egress', 'external-network', ${digest}, ${digest},
+              '1.0.0', 1000
+            )
+          `);
+
+          expect(inspect(violation, { depth: 10 })).toContain("epistemic_execution_decision_reason_iff_denied");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects an unbounded settlement literal, by the settlement CHECK",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("0".repeat(64));
+          const [first] = sealedRun(runKey);
+          yield* ledger.appendDecision(first);
+
+          const sql = yield* rawSql;
+          const violation = yield* Effect.flip(sql`
+            INSERT INTO epistemic_execution_outcome (
+              run_key, decision_hash, settlement, recorded_at, hash
+            ) VALUES (
+              ${runKey}, ${first.hash}, 'exfiltrated', 2000, ${"9".repeat(64)}
+            )
+          `);
+
+          expect(inspect(violation, { depth: 10 })).toContain("epistemic_execution_outcome_settlement_bounded");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects a direct UPDATE by the append-only trigger",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("6".repeat(64));
+          const [first] = sealedRun(runKey);
+          yield* ledger.appendDecision(first);
+
+          const sql = yield* rawSql;
+          const mutation = yield* Effect.flip(sql`
+            UPDATE epistemic_execution_decision
+            SET destination_digest = ${"9".repeat(64)}
+            WHERE run_key = ${runKey}
+          `);
+
+          expect(inspect(mutation, { depth: 10 })).toContain("append-only");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "rejects a direct DELETE by the append-only trigger",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("7".repeat(64));
+          const [first] = sealedRun(runKey);
+          yield* ledger.appendDecision(first);
+
+          const sql = yield* rawSql;
+          const deletion = yield* Effect.flip(sql`
+            DELETE FROM epistemic_execution_decision WHERE run_key = ${runKey}
+          `);
+
+          expect(inspect(deletion, { depth: 10 })).toContain("append-only");
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "detects a tampered row at its index once the owner drops the trigger",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("8".repeat(64));
+          const chain = sealedRun(runKey);
+          for (const decision of chain) {
+            yield* ledger.appendDecision(decision);
+          }
+
+          // PGlite connects as table owner and an owner can drop the trigger —
+          // the documented reason this ledger is tamper-EVIDENT, not
+          // tamper-proof. The trigger is defense in depth; the chain verifier
+          // is the primary proof, and this is the test that makes that claim
+          // earn itself: mutate a sealed field mid-chain and the verifier must
+          // name the exact index.
+          const sql = yield* rawSql;
+          yield* sql`DROP TRIGGER epistemic_execution_decision_append_only ON epistemic_execution_decision`;
+          yield* sql`
+            UPDATE epistemic_execution_decision
+            SET destination_digest = ${"9".repeat(64)}
+            WHERE run_key = ${runKey} AND seq = 1
+          `;
+
+          const tampered = yield* ledger.readDecisions(runKey);
+          expect(tampered).toHaveLength(3);
+          const verification = verifyExecutionDecisionChain(tampered, runKey);
+          expect(verification.result).toBe("chain-broken");
+          if (verification.result === "chain-broken") {
+            expect(verification.atIndex).toBe(1);
+          }
+
+          // Restore the trigger so later suites against this database keep the
+          // guard they expect.
+          yield* sql`
+            CREATE TRIGGER epistemic_execution_decision_append_only
+              BEFORE UPDATE OR DELETE ON epistemic_execution_decision
+              FOR EACH ROW EXECUTE FUNCTION epistemic_execution_ledger_block_mutation()
+          `;
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+
+      it.effect(
+        "detects a forged outcome binding once the owner drops the outcome trigger",
+        Effect.fnUntraced(function* () {
+          yield* migrateLedger();
+          const ledger = yield* ExecutionLedger;
+          const runKey = ExecutionRunKey.make("9".repeat(64));
+          const [first] = sealedRun(runKey);
+          yield* ledger.appendDecision(first);
+          const outcome = sealExecutionOutcome({
+            decisionHash: first.hash,
+            recordedAt: DateTime.makeUnsafe(2_000),
+            runKey,
+            settlement: "failed",
+          });
+          yield* ledger.appendOutcome(outcome);
+
+          const sql = yield* rawSql;
+          yield* sql`DROP TRIGGER epistemic_execution_outcome_append_only ON epistemic_execution_outcome`;
+          // Rewrite history: a failed execution becomes a completed one.
+          yield* sql`
+            UPDATE epistemic_execution_outcome
+            SET settlement = 'completed'
+            WHERE run_key = ${runKey}
+          `;
+
+          const outcomes = yield* ledger.readOutcomes(runKey);
+          const forged = yield* pipe(
+            A.head(outcomes),
+            O.match({
+              onNone: () => Effect.die("expected the forged outcome to read back"),
+              onSome: Effect.succeed,
+            })
+          );
+          expect(forged.settlement).toBe("completed");
+          expect(verifyOutcomeBinding(forged, first)).toBe(false);
+
+          yield* sql`
+            CREATE TRIGGER epistemic_execution_outcome_append_only
+              BEFORE UPDATE OR DELETE ON epistemic_execution_outcome
+              FOR EACH ROW EXECUTE FUNCTION epistemic_execution_ledger_block_mutation()
+          `;
+        }),
+        pgliteIntegrationTimeoutMillis
+      );
+    });
+  });
+}

--- a/packages/epistemic/tables/docgen.json
+++ b/packages/epistemic/tables/docgen.json
@@ -122,6 +122,12 @@
       ],
       "@beep/test-utils/*": [
         "../../../packages/tooling/test-kit/test-utils/src/*.ts"
+      ],
+      "@beep/epistemic-tables/values": [
+        "../../../packages/epistemic/tables/src/values/index.ts"
+      ],
+      "@beep/epistemic-tables/values/ExecutionRecord": [
+        "../../../packages/epistemic/tables/src/values/ExecutionRecord/index.ts"
       ]
     }
   }

--- a/packages/epistemic/tables/dtslint/EpistemicTables.tst.ts
+++ b/packages/epistemic/tables/dtslint/EpistemicTables.tst.ts
@@ -11,6 +11,7 @@ import type * as ClaimDispositionTables from "@beep/epistemic-tables/entities/Cl
 import type * as EdgeVersionTables from "@beep/epistemic-tables/entities/EdgeVersion";
 import type * as EvidenceTables from "@beep/epistemic-tables/entities/Evidence";
 import type * as UsageRecordTables from "@beep/epistemic-tables/entities/UsageRecord";
+import type * as ExecutionRecordTables from "@beep/epistemic-tables/values/ExecutionRecord";
 
 describe("EpistemicTables types", () => {
   it("exports the DbSchema type from the package entrypoint", () => {
@@ -19,8 +20,25 @@ describe("EpistemicTables types", () => {
       readonly claimDisposition: typeof ClaimDispositionTables.Table;
       readonly edgeVersion: typeof EdgeVersionTables.Table;
       readonly evidence: typeof EvidenceTables.Table;
+      readonly executionDecision: typeof ExecutionRecordTables.executionDecisionTable;
+      readonly executionOutcome: typeof ExecutionRecordTables.executionOutcomeTable;
       readonly usageRecord: typeof UsageRecordTables.Table;
     }>();
+  });
+
+  it("keeps the execution ledger tables raw and name-pinned", () => {
+    // These tables are deliberately NOT EntityTable projections: an insert-only
+    // ledger carries no BaseEntity mutability columns, so there is no
+    // `.definition` to assert against — the drizzle inference itself is the
+    // contract.
+    expect<typeof ExecutionRecordTables.EXECUTION_DECISION_TABLE_NAME>().type.toBe<"epistemic_execution_decision">();
+    expect<typeof ExecutionRecordTables.EXECUTION_OUTCOME_TABLE_NAME>().type.toBe<"epistemic_execution_outcome">();
+    expect<ExecutionRecordTables.ExecutionDecisionRow["prevHash"]>().type.toBe<string | null>();
+    expect<ExecutionRecordTables.ExecutionDecisionRow["verdict"]>().type.toBe<"allowed" | "denied">();
+    expect<ExecutionRecordTables.ExecutionDecisionRow["seq"]>().type.toBe<number>();
+    expect<ExecutionRecordTables.ExecutionOutcomeRow["settlement"]>().type.toBe<
+      "completed" | "failed" | "interrupted"
+    >();
   });
 
   it("preserves UsageRecord table and descriptor metadata literals", () => {

--- a/packages/epistemic/tables/package.json
+++ b/packages/epistemic/tables/package.json
@@ -40,6 +40,8 @@
     "./entities/EdgeVersion": "./src/entities/EdgeVersion/index.ts",
     "./entities/Evidence": "./src/entities/Evidence/index.ts",
     "./entities/UsageRecord": "./src/entities/UsageRecord/index.ts",
+    "./values": "./src/values/index.ts",
+    "./values/ExecutionRecord": "./src/values/ExecutionRecord/index.ts",
     "./package.json": "./package.json"
   },
   "files": [
@@ -61,6 +63,8 @@
       "./entities/EdgeVersion": "./dist/entities/EdgeVersion/index.js",
       "./entities/Evidence": "./dist/entities/Evidence/index.js",
       "./entities/UsageRecord": "./dist/entities/UsageRecord/index.js",
+      "./values": "./dist/values/index.js",
+      "./values/ExecutionRecord": "./dist/values/ExecutionRecord/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/epistemic/tables/src/Schema.ts
+++ b/packages/epistemic/tables/src/Schema.ts
@@ -6,12 +6,15 @@
  */
 
 import { CandidateClaim, ClaimDisposition, EdgeVersion, Evidence, UsageRecord } from "./entities/index.ts";
+import { ExecutionRecord } from "./values/index.ts";
 
 type DbSchemaShape = {
   readonly candidateClaim: typeof CandidateClaim.Table;
   readonly claimDisposition: typeof ClaimDisposition.Table;
   readonly edgeVersion: typeof EdgeVersion.Table;
   readonly evidence: typeof Evidence.Table;
+  readonly executionDecision: typeof ExecutionRecord.executionDecisionTable;
+  readonly executionOutcome: typeof ExecutionRecord.executionOutcomeTable;
   readonly usageRecord: typeof UsageRecord.Table;
 };
 
@@ -33,6 +36,8 @@ export const DbSchema: DbSchemaShape = {
   claimDisposition: ClaimDisposition.Table,
   edgeVersion: EdgeVersion.Table,
   evidence: Evidence.Table,
+  executionDecision: ExecutionRecord.executionDecisionTable,
+  executionOutcome: ExecutionRecord.executionOutcomeTable,
   usageRecord: UsageRecord.Table,
 };
 

--- a/packages/epistemic/tables/src/index.ts
+++ b/packages/epistemic/tables/src/index.ts
@@ -26,3 +26,17 @@ export * as Entities from "./entities/index.ts";
  * @category tables
  */
 export { DbSchema } from "./Schema.ts";
+/**
+ * Epistemic value-record table metadata namespaces.
+ *
+ * @example
+ * ```ts
+ * import { Values } from "@beep/epistemic-tables"
+ *
+ * console.log(Values.ExecutionRecord.EXECUTION_DECISION_TABLE_NAME)
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export * as Values from "./values/index.ts";

--- a/packages/epistemic/tables/src/values/ExecutionRecord/ExecutionRecord.converters.ts
+++ b/packages/epistemic/tables/src/values/ExecutionRecord/ExecutionRecord.converters.ts
@@ -1,0 +1,180 @@
+/**
+ * Execution ledger row conversions.
+ *
+ * The PR 1 record schemas are their own row codecs: their encoded form is
+ * already the flat wire projection these tables persist — digests as hex
+ * strings, instants as epoch millis, `prevHash` as `null` at genesis — so the
+ * converters are `S.encode`/`S.decode` at the boundary and nothing else. The
+ * only asymmetry is `reason`: the column exists on every decision row (`null`
+ * for allowed), while the domain union carries the field only on the denied
+ * variant, so the null is stripped before decoding. The reason-shape invariant
+ * itself (present iff denied) is owned by the migration's CHECK constraints,
+ * not re-guarded here.
+ *
+ * @packageDocumentation
+ * @category tables
+ * @since 0.0.0
+ */
+
+import { ExecutionDecisionRecord, ExecutionOutcomeRecord } from "@beep/epistemic-domain/values/ExecutionRecord";
+import * as S from "effect/Schema";
+import type { executionDecisionTable, executionOutcomeTable } from "./ExecutionRecord.table.ts";
+
+/**
+ * Row type selected from {@link executionDecisionTable}.
+ *
+ * @example
+ * ```ts
+ * import type { ExecutionDecisionRow } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * const seqOf = (row: ExecutionDecisionRow): number => row.seq
+ * console.log(seqOf.length) // 1
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export type ExecutionDecisionRow = typeof executionDecisionTable.$inferSelect;
+
+/**
+ * Insert row type for {@link executionDecisionTable}.
+ *
+ * @example
+ * ```ts
+ * import type { ExecutionDecisionInsert } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * const hashOf = (insert: ExecutionDecisionInsert): string => insert.hash
+ * console.log(hashOf.length) // 1
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export type ExecutionDecisionInsert = typeof executionDecisionTable.$inferInsert;
+
+/**
+ * Row type selected from {@link executionOutcomeTable}.
+ *
+ * @example
+ * ```ts
+ * import type { ExecutionOutcomeRow } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * const settlementOf = (row: ExecutionOutcomeRow): string => row.settlement
+ * console.log(settlementOf.length) // 1
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export type ExecutionOutcomeRow = typeof executionOutcomeTable.$inferSelect;
+
+/**
+ * Insert row type for {@link executionOutcomeTable}.
+ *
+ * @example
+ * ```ts
+ * import type { ExecutionOutcomeInsert } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * const hashOf = (insert: ExecutionOutcomeInsert): string => insert.hash
+ * console.log(hashOf.length) // 1
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export type ExecutionOutcomeInsert = typeof executionOutcomeTable.$inferInsert;
+
+const encodeExecutionDecision = S.encodeSync(ExecutionDecisionRecord);
+const decodeExecutionDecisionRow = S.decodeUnknownSync(ExecutionDecisionRecord);
+const encodeExecutionOutcome = S.encodeSync(ExecutionOutcomeRecord);
+const decodeExecutionOutcomeRow = S.decodeUnknownSync(ExecutionOutcomeRecord);
+
+/**
+ * Project a sealed decision record onto its insert row.
+ *
+ * @example
+ * ```ts
+ * import { ExecutionDecisionRecord } from "@beep/epistemic-domain/values/ExecutionRecord"
+ * import { toExecutionDecisionInsert } from "@beep/epistemic-tables/values/ExecutionRecord"
+ * import * as S from "effect/Schema"
+ *
+ * const digest = "a".repeat(64)
+ * const record = S.decodeUnknownSync(ExecutionDecisionRecord)({
+ *   audience: "external-network",
+ *   decidedAt: 0,
+ *   destinationDigest: digest,
+ *   grantSetDigest: digest,
+ *   hash: digest,
+ *   operationDigest: digest,
+ *   policyRevision: "1.0.0",
+ *   prevHash: null,
+ *   runKey: digest,
+ *   seq: 0,
+ *   sinkClass: "network-egress",
+ *   verdict: "allowed"
+ * })
+ *
+ * console.log(toExecutionDecisionInsert(record).seq) // 0
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export const toExecutionDecisionInsert = (record: ExecutionDecisionRecord): ExecutionDecisionInsert =>
+  encodeExecutionDecision(record);
+
+/**
+ * Decode a decision row back into the domain record.
+ *
+ * A `null` reason is the column's shape for the allowed variant, not domain
+ * data, so it is stripped before decoding. A non-null reason on an allowed row
+ * is NOT guarded here — union decoding drops the excess key silently — because
+ * the migration's `reason_iff_denied` CHECK makes such a row unrepresentable at
+ * the table; the database owns that invariant, not this converter.
+ *
+ * @example
+ * ```ts
+ * import { fromExecutionDecisionRow } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * console.log(typeof fromExecutionDecisionRow) // "function"
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export const fromExecutionDecisionRow = (row: ExecutionDecisionRow): ExecutionDecisionRecord => {
+  const { reason, ...allowedShape } = row;
+  return decodeExecutionDecisionRow(reason === null ? allowedShape : row);
+};
+
+/**
+ * Project a sealed outcome record onto its insert row.
+ *
+ * @example
+ * ```ts
+ * import { toExecutionOutcomeInsert } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * console.log(typeof toExecutionOutcomeInsert) // "function"
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export const toExecutionOutcomeInsert = (record: ExecutionOutcomeRecord): ExecutionOutcomeInsert =>
+  encodeExecutionOutcome(record);
+
+/**
+ * Decode an outcome row back into the domain record.
+ *
+ * @example
+ * ```ts
+ * import { fromExecutionOutcomeRow } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * console.log(typeof fromExecutionOutcomeRow) // "function"
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export const fromExecutionOutcomeRow = (row: ExecutionOutcomeRow): ExecutionOutcomeRecord =>
+  decodeExecutionOutcomeRow(row);

--- a/packages/epistemic/tables/src/values/ExecutionRecord/ExecutionRecord.table.ts
+++ b/packages/epistemic/tables/src/values/ExecutionRecord/ExecutionRecord.table.ts
@@ -1,0 +1,127 @@
+/**
+ * Execution ledger table metadata: the write-ahead decision chain and the
+ * post-settlement outcome records.
+ *
+ * These are deliberately raw `pgTable` projections, not `EntityTable.pgTableFrom`
+ * over a `BaseEntity` model: `BaseEntity` bakes in `row_version`, `updated_at`,
+ * and `updated_by_principal` — update vocabulary that would be a lie in the
+ * schema of rows that must never mutate. The append-only guards that make the
+ * ledger trustworthy — the chain primary key, the outcome-per-decision primary
+ * key, the reason-iff-denied CHECK, and the `BEFORE UPDATE`/`BEFORE DELETE`
+ * triggers — are owned by the raw-SQL migration rather than by Drizzle
+ * metadata, because Drizzle cannot express them. This projection publishes the
+ * columns; the migration publishes the invariants.
+ *
+ * There is deliberately no column here capable of carrying a payload: every
+ * text column is a digest, a bounded literal, or a pinned semver, and the
+ * absence of `jsonb` is asserted by test, not comment.
+ *
+ * @packageDocumentation
+ * @category tables
+ * @since 0.0.0
+ */
+
+import { bigint, integer, pgTable, text } from "drizzle-orm/pg-core";
+import type { SinkAudience, SinkClass } from "@beep/epistemic-domain/values/ExecutionGrant";
+import type { ExecutionSettlement } from "@beep/epistemic-domain/values/ExecutionRecord";
+import type { DenialReason } from "@beep/epistemic-domain/values/ExecutionVerdict";
+
+/**
+ * Physical Postgres table name for write-ahead execution decisions.
+ *
+ * @example
+ * ```ts
+ * import { EXECUTION_DECISION_TABLE_NAME } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * console.log(EXECUTION_DECISION_TABLE_NAME) // "epistemic_execution_decision"
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export const EXECUTION_DECISION_TABLE_NAME = "epistemic_execution_decision" as const;
+
+/**
+ * Physical Postgres table name for post-settlement execution outcomes.
+ *
+ * @example
+ * ```ts
+ * import { EXECUTION_OUTCOME_TABLE_NAME } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * console.log(EXECUTION_OUTCOME_TABLE_NAME) // "epistemic_execution_outcome"
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export const EXECUTION_OUTCOME_TABLE_NAME = "epistemic_execution_outcome" as const;
+
+/**
+ * Drizzle projection of the write-ahead execution decision chain.
+ *
+ * The natural key is `(run_key, seq)` — there is no surrogate id, because a
+ * surrogate would add nothing the chain does not already pin. `prev_hash` is
+ * null only at `seq` zero; the migration's `genesis_prev` CHECK makes that
+ * shape unrepresentable otherwise.
+ *
+ * @example
+ * ```ts
+ * import { getTableName } from "drizzle-orm"
+ * import { executionDecisionTable } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * console.log(getTableName(executionDecisionTable)) // "epistemic_execution_decision"
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export const executionDecisionTable = pgTable(EXECUTION_DECISION_TABLE_NAME, {
+  runKey: text("run_key").notNull(),
+  seq: integer("seq").notNull(),
+  prevHash: text("prev_hash"),
+  hash: text("hash").notNull(),
+  verdict: text("verdict").notNull().$type<"allowed" | "denied">(),
+  reason: text("reason").$type<DenialReason>(),
+  operationDigest: text("operation_digest").notNull(),
+  sinkClass: text("sink_class").notNull().$type<SinkClass>(),
+  audience: text("audience").notNull().$type<SinkAudience>(),
+  destinationDigest: text("destination_digest").notNull(),
+  grantSetDigest: text("grant_set_digest").notNull(),
+  policyRevision: text("policy_revision").notNull(),
+  decidedAt: bigint("decided_at", { mode: "number" }).notNull(),
+});
+
+/**
+ * Drizzle projection of the post-settlement execution outcome records.
+ *
+ * `decision_hash` is the primary key, so one outcome per decision is a table
+ * shape rather than a convention, and the composite foreign key to
+ * `(run_key, hash)` makes an outcome without its write-ahead decision
+ * unrepresentable.
+ *
+ * The physical table carries one column this projection deliberately omits:
+ * `decision_verdict`, defaulted to `'allowed'`, CHECK-pinned to that literal,
+ * and bound by a second composite foreign key to the decision's
+ * `(hash, verdict)` — which makes an outcome settling a DENIED decision
+ * unrepresentable too. The column never varies, never carries data, and is
+ * filled by the database default, so it stays out of the TypeScript surface on
+ * purpose.
+ *
+ * @example
+ * ```ts
+ * import { getTableName } from "drizzle-orm"
+ * import { executionOutcomeTable } from "@beep/epistemic-tables/values/ExecutionRecord"
+ *
+ * console.log(getTableName(executionOutcomeTable)) // "epistemic_execution_outcome"
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export const executionOutcomeTable = pgTable(EXECUTION_OUTCOME_TABLE_NAME, {
+  runKey: text("run_key").notNull(),
+  decisionHash: text("decision_hash").notNull().primaryKey(),
+  settlement: text("settlement").notNull().$type<ExecutionSettlement>(),
+  recordedAt: bigint("recorded_at", { mode: "number" }).notNull(),
+  hash: text("hash").notNull(),
+});

--- a/packages/epistemic/tables/src/values/ExecutionRecord/index.ts
+++ b/packages/epistemic/tables/src/values/ExecutionRecord/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Execution ledger table exports.
+ *
+ * @packageDocumentation
+ * @category tables
+ * @since 0.0.0
+ */
+
+/**
+ * Execution ledger row conversion exports.
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export * from "./ExecutionRecord.converters.ts";
+/**
+ * Execution ledger table metadata exports.
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export * from "./ExecutionRecord.table.ts";

--- a/packages/epistemic/tables/src/values/index.ts
+++ b/packages/epistemic/tables/src/values/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Epistemic value-record table namespaces.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+/**
+ * Execution ledger table metadata namespace.
+ *
+ * @example
+ * ```ts
+ * import { ExecutionRecord } from "@beep/epistemic-tables/values"
+ *
+ * console.log(ExecutionRecord.EXECUTION_DECISION_TABLE_NAME)
+ * ```
+ *
+ * @category tables
+ * @since 0.0.0
+ */
+export * as ExecutionRecord from "./ExecutionRecord/index.ts";

--- a/packages/epistemic/tables/test/ExecutionRecordTables.test.ts
+++ b/packages/epistemic/tables/test/ExecutionRecordTables.test.ts
@@ -1,0 +1,182 @@
+import {
+  ExecutionDecisionRecord,
+  ExecutionOutcomeRecord,
+  sealExecutionDecision,
+  sealExecutionOutcome,
+} from "@beep/epistemic-domain/values/ExecutionRecord";
+import {
+  EXECUTION_DECISION_TABLE_NAME,
+  EXECUTION_OUTCOME_TABLE_NAME,
+  executionDecisionTable,
+  executionOutcomeTable,
+  fromExecutionDecisionRow,
+  fromExecutionOutcomeRow,
+  toExecutionDecisionInsert,
+  toExecutionOutcomeInsert,
+} from "@beep/epistemic-tables/values/ExecutionRecord";
+import { describe, expect, it } from "@effect/vitest";
+import { getColumns, getTableName } from "drizzle-orm";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Order from "effect/Order";
+import * as R from "effect/Record";
+import * as S from "effect/Schema";
+import type { ExecutionDecisionInsert, ExecutionDecisionRow } from "@beep/epistemic-tables/values/ExecutionRecord";
+import type { Table } from "drizzle-orm";
+
+const digest = (fill: string): string => fill.repeat(64);
+
+// A selected row always carries every column; the insert projection leaves the
+// nullable ones optional, so the row shape fills them with the null the
+// database would return.
+const asSelectedRow = (insert: ExecutionDecisionInsert): ExecutionDecisionRow => ({
+  ...insert,
+  prevHash: insert.prevHash ?? null,
+  reason: insert.reason ?? null,
+});
+
+const decodeDecision = S.decodeUnknownSync(ExecutionDecisionRecord);
+const decodeOutcome = S.decodeUnknownSync(ExecutionOutcomeRecord);
+const decisionEquivalence = S.toEquivalence(ExecutionDecisionRecord);
+const outcomeEquivalence = S.toEquivalence(ExecutionOutcomeRecord);
+
+const allowedDecision = decodeDecision({
+  audience: "external-network",
+  decidedAt: 1_000,
+  destinationDigest: digest("d"),
+  grantSetDigest: digest("e"),
+  hash: digest("1"),
+  operationDigest: digest("c"),
+  policyRevision: "1.0.0",
+  prevHash: null,
+  runKey: digest("a"),
+  seq: 0,
+  sinkClass: "network-egress",
+  verdict: "allowed",
+});
+
+const deniedDecision = decodeDecision({
+  audience: "external-network",
+  decidedAt: 2_000,
+  destinationDigest: digest("d"),
+  grantSetDigest: digest("e"),
+  hash: digest("2"),
+  operationDigest: digest("c"),
+  policyRevision: "1.0.0",
+  prevHash: digest("1"),
+  reason: "destination-not-granted",
+  runKey: digest("a"),
+  seq: 1,
+  sinkClass: "network-egress",
+  verdict: "denied",
+});
+
+const outcome = decodeOutcome({
+  decisionHash: digest("1"),
+  hash: digest("f"),
+  recordedAt: 3_000,
+  runKey: digest("a"),
+  settlement: "completed",
+});
+
+// The payload-capable drizzle column types this ledger must never grow. The
+// UsageRecord table's `metadata: jsonb` is the precedent escape hatch these
+// tables exist to not have.
+const payloadCapableColumnTypes: ReadonlyArray<string> = ["PgJsonb", "PgJson", "PgBytea"];
+
+const columnFacts = (table: Table): Readonly<Record<string, { readonly columnType: string; readonly name: string }>> =>
+  R.map(getColumns(table), (column) => ({
+    columnType: column.columnType,
+    name: column.name,
+  }));
+
+describe("ExecutionRecordTables", () => {
+  it("pins the physical table names", () => {
+    expect(getTableName(executionDecisionTable)).toBe(EXECUTION_DECISION_TABLE_NAME);
+    expect(getTableName(executionOutcomeTable)).toBe(EXECUTION_OUTCOME_TABLE_NAME);
+  });
+
+  it("exposes exactly the decision columns and no payload-capable column", () => {
+    const facts = columnFacts(executionDecisionTable);
+
+    // Exact column set: a payload column cannot be added unnoticed.
+    expect(A.sort(R.keys(facts), Order.String)).toEqual([
+      "audience",
+      "decidedAt",
+      "destinationDigest",
+      "grantSetDigest",
+      "hash",
+      "operationDigest",
+      "policyRevision",
+      "prevHash",
+      "reason",
+      "runKey",
+      "seq",
+      "sinkClass",
+      "verdict",
+    ]);
+
+    for (const fact of R.values(facts)) {
+      expect(payloadCapableColumnTypes).not.toContain(fact.columnType);
+    }
+  });
+
+  it("exposes exactly the outcome columns and no payload-capable column", () => {
+    const facts = columnFacts(executionOutcomeTable);
+
+    expect(A.sort(R.keys(facts), Order.String)).toEqual(["decisionHash", "hash", "recordedAt", "runKey", "settlement"]);
+
+    for (const fact of R.values(facts)) {
+      expect(payloadCapableColumnTypes).not.toContain(fact.columnType);
+    }
+  });
+
+  it("round-trips an allowed decision through insert and select rows", () => {
+    const insert = toExecutionDecisionInsert(allowedDecision);
+
+    expect(decisionEquivalence(fromExecutionDecisionRow(asSelectedRow(insert)), allowedDecision)).toBe(true);
+  });
+
+  it("round-trips a denied decision with its bounded reason", () => {
+    const insert = toExecutionDecisionInsert(deniedDecision);
+
+    expect(insert.reason).toBe("destination-not-granted");
+    expect(decisionEquivalence(fromExecutionDecisionRow(asSelectedRow(insert)), deniedDecision)).toBe(true);
+  });
+
+  it("round-trips an outcome record", () => {
+    const insert = toExecutionOutcomeInsert(outcome);
+
+    expect(outcomeEquivalence(fromExecutionOutcomeRow({ ...insert }), outcome)).toBe(true);
+  });
+
+  it("keeps sealed records and their row projections in agreement", () => {
+    const sealed = sealExecutionDecision({
+      audience: allowedDecision.audience,
+      decidedAt: allowedDecision.decidedAt,
+      destinationDigest: allowedDecision.destinationDigest,
+      grantSetDigest: allowedDecision.grantSetDigest,
+      operationDigest: allowedDecision.operationDigest,
+      policyRevision: allowedDecision.policyRevision,
+      prevHash: O.none(),
+      runKey: allowedDecision.runKey,
+      seq: allowedDecision.seq,
+      sinkClass: allowedDecision.sinkClass,
+      verdict: "allowed",
+    });
+    const rebuilt = fromExecutionDecisionRow(asSelectedRow(toExecutionDecisionInsert(sealed)));
+
+    expect(decisionEquivalence(rebuilt, sealed)).toBe(true);
+
+    const sealedOutcome = sealExecutionOutcome({
+      decisionHash: sealed.hash,
+      recordedAt: outcome.recordedAt,
+      runKey: sealed.runKey,
+      settlement: "completed",
+    });
+
+    expect(outcomeEquivalence(fromExecutionOutcomeRow(toExecutionOutcomeInsert(sealedOutcome)), sealedOutcome)).toBe(
+      true
+    );
+  });
+});

--- a/packages/epistemic/use-cases/package.json
+++ b/packages/epistemic/use-cases/package.json
@@ -38,6 +38,7 @@
     "./ClaimLifecycle": "./src/ClaimLifecycle/index.ts",
     "./ClaimProjection": "./src/ClaimProjection/index.ts",
     "./EdgeAuthority": "./src/EdgeAuthority/index.ts",
+    "./ExecutionLedger": "./src/ExecutionLedger/index.ts",
     "./internal/*": null,
     "./package.json": "./package.json"
   },

--- a/packages/epistemic/use-cases/src/ExecutionLedger/ExecutionLedger.errors.ts
+++ b/packages/epistemic/use-cases/src/ExecutionLedger/ExecutionLedger.errors.ts
@@ -1,0 +1,217 @@
+/**
+ * Execution ledger port errors.
+ *
+ * The ledger is fail-closed by consumption, not by shape: `appendDecision`
+ * failing with any of these is what the governed gate turns into a refusal, so
+ * the error vocabulary stays small and total — a constraint the database
+ * rejected by name, or an unavailable repository. No error here carries request
+ * payload, for the same reason the ledger rows carry none.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $EpistemicUseCasesId } from "@beep/identity/packages";
+import { LiteralKit, SchemaUtils, TaggedErrorClass } from "@beep/schema";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+
+const $I = $EpistemicUseCasesId.create("ExecutionLedger/ExecutionLedger.errors");
+
+/**
+ * Operations the execution ledger port exposes.
+ *
+ * @example
+ * ```ts
+ * import { ExecutionLedgerOperation } from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * console.log(ExecutionLedgerOperation.Enum.appendDecision)
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ExecutionLedgerOperation = LiteralKit([
+  "appendDecision",
+  "appendOutcome",
+  "readDecisions",
+  "readOutcomes",
+  "readUnsettledAllowed",
+]).pipe(
+  $I.annoteSchema("ExecutionLedgerOperation", {
+    description: "Closed domain of execution ledger port operations.",
+  })
+);
+
+/**
+ * Runtime type for {@link ExecutionLedgerOperation}.
+ *
+ * @example
+ * ```ts
+ * import type { ExecutionLedgerOperation } from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * const operation: ExecutionLedgerOperation = "appendDecision"
+ * console.log(operation)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ExecutionLedgerOperation = typeof ExecutionLedgerOperation.Type;
+
+const optionalDefect = (description: string) =>
+  S.OptionFromOptionalKey(S.Defect({ includeStack: true }))
+    .pipe(SchemaUtils.withNoneDefault)
+    .annotateKey({
+      description,
+    });
+
+/**
+ * A ledger write the database rejected by constraint name.
+ *
+ * The append-only tables reject chain collisions, fabricated outcomes, and
+ * shape violations by NAME — never by message prose — so the adapter maps the
+ * name straight into this error and the caller branches on nothing weaker.
+ *
+ * @example
+ * ```ts
+ * import { ExecutionLedgerConstraintViolation } from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * const error = ExecutionLedgerConstraintViolation.on("appendDecision", "epistemic_execution_decision_pk")
+ * console.log(error.constraintName)
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class ExecutionLedgerConstraintViolation extends TaggedErrorClass<ExecutionLedgerConstraintViolation>(
+  $I`ExecutionLedgerConstraintViolation`
+)(
+  "ExecutionLedgerConstraintViolation",
+  {
+    constraintName: S.NonEmptyString.annotateKey({
+      description: "Name of the database constraint that rejected the write.",
+    }),
+    operation: ExecutionLedgerOperation.annotateKey({
+      description: "Ledger operation the constraint rejected.",
+    }),
+  },
+  $I.annote("ExecutionLedgerConstraintViolation", {
+    title: "Execution ledger constraint violation",
+    description: "A ledger write was rejected by a named append-only constraint.",
+  })
+) {
+  static readonly is = S.is(ExecutionLedgerConstraintViolation);
+
+  /**
+   * Build the violation for a named constraint rejection.
+   *
+   * @example
+   * ```ts
+   * import { ExecutionLedgerConstraintViolation } from "@beep/epistemic-use-cases/ExecutionLedger"
+   *
+   * console.log(ExecutionLedgerConstraintViolation.on("appendOutcome", "epistemic_execution_outcome_pk")._tag)
+   * ```
+   *
+   * @category constructors
+   * @since 0.0.0
+   */
+  static on(operation: ExecutionLedgerOperation, constraintName: string): ExecutionLedgerConstraintViolation {
+    return ExecutionLedgerConstraintViolation.make({
+      constraintName,
+      operation,
+    });
+  }
+}
+
+/**
+ * The execution ledger could not serve a request.
+ *
+ * @example
+ * ```ts
+ * import { ExecutionLedgerUnavailable } from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * const error = ExecutionLedgerUnavailable.during("readDecisions", "read failed against epistemic_execution_decision")
+ * console.log(error.operation)
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class ExecutionLedgerUnavailable extends TaggedErrorClass<ExecutionLedgerUnavailable>(
+  $I`ExecutionLedgerUnavailable`
+)(
+  "ExecutionLedgerUnavailable",
+  {
+    cause: optionalDefect("Optional underlying driver defect captured when the ledger could not serve a request."),
+    operation: ExecutionLedgerOperation.annotateKey({
+      description: "Ledger operation that could not be served.",
+    }),
+    reason: S.NonEmptyString.annotateKey({
+      description: "Non-empty ledger availability diagnostic.",
+    }),
+  },
+  $I.annote("ExecutionLedgerUnavailable", {
+    title: "Execution ledger unavailable",
+    description: "The execution ledger could not serve the request.",
+  })
+) {
+  static readonly is = S.is(ExecutionLedgerUnavailable);
+
+  /**
+   * Build the availability failure for an operation.
+   *
+   * @example
+   * ```ts
+   * import { ExecutionLedgerUnavailable } from "@beep/epistemic-use-cases/ExecutionLedger"
+   *
+   * console.log(ExecutionLedgerUnavailable.during("appendDecision", "write failed")._tag)
+   * ```
+   *
+   * @category constructors
+   * @since 0.0.0
+   */
+  static during(operation: ExecutionLedgerOperation, reason: string, cause?: unknown): ExecutionLedgerUnavailable {
+    return ExecutionLedgerUnavailable.make({
+      cause: O.fromUndefinedOr(cause),
+      operation,
+      reason,
+    });
+  }
+}
+
+/**
+ * Union of execution ledger write failures.
+ *
+ * @example
+ * ```ts
+ * import { ExecutionLedgerError, ExecutionLedgerUnavailable } from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * console.log(ExecutionLedgerError.is(ExecutionLedgerUnavailable.during("appendDecision", "write failed")))
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export const ExecutionLedgerError = S.Union([ExecutionLedgerConstraintViolation, ExecutionLedgerUnavailable]).pipe(
+  $I.annoteSchema("ExecutionLedgerError", {
+    description: "Every failure an execution ledger write can produce.",
+  }),
+  SchemaUtils.withCodecStatics
+);
+
+/**
+ * Runtime type for {@link ExecutionLedgerError}.
+ *
+ * @example
+ * ```ts
+ * import type { ExecutionLedgerError } from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * const describe = (error: ExecutionLedgerError): string => error._tag
+ * console.log(describe.length) // 1
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ExecutionLedgerError = typeof ExecutionLedgerError.Type;

--- a/packages/epistemic/use-cases/src/ExecutionLedger/ExecutionLedger.ports.ts
+++ b/packages/epistemic/use-cases/src/ExecutionLedger/ExecutionLedger.ports.ts
@@ -1,0 +1,108 @@
+/**
+ * Execution ledger port: the typed contract through which write-ahead decisions
+ * and post-settlement outcomes are appended and read back. The live Drizzle
+ * implementation is provided in the epistemic server tier.
+ *
+ * The surface is deliberately append-and-read only: there is no update, no
+ * delete, and no way to express either, because the tables reject both by
+ * trigger and the mutable operation would be exactly what an attacker wants.
+ * Chain verification is not on the port — `verifyExecutionDecisionChain` in
+ * `epistemic/domain` recomputes every seal from the rows a reader fetched, so a
+ * lying adapter cannot vouch for its own chain.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $EpistemicUseCasesId } from "@beep/identity/packages";
+import { Context } from "effect";
+import type {
+  ExecutionDecisionRecord,
+  ExecutionOutcomeRecord,
+  ExecutionRunKey,
+} from "@beep/epistemic-domain/values/ExecutionRecord";
+import type { Effect } from "effect";
+import type { ExecutionLedgerError, ExecutionLedgerUnavailable } from "./ExecutionLedger.errors.ts";
+
+const $I = $EpistemicUseCasesId.create("ExecutionLedger/ExecutionLedger.ports");
+
+/**
+ * Service shape for the execution ledger.
+ *
+ * `appendDecision` is the write-ahead half: the governed gate calls it before
+ * the effect runs and converts any failure into a refusal. `appendOutcome`
+ * settles an allowed decision after the effect ran; its failure cannot fail the
+ * dispatch, because the effect has already happened. `readDecisions` returns a
+ * run's chain in dense `seq` order so the domain verifier can be applied
+ * directly. `readUnsettledAllowed` is the derived "decided, outcome unknown"
+ * predicate, scoped to allowed decisions — a refused dispatch legitimately has
+ * no outcome row and must never be reported as unknown.
+ *
+ * @example
+ * ```ts
+ * import { strictEqual } from "node:assert"
+ * import { Effect } from "effect"
+ * import type { ExecutionLedgerShape } from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * const shape: ExecutionLedgerShape = {
+ *   appendDecision: () => Effect.void,
+ *   appendOutcome: () => Effect.void,
+ *   readDecisions: () => Effect.succeed([]),
+ *   readOutcomes: () => Effect.succeed([]),
+ *   readUnsettledAllowed: () => Effect.succeed([])
+ * }
+ *
+ * strictEqual(typeof shape.appendDecision, "function")
+ * ```
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export interface ExecutionLedgerShape {
+  readonly appendDecision: (record: ExecutionDecisionRecord) => Effect.Effect<void, ExecutionLedgerError>;
+  readonly appendOutcome: (record: ExecutionOutcomeRecord) => Effect.Effect<void, ExecutionLedgerError>;
+  readonly readDecisions: (
+    runKey: ExecutionRunKey
+  ) => Effect.Effect<ReadonlyArray<ExecutionDecisionRecord>, ExecutionLedgerUnavailable>;
+  readonly readOutcomes: (
+    runKey: ExecutionRunKey
+  ) => Effect.Effect<ReadonlyArray<ExecutionOutcomeRecord>, ExecutionLedgerUnavailable>;
+  readonly readUnsettledAllowed: (
+    runKey: ExecutionRunKey
+  ) => Effect.Effect<ReadonlyArray<ExecutionDecisionRecord>, ExecutionLedgerUnavailable>;
+}
+
+/**
+ * Execution ledger service tag.
+ *
+ * @example
+ * ```ts
+ * import { strictEqual } from "node:assert"
+ * import { Effect } from "effect"
+ * import { ExecutionLedger } from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * const hasAppend = Effect.runSync(
+ *   Effect.gen(function* () {
+ *     const ledger = yield* ExecutionLedger
+ *     return typeof ledger.appendDecision === "function"
+ *   }).pipe(
+ *     Effect.provideService(
+ *       ExecutionLedger,
+ *       ExecutionLedger.of({
+ *         appendDecision: () => Effect.void,
+ *         appendOutcome: () => Effect.void,
+ *         readDecisions: () => Effect.succeed([]),
+ *         readOutcomes: () => Effect.succeed([]),
+ *         readUnsettledAllowed: () => Effect.succeed([])
+ *       })
+ *     )
+ *   )
+ * )
+ *
+ * strictEqual(hasAppend, true)
+ * ```
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export class ExecutionLedger extends Context.Service<ExecutionLedger, ExecutionLedgerShape>()($I`ExecutionLedger`) {}

--- a/packages/epistemic/use-cases/src/ExecutionLedger/index.ts
+++ b/packages/epistemic/use-cases/src/ExecutionLedger/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Package entrypoint.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+/**
+ * Execution ledger port error exports.
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export * from "./ExecutionLedger.errors.ts";
+/**
+ * Execution ledger port exports.
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export * from "./ExecutionLedger.ports.ts";

--- a/packages/epistemic/use-cases/src/server.ts
+++ b/packages/epistemic/use-cases/src/server.ts
@@ -66,3 +66,18 @@ export * as ClaimLifecycle from "./ClaimLifecycle/index.ts";
  * @since 0.0.0
  */
 export * as EdgeAuthority from "./EdgeAuthority/index.ts";
+/**
+ * Execution ledger error and repository port exports.
+ *
+ * @example
+ * ```ts
+ * import { strictEqual } from "node:assert"
+ * import * as ExecutionLedger from "@beep/epistemic-use-cases/ExecutionLedger"
+ *
+ * strictEqual(typeof ExecutionLedger.ExecutionLedger, "function")
+ * ```
+ *
+ * @category repositories
+ * @since 0.0.0
+ */
+export * as ExecutionLedger from "./ExecutionLedger/index.ts";

--- a/packages/epistemic/use-cases/test/ExecutionLedger.test.ts
+++ b/packages/epistemic/use-cases/test/ExecutionLedger.test.ts
@@ -1,0 +1,95 @@
+import {
+  ExecutionLedger,
+  ExecutionLedgerConstraintViolation,
+  ExecutionLedgerError,
+  ExecutionLedgerOperation,
+  ExecutionLedgerUnavailable,
+} from "@beep/epistemic-use-cases/ExecutionLedger";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+
+describe("ExecutionLedger", () => {
+  describe("ExecutionLedgerOperation", () => {
+    it("is the closed five-operation domain", () => {
+      expect(ExecutionLedgerOperation.Options).toEqual([
+        "appendDecision",
+        "appendOutcome",
+        "readDecisions",
+        "readOutcomes",
+        "readUnsettledAllowed",
+      ]);
+    });
+  });
+
+  describe("ExecutionLedgerConstraintViolation", () => {
+    it("carries the constraint name and operation it rejected", () => {
+      const violation = ExecutionLedgerConstraintViolation.on("appendDecision", "epistemic_execution_decision_pk");
+
+      expect(violation._tag).toBe("ExecutionLedgerConstraintViolation");
+      expect(violation.constraintName).toBe("epistemic_execution_decision_pk");
+      expect(violation.operation).toBe("appendDecision");
+      expect(ExecutionLedgerConstraintViolation.is(violation)).toBe(true);
+    });
+  });
+
+  describe("ExecutionLedgerUnavailable", () => {
+    it("retains an optional driver defect as its cause", () => {
+      const bare = ExecutionLedgerUnavailable.during("readDecisions", "read failed");
+      const caused = ExecutionLedgerUnavailable.during("appendOutcome", "write failed", new Error("ECONNRESET"));
+
+      expect(bare._tag).toBe("ExecutionLedgerUnavailable");
+      expect(O.isNone(bare.cause)).toBe(true);
+      expect(bare.reason).toBe("read failed");
+      expect(O.isSome(caused.cause)).toBe(true);
+      expect(caused.operation).toBe("appendOutcome");
+      expect(ExecutionLedgerUnavailable.is(caused)).toBe(true);
+    });
+
+    it("rejects an empty reason at construction", () => {
+      expect(() => ExecutionLedgerUnavailable.during("readOutcomes", "")).toThrow();
+    });
+  });
+
+  describe("ExecutionLedgerError", () => {
+    it("admits exactly the two ledger failures", () => {
+      const violation = ExecutionLedgerConstraintViolation.on("appendDecision", "epistemic_execution_outcome_pk");
+      const unavailable = ExecutionLedgerUnavailable.during("readUnsettledAllowed", "read failed");
+
+      expect(ExecutionLedgerError.is(violation)).toBe(true);
+      expect(ExecutionLedgerError.is(unavailable)).toBe(true);
+      expect(ExecutionLedgerError.is({ _tag: "SomethingElse" })).toBe(false);
+      expect(S.is(ExecutionLedgerError)(new Error("plain"))).toBe(false);
+    });
+  });
+
+  describe("ExecutionLedger service tag", () => {
+    it.effect(
+      "provides and resolves a ledger implementation",
+      Effect.fnUntraced(function* () {
+        const ledger = yield* ExecutionLedger.pipe(
+          Effect.provideService(
+            ExecutionLedger,
+            ExecutionLedger.of({
+              appendDecision: Effect.fn("ExecutionLedgerTest.appendDecision")(function* () {}),
+              appendOutcome: Effect.fn("ExecutionLedgerTest.appendOutcome")(function* () {}),
+              readDecisions: Effect.fn("ExecutionLedgerTest.readDecisions")(function* () {
+                return [];
+              }),
+              readOutcomes: Effect.fn("ExecutionLedgerTest.readOutcomes")(function* () {
+                return [];
+              }),
+              readUnsettledAllowed: Effect.fn("ExecutionLedgerTest.readUnsettledAllowed")(function* () {
+                return [];
+              }),
+            })
+          )
+        );
+
+        expect(typeof ledger.appendDecision).toBe("function");
+        expect(typeof ledger.readUnsettledAllowed).toBe("function");
+      })
+    );
+  });
+});

--- a/packages/law-practice/server/docgen.json
+++ b/packages/law-practice/server/docgen.json
@@ -197,7 +197,13 @@
         "../../../packages/tooling/test-kit/test-utils/src/*.ts"
       ],
       "@beep/tika": ["../../../packages/drivers/tika/src/index.ts"],
-      "@beep/tika/*": ["../../../packages/drivers/tika/src/*.ts"]
+      "@beep/tika/*": ["../../../packages/drivers/tika/src/*.ts"],
+      "@beep/epistemic-server/ExecutionLedger": [
+        "../../../packages/epistemic/server/src/ExecutionLedger/index.ts"
+      ],
+      "@beep/epistemic-use-cases/ExecutionLedger": [
+        "../../../packages/epistemic/use-cases/src/ExecutionLedger/index.ts"
+      ]
     }
   }
 }

--- a/packages/law-practice/use-cases/docgen.json
+++ b/packages/law-practice/use-cases/docgen.json
@@ -682,6 +682,9 @@
       ],
       "@beep/test-utils/*": [
         "../../../packages/tooling/test-kit/test-utils/src/*.ts"
+      ],
+      "@beep/epistemic-use-cases/ExecutionLedger": [
+        "../../../packages/epistemic/use-cases/src/ExecutionLedger/index.ts"
       ]
     }
   }

--- a/packages/tooling/tool/cli/src/commands/Architecture/internal/AcceptedProofManifest.ts
+++ b/packages/tooling/tool/cli/src/commands/Architecture/internal/AcceptedProofManifest.ts
@@ -792,6 +792,12 @@ export const acceptedProofFiles: ReadonlyArray<AcceptedProofFile> = [
   AcceptedProofFile.make({
     role: "db-admin",
     stage: "persistence",
+    path: "packages/_internal/db-admin/src/migrations/EpistemicExecutionLedger.ts",
+    writer: "template",
+  }),
+  AcceptedProofFile.make({
+    role: "db-admin",
+    stage: "persistence",
     path: "packages/_internal/db-admin/src/migrations/DocumentsSync.ts",
     writer: "template",
   }),
@@ -840,6 +846,12 @@ export const acceptedProofFiles: ReadonlyArray<AcceptedProofFile> = [
   AcceptedProofFile.make({
     role: "db-admin",
     stage: "persistence",
+    path: "packages/_internal/db-admin/drizzle/20260726210000_epistemic_execution_ledger/migration.sql",
+    writer: "template",
+  }),
+  AcceptedProofFile.make({
+    role: "db-admin",
+    stage: "persistence",
     path: "packages/_internal/db-admin/drizzle/20260725222615_baseline/migration.sql",
     writer: "template",
   }),
@@ -877,6 +889,12 @@ export const acceptedProofFiles: ReadonlyArray<AcceptedProofFile> = [
     role: "db-admin",
     stage: "persistence",
     path: "packages/_internal/db-admin/test/integration/EpistemicEdgeMigration.pglite.test.ts",
+    writer: "template",
+  }),
+  AcceptedProofFile.make({
+    role: "db-admin",
+    stage: "persistence",
+    path: "packages/_internal/db-admin/test/integration/EpistemicExecutionLedgerMigration.pglite.test.ts",
     writer: "template",
   }),
   AcceptedProofFile.make({

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -17,8 +17,8 @@
     },
     "@beep/agents-client": {
       "path": "packages/agents/client",
-      "lines": 87.93,
-      "statements": 86.74,
+      "lines": 87.87,
+      "statements": 86.69,
       "branches": 67.69,
       "functions": 78.02
     },
@@ -143,10 +143,10 @@
     },
     "@beep/chalk": {
       "path": "packages/foundation/capability/chalk",
-      "lines": 94.23,
-      "statements": 93.85,
+      "lines": 94.03,
+      "statements": 93.66,
       "branches": 82.05,
-      "functions": 86.29
+      "functions": 85.78
     },
     "@beep/colors": {
       "path": "packages/foundation/capability/colors",
@@ -220,10 +220,10 @@
     },
     "@beep/documents-server": {
       "path": "packages/documents/server",
-      "lines": 84.11,
-      "statements": 84.17,
+      "lines": 83.74,
+      "statements": 83.81,
       "branches": 74.52,
-      "functions": 77.82
+      "functions": 77.22
     },
     "@beep/documents-tables": {
       "path": "packages/documents/tables",
@@ -388,8 +388,8 @@
     },
     "@beep/identity": {
       "path": "packages/foundation/modeling/identity",
-      "lines": 94.63,
-      "statements": 94.55,
+      "lines": 94.62,
+      "statements": 94.54,
       "branches": 87.21,
       "functions": 85.27
     },
@@ -402,10 +402,10 @@
     },
     "@beep/law-practice-domain": {
       "path": "packages/law-practice/domain",
-      "lines": 51.59,
-      "statements": 51.1,
-      "branches": 40,
-      "functions": 7.58
+      "lines": 48.67,
+      "statements": 48.44,
+      "branches": 0,
+      "functions": 4.96
     },
     "@beep/law-practice-server": {
       "path": "packages/law-practice/server",
@@ -528,10 +528,10 @@
     },
     "@beep/ontology-client": {
       "path": "packages/ontology/client",
-      "lines": 66.78,
-      "statements": 65.37,
-      "branches": 55.48,
-      "functions": 48.8
+      "lines": 61.36,
+      "statements": 60.22,
+      "branches": 51.85,
+      "functions": 40
     },
     "@beep/ontology-config": {
       "path": "packages/ontology/config",
@@ -556,10 +556,10 @@
     },
     "@beep/ontology-ui": {
       "path": "packages/ontology/ui",
-      "lines": 21.85,
-      "statements": 21.23,
-      "branches": 6.42,
-      "functions": 12.8
+      "lines": 20.64,
+      "statements": 20.23,
+      "branches": 4.63,
+      "functions": 11.85
     },
     "@beep/ontology-use-cases": {
       "path": "packages/ontology/use-cases",
@@ -612,10 +612,10 @@
     },
     "@beep/postgres": {
       "path": "packages/drivers/postgres",
-      "lines": 86.08,
-      "statements": 85.92,
-      "branches": 70.5,
-      "functions": 82.39
+      "lines": 84.1,
+      "statements": 83.79,
+      "branches": 69.78,
+      "functions": 78.41
     },
     "@beep/pretext": {
       "path": "packages/drivers/pretext",
@@ -626,10 +626,10 @@
     },
     "@beep/professional-desktop": {
       "path": "apps/professional-desktop",
-      "lines": 65.49,
-      "statements": 64.14,
-      "branches": 54.5,
-      "functions": 56.41
+      "lines": 54.7,
+      "statements": 53.27,
+      "branches": 45.49,
+      "functions": 44.77
     },
     "@beep/protobuf": {
       "path": "packages/drivers/protobuf",
@@ -668,10 +668,10 @@
     },
     "@beep/repo-cli": {
       "path": "packages/tooling/tool/cli",
-      "lines": 67.77,
-      "statements": 67.57,
-      "branches": 52.02,
-      "functions": 59.09
+      "lines": 65.95,
+      "statements": 65.74,
+      "branches": 50.95,
+      "functions": 57.36
     },
     "@beep/repo-configs": {
       "path": "packages/tooling/policy-pack/repo-configs",
@@ -689,10 +689,10 @@
     },
     "@beep/repo-utils": {
       "path": "packages/tooling/library/repo-utils",
-      "lines": 73.65,
-      "statements": 73.03,
-      "branches": 51.93,
-      "functions": 53
+      "lines": 70.55,
+      "statements": 69.91,
+      "branches": 51.29,
+      "functions": 51.01
     },
     "@beep/runpod": {
       "path": "packages/drivers/runpod",
@@ -752,10 +752,10 @@
     },
     "@beep/tika": {
       "path": "packages/drivers/tika",
-      "lines": 87.22,
-      "statements": 86.88,
-      "branches": 71.92,
-      "functions": 83.07
+      "lines": 75.28,
+      "statements": 76.08,
+      "branches": 58.06,
+      "functions": 63.63
     },
     "@beep/types": {
       "path": "packages/foundation/primitive/types",

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -3,8 +3,8 @@
 // Epsilon: 0.001 percentage points; only smaller floating-point noise is ignored.
 {
   "schema_version": 1,
-  "generated_at": "2026-07-26T00:51:33.966Z",
-  "git_sha": "57c475f724b8404407829b538097d668b64b1a5b",
+  "generated_at": "2026-07-26T22:39:22.234Z",
+  "git_sha": "20d7295ef2707335d93de130461c4d925a84a4fc",
   "command": "bun run coverage:baseline:write",
   "epsilon": 0.001,
   "packages": {
@@ -17,8 +17,8 @@
     },
     "@beep/agents-client": {
       "path": "packages/agents/client",
-      "lines": 87.87,
-      "statements": 86.69,
+      "lines": 87.93,
+      "statements": 86.74,
       "branches": 67.69,
       "functions": 78.02
     },
@@ -143,10 +143,10 @@
     },
     "@beep/chalk": {
       "path": "packages/foundation/capability/chalk",
-      "lines": 94.03,
-      "statements": 93.66,
+      "lines": 94.23,
+      "statements": 93.85,
       "branches": 82.05,
-      "functions": 85.78
+      "functions": 86.29
     },
     "@beep/colors": {
       "path": "packages/foundation/capability/colors",
@@ -178,8 +178,8 @@
     },
     "@beep/db-admin": {
       "path": "packages/_internal/db-admin",
-      "lines": 84,
-      "statements": 86.2,
+      "lines": 89.18,
+      "statements": 90.24,
       "branches": 100,
       "functions": 80
     },
@@ -220,10 +220,10 @@
     },
     "@beep/documents-server": {
       "path": "packages/documents/server",
-      "lines": 83.74,
-      "statements": 83.81,
+      "lines": 84.11,
+      "statements": 84.17,
       "branches": 74.52,
-      "functions": 77.22
+      "functions": 77.82
     },
     "@beep/documents-tables": {
       "path": "packages/documents/tables",
@@ -274,19 +274,26 @@
       "branches": 12.54,
       "functions": 13.38
     },
+    "@beep/epistemic-config": {
+      "path": "packages/epistemic/config",
+      "lines": 96,
+      "statements": 96.15,
+      "branches": 100,
+      "functions": 100
+    },
     "@beep/epistemic-domain": {
       "path": "packages/epistemic/domain",
-      "lines": 75.25,
-      "statements": 69.44,
+      "lines": 89.14,
+      "statements": 86.53,
       "branches": 100,
-      "functions": 34.04
+      "functions": 60.25
     },
     "@beep/epistemic-server": {
       "path": "packages/epistemic/server",
-      "lines": 33.04,
-      "statements": 31.93,
+      "lines": 32.63,
+      "statements": 31.54,
       "branches": 0,
-      "functions": 5.45
+      "functions": 4.16
     },
     "@beep/epistemic-tables": {
       "path": "packages/epistemic/tables",
@@ -297,10 +304,10 @@
     },
     "@beep/epistemic-use-cases": {
       "path": "packages/epistemic/use-cases",
-      "lines": 90.36,
-      "statements": 90.9,
+      "lines": 91.39,
+      "statements": 91.83,
       "branches": 100,
-      "functions": 97.36
+      "functions": 97.56
     },
     "@beep/face-detection": {
       "path": "packages/drivers/face-detection",
@@ -381,8 +388,8 @@
     },
     "@beep/identity": {
       "path": "packages/foundation/modeling/identity",
-      "lines": 94.62,
-      "statements": 94.54,
+      "lines": 94.63,
+      "statements": 94.55,
       "branches": 87.21,
       "functions": 85.27
     },
@@ -395,10 +402,10 @@
     },
     "@beep/law-practice-domain": {
       "path": "packages/law-practice/domain",
-      "lines": 48.67,
-      "statements": 48.44,
-      "branches": 0,
-      "functions": 4.96
+      "lines": 51.59,
+      "statements": 51.1,
+      "branches": 40,
+      "functions": 7.58
     },
     "@beep/law-practice-server": {
       "path": "packages/law-practice/server",
@@ -521,15 +528,15 @@
     },
     "@beep/ontology-client": {
       "path": "packages/ontology/client",
-      "lines": 61.36,
-      "statements": 60.22,
-      "branches": 51.85,
-      "functions": 40
+      "lines": 66.78,
+      "statements": 65.37,
+      "branches": 55.48,
+      "functions": 48.8
     },
     "@beep/ontology-config": {
       "path": "packages/ontology/config",
-      "lines": 75,
-      "statements": 66.66,
+      "lines": 80,
+      "statements": 70.58,
       "branches": 100,
       "functions": 50
     },
@@ -549,10 +556,10 @@
     },
     "@beep/ontology-ui": {
       "path": "packages/ontology/ui",
-      "lines": 20.64,
-      "statements": 20.23,
-      "branches": 4.63,
-      "functions": 11.85
+      "lines": 21.85,
+      "statements": 21.23,
+      "branches": 6.42,
+      "functions": 12.8
     },
     "@beep/ontology-use-cases": {
       "path": "packages/ontology/use-cases",
@@ -605,10 +612,10 @@
     },
     "@beep/postgres": {
       "path": "packages/drivers/postgres",
-      "lines": 84.1,
-      "statements": 83.79,
-      "branches": 69.78,
-      "functions": 78.41
+      "lines": 86.08,
+      "statements": 85.92,
+      "branches": 70.5,
+      "functions": 82.39
     },
     "@beep/pretext": {
       "path": "packages/drivers/pretext",
@@ -619,10 +626,10 @@
     },
     "@beep/professional-desktop": {
       "path": "apps/professional-desktop",
-      "lines": 54.7,
-      "statements": 53.27,
-      "branches": 45.49,
-      "functions": 44.77
+      "lines": 65.49,
+      "statements": 64.14,
+      "branches": 54.5,
+      "functions": 56.41
     },
     "@beep/protobuf": {
       "path": "packages/drivers/protobuf",
@@ -661,10 +668,10 @@
     },
     "@beep/repo-cli": {
       "path": "packages/tooling/tool/cli",
-      "lines": 65.95,
-      "statements": 65.74,
-      "branches": 50.95,
-      "functions": 57.36
+      "lines": 67.77,
+      "statements": 67.57,
+      "branches": 52.02,
+      "functions": 59.09
     },
     "@beep/repo-configs": {
       "path": "packages/tooling/policy-pack/repo-configs",
@@ -682,10 +689,10 @@
     },
     "@beep/repo-utils": {
       "path": "packages/tooling/library/repo-utils",
-      "lines": 70.55,
-      "statements": 69.91,
-      "branches": 51.29,
-      "functions": 51.01
+      "lines": 73.65,
+      "statements": 73.03,
+      "branches": 51.93,
+      "functions": 53
     },
     "@beep/runpod": {
       "path": "packages/drivers/runpod",
@@ -745,10 +752,10 @@
     },
     "@beep/tika": {
       "path": "packages/drivers/tika",
-      "lines": 75.28,
-      "statements": 76.08,
-      "branches": 58.06,
-      "functions": 63.63
+      "lines": 87.22,
+      "statements": 86.88,
+      "branches": 71.92,
+      "functions": 83.07
     },
     "@beep/types": {
       "path": "packages/foundation/primitive/types",

--- a/standards/schema-first.inventory.jsonc
+++ b/standards/schema-first.inventory.jsonc
@@ -672,6 +672,14 @@
       "reason": "Effect service contract containing repository functions; the RecordEdgeFact, SupersedeEdgeFact, and EdgeAsOfQuery payloads it accepts and the EdgeVersion it returns are all schemas."
     },
     {
+      "file": "packages/epistemic/use-cases/src/ExecutionLedger/ExecutionLedger.ports.ts",
+      "symbol": "ExecutionLedgerShape",
+      "kind": "exported-interface",
+      "status": "exception",
+      "owner": "@beep/epistemic-use-cases",
+      "reason": "Effect service contract containing repository functions; the ExecutionDecisionRecord and ExecutionOutcomeRecord payloads it accepts and returns are all schemas, mirroring the EdgeAuthorityRepositoryShape exception."
+    },
+    {
       "file": "packages/foundation/capability/api-transport/src/Transport.ts",
       "symbol": "ApiTransport",
       "kind": "exported-interface",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1620,7 +1620,21 @@
       "@beep/epistemic-config/server": [
         "./packages/epistemic/config/src/server.ts"
       ],
-      "@beep/epistemic-config/test": ["./packages/epistemic/config/src/test.ts"]
+      "@beep/epistemic-config/test": [
+        "./packages/epistemic/config/src/test.ts"
+      ],
+      "@beep/epistemic-server/ExecutionLedger": [
+        "./packages/epistemic/server/src/ExecutionLedger/index.ts"
+      ],
+      "@beep/epistemic-tables/values": [
+        "./packages/epistemic/tables/src/values/index.ts"
+      ],
+      "@beep/epistemic-tables/values/ExecutionRecord": [
+        "./packages/epistemic/tables/src/values/ExecutionRecord/index.ts"
+      ],
+      "@beep/epistemic-use-cases/ExecutionLedger": [
+        "./packages/epistemic/use-cases/src/ExecutionLedger/index.ts"
+      ]
     }
   }
 }


### PR DESCRIPTION
## feat(epistemic): append-only execution ledger tables, port, and adapter

PR 3 of `goals/agent-execution-authority` — the second one-way door. The ledger is the
piece the headline claim eventually stands on: a hash-chained, append-only record of every
execution decision and settlement.

### The fork, settled

The packet recorded an open fork: raw `pgTable` vs `EntityTable.pgTableFrom` over
`BaseEntity`. Settled as **raw `pgTable`** — the SPEC's Persistence section was already
normative ("Non-`BaseEntity` rows"), and `BaseEntity` bakes in
`row_version`/`updated_at`/`updated_by_principal`, update vocabulary that would be schema
lies on rows that must never mutate. A third path (`EntitySchema.ClassFactory` without
`BaseEntity`) was found and rejected: zero product usage anywhere, wrong place to pioneer
machinery. The PR 1 record schemas turn out to be their own row codecs — encoded form is
already the flat wire projection — so the converters are `S.encode`/`S.decode` and
nothing else.

### What the database enforces, by name

- `epistemic_execution_decision`: chain `PRIMARY KEY (run_key, seq)`, genesis rule
  `(seq = 0) = (prev_hash IS NULL)`, bounded verdict/sink-class/audience literals, and the
  nine-member denial-reason domain as a CHECK — free text cannot be smuggled into a
  no-payload ledger even by a writer that bypasses every schema.
- `epistemic_execution_outcome`: `PRIMARY KEY (decision_hash)` makes one-outcome-per-
  decision a table shape; a composite FK to `(run_key, hash)` makes an outcome without its
  write-ahead decision unrepresentable; a second FK to `(hash, verdict)` through a
  CHECK-pinned constant column makes an outcome settling a **denied** decision
  unrepresentable too.
- The repo's **first plpgsql triggers**: row-level `BEFORE UPDATE OR DELETE` guards plus
  statement-level `BEFORE TRUNCATE` guards, authored inside the statement splitter's rule
  (no `;` + newline + boundary keyword inside the body — `BEGIN` is one) and proven
  through the real `migrate()` path. The constraint is now documented in db-admin's agent
  guide.

### Adversarial review before publish

A 3-dimension × 3-refuter review workflow ran over the diff; 6 findings survived
refutation and all are fixed here, two of them materially:

1. **TRUNCATE bypassed the row-level triggers** — and a truncated run reads back as an
   empty chain the verifier certifies intact, making it the one wipe that would not even
   be tamper-evident. Now blocked by statement-level triggers, with a probe.
2. **An outcome could settle a denied decision** and append-only would make the
   fabrication permanent. Now unrepresentable via the verdict-pinned FK, with a probe.

### Proof

27 integration tests in `epistemic/server` + the db-admin migration proof. Highlights:

- Chained run (allowed/denied/allowed) appends, reads back, `verifyExecutionDecisionChain`
  intact; outcome binding verified.
- The derived "decided, outcome unknown" predicate is scoped to allowed decisions — a
  probe proves an ordinary denial is never reported as a crash.
- Every load-bearing constraint has a behavioral probe, not just a name assertion:
  chain collision, orphan outcome, duplicate outcome, denied-outcome fabrication,
  genesis violation, reason-on-allowed, unbounded settlement, free-text reason.
- UPDATE, DELETE, and TRUNCATE rejected by trigger on both tables.
- **The tamper proof**: owner drops the trigger (PGlite connects as owner — the documented
  reason this is tamper-EVIDENT, not tamper-proof), mutates a sealed field mid-chain, and
  the domain verifier reports `chain-broken` at exactly that index. A forged outcome
  settlement is likewise detected by `verifyOutcomeBinding`.
- A structural no-payload test pins the exact column set of both tables and rejects any
  payload-capable column type (`PgJsonb`/`PgJson`/`PgBytea`).

Registration hit all the places the bitemporal spike proved are load-bearing: db-admin
target + `targets.ts`, `AcceptedProofManifest` entries for all three new db-admin files
(byte-equality proof passes), regenerated desktop `Migrations.gen.ts`, and the migration
folder invisible to drizzle-kit's chain by design (raw SQL owns constraints — Exception
Ledger row already in `SPEC.md`).

Coverage: `@beep/epistemic-config` (PR 2's package) enters the baseline at 96–100%;
`epistemic-use-cases` coverage rises with a new unit suite for the port errors; the only
baseline drops are `epistemic-server`'s, attributable to the integration-only Drizzle
adapter — the same profile as the EdgeAuthority precedent.
