### PR TITLE
ci(check): increase lint runner capacity

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,7 +53,7 @@ jobs:
         include:
           - id: lint
             name: Lint
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: blacksmith-8vcpu-ubuntu-2404
             timeout_minutes: 30
             uses_turbo: "true"
             install_typos: "true"


### PR DESCRIPTION
## Summary

- Run only the Check workflow's Lint lane on an 8-vCPU Blacksmith runner.
- Keep every other verification lane and timeout unchanged.

## Why

The direct-parent `main` Lint job lost its 4-vCPU runner without producing logs,
and rerun attempt 2 failed the same way. The document-hardening PR's Lint job
passed, but post-merge `main` cannot close while this required lane is unstable.
The narrow capacity increase adds headroom without changing lint behavior or
broadly increasing CI cost.

## Verification

- Exact verified commit: `a06fb24ca67818541f697c97f8e35d66a8ca9c54`.
- `bun run beep yeet repair` passed.
- `bun run beep yeet verify` passed the full pre-push suite and detached frozen
  install.
- Build, check, lint, unit, type, integration, Fallow, changeset graph,
  secrets, OSV, SAST, and Nix lanes passed locally.
- No source, dependency, API, documentation, or release surface changed.
- Hosted Lint ran on `blacksmith-8vcpu-ubuntu-2404` and passed in 1m17s.
- All 26 hosted checks are terminal with zero failures or pending checks; the
  two skipped checks are intentional.
- Greptile reviewed the exact head at 5/5 with zero issues.
- Yeet closeout reports zero closeout issues and zero actionable threads.
