### PR TITLE
docs(explorations): decompose fleet-coordination into the fleet-mirror map

### DIFF
--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -80,11 +80,14 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   capture-stage preservation of the paused goal’s load-bearing governance
   design: ordered law canon, explicit role authority, gated lifecycle,
   decision-complete artifacts, and expiring exception contracts.
-- [`fleet-coordination`](./fleet-coordination/README.md) — shape-stage: ~13
+- [`fleet-coordination`](./fleet-coordination/README.md) — decompose-stage: ~13
   agent checkouts on one workstation duplicating each other’s fixes and rotting
   each other’s in-flight PRs. Research verdict is a derived **mirror**, not a
   message board — derive early, deliver ambiently, enforce late — shipped
-  through the reserved `AgentBrief.fleet` field, sequenced behind PR-I. Grill #1
+  through the reserved `AgentBrief.fleet` field. `MAP.md` names one packet
+  (`fleet-mirror`) and splits it into a derivation rung that is unblocked today
+  and a delivery rung gated on PR-I, after verifying against `main` that
+  `AgentBrief`/`OwnershipClaim` do not exist yet. Grill #1
   locked D1–D5 and disposed four questions; en route it killed `law-pulse.sh`
   ever reaching the model (fixed here), `beep yeet` being a gate, `flock`
   releasing on holder death, and merge queue at this repo’s measured shape (19%

--- a/explorations/fleet-coordination/MAP.md
+++ b/explorations/fleet-coordination/MAP.md
@@ -1,0 +1,108 @@
+# Map
+
+<!--
+Stage 4. Names the goal packets, their sequencing edges, the first vertical
+slice, and the capability check. Written 2026-08-05 after the operator approved
+BRIEF.md. Every capability claim below was verified against main at 680a862a8e,
+not carried over from the research.
+-->
+
+## Candidate goal packets
+
+### 1. `fleet-mirror` — the only packet this exploration produces
+
+**Mission.** Derive a read-only view of every checkout sharing this origin, and
+deliver it ambiently so an agent learns about duplicate work and moved base state
+before it pays for them — without any agent posting anything.
+
+Everything else in `DECISIONS.md` is either out of scope by ruling (claim
+registry, enforcement, cross-machine) or owned elsewhere (below).
+
+## Not our packets — sequencing edges outward
+
+| Work | Owner | Edge |
+|---|---|---|
+| Repo-wide regeneration rule (#60) | speed-loop ledger | D1 requires it be repo-wide policy, not a `WaveManifest` carve-out. Independent of the mirror; neither blocks the other. |
+| `AgentBrief` + reserved `fleet` block (#52) | speed-loop **PR-I** | **Hard blocker for rung 2 only.** |
+| `OwnershipClaim` (#49) | speed-loop **PR-I** | Wrap, never rebuild (decision 37). Rung 2. |
+| `beep agent report list` (#45) | speed-loop **PR-I** | Optional enrichment — a live agent's own account of `filesTouched`. Rung 2. |
+| Pre-push wiring (PR-G), Q7 guard, #551 regression | speed-loop | Handed off in `research/HANDOFF-2-pre-push-and-guard.md`; dispositioned as A6–A10. |
+
+## Capability check
+
+Verified against `main` at `680a862a8e` by source search, not assumed.
+
+| Component | Status |
+|---|---|
+| `beep worktree doctor` | **Exists** — `packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts`, per-worktree diagnostic row schema (`:216`, `:251`), read-only report schema (`:256`, `:281`), report builder (`:586`). Widen its enumeration from one clone to all checkouts sharing the origin URL. |
+| `git merge-tree --write-tree --name-only` | **Exists** — plumbing, measured ~50–65 ms. Requires the target *object*, not just its SHA. |
+| `/proc/<pid>/cwd` scan | **Exists** — 6.8 ms in Bun. Not universally readable; unreadable ⇒ `unknown`. |
+| `AgentBrief` / `AgentBrief.fleet` | ⚠ **Not on main.** Zero source references at `680a862a8e`. Ships in PR-I. |
+| `OwnershipClaim` | ⚠ **Not on main.** Zero source references. Ships in PR-I. |
+| `beep agent report list` | ⚠ **Not on main.** Not registered as a command. Ships in PR-I. |
+| `FleetCheckout` schema row | **Net-new.** One schema in the Worktree command's existing schema family. |
+| `beep worktree fleet` subcommand | **Net-new.** One subcommand, or a flag on `doctor` — see the open decomposition choice below. |
+| Scanner object database | **Net-new.** A cache dir holding one fetched target per epoch, so `merge-tree` has an object to work against. |
+
+Net-new surface for the whole packet: **one widened enumeration, one schema row,
+one subcommand, one cache directory.** Nothing else.
+
+## The decomposition finding — two rungs, and only one is blocked
+
+`BRIEF.md` sets the appetite as "starting when PR-I merges," on the grounds that
+`AgentBrief.fleet` is the delivery vehicle. The capability check above refines
+that: **the delivery half is blocked; the derivation half is not.**
+
+**Rung 1 — derivation, unblocked today.** The scan, the three signals, the
+liveness classifier, the scanner ODB, and a human-invokable read-only command.
+This composes only `worktree doctor`, `merge-tree`, and `/proc` — all present on
+main. It needs nothing from PR-I, because a human running a command is a delivery
+vector that already exists.
+
+**Rung 2 — ambient delivery, gated on PR-I.** Emitting the derived snapshot into
+`AgentBrief.fleet`, plus the D4 receipt posture and the epoch-gated re-pulse.
+This is where the mirror stops being a tool you run and starts being a thing that
+reaches you.
+
+Splitting this way also retires the packet's real risk earlier: the uncertain
+part was always whether the signals are *correct and quiet enough*, and rung 1
+answers that against the live fleet without waiting on another session's PR.
+
+⚠ **This refines the approved BRIEF's sequencing and needs an operator ruling
+before graduation.** The BRIEF is not wrong — rung 2 genuinely cannot start
+before PR-I — but "the packet starts when PR-I merges" is stronger than the
+evidence requires.
+
+## First vertical slice
+
+Rung 1, ending at a test rather than a feature:
+
+1. `FleetCheckout` schema — one row per checkout: path, branch, head SHA, dirty
+   count (`status --porcelain -uall`), liveness ∈ `live | dormant | unknown`,
+   and the fields the D4/D5 amendments require to be measured-or-`unknown`.
+2. A `Context.Service` that derives the snapshot: enumerate checkouts sharing the
+   origin URL, classify liveness, fetch the epoch target into the scanner ODB,
+   run `merge-tree` per live checkout, and compute policy-path movement against a
+   **measured** surface.
+3. `beep worktree fleet` renders it read-only.
+4. **The proof:** a failing-then-green test reconstructing the #551 shape — main
+   moves onto a measured policy path while a checkout holds an in-flight branch
+   that never touched the changed file. Signal 3 must fire; signals 1 and 2 must
+   stay silent, because there is no textual conflict. A mirror that cannot
+   distinguish those is not carrying Mode B.
+
+Design order is schema → `Context.Service` contract → implementation, per
+standing law.
+
+## Open decomposition choices
+
+Neither blocks graduation; both are goal-packet design latitude.
+
+- **`beep worktree fleet` vs a flag on `beep worktree doctor`.** `SYNTHESIS.md`
+  says a subcommand; `RESEARCH.md`'s capability inventory says widen `doctor`.
+  Recommendation: **a sibling subcommand.** `doctor` answers "is *this* checkout
+  healthy," the mirror answers "what is the *fleet* doing" — different question,
+  different output shape, and `doctor`'s row schema stays single-clone.
+- **Where the scanner ODB lives.** A gitignored cache dir is the obvious answer;
+  the alternative is `objects/info/alternates` against a sibling clone, which is
+  faster but couples the scanner to another checkout's object store.

--- a/explorations/fleet-coordination/README.md
+++ b/explorations/fleet-coordination/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Stage: `shape`
+Stage: `decompose`
 Status: `active`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
@@ -26,19 +26,24 @@ checkouts share one filesystem, one kernel, one user.
 
 ## Next Open Question
 
-Does [`BRIEF.md`](./BRIEF.md) match the picture in the operator's head? On yes,
-the packet moves to `decompose` and writes `MAP.md` naming the goal packet(s),
-sequenced **behind PR-I** — `AgentBrief.fleet` is the delivery vehicle and that
-field ships there. All nine align questions are closed
-([`DECISIONS.md`](./DECISIONS.md)).
+**Does rung 1 start now, or does the whole packet wait for PR-I?**
+[`MAP.md`](./MAP.md) verified the capability surface against `main` and found the
+split the BRIEF did not: `AgentBrief`, `OwnershipClaim`, and `beep agent report
+list` are **not on main** — so ambient delivery (rung 2) is genuinely blocked —
+but `worktree doctor`, `merge-tree`, and `/proc` all are, so **derivation (rung
+1) is not blocked by anything**. The BRIEF's "starting when PR-I merges" is
+therefore stronger than the evidence requires. That ruling is the last thing
+standing between this packet and graduation; the graduation contract's other
+three conditions are met.
 
 ## Read This First
 
 1. [`ops/manifest.json`](./ops/manifest.json) — machine state.
 2. [`BRIEF.md`](./BRIEF.md) — the shaped pitch: problem, appetite, sketch, rabbit holes, no-gos.
-3. [`RESEARCH.md`](./RESEARCH.md) — the distilled landscape and what died.
-4. [`research/SYNTHESIS.md`](./research/SYNTHESIS.md) — full cross-track synthesis, five options, recommended sequence.
-5. Track deliverables only as needed: [`T1`](./research/T1-prior-art.md) prior art · [`T2`](./research/T2-theory.md) blackboard/lease theory · [`T3`](./research/T3-delivery-vector.md) delivery vectors · [`T4`](./research/T4-merge-queue.md) merge queue · [`T5`](./research/T5-derivation.md) derivation surface.
+3. [`MAP.md`](./MAP.md) — the goal packet, sequencing edges, verified capability check, first vertical slice.
+4. [`RESEARCH.md`](./RESEARCH.md) — the distilled landscape and what died.
+5. [`research/SYNTHESIS.md`](./research/SYNTHESIS.md) — full cross-track synthesis, five options, recommended sequence.
+6. Track deliverables only as needed: [`T1`](./research/T1-prior-art.md) prior art · [`T2`](./research/T2-theory.md) blackboard/lease theory · [`T3`](./research/T3-delivery-vector.md) delivery vectors · [`T4`](./research/T4-merge-queue.md) merge queue · [`T5`](./research/T5-derivation.md) derivation surface.
 
 ## Cross-Session Coordination
 
@@ -54,6 +59,15 @@ capability this packet is about does not exist yet.
 
 ## Trail
 
+- 2026-08-05: operator approved `BRIEF.md` → `decompose`. [`MAP.md`](./MAP.md)
+  names one goal packet (`fleet-mirror`) and verifies every cited capability
+  against `main` at `680a862a8e` rather than against the research. That check
+  produced the stage's real finding: `AgentBrief`, `OwnershipClaim`, and `beep
+  agent report list` have **zero source references on main**, while `worktree
+  doctor`, `merge-tree`, and `/proc` are all present — so the work splits into a
+  **derivation rung that is unblocked today** and a **delivery rung gated on
+  PR-I**, and the BRIEF's "starts when PR-I merges" is stronger than the evidence
+  requires. Awaiting the operator's ruling on that split before graduation.
 - 2026-08-05: PR #562 review closed — seven findings, **all seven valid**. Three
   were design defects, now amended: `merge-tree` needs the target *object* and
   `ls-remote` only supplies its SHA (signal 2 was unavailable exactly when main

--- a/explorations/fleet-coordination/README.md
+++ b/explorations/fleet-coordination/README.md
@@ -33,8 +33,13 @@ list` are **not on main** — so ambient delivery (rung 2) is genuinely blocked 
 but `worktree doctor`, `merge-tree`, and `/proc` all are, so **derivation (rung
 1) is not blocked by anything**. The BRIEF's "starting when PR-I merges" is
 therefore stronger than the evidence requires. That ruling is the last thing
-standing between this packet and graduation; the graduation contract's other
-three conditions are met.
+standing between this packet and graduation, and it is recorded in the manifest's
+`openQuestions` so a session orienting from machine state sees it too.
+
+Graduation contract status: **brief complete ✓**, **map names the work ✓**,
+**capability check ✓** (verified against `main`, not assumed) — and **blocking
+questions ✗**, held open by exactly the ruling above. Graduation is one decision
+away, not zero.
 
 ## Read This First
 

--- a/explorations/fleet-coordination/ops/manifest.json
+++ b/explorations/fleet-coordination/ops/manifest.json
@@ -4,7 +4,7 @@
     "slug": "fleet-coordination",
     "title": "Fleet Coordination For Parallel Agent Checkouts",
     "status": "active",
-    "stage": "shape",
+    "stage": "decompose",
     "openQuestions": [],
     "sources": ["research/SOURCES.md"],
     "links": {

--- a/explorations/fleet-coordination/ops/manifest.json
+++ b/explorations/fleet-coordination/ops/manifest.json
@@ -5,7 +5,9 @@
     "title": "Fleet Coordination For Parallel Agent Checkouts",
     "status": "active",
     "stage": "decompose",
-    "openQuestions": [],
+    "openQuestions": [
+      "Does the derivation rung start now, or does the whole fleet-mirror packet wait for PR-I? MAP.md verified against main that AgentBrief, OwnershipClaim, and beep agent report list have zero source references, so ambient delivery (rung 2) is genuinely blocked — but worktree doctor, merge-tree, and /proc are all present, so derivation (rung 1) is not blocked by anything. This makes BRIEF.md's 'starting when PR-I merges' stronger than the evidence requires. Operator ruling required; it is the last condition standing between this packet and graduation."
+    ],
     "sources": ["research/SOURCES.md"],
     "links": {
       "goals": [],


### PR DESCRIPTION
## docs(explorations): decompose fleet-coordination into the fleet-mirror map

Operator approved BRIEF.md, closing the shape stage. MAP.md names one goal
packet, fleet-mirror, with its sequencing edges outward to the speed-loop items
that own the rest, and a first vertical slice that ends at a test rather than a
feature: reconstruct the #551 shape and assert signal 3 fires while signals 1
and 2 stay silent, because that collision has no textual conflict.

The capability check was run against main at 680a862a8e by source search rather
than carried over from the research, and it produced the stage's real finding.
AgentBrief, OwnershipClaim, and beep agent report list have zero source
references on main; worktree doctor, merge-tree, and /proc are all present. The
work therefore splits into a derivation rung that is unblocked today and a
delivery rung genuinely gated on PR-I, which makes the BRIEF's "starts when PR-I
merges" stronger than the evidence requires. That split needs an operator ruling
and is now the packet's only open question; the graduation contract's other
three conditions are met.

Net-new surface for the whole packet stays small: one widened enumeration, one
schema row, one subcommand, one cache directory.

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/docs_fleet-coordination-decompose-map-e78141df88e1/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788577919&installation_model_id=424656&pr_number=567&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F567&signature=424a1b257f90ba478f05e8ffd65f7efcbbc589a579739c43e15d8fb5a2c66b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->