### PR TITLE
feat(repo-cli): add flatten-media command

### DIFF
--- a/packages/tooling/tool/cli/README.md
+++ b/packages/tooling/tool/cli/README.md
@@ -221,8 +221,26 @@ The package binary works the same way:
 bunx @beep/repo-cli files <subcommand> [options]
 ```
 
-All `files` subcommands work on direct children of `--dir`; they do not recurse
-into nested directories.
+Except for `flatten-media`, `files` subcommands work on direct children of
+`--dir`; they do not recurse into nested directories.
+
+#### `files flatten-media`
+
+Recursively move image and video files into one flat output directory while
+leaving non-media files and source directories in place.
+
+```bash
+bun run files flatten-media --dir ./dataset/raw --out-dir ./dataset/media --dry-run
+bun run files flatten-media --dir ./dataset/raw --out-dir ./dataset/media
+```
+
+Existing output files are preserved. Name collisions are checked
+case-insensitively and use numeric suffixes such as `_01` and `_02`. Use
+`--dry-run` to print the complete move plan without creating the output
+directory or moving files. If a move fails, completed moves are restored; a
+newly created output directory may remain empty.
+
+Do not modify the source or output tree concurrently while this command runs.
 
 #### `files sort-and-rename`
 

--- a/packages/tooling/tool/cli/dtslint/Files.tst.ts
+++ b/packages/tooling/tool/cli/dtslint/Files.tst.ts
@@ -7,6 +7,8 @@ import {
   cropBordersFiles,
   DetectBordersOptions,
   detectBordersFiles,
+  FlattenMediaOptions,
+  flattenMediaFiles,
   NormalizeFilesOptions,
   normalizeFiles,
 } from "@beep/repo-cli/test/Files";
@@ -30,6 +32,8 @@ import type {
   FileSha256Hash,
   FilesCommandError,
   FilesCommandService,
+  FilesCommandServiceShape,
+  FlattenMediaSummary,
   NormalizeImageFormat,
   NormalizeManifest,
   NormalizePlanEntry,
@@ -66,6 +70,34 @@ describe("Files command", () => {
       | "symlink"
       | "video"
     >();
+  });
+
+  it("returns the flatten-media summary through the files service", () => {
+    const options = FlattenMediaOptions.make({
+      dir: "./raw",
+      dryRun: true,
+      outDir: "./flat",
+    });
+
+    expect(flattenMediaFiles(options)).type.toBe<
+      Effect.Effect<FlattenMediaSummary, FilesCommandError, FilesCommandService>
+    >();
+    expect<FilesCommandServiceShape["flattenMediaFiles"]>().type.toBe<
+      (options: FlattenMediaOptions) => Effect.Effect<FlattenMediaSummary, FilesCommandError>
+    >();
+  });
+
+  it("keeps flatten-media options and summary fields JSON-safe", () => {
+    expect<FlattenMediaOptions["dir"]>().type.toBe<string>();
+    expect<FlattenMediaOptions["dryRun"]>().type.toBe<boolean>();
+    expect<FlattenMediaOptions["outDir"]>().type.toBe<string>();
+    expect<FlattenMediaSummary["collisionCount"]>().type.toBe<number>();
+    expect<FlattenMediaSummary["destinationDirectory"]>().type.toBe<string>();
+    expect<FlattenMediaSummary["dryRun"]>().type.toBe<boolean>();
+    expect<FlattenMediaSummary["movedCount"]>().type.toBe<number>();
+    expect<FlattenMediaSummary["plannedCount"]>().type.toBe<number>();
+    expect<FlattenMediaSummary["skippedCount"]>().type.toBe<number>();
+    expect<FlattenMediaSummary["sourceDirectory"]>().type.toBe<string>();
   });
 
   it("returns the archive-poor-candidates summary through the files service", () => {

--- a/packages/tooling/tool/cli/src/commands/Files/Files.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.command.ts
@@ -14,6 +14,7 @@ import {
   CropBordersOptions,
   DetectBordersOptions,
   DetectFacesOptions,
+  FlattenMediaOptions,
   ImageAuditOptions,
   ImageCurationOptions,
   NormalizeFilesOptions,
@@ -28,6 +29,7 @@ import {
   detectBordersFiles,
   detectFacesFiles,
   FilesCommandServiceLive,
+  flattenMediaFiles,
   normalizeFiles,
   printFilesIndex,
   processFiles,
@@ -43,6 +45,9 @@ const runFilesProgram = <A>(
 
 const sortDirFlag = Flag.directory("dir", { mustExist: true }).pipe(
   Flag.withDescription("Directory whose direct regular files should be sorted and renamed")
+);
+const flattenMediaDirFlag = Flag.directory("dir", { mustExist: true }).pipe(
+  Flag.withDescription("Directory recursively searched for image and video files to move")
 );
 const stripDirFlag = Flag.directory("dir", { mustExist: true }).pipe(
   Flag.withDescription("Directory whose direct image and video files should have metadata stripped")
@@ -96,6 +101,9 @@ const archiveDirFlag = Flag.directory("archive-dir").pipe(
 const normalizeOutDirFlag = Flag.directory("out-dir").pipe(
   Flag.withDescription("Output directory for normalized image files")
 );
+const flattenMediaOutDirFlag = Flag.directory("out-dir").pipe(
+  Flag.withDescription("Flat output directory for moved image and video files")
+);
 const processInputFlag = Flag.path("input", { mustExist: true, pathType: "either" }).pipe(
   Flag.withDescription("File or directory to process into a V1 proof manifest")
 );
@@ -147,6 +155,9 @@ const prefixFlag = Flag.string("prefix").pipe(
 );
 const sortDryRunFlag = Flag.boolean("dry-run").pipe(
   Flag.withDescription("Print the planned renames without touching files")
+);
+const flattenMediaDryRunFlag = Flag.boolean("dry-run").pipe(
+  Flag.withDescription("Print the planned moves without touching files")
 );
 const stripDryRunFlag = Flag.boolean("dry-run").pipe(
   Flag.withDescription("Print the planned metadata rewrites without touching files")
@@ -604,6 +615,21 @@ const filesSortAndRenameCommand = Command.make(
   Command.provide(FilesCommandServiceLive)
 );
 
+const filesFlattenMediaCommand = Command.make(
+  "flatten-media",
+  {
+    dir: flattenMediaDirFlag,
+    dryRun: flattenMediaDryRunFlag,
+    outDir: flattenMediaOutDirFlag,
+  },
+  Effect.fn(function* ({ dir, dryRun, outDir }) {
+    yield* runFilesProgram(flattenMediaFiles(FlattenMediaOptions.make({ dir, dryRun, outDir })));
+  })
+).pipe(
+  Command.withDescription("Recursively move image and video files into a flat directory"),
+  Command.provide(FilesCommandServiceLive)
+);
+
 const filesStripMetadataCommand = Command.make(
   "strip-metadata",
   {
@@ -643,6 +669,7 @@ export const filesCommand = Command.make("files", {}, () => printFilesIndex).pip
     filesCurateImagesCommand,
     filesDetectBordersCommand,
     filesDetectFacesCommand,
+    filesFlattenMediaCommand,
     filesNormalizeCommand,
     filesProcessCommand,
     filesSortAndRenameCommand,

--- a/packages/tooling/tool/cli/src/commands/Files/Files.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.schemas.ts
@@ -34,6 +34,13 @@ export * from "./internal/CreateCaptions.schemas.ts";
  */
 export * from "./internal/DetectFaces.schemas.ts";
 /**
+ * Recursive media flattening option and summary schemas.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./internal/FlattenMedia.schemas.ts";
+/**
  * Read-only image audit schemas.
  *
  * @category schemas

--- a/packages/tooling/tool/cli/src/commands/Files/Files.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.service.ts
@@ -98,6 +98,7 @@ import {
   preflightNormalizeOutputs,
   preflightTargetCollisions,
 } from "./internal/Apply.ts";
+import { runFlattenMediaFiles } from "./internal/FlattenMedia.ts";
 import { auditImagesImpl, curateImagesImpl } from "./internal/ImageCuration.ts";
 import { isUnsafeMetadataVideoExtension, probeImageDimensions, probeMediaDimensions } from "./internal/MediaExec.ts";
 import { processFilesImpl } from "./internal/Process.ts";
@@ -131,6 +132,8 @@ import type {
   DetectFacesEntry,
   DetectFacesOptions,
   DetectFacesSkippedReason,
+  FlattenMediaOptions,
+  FlattenMediaSummary,
   ImageAuditManifest,
   ImageAuditOptions,
   ImageCurationOptions,
@@ -240,6 +243,13 @@ export interface FilesCommandServiceShape {
    * @since 0.0.0
    */
   readonly detectFacesFiles: (options: DetectFacesOptions) => Effect.Effect<DetectFacesReport, FilesCommandError>;
+
+  /**
+   * Recursively move image and video files into one flat destination directory.
+   *
+   * @since 0.0.0
+   */
+  readonly flattenMediaFiles: (options: FlattenMediaOptions) => Effect.Effect<FlattenMediaSummary, FilesCommandError>;
 
   /**
    * Normalize direct image files into a reversible output directory.
@@ -1716,6 +1726,7 @@ export const printFilesIndex = printLines([
   "- bun run files curate-images --dir ./raw --decisions ./decisions.json --out-dir ./prepared",
   "- bun run files sort-and-rename --prefix image --dir ./tmp",
   "- bun run files sort-and-rename --prefix image --dir ./tmp --with-dimensions",
+  "- bun run files flatten-media --dir ./raw --out-dir ./flat --dry-run",
   "- bun run files strip-metadata --dir ./tmp",
   "- bun run files normalize --dir ./raw --out-dir ./dataset/images --format png",
   "- bun run files normalize --dir ./raw --out-dir ./dataset/images --format png --dedupe",
@@ -2375,6 +2386,17 @@ const sortAndRenameFilesImpl = Effect.fn("FilesCommandService.sortAndRenameFiles
   });
 });
 
+const flattenMediaFilesImpl = Effect.fn("FilesCommandService.flattenMediaFiles")(function* (
+  options: FlattenMediaOptions
+): Effect.fn.Return<FlattenMediaSummary, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  return yield* profilePhase(runFlattenMediaFiles(options), {
+    phase: "files.flatten-media",
+    attributes: {
+      dryRun: `${options.dryRun}`,
+    },
+  });
+});
+
 const stripMetadataFilesImpl = Effect.fn("FilesCommandService.stripMetadataFiles")(function* (
   dir: string,
   dryRun: boolean
@@ -2458,6 +2480,9 @@ const makeFilesCommandService = Effect.fn("FilesCommandService.make")(function* 
     ),
     detectFacesFiles: Effect.fn("FilesCommandService.detectFacesFiles")((options) =>
       detectFacesFilesImpl(options).pipe(Effect.provide(runtimeContext))
+    ),
+    flattenMediaFiles: Effect.fn("FilesCommandService.flattenMediaFiles")((options) =>
+      flattenMediaFilesImpl(options).pipe(Effect.provide(runtimeContext))
     ),
     normalizeFiles: Effect.fn("FilesCommandService.normalizeFiles")((options) =>
       normalizeFilesImpl(options).pipe(Effect.provide(runtimeContext))
@@ -2635,6 +2660,32 @@ export const detectFacesFiles = Effect.fn("Files.detectFacesFiles")(function* (
 ): Effect.fn.Return<DetectFacesReport, FilesCommandError, FilesCommandService> {
   const files = yield* FilesCommandService;
   return yield* files.detectFacesFiles(options);
+});
+
+/**
+ * Recursively move image and video files into one flat destination directory.
+ *
+ * @effects Recursively reads source directories and moves selected files unless dry-run is enabled.
+ * @example
+ * ```ts
+ * import { FlattenMediaOptions, flattenMediaFiles } from "@beep/repo-cli/commands/Files"
+ * import { Effect } from "effect"
+ *
+ * const program = flattenMediaFiles(FlattenMediaOptions.make({
+ *   dir: "./raw",
+ *   dryRun: true,
+ *   outDir: "./flat"
+ * }))
+ * console.log(Effect.isEffect(program))
+ * ```
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const flattenMediaFiles = Effect.fn("Files.flattenMediaFiles")(function* (
+  options: FlattenMediaOptions
+): Effect.fn.Return<FlattenMediaSummary, FilesCommandError, FilesCommandService> {
+  const files = yield* FilesCommandService;
+  return yield* files.flattenMediaFiles(options);
 });
 
 /**

--- a/packages/tooling/tool/cli/src/commands/Files/internal/FlattenMedia.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/internal/FlattenMedia.schemas.ts
@@ -1,0 +1,84 @@
+/**
+ * Flatten-media option and summary schemas for Files commands.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { Effect } from "effect";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("commands/Files/internal/FlattenMedia.schemas");
+
+/**
+ * Options used by the recursive media flattening operation.
+ *
+ * @example
+ * ```ts
+ * import { FlattenMediaOptions } from "@beep/repo-cli/commands/Files"
+ *
+ * const options = FlattenMediaOptions.make({
+ *   dir: "./raw",
+ *   outDir: "./flat"
+ * })
+ * console.log(options.dryRun)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class FlattenMediaOptions extends S.Class<FlattenMediaOptions>($I`FlattenMediaOptions`)(
+  {
+    dir: S.String,
+    dryRun: S.Boolean.pipe(S.withConstructorDefault(Effect.succeed(false))),
+    outDir: S.String,
+  },
+  $I.annote("FlattenMediaOptions", {
+    description: "Source, destination, and preview options for recursively flattening media files.",
+  })
+) {}
+
+/**
+ * Summary returned by `flattenMediaFiles`.
+ *
+ * @example
+ * ```ts
+ * import * as S from "effect/Schema"
+ * import { FlattenMediaSummary } from "@beep/repo-cli/commands/Files"
+ *
+ * const acceptsUndefined = S.is(FlattenMediaSummary)(undefined)
+ * console.log(acceptsUndefined)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class FlattenMediaSummary extends S.Class<FlattenMediaSummary>($I`FlattenMediaSummary`)(
+  {
+    collisionCount: S.Finite,
+    destinationDirectory: S.String,
+    dryRun: S.Boolean,
+    movedCount: S.Finite,
+    plannedCount: S.Finite,
+    skippedCount: S.Finite,
+    sourceDirectory: S.String,
+  },
+  $I.annote("FlattenMediaSummary", {
+    description: "Summary counts and resolved directories for a recursive media flattening run.",
+  })
+) {}
+
+/**
+ * Decode unknown recursive media flattening options.
+ *
+ * @example
+ * ```ts
+ * import { decodeFlattenMediaOptions } from "@beep/repo-cli/commands/Files"
+ * import { Effect } from "effect"
+ *
+ * const program = decodeFlattenMediaOptions(undefined)
+ * console.log(Effect.isEffect(program))
+ * ```
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeFlattenMediaOptions = S.decodeUnknownEffect(FlattenMediaOptions);

--- a/packages/tooling/tool/cli/src/commands/Files/internal/FlattenMedia.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/internal/FlattenMedia.ts
@@ -1,0 +1,512 @@
+/**
+ * Recursive media flattening planning and mutation.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { isPathWithinRoot } from "@beep/file-processing/PathSafety";
+import { $RepoCliId } from "@beep/identity/packages";
+import { walkFiles } from "@beep/repo-utils";
+import { A, Str } from "@beep/utils";
+import * as O from "@beep/utils/Option";
+import { Cause, Console, Effect, Exit, FileSystem, HashSet, Path } from "effect";
+import * as Eq from "effect/Equal";
+import * as S from "effect/Schema";
+import { allocateUniqueName } from "../../../internal/cli/FsGuards.ts";
+import { FilesCommandError, formatPlatformError } from "../Files.errors.ts";
+import { hasSkippedFiles, mediaKindFromExtension } from "../Files.media.ts";
+import { decodeFlattenMediaOptions, FlattenMediaSummary } from "./FlattenMedia.schemas.ts";
+import { validateDirectory } from "./Validation.ts";
+import type { FlattenMediaOptions } from "./FlattenMedia.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Files/internal/FlattenMedia");
+
+class FlattenMediaTarget extends S.Class<FlattenMediaTarget>($I`FlattenMediaTarget`)(
+  {
+    canonicalDirectory: S.String,
+    destinationDevice: S.Finite,
+    destinationExisted: S.Boolean,
+    directory: S.String,
+  },
+  $I.annote("FlattenMediaTarget", {
+    description: "Resolved flatten-media destination with its canonical path and filesystem device.",
+  })
+) {}
+
+class FlattenMediaDirectories extends S.Class<FlattenMediaDirectories>($I`FlattenMediaDirectories`)(
+  {
+    destinationDevice: S.Finite,
+    destinationDirectory: S.String,
+    destinationExisted: S.Boolean,
+    sourceDirectory: S.String,
+  },
+  $I.annote("FlattenMediaDirectories", {
+    description: "Validated, non-overlapping source and destination directories for flatten-media.",
+  })
+) {}
+
+class FlattenMediaPlanEntry extends S.Class<FlattenMediaPlanEntry>($I`FlattenMediaPlanEntry`)(
+  {
+    sourcePath: S.String,
+    sourceRelativePath: S.String,
+    targetName: S.String,
+    targetPath: S.String,
+  },
+  $I.annote("FlattenMediaPlanEntry", {
+    description: "One recursive media source paired with its collision-safe flat destination.",
+  })
+) {}
+
+class FlattenMediaPlan extends S.Class<FlattenMediaPlan>($I`FlattenMediaPlan`)(
+  {
+    collisionCount: S.Finite,
+    destinationDevice: S.Finite,
+    destinationDirectory: S.String,
+    destinationExisted: S.Boolean,
+    entries: S.Array(FlattenMediaPlanEntry),
+    skippedCount: S.Finite,
+    sourceDirectory: S.String,
+  },
+  $I.annote("FlattenMediaPlan", {
+    description: "Deterministic recursive media move plan and its preflight metadata.",
+  })
+) {}
+
+const canonicalizeFlattenMediaTarget = Effect.fn("Files.canonicalizeFlattenMediaTarget")(function* (
+  outDir: string
+): Effect.fn.Return<FlattenMediaTarget, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const directory = path.resolve(outDir);
+  let candidate = directory;
+
+  while (true) {
+    const exists = yield* fs
+      .exists(candidate)
+      .pipe(
+        Effect.mapError((cause) =>
+          formatPlatformError("Failed to inspect flatten-media output path", candidate, { cause })
+        )
+      );
+
+    if (exists) {
+      const info = yield* fs
+        .stat(candidate)
+        .pipe(
+          Effect.mapError((cause) =>
+            formatPlatformError("Failed to stat flatten-media output path", candidate, { cause })
+          )
+        );
+
+      if (!Eq.equals(info.type, "Directory")) {
+        return yield* FilesCommandError.make({
+          message: `Expected --out-dir and its existing ancestors to be directories: "${candidate}"`,
+        });
+      }
+
+      const canonicalCandidate = yield* fs
+        .realPath(candidate)
+        .pipe(
+          Effect.mapError((cause) =>
+            formatPlatformError("Failed to resolve flatten-media output path", candidate, { cause })
+          )
+        );
+      const relativeSuffix = path.relative(candidate, directory);
+
+      return FlattenMediaTarget.make({
+        canonicalDirectory: Str.equivalence(relativeSuffix, "")
+          ? canonicalCandidate
+          : path.resolve(canonicalCandidate, relativeSuffix),
+        destinationDevice: info.dev,
+        destinationExisted: Str.equivalence(candidate, directory),
+        directory,
+      });
+    }
+
+    const parent = path.dirname(candidate);
+    if (Str.equivalence(parent, candidate)) {
+      return yield* FilesCommandError.make({
+        message: `Failed to find an existing ancestor for --out-dir "${directory}".`,
+      });
+    }
+    candidate = parent;
+  }
+});
+
+const validateFlattenMediaDirectories = Effect.fn("Files.validateFlattenMediaDirectories")(function* (
+  options: FlattenMediaOptions
+): Effect.fn.Return<FlattenMediaDirectories, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const { canonicalDir, directory } = yield* validateDirectory(options.dir);
+  const target = yield* canonicalizeFlattenMediaTarget(options.outDir);
+
+  if (
+    isPathWithinRoot(canonicalDir, target.canonicalDirectory) ||
+    isPathWithinRoot(target.canonicalDirectory, canonicalDir)
+  ) {
+    return yield* FilesCommandError.make({
+      message: `Refusing to flatten media across overlapping source/output trees: "${directory}" and "${target.directory}"`,
+    });
+  }
+
+  return FlattenMediaDirectories.make({
+    destinationDevice: target.destinationDevice,
+    destinationDirectory: target.directory,
+    destinationExisted: target.destinationExisted,
+    sourceDirectory: directory,
+  });
+});
+
+const buildFlattenMediaPlan = Effect.fn("Files.buildFlattenMediaPlan")(function* (
+  directories: FlattenMediaDirectories
+): Effect.fn.Return<FlattenMediaPlan, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const existingNames = directories.destinationExisted
+    ? yield* fs.readDirectory(directories.destinationDirectory).pipe(
+        Effect.mapError((cause) =>
+          formatPlatformError("Failed to read flatten-media output directory", directories.destinationDirectory, {
+            cause,
+          })
+        )
+      )
+    : A.empty<string>();
+  const sourcePaths = yield* walkFiles(directories.sourceDirectory, {
+    symlinkGuard: "skip-symlinks",
+  }).pipe(
+    Effect.mapError((cause) =>
+      FilesCommandError.new(cause, `Failed to recursively scan "${directories.sourceDirectory}" for media files.`)
+    )
+  );
+  let collisionCount = 0;
+  let entries = A.empty<FlattenMediaPlanEntry>();
+  let skippedCount = 0;
+  let usedNames = HashSet.fromIterable(existingNames);
+
+  for (const sourcePath of sourcePaths) {
+    const sourceName = path.basename(sourcePath);
+    const extension = path.extname(sourceName);
+    const mediaKind = mediaKindFromExtension(extension);
+
+    if (O.isNone(mediaKind)) {
+      skippedCount += 1;
+      continue;
+    }
+
+    const allocation = allocateUniqueName(path.basename(sourceName, extension), extension, usedNames);
+    usedNames = allocation.usedTargetNames;
+    if (!Str.equivalence(sourceName, allocation.targetName)) {
+      collisionCount += 1;
+    }
+
+    entries = A.append(
+      entries,
+      FlattenMediaPlanEntry.make({
+        sourcePath,
+        sourceRelativePath: path.relative(directories.sourceDirectory, sourcePath),
+        targetName: allocation.targetName,
+        targetPath: path.join(directories.destinationDirectory, allocation.targetName),
+      })
+    );
+  }
+
+  return FlattenMediaPlan.make({
+    collisionCount,
+    destinationDevice: directories.destinationDevice,
+    destinationDirectory: directories.destinationDirectory,
+    destinationExisted: directories.destinationExisted,
+    entries,
+    skippedCount,
+    sourceDirectory: directories.sourceDirectory,
+  });
+});
+
+const ensureFlattenMediaTargetAvailable = Effect.fn("Files.ensureFlattenMediaTargetAvailable")(function* (
+  targetPath: string
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const exists = yield* fs
+    .exists(targetPath)
+    .pipe(
+      Effect.mapError((cause) => formatPlatformError("Failed to inspect flatten-media target", targetPath, { cause }))
+    );
+
+  if (exists) {
+    return yield* FilesCommandError.make({
+      message: `Refusing to overwrite an existing flatten-media target: "${targetPath}"`,
+    });
+  }
+});
+
+const preflightFlattenMediaPlan = Effect.fn("Files.preflightFlattenMediaPlan")(function* (
+  plan: FlattenMediaPlan
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+
+  for (const entry of plan.entries) {
+    const info = yield* fs
+      .stat(entry.sourcePath)
+      .pipe(
+        Effect.mapError((cause) =>
+          formatPlatformError("Failed to stat flatten-media source file", entry.sourcePath, { cause })
+        )
+      );
+
+    if (!Eq.equals(info.type, "File")) {
+      return yield* FilesCommandError.make({
+        message: `Expected flatten-media source to remain a regular file: "${entry.sourcePath}"`,
+      });
+    }
+
+    if (!Eq.equals(info.dev, plan.destinationDevice)) {
+      return yield* FilesCommandError.make({
+        message: `Cannot move "${entry.sourcePath}" to "${plan.destinationDirectory}" with rename-only semantics because they are on different filesystems.`,
+      });
+    }
+
+    yield* ensureFlattenMediaTargetAvailable(entry.targetPath);
+  }
+});
+
+const renderFlattenMediaCause = (cause: Cause.Cause<FilesCommandError>): string => {
+  const error = Cause.findErrorOption(cause);
+  return O.isSome(error) ? error.value.message : Cause.pretty(cause);
+};
+
+const moveFlattenMediaPath = Effect.fn("Files.moveFlattenMediaPath")(function* (
+  sourcePath: string,
+  targetPath: string
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs
+    .rename(sourcePath, targetPath)
+    .pipe(
+      Effect.mapError((cause) =>
+        FilesCommandError.new(cause, `Failed to move flatten-media source "${sourcePath}" to "${targetPath}".`)
+      )
+    );
+});
+
+const moveFlattenMediaEntry = Effect.fn("Files.moveFlattenMediaEntry")(function* (
+  entry: FlattenMediaPlanEntry
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem> {
+  yield* ensureFlattenMediaTargetAvailable(entry.targetPath);
+  yield* moveFlattenMediaPath(entry.sourcePath, entry.targetPath);
+});
+
+const rollbackFlattenMediaEntries = Effect.fn("Files.rollbackFlattenMediaEntries")(function* (
+  completed: ReadonlyArray<FlattenMediaPlanEntry>
+): Effect.fn.Return<ReadonlyArray<string>, never, FileSystem.FileSystem> {
+  let failures = A.empty<string>();
+
+  for (const entry of A.reverse(completed)) {
+    const restored = yield* Effect.exit(
+      ensureFlattenMediaTargetAvailable(entry.sourcePath).pipe(
+        Effect.andThen(moveFlattenMediaPath(entry.targetPath, entry.sourcePath))
+      )
+    );
+
+    if (Exit.isFailure(restored)) {
+      failures = A.append(failures, renderFlattenMediaCause(restored.cause));
+    }
+  }
+
+  return failures;
+});
+
+const createFlattenMediaDestination = Effect.fn("Files.createFlattenMediaDestination")(function* (
+  plan: FlattenMediaPlan
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  if (plan.destinationExisted) {
+    return;
+  }
+
+  yield* fs.makeDirectory(path.dirname(plan.destinationDirectory), { recursive: true }).pipe(
+    Effect.mapError((cause) =>
+      formatPlatformError("Failed to create flatten-media output parent directory", plan.destinationDirectory, {
+        cause,
+      })
+    )
+  );
+
+  const created = yield* Effect.exit(
+    fs.makeDirectory(plan.destinationDirectory).pipe(
+      Effect.mapError((cause) =>
+        formatPlatformError("Failed to create flatten-media output directory", plan.destinationDirectory, {
+          cause,
+        })
+      )
+    )
+  );
+
+  if (Exit.isFailure(created)) {
+    const inspected = yield* Effect.exit(
+      fs.stat(plan.destinationDirectory).pipe(
+        Effect.mapError((cause) =>
+          formatPlatformError("Failed to inspect concurrently created output directory", plan.destinationDirectory, {
+            cause,
+          })
+        )
+      )
+    );
+
+    if (Exit.isSuccess(inspected) && Eq.equals(inspected.value.type, "Directory")) {
+      return;
+    }
+
+    return yield* Effect.failCause(created.cause);
+  }
+});
+
+const flattenMediaRecoveryMessage = (
+  completed: ReadonlyArray<FlattenMediaPlanEntry>,
+  recoveryFailures: ReadonlyArray<string>
+): string => {
+  if (A.isReadonlyArrayNonEmpty(recoveryFailures)) {
+    return `Rollback incomplete: ${A.join("; ")(recoveryFailures)}`;
+  }
+  return A.isReadonlyArrayNonEmpty(completed)
+    ? "Completed moves were restored."
+    : "No earlier moves required rollback.";
+};
+
+const recoverFlattenMediaFailure = Effect.fn("Files.recoverFlattenMediaFailure")(function* (
+  destinationDirectory: string,
+  completed: ReadonlyArray<FlattenMediaPlanEntry>,
+  cause: Cause.Cause<FilesCommandError>
+): Effect.fn.Return<never, FilesCommandError, FileSystem.FileSystem> {
+  const recoveryFailures = yield* rollbackFlattenMediaEntries(completed);
+
+  if (A.isReadonlyArrayNonEmpty(recoveryFailures)) {
+    yield* Effect.logWarning({
+      message: "files flatten-media recovery was incomplete",
+      destinationDirectory,
+      failures: recoveryFailures,
+    });
+  }
+
+  const originalError = Cause.findErrorOption(cause);
+  if (O.isNone(originalError)) {
+    return yield* Effect.failCause(cause);
+  }
+
+  return yield* FilesCommandError.make({
+    cause: originalError.value,
+    message: `${originalError.value.message} ${flattenMediaRecoveryMessage(completed, recoveryFailures)}`,
+  });
+});
+
+const applyFlattenMediaPlan = Effect.fn("Files.applyFlattenMediaPlan")(function* (
+  plan: FlattenMediaPlan
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  return yield* Effect.uninterruptibleMask(
+    Effect.fnUntraced(function* (restore) {
+      yield* createFlattenMediaDestination(plan);
+      let completed = A.empty<FlattenMediaPlanEntry>();
+
+      for (const entry of plan.entries) {
+        const moved = yield* Effect.exit(
+          restore(
+            Effect.uninterruptible(
+              moveFlattenMediaEntry(entry).pipe(
+                Effect.tap(() =>
+                  Effect.sync(() => {
+                    completed = A.append(completed, entry);
+                  })
+                )
+              )
+            )
+          )
+        );
+
+        if (Exit.isFailure(moved)) {
+          return yield* recoverFlattenMediaFailure(plan.destinationDirectory, completed, moved.cause);
+        }
+      }
+    })
+  );
+});
+
+const logFlattenMediaPlan = Effect.fn("Files.logFlattenMediaPlan")(function* (plan: FlattenMediaPlan) {
+  yield* Effect.forEach(plan.entries, (entry) => Console.log(`${entry.sourceRelativePath} -> ${entry.targetName}`), {
+    discard: true,
+  });
+});
+
+const makeFlattenMediaSummary = (plan: FlattenMediaPlan, dryRun: boolean, movedCount: number): FlattenMediaSummary =>
+  FlattenMediaSummary.make({
+    collisionCount: plan.collisionCount,
+    destinationDirectory: plan.destinationDirectory,
+    dryRun,
+    movedCount,
+    plannedCount: A.length(plan.entries),
+    skippedCount: plan.skippedCount,
+    sourceDirectory: plan.sourceDirectory,
+  });
+
+/**
+ * Validate, plan, preview, and apply a recursive media flattening operation.
+ *
+ * @internal
+ * @effects Recursively reads source directories and moves selected files unless dry-run is enabled.
+ * @example
+ * ```ts
+ * import { FlattenMediaOptions } from "@beep/repo-cli/commands/Files"
+ * import { runFlattenMediaFiles } from "@beep/repo-cli/commands/Files/internal/FlattenMedia"
+ * import { Effect } from "effect"
+ *
+ * const program = runFlattenMediaFiles(FlattenMediaOptions.make({
+ *   dir: "./raw",
+ *   outDir: "./flat"
+ * }))
+ * console.log(Effect.isEffect(program))
+ * ```
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const runFlattenMediaFiles = Effect.fn("Files.runFlattenMediaFiles")(function* (
+  options: FlattenMediaOptions
+): Effect.fn.Return<FlattenMediaSummary, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const decodedOptions = yield* decodeFlattenMediaOptions(options).pipe(
+    FilesCommandError.mapError(
+      "Invalid flatten-media options. Expected --dir, --out-dir, and a boolean --dry-run flag."
+    )
+  );
+  const directories = yield* validateFlattenMediaDirectories(decodedOptions);
+  const plan = yield* buildFlattenMediaPlan(directories);
+  const plannedCount = A.length(plan.entries);
+
+  if (!A.isReadonlyArrayNonEmpty(plan.entries)) {
+    yield* Console.log(
+      `files flatten-media: 0 media file(s) found beneath "${plan.sourceDirectory}"; nothing to move.`
+    );
+    if (hasSkippedFiles(plan.skippedCount)) {
+      yield* Console.log(`files flatten-media: skipped ${plan.skippedCount} non-media file(s).`);
+    }
+    return makeFlattenMediaSummary(plan, decodedOptions.dryRun, 0);
+  }
+
+  yield* preflightFlattenMediaPlan(plan);
+  yield* Console.log(
+    `files flatten-media: ${plannedCount} media file(s) planned from "${plan.sourceDirectory}" to "${plan.destinationDirectory}".`
+  );
+  if (hasSkippedFiles(plan.collisionCount)) {
+    yield* Console.log(`files flatten-media: resolved ${plan.collisionCount} filename collision(s).`);
+  }
+  if (hasSkippedFiles(plan.skippedCount)) {
+    yield* Console.log(`files flatten-media: skipped ${plan.skippedCount} non-media file(s).`);
+  }
+  yield* logFlattenMediaPlan(plan);
+
+  if (decodedOptions.dryRun) {
+    yield* Console.log("files flatten-media: dry run; no directory created and no files moved.");
+    return makeFlattenMediaSummary(plan, true, 0);
+  }
+
+  yield* applyFlattenMediaPlan(plan);
+  yield* Console.log(`files flatten-media: moved ${plannedCount} media file(s).`);
+  return makeFlattenMediaSummary(plan, false, plannedCount);
+});

--- a/packages/tooling/tool/cli/src/internal/cli/FsGuards.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/FsGuards.ts
@@ -148,8 +148,8 @@ export const dedupeBySha256 = <A extends { readonly sha256: string }>(
 };
 
 /**
- * Allocate a filesystem name that does not collide with an in-use set,
- * suffixing `_NN` on collision.
+ * Allocate a filesystem name that does not collide case-insensitively with an
+ * in-use set, suffixing `_NN` on collision.
  *
  * @param stem - The base file name without extension.
  * @param extension - The extension (including any leading dot) to append.
@@ -172,8 +172,9 @@ export const allocateUniqueName: {
 } = dual(3, (stem: string, extension: string, usedNames: HashSet.HashSet<string>): UniqueNameAllocation => {
   let suffix = 0;
   let targetName = `${stem}${extension}`;
+  const normalizedUsedNames = HashSet.map(usedNames, Str.toLowerCase);
 
-  while (HashSet.has(usedNames, targetName)) {
+  while (HashSet.has(normalizedUsedNames, Str.toLowerCase(targetName))) {
     suffix += 1;
     targetName = `${stem}_${Str.padStart(2, "0")(`${suffix}`)}${extension}`;
   }

--- a/packages/tooling/tool/cli/test/cli-kits.test.ts
+++ b/packages/tooling/tool/cli/test/cli-kits.test.ts
@@ -144,6 +144,9 @@ describe("internal/cli/FsGuards", () => {
 
     const dataLast = allocateUniqueName(".webp", HashSet.make("photo.webp"))("photo");
     expect(dataLast.targetName).toBe("photo_01.webp");
+
+    const caseCollided = allocateUniqueName("PHOTO", ".WEBP", HashSet.make("photo.webp", "Photo_01.webp"));
+    expect(caseCollided.targetName).toBe("PHOTO_02.WEBP");
   });
 
   it("validatePathSegment works data-first and data-last", () => {

--- a/packages/tooling/tool/cli/test/files-command.test.ts
+++ b/packages/tooling/tool/cli/test/files-command.test.ts
@@ -14,6 +14,8 @@ import {
   DetectBordersReport,
   DetectFacesReport,
   FilesCommandServiceLive,
+  FlattenMediaOptions,
+  flattenMediaFiles,
   ImageAuditManifest,
   ImageCurationDecisionDocument,
   ImageCurationManifest,
@@ -26,6 +28,7 @@ import { fcRuns } from "@beep/test-utils";
 import { A, O, Str } from "@beep/utils";
 import { NodeChildProcessSpawner, NodeServices } from "@effect/platform-node";
 import { Cause, ConfigProvider, Data, Effect, Exit, FileSystem, Layer, Order, Path, pipe } from "effect";
+import * as PlatformError from "effect/PlatformError";
 import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
 import { FastCheck as fc } from "effect/testing";
@@ -1848,6 +1851,511 @@ describe("files command", { concurrent: false }, () => {
 
           expect(yield* sortedDirectoryEntries(datasetDir)).toEqual(["broken.png", "valid.svg"]);
           expect(output).toContain("Failed to probe image dimensions");
+        })
+      )
+    ));
+
+  it("recursively flattens image and video files while preserving non-media files and source directories", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const nestedDir = path.join(sourceDir, "nestedFolder");
+          const hiddenDir = path.join(sourceDir, ".hidden");
+          const emptyDir = path.join(nestedDir, "empty");
+          const outDir = path.join(tmpDir, "flat");
+
+          yield* fs.makeDirectory(emptyDir, { recursive: true });
+          yield* fs.makeDirectory(hiddenDir, { recursive: true });
+          yield* fs.writeFileString(path.join(sourceDir, "1.jpg"), "direct image");
+          yield* fs.writeFileString(path.join(sourceDir, "1.mkv"), "direct video");
+          yield* fs.writeFileString(path.join(nestedDir, "2.png"), "nested image");
+          yield* fs.writeFileString(path.join(nestedDir, "beep.mp4"), "nested video");
+          yield* fs.writeFileString(path.join(hiddenDir, "secret.WEBM"), "hidden video");
+          yield* fs.writeFileString(path.join(sourceDir, "notes.txt"), "keep direct");
+          yield* fs.writeFileString(path.join(nestedDir, "keep.md"), "keep nested");
+
+          yield* runFilesCommand(["flatten-media", "--dir", sourceDir, "--out-dir", outDir]);
+
+          expect(yield* sortedDirectoryEntries(outDir)).toEqual(["1.jpg", "1.mkv", "2.png", "beep.mp4", "secret.WEBM"]);
+          expect(yield* fs.readFileString(path.join(outDir, "1.jpg"))).toBe("direct image");
+          expect(yield* fs.readFileString(path.join(outDir, "beep.mp4"))).toBe("nested video");
+          expect(yield* fs.readFileString(path.join(outDir, "secret.WEBM"))).toBe("hidden video");
+          expect(yield* sortedDirectoryEntries(sourceDir)).toEqual([".hidden", "nestedFolder", "notes.txt"]);
+          expect(yield* sortedDirectoryEntries(nestedDir)).toEqual(["empty", "keep.md"]);
+          expect(yield* sortedDirectoryEntries(hiddenDir)).toEqual([]);
+          expect(yield* fs.readFileString(path.join(sourceDir, "notes.txt"))).toBe("keep direct");
+          expect(yield* fs.readFileString(path.join(nestedDir, "keep.md"))).toBe("keep nested");
+        })
+      )
+    ));
+
+  it("allocates deterministic collision suffixes around existing file and directory names", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const outDir = path.join(tmpDir, "flat");
+
+          yield* fs.makeDirectory(path.join(sourceDir, "a"), { recursive: true });
+          yield* fs.makeDirectory(path.join(sourceDir, "b"), { recursive: true });
+          yield* fs.makeDirectory(path.join(sourceDir, "c"), { recursive: true });
+          yield* fs.makeDirectory(path.join(outDir, "photo_01.JPG"), { recursive: true });
+          yield* fs.writeFileString(path.join(sourceDir, "a", "photo.JPG"), "source a");
+          yield* fs.writeFileString(path.join(sourceDir, "b", "photo.JPG"), "source b");
+          yield* fs.writeFileString(path.join(sourceDir, "c", "photo.JPG"), "source c");
+          yield* fs.writeFileString(path.join(outDir, "photo.JPG"), "existing original");
+          yield* fs.writeFileString(path.join(outDir, "photo_03.JPG"), "existing gap");
+
+          yield* runFilesCommand(["flatten-media", "--dir", sourceDir, "--out-dir", outDir]);
+
+          expect(yield* sortedDirectoryEntries(outDir)).toEqual([
+            "photo.JPG",
+            "photo_01.JPG",
+            "photo_02.JPG",
+            "photo_03.JPG",
+            "photo_04.JPG",
+            "photo_05.JPG",
+          ]);
+          expect(yield* fs.readFileString(path.join(outDir, "photo.JPG"))).toBe("existing original");
+          expect(yield* fs.readFileString(path.join(outDir, "photo_02.JPG"))).toBe("source a");
+          expect(yield* fs.readFileString(path.join(outDir, "photo_03.JPG"))).toBe("existing gap");
+          expect(yield* fs.readFileString(path.join(outDir, "photo_04.JPG"))).toBe("source b");
+          expect(yield* fs.readFileString(path.join(outDir, "photo_05.JPG"))).toBe("source c");
+          expect(yield* sortedDirectoryEntries(path.join(outDir, "photo_01.JPG"))).toEqual([]);
+        })
+      )
+    ));
+
+  it("keeps mixed-case collision planning and application filesystem-safe", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const outDir = path.join(tmpDir, "flat");
+
+          yield* fs.makeDirectory(path.join(sourceDir, "a"), { recursive: true });
+          yield* fs.makeDirectory(path.join(sourceDir, "b"), { recursive: true });
+          yield* fs.makeDirectory(outDir, { recursive: true });
+          yield* fs.writeFileString(path.join(sourceDir, "a", "photo.jpg"), "lowercase source");
+          yield* fs.writeFileString(path.join(sourceDir, "b", "PHOTO.JPG"), "uppercase source");
+          yield* fs.writeFileString(path.join(outDir, "Photo.jpg"), "existing mixed-case target");
+
+          yield* runFilesCommand(["flatten-media", "--dir", sourceDir, "--out-dir", outDir, "--dry-run"]);
+
+          expect(yield* TestConsole.logLines).toContain("a/photo.jpg -> photo_01.jpg");
+          expect(yield* TestConsole.logLines).toContain("b/PHOTO.JPG -> PHOTO_02.JPG");
+          expect(yield* fs.readFileString(path.join(sourceDir, "a", "photo.jpg"))).toBe("lowercase source");
+          expect(yield* fs.readFileString(path.join(sourceDir, "b", "PHOTO.JPG"))).toBe("uppercase source");
+
+          yield* runFilesCommand(["flatten-media", "--dir", sourceDir, "--out-dir", outDir]);
+
+          expect(yield* sortedDirectoryEntries(outDir)).toEqual(["PHOTO_02.JPG", "Photo.jpg", "photo_01.jpg"]);
+          expect(yield* fs.readFileString(path.join(outDir, "Photo.jpg"))).toBe("existing mixed-case target");
+          expect(yield* fs.readFileString(path.join(outDir, "photo_01.jpg"))).toBe("lowercase source");
+          expect(yield* fs.readFileString(path.join(outDir, "PHOTO_02.JPG"))).toBe("uppercase source");
+        })
+      )
+    ));
+
+  it("prints a dry-run plan without moving files or creating the destination", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const nestedDir = path.join(sourceDir, "nested");
+          const outDir = path.join(tmpDir, "flat");
+
+          yield* fs.makeDirectory(nestedDir, { recursive: true });
+          yield* fs.writeFileString(path.join(nestedDir, "photo.png"), "image");
+
+          yield* runFilesCommand(["flatten-media", "--dir", sourceDir, "--out-dir", outDir, "--dry-run"]);
+
+          expect(yield* fs.readFileString(path.join(nestedDir, "photo.png"))).toBe("image");
+          expect(yield* fs.exists(outDir)).toBe(false);
+          expect(yield* TestConsole.logLines).toContain(
+            "files flatten-media: dry run; no directory created and no files moved."
+          );
+        })
+      )
+    ));
+
+  it("does not create the destination when no media files are found", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const outDir = path.join(tmpDir, "flat");
+
+          yield* fs.makeDirectory(sourceDir, { recursive: true });
+          yield* fs.writeFileString(path.join(sourceDir, "notes.txt"), "keep");
+
+          yield* runFilesCommand(["flatten-media", "--dir", sourceDir, "--out-dir", outDir]);
+
+          expect(yield* fs.readFileString(path.join(sourceDir, "notes.txt"))).toBe("keep");
+          expect(yield* fs.exists(outDir)).toBe(false);
+        })
+      )
+    ));
+
+  it("rejects an output path that is not a directory without moving media", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const outPath = path.join(tmpDir, "not-a-directory");
+          const sourcePath = path.join(sourceDir, "photo.jpg");
+
+          yield* fs.makeDirectory(sourceDir, { recursive: true });
+          yield* fs.writeFileString(sourcePath, "image");
+          yield* fs.writeFileString(outPath, "existing file");
+
+          yield* expectFilesCommandFailure(["flatten-media", "--dir", sourceDir, "--out-dir", outPath]);
+
+          expect(yield* fs.readFileString(sourcePath)).toBe("image");
+          expect(yield* fs.readFileString(outPath)).toBe("existing file");
+        })
+      )
+    ));
+
+  it("rejects destination overlap in both containment directions", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const outerSourceDir = path.join(tmpDir, "outer-source");
+          const nestedOutDir = path.join(outerSourceDir, "flat");
+          const outerSourcePath = path.join(outerSourceDir, "outer.jpg");
+          const sourceAlias = path.join(tmpDir, "source-alias");
+          const aliasedNestedOutDir = path.join(sourceAlias, "aliased-flat");
+          const outerOutDir = path.join(tmpDir, "outer-output");
+          const nestedSourceDir = path.join(outerOutDir, "nested-source");
+          const nestedSourcePath = path.join(nestedSourceDir, "nested.png");
+
+          yield* fs.makeDirectory(outerSourceDir, { recursive: true });
+          yield* fs.makeDirectory(nestedSourceDir, { recursive: true });
+          yield* fs.writeFileString(outerSourcePath, "outer");
+          yield* fs.writeFileString(nestedSourcePath, "nested");
+          yield* fs.symlink(outerSourceDir, sourceAlias);
+
+          yield* expectFilesCommandFailure(["flatten-media", "--dir", outerSourceDir, "--out-dir", nestedOutDir]);
+          yield* expectFilesCommandFailure(["flatten-media", "--dir", outerSourceDir, "--out-dir", outerSourceDir]);
+          yield* expectFilesCommandFailure(["flatten-media", "--dir", nestedSourceDir, "--out-dir", outerOutDir]);
+          yield* expectFilesCommandFailure([
+            "flatten-media",
+            "--dir",
+            outerSourceDir,
+            "--out-dir",
+            aliasedNestedOutDir,
+          ]);
+
+          expect(yield* fs.readFileString(outerSourcePath)).toBe("outer");
+          expect(yield* fs.readFileString(nestedSourcePath)).toBe("nested");
+          expect(yield* fs.exists(nestedOutDir)).toBe(false);
+          expect(yield* fs.exists(path.join(outerSourceDir, "aliased-flat"))).toBe(false);
+        })
+      )
+    ));
+
+  it("skips symlinked media files and directories during recursive traversal", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const outsideDir = path.join(tmpDir, "outside");
+          const outsideFile = path.join(tmpDir, "outside.png");
+          const outDir = path.join(tmpDir, "flat");
+
+          yield* fs.makeDirectory(sourceDir, { recursive: true });
+          yield* fs.makeDirectory(outsideDir, { recursive: true });
+          yield* fs.writeFileString(path.join(sourceDir, "actual.jpg"), "actual");
+          yield* fs.writeFileString(outsideFile, "outside file");
+          yield* fs.writeFileString(path.join(outsideDir, "hidden.mp4"), "outside directory");
+          yield* fs.symlink(outsideFile, path.join(sourceDir, "linked.png"));
+          yield* fs.symlink(outsideDir, path.join(sourceDir, "linked-dir"));
+
+          yield* runFilesCommand(["flatten-media", "--dir", sourceDir, "--out-dir", outDir]);
+
+          expect(yield* sortedDirectoryEntries(outDir)).toEqual(["actual.jpg"]);
+          expect(yield* sortedDirectoryEntries(sourceDir)).toEqual(["linked-dir", "linked.png"]);
+          expect(yield* fs.readFileString(outsideFile)).toBe("outside file");
+          expect(yield* fs.readFileString(path.join(outsideDir, "hidden.mp4"))).toBe("outside directory");
+        })
+      )
+    ));
+
+  it("fails cross-device preflight before creating the destination or moving files", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const firstSourcePath = path.join(sourceDir, "a.jpg");
+          const secondSourcePath = path.join(sourceDir, "b.mp4");
+          const outDir = path.join(tmpDir, "flat");
+          let renameCallCount = 0;
+
+          yield* fs.makeDirectory(sourceDir, { recursive: true });
+          yield* fs.writeFileString(firstSourcePath, "first");
+          yield* fs.writeFileString(secondSourcePath, "second");
+
+          const crossDeviceFileSystem: FileSystem.FileSystem = {
+            ...fs,
+            rename: (fromPath, toPath) =>
+              Effect.sync(() => {
+                renameCallCount += 1;
+              }).pipe(Effect.flatMap(() => fs.rename(fromPath, toPath))),
+            stat: (filePath) =>
+              fs
+                .stat(filePath)
+                .pipe(Effect.map((info) => (filePath === secondSourcePath ? { ...info, dev: info.dev + 1 } : info))),
+          };
+          const error = yield* flattenMediaFiles(
+            FlattenMediaOptions.make({ dir: sourceDir, dryRun: false, outDir })
+          ).pipe(
+            provideScopedLayer(FilesCommandServiceLive),
+            Effect.provideService(FileSystem.FileSystem, crossDeviceFileSystem),
+            Effect.flip
+          );
+
+          expect(error.message).toContain("different filesystems");
+          expect(renameCallCount).toBe(0);
+          expect(yield* fs.readFileString(firstSourcePath)).toBe("first");
+          expect(yield* fs.readFileString(secondSourcePath)).toBe("second");
+          expect(yield* fs.exists(outDir)).toBe(false);
+        })
+      )
+    ));
+
+  it("preserves a target discovered immediately before the move", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const sourcePath = path.join(sourceDir, "photo.jpg");
+          const outDir = path.join(tmpDir, "flat");
+          const targetPath = path.join(outDir, "photo.jpg");
+          let targetProbeCount = 0;
+          let injectedTarget = false;
+
+          yield* fs.makeDirectory(sourceDir, { recursive: true });
+          yield* fs.writeFileString(sourcePath, "source");
+
+          const racingFileSystem: FileSystem.FileSystem = {
+            ...fs,
+            exists: (filePath) =>
+              Effect.suspend(() => {
+                if (filePath !== targetPath) {
+                  return fs.exists(filePath);
+                }
+
+                targetProbeCount += 1;
+                if (targetProbeCount < 2) {
+                  return fs.exists(filePath);
+                }
+
+                injectedTarget = true;
+                return fs.writeFileString(filePath, "concurrent target").pipe(Effect.as(true));
+              }),
+          };
+          const error = yield* flattenMediaFiles(
+            FlattenMediaOptions.make({ dir: sourceDir, dryRun: false, outDir })
+          ).pipe(
+            provideScopedLayer(FilesCommandServiceLive),
+            Effect.provideService(FileSystem.FileSystem, racingFileSystem),
+            Effect.flip
+          );
+
+          expect(error.message).toContain("Refusing to overwrite");
+          expect(injectedTarget).toBe(true);
+          expect(yield* fs.readFileString(sourcePath)).toBe("source");
+          expect(yield* fs.readFileString(targetPath)).toBe("concurrent target");
+        })
+      )
+    ));
+
+  it("rolls completed moves back and leaves the new output directory in place when a later move fails", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const firstSourcePath = path.join(sourceDir, "a.jpg");
+          const secondSourcePath = path.join(sourceDir, "b.mp4");
+          const outDir = path.join(tmpDir, "flat");
+          let renameCallCount = 0;
+
+          yield* fs.makeDirectory(sourceDir, { recursive: true });
+          yield* fs.writeFileString(firstSourcePath, "first");
+          yield* fs.writeFileString(secondSourcePath, "second");
+
+          const failingFileSystem: FileSystem.FileSystem = {
+            ...fs,
+            rename: (fromPath, toPath) =>
+              Effect.suspend(() => {
+                renameCallCount += 1;
+                return renameCallCount === 2
+                  ? Effect.fail(
+                      PlatformError.badArgument({
+                        description: "simulated second rename failure",
+                        method: "rename",
+                        module: "FileSystem",
+                      })
+                    )
+                  : fs.rename(fromPath, toPath);
+              }),
+          };
+
+          const error = yield* flattenMediaFiles(
+            FlattenMediaOptions.make({ dir: sourceDir, dryRun: false, outDir })
+          ).pipe(
+            provideScopedLayer(FilesCommandServiceLive),
+            Effect.provideService(FileSystem.FileSystem, failingFileSystem),
+            Effect.flip
+          );
+
+          expect(renameCallCount).toBe(3);
+          expect(error.message).toContain("Completed moves were restored.");
+          expect(yield* fs.readFileString(firstSourcePath)).toBe("first");
+          expect(yield* fs.readFileString(secondSourcePath)).toBe("second");
+          expect(yield* sortedDirectoryEntries(outDir)).toEqual([]);
+        })
+      )
+    ));
+
+  it("does not clean up an output directory created by another actor after planning", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const firstSourcePath = path.join(sourceDir, "a.jpg");
+          const secondSourcePath = path.join(sourceDir, "b.mp4");
+          const outDir = path.join(tmpDir, "flat");
+          let injectedDirectory = false;
+          let renameCallCount = 0;
+
+          yield* fs.makeDirectory(sourceDir, { recursive: true });
+          yield* fs.writeFileString(firstSourcePath, "first");
+          yield* fs.writeFileString(secondSourcePath, "second");
+
+          const racingFileSystem: FileSystem.FileSystem = {
+            ...fs,
+            makeDirectory: (directoryPath, options) =>
+              Effect.suspend(() => {
+                if (directoryPath !== outDir || injectedDirectory) {
+                  return fs.makeDirectory(directoryPath, options);
+                }
+
+                injectedDirectory = true;
+                return fs.makeDirectory(directoryPath).pipe(Effect.andThen(fs.makeDirectory(directoryPath, options)));
+              }),
+            rename: (fromPath, toPath) =>
+              Effect.suspend(() => {
+                renameCallCount += 1;
+                return renameCallCount === 2
+                  ? Effect.fail(
+                      PlatformError.badArgument({
+                        description: "simulated second rename failure",
+                        method: "rename",
+                        module: "FileSystem",
+                      })
+                    )
+                  : fs.rename(fromPath, toPath);
+              }),
+          };
+
+          const error = yield* flattenMediaFiles(
+            FlattenMediaOptions.make({ dir: sourceDir, dryRun: false, outDir })
+          ).pipe(
+            provideScopedLayer(FilesCommandServiceLive),
+            Effect.provideService(FileSystem.FileSystem, racingFileSystem),
+            Effect.flip
+          );
+
+          expect(error.message).toContain("Completed moves were restored.");
+          expect(injectedDirectory).toBe(true);
+          expect(yield* fs.exists(outDir)).toBe(true);
+          expect(yield* sortedDirectoryEntries(outDir)).toEqual([]);
+          expect(yield* fs.readFileString(firstSourcePath)).toBe("first");
+          expect(yield* fs.readFileString(secondSourcePath)).toBe("second");
+        })
+      )
+    ));
+
+  it("reports rollback failures without disturbing source files that were not moved", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const sourceDir = path.join(tmpDir, "source");
+          const firstSourcePath = path.join(sourceDir, "a.jpg");
+          const secondSourcePath = path.join(sourceDir, "b.mp4");
+          const outDir = path.join(tmpDir, "flat");
+          const firstTargetPath = path.join(outDir, "a.jpg");
+          const sentinelDirectory = path.join(outDir, "reserved");
+          const sentinelPath = path.join(outDir, "sentinel.txt");
+          let renameCallCount = 0;
+
+          yield* fs.makeDirectory(sourceDir, { recursive: true });
+          yield* fs.makeDirectory(sentinelDirectory, { recursive: true });
+          yield* fs.writeFileString(firstSourcePath, "first");
+          yield* fs.writeFileString(secondSourcePath, "second");
+          yield* fs.writeFileString(sentinelPath, "sentinel");
+
+          const failingFileSystem: FileSystem.FileSystem = {
+            ...fs,
+            rename: (fromPath, toPath) =>
+              Effect.suspend(() => {
+                renameCallCount += 1;
+                return renameCallCount === 1
+                  ? fs.rename(fromPath, toPath)
+                  : Effect.fail(
+                      PlatformError.badArgument({
+                        description:
+                          renameCallCount === 2 ? "simulated second rename failure" : "simulated rollback failure",
+                        method: "rename",
+                        module: "FileSystem",
+                      })
+                    );
+              }),
+          };
+          const error = yield* flattenMediaFiles(
+            FlattenMediaOptions.make({ dir: sourceDir, dryRun: false, outDir })
+          ).pipe(
+            provideScopedLayer(FilesCommandServiceLive),
+            Effect.provideService(FileSystem.FileSystem, failingFileSystem),
+            Effect.flip
+          );
+
+          expect(renameCallCount).toBe(3);
+          expect(error.message).toMatch(/rollback/i);
+          expect(yield* fs.exists(firstSourcePath)).toBe(false);
+          expect(yield* fs.readFileString(secondSourcePath)).toBe("second");
+          expect(yield* fs.readFileString(firstTargetPath)).toBe("first");
+          expect(yield* fs.readFileString(sentinelPath)).toBe("sentinel");
+          expect(yield* sortedDirectoryEntries(sentinelDirectory)).toEqual([]);
         })
       )
     ));


### PR DESCRIPTION
## Summary

- Adds `beep files flatten-media --dir <source> --out-dir <destination>`.
- Recursively moves image and video files into one flat destination directory.
- Uses deterministic, case-insensitive collision suffixes shared by dry-run and apply.
- Rejects overlapping source/destination paths and skips symlinks and non-media files.
- Rolls moved files back on failure while leaving a newly created empty destination in place.

## Verification

- `bun run beep yeet verify`
- Independent review found no remaining blockers or nits.

## feat(repo-cli): add flatten-media command

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_files-flatten-media-3696b4f5557c/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787866786&installation_model_id=424656&pr_number=491&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F491&signature=8aa8ca871aca9e04670c00b19de196f5675748cf6fd513fca82d0458008accea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->