### PR TITLE
fix(repo): stop effect-tsgo patch leaking a binary backup per install

### DIFF
--- a/.changeset/prune-tsgo-binary-backups.md
+++ b/.changeset/prune-tsgo-binary-backups.md
@@ -1,0 +1,22 @@
+---
+{}
+---
+
+No release: stop `effect-tsgo patch` leaking a ~30 MB binary backup on every install.
+
+`effect-tsgo patch` renames the current binary to a fresh numbered backup each run and never
+reuses or removes one, hard-failing at 100 with `BackupRestoreError: Too many backup files
+exist (over 100)`. `unpatch` does not reclaim them either — it restores only the unsuffixed
+`.original` and leaves the patched binary behind as a `.<uuid>.patched` file.
+
+That ceiling is reachable. The `oip-web` Vercel project restored its build cache across
+deployments until the count crossed 100, after which no deployment could get past `install` —
+and because the failure happens during install, the build never wrote a fresh cache, so every
+later deployment restored the same poisoned one and failed identically. A developer checkout
+here had accumulated 42 backups totalling 1.2 GB.
+
+The root `prepare` script now prunes rotated `*.original.<n>` backups and `*.patched`
+leftovers before patching, across every `node_modules/@typescript/*` package. The genuine
+unsuffixed `*.original` is kept, since it is the only one `patch` cannot regenerate. Steady
+state is two files rather than unbounded growth, and pruning never gates the install: if it
+fails it warns and lets `patch` proceed.

--- a/package.json
+++ b/package.json
@@ -411,7 +411,7 @@
     "pkg:verify": "beep-cli quality package-verify",
     "pkg:verify:quick": "beep-cli quality package-verify --quick",
     "postinstall": "lefthook install",
-    "prepare": "effect-tsgo patch",
+    "prepare": "node scripts/prune-tsgo-backups.mjs && effect-tsgo patch",
     "purge": "bun run beep purge",
     "quality:dev": "bun run beep quality dev",
     "release": "bun run build && bun run test && bun run lint && bun run audit:full && changeset publish",

--- a/scripts/prune-tsgo-backups.mjs
+++ b/scripts/prune-tsgo-backups.mjs
@@ -1,0 +1,69 @@
+// Reclaim the binary backups `effect-tsgo patch` leaves behind, so a long-lived
+// `node_modules` cannot accumulate them without bound.
+//
+// Why this exists. `effect-tsgo patch` backs the current binary up before
+// writing its own, and it never reuses or removes a backup:
+//
+//   let actualBackupPath = binary + ".original"
+//   while (exists(actualBackupPath)) {
+//     if (counter > 100) fail("Too many backup files exist (over 100)")
+//     actualBackupPath = binary + ".original." + counter++
+//   }
+//   rename(binary, actualBackupPath)
+//
+// So every install adds one ~30 MB file, and at 100 the patch step fails hard.
+// The tool's restore path does not reclaim them either: it reads only the
+// plain `.original` and renames the patched binary aside as a `.patched` file.
+//
+// That ceiling is reachable in practice. A Vercel project restoring its build
+// cache across deployments crossed 100 and could no longer deploy at all - and
+// because the failure happens during `install`, the build never wrote a new
+// cache, so every later deployment restored the same poisoned one and failed
+// identically. A developer checkout here held 42 backups totalling 1.2 GB.
+//
+// What is safe to delete. The plain `<binary>.original` is the genuine
+// pre-patch binary and is kept: it is the one file `patch` cannot regenerate.
+// The numbered `<binary>.original.<n>` files are previously-patched binaries
+// rotated out by later runs, and `*.patched` files are restore leftovers; both
+// are reproducible from the package and are removed.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const typescriptPackagesRoot = path.join(process.cwd(), "node_modules", "@typescript");
+
+// `.original.12` - a rotated-out patched binary. Never the plain `.original`.
+const isReclaimable = (name) => /\.original\.\d+$/.test(name) || name.endsWith(".patched");
+
+const pruneDirectory = (directory) =>
+  fs
+    .readdirSync(directory)
+    .filter(isReclaimable)
+    .map((entry) => path.join(directory, entry))
+    .reduce((reclaimedBytes, target) => {
+      const { size } = fs.statSync(target);
+      fs.rmSync(target);
+      return reclaimedBytes + size;
+    }, 0);
+
+const libDirectories = () =>
+  fs
+    .readdirSync(typescriptPackagesRoot)
+    .map((packageName) => path.join(typescriptPackagesRoot, packageName, "lib"))
+    .filter((directory) => fs.existsSync(directory));
+
+const main = () => {
+  // A fresh clone has no @typescript packages until install finishes; nothing
+  // to prune is the normal case, not a failure.
+  if (!fs.existsSync(typescriptPackagesRoot)) return;
+  const reclaimedBytes = libDirectories().reduce((total, directory) => total + pruneDirectory(directory), 0);
+  console.log(`[prune-tsgo-backups] reclaimed ~${Math.round(reclaimedBytes / 1024 / 1024)} MB of stale binary backups`);
+};
+
+// Pruning is an optimization, never a gate: if it cannot run, `patch` should
+// still get its chance rather than failing the whole install.
+try {
+  main();
+} catch (cause) {
+  console.warn(`[prune-tsgo-backups] skipped: ${cause instanceof Error ? cause.message : String(cause)}`);
+}


### PR DESCRIPTION
Fixes the `oip-web` Vercel failure at its cause, and the same leak on every developer machine.

## What is happening

`effect-tsgo patch` (the repo's root `prepare` script) backs up the current binary before
writing its own, and never reuses or reclaims a backup:

```js
let actualBackupPath = binary + ".original"
while (exists(actualBackupPath)) {
  if (counter > 100) fail("Too many backup files exist (over 100)")
  actualBackupPath = binary + ".original." + counter++
}
rename(binary, actualBackupPath)
```

So each install leaves one more ~30 MB file behind, and at 100 the patch step fails hard.
The tool's restore path does not help either — it reads only the plain `.original` and
renames the patched binary aside as a `.patched` file, leaking in its own way. `--force`
does not affect this loop.

## Why it took the site down

`oip-web` restores its Vercel build cache across deployments, so the count kept climbing
until it crossed 100. After that no deployment could get past `install`:

```
Restored build cache from previous deployment (C8o91sEMVqTAkNEqtp2NJMqxqNSt)
$ effect-tsgo patch
BackupRestoreError: Too many backup files exist (over 100).
error: prepare script from "@beep/root" exited with 1
```

The failure lands *during install*, so the build never writes a fresh cache — every later
deployment restores that same poisoned cache and fails identically. It cannot self-heal, and
it is now failing on `main`, not just on PRs.

This is also not only a CI problem: a developer checkout here had 42 rotated backups
totalling **1.2 GB** in a single `node_modules`.

## The fix

Root `prepare` prunes rotated `*.original.<n>` backups and `*.patched` leftovers across every
`node_modules/@typescript/*` package before patching. The plain `*.original` is kept — it is
the genuine pre-patch binary and the only one `patch` cannot regenerate.

Steady state becomes two files (`*.original` plus one rotation) instead of unbounded growth,
so the 100 ceiling is unreachable.

Pruning never gates the install: on any failure it warns and lets `patch` proceed. Reclaiming
disk is an optimization; patching is not.

## Verification

- `bun run beep yeet verify` — exit 0, all lanes passed
- Ran end-to-end via `bun run prepare`: seeded backups pruned, `patch` then succeeded and
  self-verified
- Confirmed both live binaries survive across all `@typescript` packages (`tsc`/`tsc.original`
  and `tsgo`/`tsgo.original`), and `tsgo -b` type-checks clean afterward
- Reclaimed 1.3 GB → 56 MB in this checkout

## Note

This unblocks *future* deploys. The already-poisoned `oip-web` build cache still needs one
manual clear — redeploy with "Use existing Build Cache" unchecked — because the cache cannot
fix itself once past the ceiling.

Worth reporting upstream to `@effect/tsgo` as well: both `patch` and its restore path leak,
and neither has a cleanup mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3WERQAp3dqd4oczWab8QN

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787880219&installation_model_id=424656&pr_number=495&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F495&signature=f89758b136575e0e8cea4237499f7d7fdea498e6e56fe98723fbee3cb141a776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->