### PR TITLE
perf(quality-speedup): leaf import boundaries for Md.safe and BlockRepair

### DIFF
--- a/.changeset/leaf-boundaries-instantiation.md
+++ b/.changeset/leaf-boundaries-instantiation.md
@@ -1,0 +1,15 @@
+---
+"@beep/md": patch
+"@beep/agents-server": patch
+"@beep/agents-use-cases": patch
+---
+
+Cut typecheck instantiation mass via probe-proved leaf import boundaries
+(quality-speedup follow-up): Md.safe imports its two policy schemas from
+`@beep/html/Html.policy` instead of the barrel (−21.8% for the module), and
+BlockRepair consumes `IndexedBlock`/`BlockRepairFailed` through new
+`@beep/agents-use-cases/AssistantTurn.contracts` and
+`.../AssistantTurn.repair-errors` leaf entry points instead of the public and
+server barrels (−86.8%, 15.2M → 2.0M instantiations; peak RSS 5.1GB → 0.85GB).
+A `@beep/agents-server/BlockRepair` leaf entry is exported alongside the
+existing AssistantTurn barrel, which is retained for compatibility.

--- a/packages/agents/server/package.json
+++ b/packages/agents/server/package.json
@@ -33,13 +33,14 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./test": "./src/test.ts",
-    "./AssistantTurn": "./src/AssistantTurn/index.ts",
-    "./ProviderInstance": "./src/ProviderInstance/index.ts",
     "./AnthropicTurnCodec": "./src/AssistantTurn/AnthropicTurnCodec.ts",
     "./AnthropicTurnKernel": "./src/AssistantTurn/AnthropicTurnKernel.ts",
+    "./AssistantTurn": "./src/AssistantTurn/index.ts",
+    "./BlockRepair": "./src/AssistantTurn/BlockRepair.ts",
+    "./ProviderInstance": "./src/ProviderInstance/index.ts",
     "./internal/*": null,
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./test": "./src/test.ts"
   },
   "files": [
     "src/**/*.ts",
@@ -54,13 +55,14 @@
     "provenance": true,
     "exports": {
       ".": "./dist/index.js",
-      "./test": "./dist/test.js",
-      "./AssistantTurn": "./dist/AssistantTurn/index.js",
-      "./ProviderInstance": "./dist/ProviderInstance/index.js",
       "./AnthropicTurnCodec": "./dist/AssistantTurn/AnthropicTurnCodec.js",
       "./AnthropicTurnKernel": "./dist/AssistantTurn/AnthropicTurnKernel.js",
+      "./AssistantTurn": "./dist/AssistantTurn/index.js",
+      "./BlockRepair": "./dist/AssistantTurn/BlockRepair.js",
+      "./ProviderInstance": "./dist/ProviderInstance/index.js",
       "./internal/*": null,
-      "./package.json": "./package.json"
+      "./package.json": "./package.json",
+      "./test": "./dist/test.js"
     }
   },
   "dependencies": {

--- a/packages/agents/server/src/AssistantTurn/AnthropicTurnKernel.ts
+++ b/packages/agents/server/src/AssistantTurn/AnthropicTurnKernel.ts
@@ -257,7 +257,8 @@ const streamTurn = (
  * failures are converted to `TurnGenerationError`; blocks that remain invalid
  * after repair are logged and dropped.
  *
- * @example
+ * **Example** (Use AnthropicTurnKernel)
+ *
  * ```ts
  * import { AgentTurnKernel } from "@beep/agents-use-cases/public"
  * import { AnthropicTurnKernel } from "@beep/agents-server/AnthropicTurnKernel"

--- a/packages/agents/server/src/AssistantTurn/AnthropicTurnKernel.ts
+++ b/packages/agents/server/src/AssistantTurn/AnthropicTurnKernel.ts
@@ -250,7 +250,8 @@ const streamTurn = (
  * requirement is the redacted `AI_ANTHROPIC_API_KEY` config resolved by the
  * plan's provided client layer.
  *
- * @remarks
+ * **Details**
+ *
  * The kernel streams valid blocks as soon as they decode. After the first
  * invalid slice, later valid blocks are buffered until the repair tail can emit
  * repaired and already-valid blocks in original envelope order. Repair-call

--- a/packages/agents/server/src/AssistantTurn/AnthropicTurnKernel.ts
+++ b/packages/agents/server/src/AssistantTurn/AnthropicTurnKernel.ts
@@ -37,8 +37,9 @@ import { LanguageModel, Tool, Toolkit } from "effect/unstable/ai";
 import { assistantBlockOutput } from "./AnthropicTurnCodec.ts";
 import { IssueReport, repairInvalidBlocks } from "./BlockRepair.ts";
 import { initialScanState, scanChunk } from "./ScanState.ts";
-import type { AssistantTurnEvent, IndexedBlock, TurnHistoryItem } from "@beep/agents-use-cases/public";
-import type { BlockRepairFailed } from "@beep/agents-use-cases/server";
+import type { IndexedBlock } from "@beep/agents-use-cases/AssistantTurn.contracts";
+import type { BlockRepairFailed } from "@beep/agents-use-cases/AssistantTurn.repair-errors";
+import type { AssistantTurnEvent, TurnHistoryItem } from "@beep/agents-use-cases/public";
 import type { Config } from "effect";
 import type { AiError, Response } from "effect/unstable/ai";
 

--- a/packages/agents/server/src/AssistantTurn/BlockRepair.ts
+++ b/packages/agents/server/src/AssistantTurn/BlockRepair.ts
@@ -82,9 +82,10 @@ const blocksRepaired = Metric.counter("agents_assistant_turn_blocks_repaired_tot
 /**
  * Validation issue report for one streamed assistant-block slice.
  *
- * @example
+ * **Example** (Use IssueReport)
+ *
  * ```ts
- * import { IssueReport } from "@beep/agents-server/AssistantTurn"
+ * import { IssueReport } from "@beep/agents-server/BlockRepair"
  *
  * const report = IssueReport.make({
  *   index: 0,
@@ -182,10 +183,11 @@ class RepairInvalidBlocksResult extends S.Class<RepairInvalidBlocksResult>($I`Re
  * usage; envelope validation, per-block decoding, unexpected indices, and
  * dropped repairs remain the adapter's responsibility.
  *
- * @example
+ * **Example** (Use BlockRepairCall)
+ *
  * ```ts
- * import { IssueReport } from "@beep/agents-server/AssistantTurn"
- * import type { BlockRepairCall } from "@beep/agents-server/AssistantTurn"
+ * import { IssueReport } from "@beep/agents-server/BlockRepair"
+ * import type { BlockRepairCall } from "@beep/agents-server/BlockRepair"
  * import { AnthropicToolJsonResponse } from "@beep/anthropic"
  * import { Effect } from "effect"
  * import { Response } from "effect/unstable/ai"
@@ -227,11 +229,12 @@ export type BlockRepairCall = (
  * tool results are handled by the adapter and do not escape as successful
  * blocks; repair-call failures are represented by `BlockRepairFailed`.
  *
- * @example
+ * **Example** (Use RepairInvalidBlocks)
+ *
  * ```ts
- * import { IssueReport, makeRepairInvalidBlocks } from "@beep/agents-server/AssistantTurn"
+ * import { IssueReport, makeRepairInvalidBlocks } from "@beep/agents-server/BlockRepair"
  * import { AnthropicToolJsonResponse } from "@beep/anthropic"
- * import type { RepairInvalidBlocks } from "@beep/agents-server/AssistantTurn"
+ * import type { RepairInvalidBlocks } from "@beep/agents-server/BlockRepair"
  * import { Effect } from "effect"
  * import { Response } from "effect/unstable/ai"
  *
@@ -300,9 +303,10 @@ const toBlockRepairFailed = (message: string): BlockRepairFailed => BlockRepairF
 /**
  * Base schema fields shared by every summarized JSON Patch operation, carrying the redacted JSON Pointer path.
  *
- * @example
+ * **Example** (Use PatchOpSummaryBase)
+ *
  * ```ts
- * import { PatchOpSummaryBase } from "@beep/agents-server/AssistantTurn"
+ * import { PatchOpSummaryBase } from "@beep/agents-server/BlockRepair"
  *
  * const base = PatchOpSummaryBase.make({ path: "/content" })
  * console.log(base.path)
@@ -326,9 +330,10 @@ export class PatchOpSummaryBase extends S.Class<PatchOpSummaryBase>($I`PatchOpSu
 /**
  * Summary of a JSON Patch add operation, tagged with the `add` op discriminant.
  *
- * @example
+ * **Example** (Use AddPatchOpSummary)
+ *
  * ```ts
- * import { AddPatchOpSummary } from "@beep/agents-server/AssistantTurn"
+ * import { AddPatchOpSummary } from "@beep/agents-server/BlockRepair"
  * import * as S from "effect/Schema"
  *
  * const summary = S.decodeUnknownSync(AddPatchOpSummary)({ op: "add", path: "/content" })
@@ -351,9 +356,10 @@ export class AddPatchOpSummary extends PatchOpSummaryBase.extend<AddPatchOpSumma
 /**
  * Summary of a JSON Patch remove operation, tagged with the `remove` op discriminant.
  *
- * @example
+ * **Example** (Use RemovePatchOpSummary)
+ *
  * ```ts
- * import { RemovePatchOpSummary } from "@beep/agents-server/AssistantTurn"
+ * import { RemovePatchOpSummary } from "@beep/agents-server/BlockRepair"
  * import * as S from "effect/Schema"
  *
  * const summary = S.decodeUnknownSync(RemovePatchOpSummary)({ op: "remove", path: "/content" })
@@ -376,9 +382,10 @@ export class RemovePatchOpSummary extends PatchOpSummaryBase.extend<RemovePatchO
 /**
  * Summary of a JSON Patch replace operation, tagged with the `replace` op discriminant.
  *
- * @example
+ * **Example** (Use ReplacePatchOpSummary)
+ *
  * ```ts
- * import { ReplacePatchOpSummary } from "@beep/agents-server/AssistantTurn"
+ * import { ReplacePatchOpSummary } from "@beep/agents-server/BlockRepair"
  * import * as S from "effect/Schema"
  *
  * const summary = S.decodeUnknownSync(ReplacePatchOpSummary)({ op: "replace", path: "/content" })
@@ -401,9 +408,10 @@ export class ReplacePatchOpSummary extends PatchOpSummaryBase.extend<ReplacePatc
 /**
  * Tagged union of summarized JSON Patch operations discriminated on the `op` field.
  *
- * @example
+ * **Example** (Use PatchOpSummary)
+ *
  * ```ts
- * import { PatchOpSummary } from "@beep/agents-server/AssistantTurn"
+ * import { PatchOpSummary } from "@beep/agents-server/BlockRepair"
  * import * as S from "effect/Schema"
  *
  * const summary = S.decodeUnknownSync(PatchOpSummary)({ op: "add", path: "/content" })
@@ -424,9 +432,10 @@ export const PatchOpSummary = S.Union([AddPatchOpSummary, RemovePatchOpSummary, 
 /**
  * Runtime type of the {@link PatchOpSummary} tagged union of JSON Patch operation summaries.
  *
- * @example
+ * **Example** (Use PatchOpSummary)
+ *
  * ```ts
- * import { PatchOpSummary } from "@beep/agents-server/AssistantTurn"
+ * import { PatchOpSummary } from "@beep/agents-server/BlockRepair"
  * import * as S from "effect/Schema"
  *
  * const summary: PatchOpSummary = S.decodeUnknownSync(PatchOpSummary)({ op: "remove", path: "/content" })
@@ -629,9 +638,10 @@ const runRepairAttempts = Effect.fn("runRepairAttempts")(function* (
  * that remain pending after the retry budget. A failed provider call or
  * malformed repair envelope fails the effect with `BlockRepairFailed`.
  *
- * @example
+ * **Example** (Use makeRepairInvalidBlocks)
+ *
  * ```ts
- * import { IssueReport, makeRepairInvalidBlocks } from "@beep/agents-server/AssistantTurn"
+ * import { IssueReport, makeRepairInvalidBlocks } from "@beep/agents-server/BlockRepair"
  * import { AnthropicToolJsonResponse } from "@beep/anthropic"
  * import { Effect } from "effect"
  * import { Response } from "effect/unstable/ai"
@@ -685,9 +695,10 @@ export const makeRepairInvalidBlocks = (callRepair: BlockRepairCall = defaultRep
  * structured failure reports. Empty batches return immediately without a
  * provider call, which is useful for branch-free repair tails.
  *
- * @example
+ * **Example** (Use repairInvalidBlocks)
+ *
  * ```ts
- * import { repairInvalidBlocks } from "@beep/agents-server/AssistantTurn"
+ * import { repairInvalidBlocks } from "@beep/agents-server/BlockRepair"
  * import { Effect } from "effect"
  *
  * Effect.runPromise(repairInvalidBlocks([])).then((result) => console.log(result.blocks.length)) // 0

--- a/packages/agents/server/src/AssistantTurn/BlockRepair.ts
+++ b/packages/agents/server/src/AssistantTurn/BlockRepair.ts
@@ -177,7 +177,8 @@ class RepairInvalidBlocksResult extends S.Class<RepairInvalidBlocksResult>($I`Re
  * Provider call used by {@link makeRepairInvalidBlocks} to obtain repair tool
  * parameters for a batch of invalid block slices.
  *
- * @remarks
+ * **Details**
+ *
  * `attempt` is one-based and never exceeds the adapter retry limit. The call
  * returns the raw repair-tool parameters JSON together with terminal provider
  * usage; envelope validation, per-block decoding, unexpected indices, and
@@ -223,7 +224,8 @@ export type BlockRepairCall = (
  * Repair function shape used by the Anthropic turn kernel after streamed block
  * validation has collected one or more failures.
  *
- * @remarks
+ * **Details**
+ *
  * The returned effect succeeds with repaired indexed blocks and aggregate
  * repair-call token usage. Missing, duplicated, unexpected, or still-invalid
  * tool results are handled by the adapter and do not escape as successful
@@ -631,7 +633,8 @@ const runRepairAttempts = Effect.fn("runRepairAttempts")(function* (
 /**
  * Build a retrying invalid-block repair function from a provider call.
  *
- * @remarks
+ * **Details**
+ *
  * The returned repair function makes at most two sequential repair attempts.
  * It keeps the first accepted repair per index, ignores unexpected indices,
  * logs codec-invalid tool results, records repair metrics, and drops failures
@@ -690,7 +693,8 @@ export const makeRepairInvalidBlocks = (callRepair: BlockRepairCall = defaultRep
 /**
  * Default Anthropic-backed invalid-block repair function.
  *
- * @remarks
+ * **Details**
+ *
  * Non-empty failure batches call the Anthropic repair tool with redacted,
  * structured failure reports. Empty batches return immediately without a
  * provider call, which is useful for branch-free repair tails.

--- a/packages/agents/server/src/AssistantTurn/BlockRepair.ts
+++ b/packages/agents/server/src/AssistantTurn/BlockRepair.ts
@@ -6,8 +6,8 @@
  */
 
 import { AssistantBlock } from "@beep/agents-domain/values/AssistantContent";
-import { IndexedBlock } from "@beep/agents-use-cases/public";
-import { BlockRepairFailed } from "@beep/agents-use-cases/server";
+import { IndexedBlock } from "@beep/agents-use-cases/AssistantTurn.contracts";
+import { BlockRepairFailed } from "@beep/agents-use-cases/AssistantTurn.repair-errors";
 import { generateAnthropicToolJson } from "@beep/anthropic";
 import { $AgentsServerId } from "@beep/identity/packages";
 import { redactString } from "@beep/observability";

--- a/packages/agents/server/test/BlockRepair.test.ts
+++ b/packages/agents/server/test/BlockRepair.test.ts
@@ -1,4 +1,4 @@
-import { IssueReport, makeRepairInvalidBlocks } from "@beep/agents-server/AssistantTurn";
+import { IssueReport, makeRepairInvalidBlocks } from "@beep/agents-server/BlockRepair";
 import { BlockRepairFailed } from "@beep/agents-use-cases/server";
 import { AnthropicToolJsonResponse, RepairError } from "@beep/anthropic";
 import { describe, expect, it } from "@effect/vitest";

--- a/packages/agents/use-cases/package.json
+++ b/packages/agents/use-cases/package.json
@@ -30,11 +30,13 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./AssistantTurn.contracts": "./src/processes/AssistantTurn/AssistantTurn.contracts.ts",
+    "./AssistantTurn.repair-errors": "./src/processes/AssistantTurn/AssistantTurn.repair-errors.ts",
+    "./package.json": "./package.json",
+    "./proof": "./src/proof.ts",
     "./public": "./src/public.ts",
     "./server": "./src/server.ts",
-    "./proof": "./src/proof.ts",
-    "./test": "./src/test.ts",
-    "./package.json": "./package.json"
+    "./test": "./src/test.ts"
   },
   "files": [
     "src/**/*.ts",

--- a/packages/foundation/modeling/md/src/Md.safe.ts
+++ b/packages/foundation/modeling/md/src/Md.safe.ts
@@ -11,7 +11,7 @@
  * @since 0.0.0
  */
 
-import { SafeImageUrlAttribute, SafeUrlAttribute } from "@beep/html";
+import { SafeImageUrlAttribute, SafeUrlAttribute } from "@beep/html/Html.policy";
 import { $MdId } from "@beep/identity";
 import { SchemaUtils } from "@beep/schema";
 import { A } from "@beep/utils";

--- a/packages/foundation/modeling/md/src/Md.safe.ts
+++ b/packages/foundation/modeling/md/src/Md.safe.ts
@@ -35,7 +35,8 @@ const schemaIssueToError = (cause: S.SchemaError | S.SchemaError["issue"]): S.Sc
 /**
  * A stable path segment locating a safety violation in the Markdown AST.
  *
- * @example
+ * **Example** (Use DocumentSafetyPathSegment)
+ *
  * ```ts
  * import { DocumentSafetyPathSegment } from "@beep/md/Md.safe"
  * import { Result } from "effect"
@@ -60,7 +61,8 @@ export const DocumentSafetyPathSegment = S.Union([S.String, S.Int.check(S.isGrea
 /**
  * Type for {@link DocumentSafetyPathSegment}.
  *
- * @example
+ * **Example** (Use DocumentSafetyPathSegment)
+ *
  * ```ts
  * import type { DocumentSafetyPathSegment } from "@beep/md/Md.safe"
  *
@@ -76,7 +78,8 @@ export type DocumentSafetyPathSegment = typeof DocumentSafetyPathSegment.Type;
 /**
  * A trusted raw Markdown or HTML node found at a user-content boundary.
  *
- * @example
+ * **Example** (Use RawNodeSafetyViolation)
+ *
  * ```ts
  * import { RawNodeSafetyViolation } from "@beep/md/Md.safe"
  *
@@ -102,7 +105,8 @@ export class RawNodeSafetyViolation extends S.TaggedClass<RawNodeSafetyViolation
  * A URL-bearing Markdown node whose destination is outside its user-content
  * allow list.
  *
- * @example
+ * **Example** (Use UrlSafetyViolation)
+ *
  * ```ts
  * import { UrlSafetyViolation } from "@beep/md/Md.safe"
  *
@@ -135,7 +139,8 @@ export class UrlSafetyViolation extends S.TaggedClass<UrlSafetyViolation>($I`Url
  * A string containing a code point that cannot be represented by the canonical
  * HTML serializer.
  *
- * @example
+ * **Example** (Use ScalarSafetyViolation)
+ *
  * ```ts
  * import { ScalarSafetyViolation } from "@beep/md/Md.safe"
  *
@@ -160,7 +165,8 @@ export class ScalarSafetyViolation extends S.TaggedClass<ScalarSafetyViolation>(
  * A repeated footnote-definition identifier that would produce duplicate HTML
  * ids during safe projection.
  *
- * @example
+ * **Example** (Use DuplicateFootnoteDefinitionSafetyViolation)
+ *
  * ```ts
  * import { DuplicateFootnoteDefinitionSafetyViolation } from "@beep/md/Md.safe"
  *
@@ -191,7 +197,8 @@ export class DuplicateFootnoteDefinitionSafetyViolation extends S.TaggedClass<Du
  * Structured safety issue returned before a document crosses an editor or RPC
  * trust boundary.
  *
- * @example
+ * **Example** (Use DocumentSafetyViolation)
+ *
  * ```ts
  * import { DocumentSafetyViolation, RawNodeSafetyViolation } from "@beep/md/Md.safe"
  *
@@ -217,7 +224,8 @@ export const DocumentSafetyViolation = S.Union([
 /**
  * Type for {@link DocumentSafetyViolation}.
  *
- * @example
+ * **Example** (Use DocumentSafetyViolation)
+ *
  * ```ts
  * import { RawNodeSafetyViolation } from "@beep/md/Md.safe"
  * import type { DocumentSafetyViolation } from "@beep/md/Md.safe"
@@ -436,7 +444,8 @@ const duplicateFootnoteDefinitionIssues = (document: Document): ReadonlyArray<Do
 /**
  * Returns every path-located user-content safety violation.
  *
- * @example
+ * **Example** (Use documentSafetyIssues)
+ *
  * ```ts
  * import { Md } from "@beep/md"
  * import { documentSafetyIssues } from "@beep/md/Md.safe"
@@ -455,7 +464,8 @@ export const documentSafetyIssues = (document: Document): ReadonlyArray<Document
 /**
  * Returns every user-content safety violation below an inline node.
  *
- * @example
+ * **Example** (Use inlineSafetyIssuesAtRoot)
+ *
  * ```ts
  * import { Md } from "@beep/md"
  * import { inlineSafetyIssuesAtRoot } from "@beep/md/Md.safe"
@@ -491,7 +501,8 @@ const SafeDocumentCheck = S.makeFilter<Document>(
  * Branded user-content inline refinement with the same wire representation as
  * {@link Inline}.
  *
- * @example
+ * **Example** (Use SafeInline)
+ *
  * ```ts
  * import { SafeInline } from "@beep/md/Md.safe"
  * import { Result } from "effect"
@@ -516,7 +527,8 @@ export const SafeInline = Inline.pipe(
 /**
  * Type for {@link SafeInline}.
  *
- * @example
+ * **Example** (Use SafeInline)
+ *
  * ```ts
  * import { SafeInline } from "@beep/md/Md.safe"
  * import { Result } from "effect"
@@ -537,7 +549,8 @@ export type SafeInline = typeof SafeInline.Type;
  * Branded user-content document refinement with the same wire representation
  * as {@link Document}.
  *
- * @example
+ * **Example** (Use SafeDocument)
+ *
  * ```ts
  * import { SafeDocument } from "@beep/md/Md.safe"
  * import { Result } from "effect"
@@ -562,7 +575,8 @@ export const SafeDocument = Document.pipe(
 /**
  * Type for {@link SafeDocument}.
  *
- * @example
+ * **Example** (Use SafeDocument)
+ *
  * ```ts
  * import { SafeDocument } from "@beep/md/Md.safe"
  * import { Result } from "effect"
@@ -582,7 +596,8 @@ export type SafeDocument = typeof SafeDocument.Type;
 /**
  * Decodes unknown input into a safe document without throwing.
  *
- * @example
+ * **Example** (Use decodeSafeDocument)
+ *
  * ```ts
  * import { decodeSafeDocument } from "@beep/md/Md.safe"
  * import { Result } from "effect"
@@ -599,7 +614,8 @@ export const decodeSafeDocument = S.decodeUnknownResult(SafeDocument);
 /**
  * Decodes unknown input into a safe document as an Effect.
  *
- * @example
+ * **Example** (Use decodeSafeDocumentEffect)
+ *
  * ```ts
  * import { decodeSafeDocumentEffect } from "@beep/md/Md.safe"
  * import { Effect } from "effect"
@@ -616,7 +632,8 @@ export const decodeSafeDocumentEffect = S.decodeUnknownEffect(SafeDocument);
 /**
  * Decodes unknown input into a safe document and throws on failure.
  *
- * @example
+ * **Example** (Use decodeSafeDocumentUnsafe)
+ *
  * ```ts
  * import { decodeSafeDocumentUnsafe } from "@beep/md/Md.safe"
  *
@@ -632,7 +649,8 @@ export const decodeSafeDocumentUnsafe = (input: unknown): SafeDocument =>
 /**
  * Narrows an already-decoded document after reporting structured issues.
  *
- * @example
+ * **Example** (Use refineSafeDocument)
+ *
  * ```ts
  * import { Md } from "@beep/md"
  * import { refineSafeDocument } from "@beep/md/Md.safe"

--- a/standards/jsdoc-documentation.inventory.jsonc
+++ b/standards/jsdoc-documentation.inventory.jsonc
@@ -1,7 +1,7 @@
 {
   "standard": "jsdoc-documentation",
   "version": 1,
-  "generatedAt": "2026-08-04T09:47:43.507Z",
+  "generatedAt": "2026-08-04T11:36:14.253Z",
   "source": {
     "packageUniverseCommand": "bun run topo-sort",
     "generator": "bun run beep quality jsdoc-inventory",
@@ -68,7 +68,7 @@
     "publicModules": 2363,
     "publicExports": 15522,
     "openModules": 443,
-    "openExports": 1384,
+    "openExports": 1379,
     "missingExportExamples": 0,
     "missingExportCategories": 0,
     "missingExportSince": 0,
@@ -90,7 +90,7 @@
     "malformed-example": 85,
     "duplicate-example": 0,
     "loose-ts-fence": 0,
-    "forbidden-remarks": 472,
+    "forbidden-remarks": 467,
     "rootPolicyOpen": 0
   },
   "packages": [
@@ -42149,8 +42149,8 @@
           "exportKind": "const",
           "filePath": "src/commands/CreatePackage/CreatePackage.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/CreatePackage/CreatePackage.command.ts",
-          "line": 772,
-          "anchor": "packages-tooling-tool-cli-src-commands-createpackage-createpackage-command-ts-772-createpackagecommand",
+          "line": 773,
+          "anchor": "packages-tooling-tool-cli-src-commands-createpackage-createpackage-command-ts-773-createpackagecommand",
           "currentTags": [
             "@category",
             "@since"
@@ -57739,10 +57739,9 @@
           "exportKind": "class",
           "filePath": "src/commands/Skills/Skills.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Skills/Skills.command.ts",
-          "line": 77,
-          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-77-remoteskillsource",
+          "line": 79,
+          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-79-remoteskillsource",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -57762,10 +57761,9 @@
           "exportKind": "class",
           "filePath": "src/commands/Skills/Skills.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Skills/Skills.command.ts",
-          "line": 105,
-          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-105-skilllockentry",
+          "line": 109,
+          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-109-skilllockentry",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -57785,10 +57783,9 @@
           "exportKind": "class",
           "filePath": "src/commands/Skills/Skills.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Skills/Skills.command.ts",
-          "line": 133,
-          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-133-skilllockfile",
+          "line": 139,
+          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-139-skilllockfile",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -57808,10 +57805,9 @@
           "exportKind": "const",
           "filePath": "src/commands/Skills/Skills.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Skills/Skills.command.ts",
-          "line": 234,
-          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-234-remoteskillsources",
+          "line": 242,
+          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-242-remoteskillsources",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -57831,12 +57827,11 @@
           "exportKind": "const",
           "filePath": "src/commands/Skills/Skills.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Skills/Skills.command.ts",
-          "line": 741,
-          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-741-rendercodexconfigwithskills",
+          "line": 757,
+          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-757-rendercodexconfigwithskills",
           "currentTags": [
             "@param",
             "@returns",
-            "@example",
             "@category",
             "@since"
           ],
@@ -57856,10 +57851,9 @@
           "exportKind": "const",
           "filePath": "src/commands/Skills/Skills.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Skills/Skills.command.ts",
-          "line": 890,
-          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-890-runskillsupdate",
+          "line": 908,
+          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-908-runskillsupdate",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -57879,10 +57873,9 @@
           "exportKind": "const",
           "filePath": "src/commands/Skills/Skills.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Skills/Skills.command.ts",
-          "line": 1002,
-          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-1002-skillscommand",
+          "line": 1022,
+          "anchor": "packages-tooling-tool-cli-src-commands-skills-skills-command-ts-1022-skillscommand",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -58617,8 +58610,8 @@
           "exportKind": "const",
           "filePath": "src/commands/TsconfigSync/TsconfigSync.plan.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.plan.ts",
-          "line": 1055,
-          "anchor": "packages-tooling-tool-cli-src-commands-tsconfigsync-tsconfigsync-plan-ts-1055-tsconfigsyncplan",
+          "line": 1056,
+          "anchor": "packages-tooling-tool-cli-src-commands-tsconfigsync-tsconfigsync-plan-ts-1056-tsconfigsyncplan",
           "currentTags": [
             "@category",
             "@since"
@@ -64637,7 +64630,7 @@
       },
       "counts": {
         "openModules": 2,
-        "openExports": 7,
+        "openExports": 2,
         "missingExportExamples": 0,
         "missingExportCategories": 0,
         "missingExportSince": 0,
@@ -64661,7 +64654,7 @@
           "malformed-example": 0,
           "duplicate-example": 0,
           "loose-ts-fence": 0,
-          "forbidden-remarks": 7
+          "forbidden-remarks": 2
         }
       },
       "modules": [
@@ -65027,11 +65020,9 @@
           "exportKind": "const",
           "filePath": "src/AssistantTurn/AnthropicTurnKernel.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/AnthropicTurnKernel.ts",
-          "line": 279,
-          "anchor": "packages-agents-server-src-assistantturn-anthropicturnkernel-ts-279-anthropicturnkernel",
+          "line": 282,
+          "anchor": "packages-agents-server-src-assistantturn-anthropicturnkernel-ts-282-anthropicturnkernel",
           "currentTags": [
-            "@remarks",
-            "@example",
             "@category",
             "@since"
           ],
@@ -65043,22 +65034,17 @@
           "unsafeExampleViolations": [],
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
-          "documentationShapeViolations": [
-            {
-              "rule": "forbidden-remarks"
-            }
-          ],
-          "remediationStatus": "open"
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
         },
         {
           "symbolName": "IssueReport",
           "exportKind": "class",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 100,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-100-issuereport",
+          "line": 101,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-101-issuereport",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -65078,11 +65064,9 @@
           "exportKind": "type",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 215,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-215-blockrepaircall",
+          "line": 218,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-218-blockrepaircall",
           "currentTags": [
-            "@remarks",
-            "@example",
             "@category",
             "@since"
           ],
@@ -65094,23 +65078,17 @@
           "unsafeExampleViolations": [],
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
-          "documentationShapeViolations": [
-            {
-              "rule": "forbidden-remarks"
-            }
-          ],
-          "remediationStatus": "open"
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
         },
         {
           "symbolName": "RepairInvalidBlocks",
           "exportKind": "type",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 256,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-256-repairinvalidblocks",
+          "line": 261,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-261-repairinvalidblocks",
           "currentTags": [
-            "@remarks",
-            "@example",
             "@category",
             "@since"
           ],
@@ -65122,22 +65100,17 @@
           "unsafeExampleViolations": [],
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
-          "documentationShapeViolations": [
-            {
-              "rule": "forbidden-remarks"
-            }
-          ],
-          "remediationStatus": "open"
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
         },
         {
           "symbolName": "PatchOpSummaryBase",
           "exportKind": "class",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 315,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-315-patchopsummarybase",
+          "line": 321,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-321-patchopsummarybase",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -65157,10 +65130,9 @@
           "exportKind": "class",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 342,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-342-addpatchopsummary",
+          "line": 349,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-349-addpatchopsummary",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -65180,10 +65152,9 @@
           "exportKind": "class",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 367,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-367-removepatchopsummary",
+          "line": 375,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-375-removepatchopsummary",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -65203,10 +65174,9 @@
           "exportKind": "class",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 392,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-392-replacepatchopsummary",
+          "line": 401,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-401-replacepatchopsummary",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -65226,10 +65196,9 @@
           "exportKind": "const",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 417,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-417-patchopsummary",
+          "line": 427,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-427-patchopsummary",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -65249,10 +65218,9 @@
           "exportKind": "type",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 440,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-440-patchopsummary",
+          "line": 451,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-451-patchopsummary",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -65272,11 +65240,9 @@
           "exportKind": "const",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 657,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-657-makerepairinvalidblocks",
+          "line": 670,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-670-makerepairinvalidblocks",
           "currentTags": [
-            "@remarks",
-            "@example",
             "@category",
             "@since"
           ],
@@ -65288,23 +65254,17 @@
           "unsafeExampleViolations": [],
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
-          "documentationShapeViolations": [
-            {
-              "rule": "forbidden-remarks"
-            }
-          ],
-          "remediationStatus": "open"
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
         },
         {
           "symbolName": "repairInvalidBlocks",
           "exportKind": "const",
           "filePath": "src/AssistantTurn/BlockRepair.ts",
           "repoPath": "packages/agents/server/src/AssistantTurn/BlockRepair.ts",
-          "line": 699,
-          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-699-repairinvalidblocks",
+          "line": 714,
+          "anchor": "packages-agents-server-src-assistantturn-blockrepair-ts-714-repairinvalidblocks",
           "currentTags": [
-            "@remarks",
-            "@example",
             "@category",
             "@since"
           ],
@@ -65316,12 +65276,8 @@
           "unsafeExampleViolations": [],
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
-          "documentationShapeViolations": [
-            {
-              "rule": "forbidden-remarks"
-            }
-          ],
-          "remediationStatus": "open"
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
         },
         {
           "symbolName": "ScanState",
@@ -148107,10 +148063,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 53,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-53-documentsafetypathsegment",
+          "line": 54,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-54-documentsafetypathsegment",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148130,10 +148085,9 @@
           "exportKind": "type",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 74,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-74-documentsafetypathsegment",
+          "line": 76,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-76-documentsafetypathsegment",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148153,10 +148107,9 @@
           "exportKind": "class",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 90,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-90-rawnodesafetyviolation",
+          "line": 93,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-93-rawnodesafetyviolation",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148176,10 +148129,9 @@
           "exportKind": "class",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 121,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-121-urlsafetyviolation",
+          "line": 125,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-125-urlsafetyviolation",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148199,10 +148151,9 @@
           "exportKind": "class",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 149,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-149-scalarsafetyviolation",
+          "line": 154,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-154-scalarsafetyviolation",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148222,10 +148173,9 @@
           "exportKind": "class",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 177,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-177-duplicatefootnotedefinitionsafetyviolation",
+          "line": 183,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-183-duplicatefootnotedefinitionsafetyviolation",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148245,10 +148195,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 205,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-205-documentsafetyviolation",
+          "line": 212,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-212-documentsafetyviolation",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148268,10 +148217,9 @@
           "exportKind": "type",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 232,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-232-documentsafetyviolation",
+          "line": 240,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-240-documentsafetyviolation",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148291,10 +148239,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 450,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-450-documentsafetyissues",
+          "line": 459,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-459-documentsafetyissues",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148314,10 +148261,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 469,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-469-inlinesafetyissuesatroot",
+          "line": 479,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-479-inlinesafetyissuesatroot",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148337,10 +148283,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 507,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-507-safeinline",
+          "line": 518,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-518-safeinline",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148360,10 +148305,9 @@
           "exportKind": "type",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 534,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-534-safeinline",
+          "line": 546,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-546-safeinline",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148383,10 +148327,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 553,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-553-safedocument",
+          "line": 566,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-566-safedocument",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148406,10 +148349,9 @@
           "exportKind": "type",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 580,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-580-safedocument",
+          "line": 594,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-594-safedocument",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148429,10 +148371,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 597,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-597-decodesafedocument",
+          "line": 612,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-612-decodesafedocument",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148452,10 +148393,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 614,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-614-decodesafedocumenteffect",
+          "line": 630,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-630-decodesafedocumenteffect",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148475,10 +148415,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 629,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-629-decodesafedocumentunsafe",
+          "line": 646,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-646-decodesafedocumentunsafe",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],
@@ -148498,10 +148437,9 @@
           "exportKind": "const",
           "filePath": "src/Md.safe.ts",
           "repoPath": "packages/foundation/modeling/md/src/Md.safe.ts",
-          "line": 647,
-          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-647-refinesafedocument",
+          "line": 665,
+          "anchor": "packages-foundation-modeling-md-src-md-safe-ts-665-refinesafedocument",
           "currentTags": [
-            "@example",
             "@category",
             "@since"
           ],

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-08-04T09:47:43.507Z
+Generated: 2026-08-04T11:36:14.253Z
 
 ## Scope
 
@@ -17,7 +17,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | publicModules | 2363 |
 | publicExports | 15522 |
 | openModules | 443 |
-| openExports | 1384 |
+| openExports | 1379 |
 | missingExportExamples | 0 |
 | missingExportCategories | 0 |
 | missingExportSince | 0 |
@@ -39,7 +39,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | malformed-example | 85 |
 | duplicate-example | 0 |
 | loose-ts-fence | 0 |
-| forbidden-remarks | 472 |
+| forbidden-remarks | 467 |
 | rootPolicyOpen | 0 |
 
 ## Root Policy
@@ -78,7 +78,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 21 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 155 | 993 | 33 | 58 |
 | 22 | `@beep/pglite` | `packages/drivers/pglite` | needs-remediation | 4 | 11 | 3 | 1 |
 | 23 | `@beep/ai-sync` | `packages/tooling/library/ai-sync` | clean | 10 | 83 | 0 | 0 |
-| 24 | `@beep/agents-server` | `packages/agents/server` | needs-remediation | 11 | 39 | 2 | 7 |
+| 24 | `@beep/agents-server` | `packages/agents/server` | needs-remediation | 11 | 39 | 2 | 2 |
 | 25 | `@beep/courtlistener` | `packages/drivers/courtlistener` | needs-remediation | 1 | 1 | 1 | 1 |
 | 26 | `@beep/workspace-use-cases` | `packages/workspace/use-cases` | needs-remediation | 12 | 46 | 1 | 1 |
 | 27 | `@beep/editor` | `packages/foundation/ui-system/editor` | needs-remediation | 25 | 145 | 13 | 13 |
@@ -584,11 +584,6 @@ Module findings:
 Export findings:
 - `src/AssistantTurn/AnthropicTurnCodec.ts:185` `assistantBlockOutput` (const) - 1 documentation section/link violation(s)
 - `src/AssistantTurn/AnthropicTurnCodec.ts:210` `assistantOutput` (const) - 1 documentation section/link violation(s)
-- `src/AssistantTurn/AnthropicTurnKernel.ts:279` `AnthropicTurnKernel` (const) - 1 documentation section/link violation(s)
-- `src/AssistantTurn/BlockRepair.ts:215` `BlockRepairCall` (type) - 1 documentation section/link violation(s)
-- `src/AssistantTurn/BlockRepair.ts:256` `RepairInvalidBlocks` (type) - 1 documentation section/link violation(s)
-- `src/AssistantTurn/BlockRepair.ts:657` `makeRepairInvalidBlocks` (const) - 1 documentation section/link violation(s)
-- `src/AssistantTurn/BlockRepair.ts:699` `repairInvalidBlocks` (const) - 1 documentation section/link violation(s)
 
 ### @beep/courtlistener
 

--- a/standards/jsdoc-totals.regression-baseline.jsonc
+++ b/standards/jsdoc-totals.regression-baseline.jsonc
@@ -8,7 +8,7 @@
   "regeneration_command": "bun run beep quality jsdoc-inventory",
   "snapshot_command": "bun run beep quality jsdoc-ratchet --write-baseline",
   "comparison": "fail-on-growth: generated inventory totals must not exceed this committed baseline",
-  "generated_at": "2026-08-04T09:51:27.416Z",
+  "generated_at": "2026-08-04T11:40:55.134Z",
   "tracked_totals": {
     "packagesNeedingRemediation": 111,
     "missingExportExamples": 0,
@@ -29,6 +29,6 @@
     "malformed-example": 85,
     "duplicate-example": 0,
     "loose-ts-fence": 0,
-    "forbidden-remarks": 472
+    "forbidden-remarks": 467
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1863,6 +1863,15 @@
       ],
       "@beep/workspace-server/SourceText": [
         "./packages/workspace/server/src/SourceText/index.ts"
+      ],
+      "@beep/agents-server/BlockRepair": [
+        "./packages/agents/server/src/AssistantTurn/BlockRepair.ts"
+      ],
+      "@beep/agents-use-cases/AssistantTurn.contracts": [
+        "./packages/agents/use-cases/src/processes/AssistantTurn/AssistantTurn.contracts.ts"
+      ],
+      "@beep/agents-use-cases/AssistantTurn.repair-errors": [
+        "./packages/agents/use-cases/src/processes/AssistantTurn/AssistantTurn.repair-errors.ts"
       ]
     }
   }


### PR DESCRIPTION
Two probe-proved instantiation cuts from the quality-speedup opportunity wave (grill #3, decision 11):

- **Md.safe.ts**: import its two policy schemas from `@beep/html/Html.policy` instead of the `@beep/html` barrel — module instantiations 14.04M → **10.97M** (−21.8%).
- **BlockRepair.ts**: consume `IndexedBlock`/`BlockRepairFailed` through new `@beep/agents-use-cases/AssistantTurn.contracts` and `.../AssistantTurn.repair-errors` leaf entry points instead of the public/server barrels, plus a `@beep/agents-server/BlockRepair` leaf export — 15.22M → **2.01M** (−86.8%), peak check RSS 5.1GB → **0.85GB**.

Method: census overlay probes (tsgo 7.0.2+effect-tsgo.0.24.3), before/after in the commit body; the AssistantTurn barrel re-export is retained for compatibility. Root tsconfig aliases synced via `beep tsconfig-sync` (check returns 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y66vimBGiye7U3YenpQEZy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788433418&installation_model_id=424656&pr_number=549&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F549&signature=ecfcd94cbb4a49e64519f0587674a469f3d2648096191566436a475d751ff7e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->