### PR TITLE
fix(test): stabilize nightly property-law sweeps

### DIFF
--- a/.changeset/property-law-nightly-timeouts.md
+++ b/.changeset/property-law-nightly-timeouts.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release: make the nightly property-law sweep reproducible and prevent deep-run timeout flakes.

--- a/.changeset/property-law-nightly-timeouts.md
+++ b/.changeset/property-law-nightly-timeouts.md
@@ -1,4 +1,5 @@
 ---
+{}
 ---
 
 No release: make the nightly property-law sweep reproducible and prevent deep-run timeout flakes.

--- a/.github/workflows/property-laws-nightly.yml
+++ b/.github/workflows/property-laws-nightly.yml
@@ -60,7 +60,12 @@ jobs:
             exit 1
           fi
 
-          bun run beep ci lane property --runs "${BEEP_PROPERTY_RUNS}" --summarize
+          BEEP_PROPERTY_SEED="$((GITHUB_RUN_ID % 2147483647))"
+          echo "BEEP_FC_SEED=${BEEP_PROPERTY_SEED}"
+          bun run beep ci lane property \
+            --runs "${BEEP_PROPERTY_RUNS}" \
+            --seed "${BEEP_PROPERTY_SEED}" \
+            --summarize
 
       - name: Append Turbo summary
         if: always()

--- a/packages/drivers/phoenix/test/Phoenix.service.test.ts
+++ b/packages/drivers/phoenix/test/Phoenix.service.test.ts
@@ -171,7 +171,7 @@ describe("@beep/phoenix", () => {
     });
   });
 
-  it("round-trips schema-derived Phoenix values through their encoded shapes", { timeout: 30000 }, () => {
+  it("round-trips schema-derived Phoenix values through their encoded shapes", () => {
     for (const [, schema] of publicSchemaRoundTripCases) {
       fc.assert(
         fc.property(S.toArbitrary(schema), (value) => {

--- a/packages/foundation/capability/semantic-web/test/ServicesAndSurface.test.ts
+++ b/packages/foundation/capability/semantic-web/test/ServicesAndSurface.test.ts
@@ -84,7 +84,7 @@ describe("Services and Surface", () => {
 
   it(
     "round-trips schema-derived RDF datasets and canonicalization DTOs through boundary encoders",
-    { timeout: 30000 },
+    {}, // Inherit the deep-sweep timeout from vitest.shared.ts.
     () =>
       fc.assert(
         fc.property(

--- a/packages/ontology/use-cases/test/SchemaParity.test.ts
+++ b/packages/ontology/use-cases/test/SchemaParity.test.ts
@@ -39,6 +39,27 @@ const quad = makeQuad(
 );
 const dataset = makeDataset([quad]);
 
+const schemaRoundTripCases: ReadonlyArray<
+  readonly [string, S.Top & S.ConstraintDecoder<unknown> & S.ConstraintEncoder<unknown>]
+> = [
+  ["OpenOntologyFileCommand", OpenOntologyFileCommand],
+  ["OpenOntologyDocumentResult", OpenOntologyDocumentResult],
+  ["SaveOntologyDocumentResult", SaveOntologyDocumentResult],
+  ["PreviewOntologyTurtleResult", PreviewOntologyTurtleResult],
+  ["ApplyOntologyBatchCommand", ApplyOntologyBatchCommand],
+  ["ApplyOntologyBatchResult", ApplyOntologyBatchResult],
+  ["OntologyRepairProposal", OntologyRepairProposal],
+  ["RunOntologyValidationInput", RunOntologyValidationInput],
+  ["RunOntologyValidationResult", RunOntologyValidationResult],
+  ["ExportOntologyProvenanceCommand", ExportOntologyProvenanceCommand],
+  ["ExportOntologyProvenanceResult", ExportOntologyProvenanceResult],
+  ["OntologyActionError", OntologyActionError],
+  ["OntologySnapshot", OntologySnapshot],
+  ["WorkerCommand", WorkerCommand],
+  ["WorkerResult", WorkerResult],
+  ["TurtleCodecError", TurtleCodecError],
+];
+
 const assertRoundTrips = <Schema extends S.Top & S.ConstraintDecoder<unknown> & S.ConstraintEncoder<unknown>>(
   schema: Schema
 ): void => {
@@ -53,23 +74,8 @@ const assertRoundTrips = <Schema extends S.Top & S.ConstraintDecoder<unknown> & 
 };
 
 describe("@beep/ontology-use-cases schema parity", () => {
-  it("round-trips schema-derived command and worker samples", () => {
-    assertRoundTrips(OpenOntologyFileCommand);
-    assertRoundTrips(OpenOntologyDocumentResult);
-    assertRoundTrips(SaveOntologyDocumentResult);
-    assertRoundTrips(PreviewOntologyTurtleResult);
-    assertRoundTrips(ApplyOntologyBatchCommand);
-    assertRoundTrips(ApplyOntologyBatchResult);
-    assertRoundTrips(OntologyRepairProposal);
-    assertRoundTrips(RunOntologyValidationInput);
-    assertRoundTrips(RunOntologyValidationResult);
-    assertRoundTrips(ExportOntologyProvenanceCommand);
-    assertRoundTrips(ExportOntologyProvenanceResult);
-    assertRoundTrips(OntologyActionError);
-    assertRoundTrips(OntologySnapshot);
-    assertRoundTrips(WorkerCommand);
-    assertRoundTrips(WorkerResult);
-    assertRoundTrips(TurtleCodecError);
+  it.each(schemaRoundTripCases)("round-trips schema-derived %s samples", (_name, schema) => {
+    assertRoundTrips(schema);
   });
 
   it("preserves command and worker protocol encoded wire shapes", () => {


### PR DESCRIPTION
## Summary

- pass a rotating, logged seed into nightly property-law sweeps
- inherit shared deep-run timeouts for Phoenix and semantic-web laws
- isolate ontology schema round trips so each law gets its own timeout budget
- keep the change version-neutral with an explicit empty Changesets mapping

## Verification

- targeted 1,000-run property sweeps for Phoenix, semantic-web, and ontology use cases
- full package tests, checks, lint, and integration sweep
- `bun run beep yeet verify`
- `bun run beep yeet verify --tier review-fix`

Closes #356.

## fix(test): stabilize nightly property-law sweeps

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_property-law-nightly-timeouts-083e7b335672/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787775829&installation_model_id=424656&pr_number=483&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F483&signature=e18bfc64f40183a301169312247507ee9c7c7eb42d89764b60c5b0292edff776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->