### PR TITLE
feat(repo-cli): yeet merge-loop porcelain, until-merged monitor, artifact codecs

### DIFF
--- a/.changeset/yeet-merge-loop-porcelain.md
+++ b/.changeset/yeet-merge-loop-porcelain.md
@@ -1,0 +1,19 @@
+---
+"@beep/repo-cli": patch
+---
+
+Add the Yeet merge loop: `beep yeet sweep [--plan]` resets the clone after a
+merge (prune refs, fast-forward main, delete merged branches, reinstall on a
+moved lockfile) as a worktree-aware plan whose every skip is reported instead
+of failing; `beep yeet merge` squash-merges without `--delete-branch`, confirms
+`MERGED` through the API, and only then hands the whole cleanup sequence to the
+sweep; `beep yeet reply` posts and resolves drafted review-thread replies from
+`.beep/yeet/reply-drafts.json` and records a report beside it; and
+`beep yeet monitor --until-merged` follows the pull request across pushes,
+giving each known-flake job one `gh run rerun --job` per head SHA before
+sweeping the clone on merge.
+
+Yeet status now carries a `mergeReady` verdict plus per-thread triage context,
+the run verdict is written through an `S.encode`-backed JSON codec, and the
+Fallow advisory phase purges stale or mode-mismatched envelopes and skips
+instead of failing the run.

--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -121,6 +121,35 @@ bun run beep yeet publish --push-only --reuse-verified
 bun run beep yeet monitor
 ```
 
+- Keep monitoring across pushes until the PR merges or closes, instead of
+  re-arming a fresh monitor after every fix wave:
+
+```bash
+bun run beep yeet monitor --until-merged
+```
+
+- Reset the clone after a merge (prune refs, fast-forward `main`, delete the
+  merged branch locally and remotely, reinstall when `bun.lock` moved, end on
+  `main`). Inspect the plan before running it:
+
+```bash
+bun run beep yeet sweep --plan
+bun run beep yeet sweep
+```
+
+- Post and resolve the drafted review-thread replies for this branch's PR:
+
+```bash
+bun run beep yeet reply
+```
+
+- Squash-merge this branch's PR, confirm `MERGED` through the API, then sweep
+  the clone. Operator-authorized only — never run it without being asked:
+
+```bash
+bun run beep yeet merge
+```
+
 - Read the local Yeet operator state before scanning logs. This is local-only
   by default and reads branch/worktree state plus the latest Yeet artifacts:
 
@@ -165,7 +194,12 @@ bun run beep yeet publish --message "type(scope): summary" --plan --json
 bun run beep yeet status --remote --plan --json
 bun run beep yeet monitor --summary --plan --json
 bun run beep yeet closeout --plan --json
+bun run beep yeet sweep --plan --json
 ```
+
+`yeet sweep --plan` is the sweep's own dry run, not the generic yeet plan: it
+prints the branch-deletion and ref-update steps with the git facts behind each
+one.
 
 ## Authoritative Gates (green local must mean green CI)
 
@@ -225,7 +259,12 @@ from a real security failure) before shipping such a fix.
    through the same Yeet publish path.
 10. Mark the PR ready only when checks are green, there are zero unresolved
     review threads (including outdated threads until explicitly resolved), and GitHub reports the branch as mergeable or not
-    conflicted.
+    conflicted. `bun run beep yeet status --remote` prints a `merge-ready:` line
+    that names the first failing criterion instead of making you read three
+    surfaces.
+11. After the merge lands, run `bun run beep yeet sweep` — or let
+    `monitor --until-merged` run it on merged detection — so the next branch does
+    not start from a stale clone.
 
 `yeet closeout` is read-first. It classifies review threads and bot findings and
 writes Yeet artifacts locally. It posts a Greptile rerun comment only when
@@ -263,6 +302,51 @@ local proof cycle. If the post-push local proof fails or writes files, fix the
 issue in a follow-up commit and publish again. Treat commit/pre-push hooks as
 local tripwires and proof-reuse adapters; Yeet full proof plus hosted checks are
 the authoritative gates.
+
+## Merge Loop
+
+`yeet monitor --until-merged`, `yeet sweep`, `yeet reply`, and `yeet merge` are
+the merge-loop porcelain. They read the clone and the PR; none of them plan
+turbo work, so they are cheap to run mid-loop.
+
+- `monitor --until-merged` re-reads status every poll, so a push landing
+  mid-session is picked up as the new budget scope. A failed job whose log
+  matches a known flake fingerprint (`ts2589-no-location`, CI timeout) gets
+  exactly one `gh run rerun --job <databaseId>` per job per head SHA — never
+  `--failed`, which would re-execute coexisting genuine reds. Anything else is
+  reported as "needs code fix". The loop ends on MERGED (after the sweep),
+  on CLOSED, or when you interrupt it.
+- **Branch-deletion contract.** `sweep` deletes with `-d` when the branch is an
+  ancestor of `origin/main`. It uses `-D` only when the PR is MERGED **and** the
+  local tip still equals the PR's recorded head SHA **and** no worktree holds the
+  branch; remote deletion needs the same tip match. Any unmet precondition is a
+  skip-and-report, not a failure — unmerged local work is never force-deleted.
+- A sweep exits 0 whether every step ran or every step skipped: "merged, cleanup
+  skipped: `<reason>`" is a success. Steps only the operator can run (a denied
+  `git push origin --delete`) are batched into a handoff block instead of being
+  discovered one failed command at a time.
+- `merge` never passes `--delete-branch`: it merges, confirms `MERGED` by bounded
+  poll, then hands the whole cleanup sequence to the worktree-aware sweep. The
+  sweep may auto-run on monitor's merged detection; the merge never auto-runs.
+
+### Reply drafts flow
+
+1. Read the unresolved threads out of `bun run beep yeet status --remote` — each
+   line carries the GraphQL thread id, the REST comment id, the file location,
+   the author, and a first-line excerpt, so drafts are writable straight from
+   that output without a second REST pass.
+2. Write `.beep/yeet/reply-drafts.json` (`yeet-reply-drafts/v1`): `prNumber`
+   plus one draft per thread with a non-empty `body` and either the GraphQL
+   `threadId` (`PRRT_...`) or the numeric `commentId`; `resolve` defaults to
+   true.
+3. Run `bun run beep yeet reply`. Drafts are validated against the live threads
+   first: an already-resolved or deleted thread is recorded `stale` and nothing
+   is written for it. Each surviving draft is posted and resolved one at a time,
+   and a denied scope or rate limit becomes that draft's `failed` outcome with a
+   retry command rather than aborting the pass.
+4. Read `.beep/yeet/reply-report.json` (`yeet-reply-report/v1`) for the per-draft
+   outcomes. Either party can run the command; when the agent session lacks the
+   write scope, hand the operator the one command instead of pasted bodies.
 
 ## Run Artifacts
 

--- a/goals/speed-loop/research/GRILL-DECISIONS.md
+++ b/goals/speed-loop/research/GRILL-DECISIONS.md
@@ -275,3 +275,149 @@ decisions close them:
     evaluated as a composition, not independently; the fleet session names
     the specific flip condition so the E-wave treadmill data settles
     adoption without reopening design.
+
+## Fleet handoff #2 amendments (2026-08-05, HANDOFF-2-pre-push-and-guard.md + PR #562)
+
+39. **#551 monitor regression → PR-E triage MUST-FIX.** Verified on
+    feat/merge-loop: `runMonitorPhase` decodes the first context result
+    unconditionally (Handler.ts:696) while all three planner variants emit
+    monitor steps only under `--monitor`; empty steps → `""` → decode
+    failure → every no-`--monitor` publish (including the CLAUDE.md default
+    `publish --message`) exits 1 after full success. The `:719` guard on
+    the status summary proves the empty case was known one call below. Fix:
+    early-return from `runMonitorPhase` when `monitorSteps` is empty
+    (restores pre-aee2664b91 no-op semantics) + a regression test asserting
+    the default plan performs no monitor decode and exits 0. Lands in PR-E
+    triage — this branch owns the file; a main-side hotfix would conflict
+    with the in-flight rebuild. Also a live Mode B specimen: a shared-file
+    change green on the author's flag path broke a different clone's
+    default path a day later → motivates ledger #61.
+40. **Pre-push wiring lands in PR-G; the marker rides earlyPushStep too.**
+    The marker's semantic is "this push is yeet-orchestrated," not "a full
+    proof exists at push time" — both pushStep and earlyPushStep are
+    orchestrated; ad-hoc `git push` is the target the hook exists to catch.
+    The earlyPushStep comment's secret-blocking rationale is satisfied
+    earlier: `gitleaks protect --staged` runs at pre-commit, so no commit
+    can exist with staged secrets. Work items: lefthook.yml pre-push stage
+    → `beep yeet pre-push-hook`; `runPrePushHookMode` honors
+    `BEEP_YEET_REUSE_PRE_PUSH_PROOF=1` as passthrough (without it,
+    `--fast --monitor` self-blocks — Planner.ts:610 omits the proof step
+    under that combination); `assertReusableVerifiedState` failure text
+    becomes caller-aware (#50 rider). The env-var marker is an
+    accidental-bypass control, not a security boundary (same class as
+    `LEFTHOOK=0`) — accepted. OPEN for grill #5: blocking-from-day-one vs
+    advisory-first, and an emergency-push carve-out — the 2026-08-05
+    drive-recovery "push everything before fs recovery" is the live case a
+    fail-closed hook must not block mid-incident.
+41. **Q7 staleness guard sequenced behind the #21/#25 comparison;
+    measure-first law accepted as binding.** No path enters a policy
+    surface unmeasured. Measured against 253 first-parent main commits,
+    only `biome.json*` (4.0%) and `turbo.json` (5.1%) clear the bar; the
+    proposed 14-path surface would hard-fail 53% of publishes one commit
+    behind, 98% at five — it reproduces the treadmill it targets. If
+    tree-keyed proof reuse (#25, proofs keyed to tree hashes surviving
+    pushes/rebases) is viable, the guard is redundant, not complementary.
+    The comparison happens in PR-G's research lane before any guard code.
+42. **Decision 36 refinements (fleet audit; sweep-engine triage items).**
+    (a) find-based liveness uses `-name .git -prune` — `-not -path
+    '*/.git/*'` does NOT exclude `.git` itself and gave a 100%
+    false-positive liveness signal fleet-wide. (b) `FETCH_HEAD` lives in
+    `--git-common-dir`, not `--git-dir` — linked-worktree reads silently
+    return nothing; #39 sweep and #48 must resolve via git-common-dir.
+    (c) Change-surface computation uses `status --porcelain -uall` — plain
+    `--porcelain` collapses a new package's N files into one path. All
+    three are PR-E triage audit items against the just-built sweep engine.
+43. **K1 correction: PR-I awareness surfaces use
+    `hookSpecificOutput.additionalContext`, never plain stdout.** Hook
+    stdout reaches model context ONLY on UserPromptSubmit,
+    UserPromptExpansion, and SessionStart; PostToolUse stdout goes to the
+    debug log. law-pulse.sh was a silent no-op 2026-07-05 → 2026-08-04
+    (fixed in fleet PR #562, confirmed firing). Every PR-I delivery path
+    (#52 AgentBrief, any pushed awareness) builds on additionalContext.
+44. **merge_group vacuous gates + T4 cost correction.** (a) Under
+    merge_group events, commitlint degrades to one commit
+    (check.yml:599-609) and gitleaks runs `-1` with the base-pinned
+    scanner-config hardening bypassed (:657-681) — both pass vacuously.
+    Fix independent of whether #22 merge queue is ever adopted → ledger
+    #62. (b) `strict_required_status_checks_policy: true` does not rebase
+    anything; true cost ≈ one extra run per merged PR (~8/day), not the
+    67–208/day herd T4 rejected by conflating it with an auto-rebase bot.
+    Re-opened as a #22-adjacent option, still gated behind a green
+    gauntlet.
+
+## PR-E build-wave ratifications (2026-08-05, run wf_da334d69-0b9)
+
+45. **Sweep engine design calls — RATIFIED (all five).**
+    (a) `requiresOperator` is derived, never asserted: true only for
+    `delete-remote-branch` with all preconditions met, so `--plan` batches
+    the known-denied handoff (#53a) up front; safety blockers (tip
+    mismatch, dirty tree, branch held) never become handoffs. (b) `ff-main`
+    has three cases: main free → `fetch origin main:main`; another
+    worktree holds main → skip; THIS worktree on main → `merge --ff-only
+    refs/remotes/origin/main` gated on clean (without it the single-clone
+    case never fast-forwards). (c) The dirty-worktree rail applies only to
+    worktree-mutating steps (`lockfile-install`, `end-state`); ref-only
+    steps stay unblocked. (d) Sweeping from the merged branch's own
+    worktree is two-pass by design — `delete-local-branch` skips ("held by
+    this worktree"), `end-state` moves to main, a re-run completes;
+    moving HEAD ahead of the plan's safety facts would violate the rails,
+    and no 7th step id is added for single-pass. (e) Failed commands
+    report as `skipped` with the failure text — `SweepStepOutcome` has no
+    failure member by design; only permission-denial remote deletions
+    become `needs-operator`.
+46. **Reply engine design calls — RATIFIED (all seven).** `isOutdated` is
+    NOT stale — an outdated thread is still open and still blocks merge;
+    only `isResolved` settles as stale (schema JSDoc narrowed to match in
+    the fix wave). Duplicate-target drafts: second settles `failed` (the
+    single live snapshot cannot see the first write). Live-action
+    `threadId` stays `S.NonEmptyString` — the PRRT_ prefix check lives
+    where paste errors are real (drafts), not on GitHub's own values. PR
+    number comes from the drafts artifact, not the checked-out branch
+    (either-party execution, 14(d)/#53(b)). Partial-failure honesty:
+    post-ok/resolve-denied settles `failed` with a resolve-only retry that
+    must NOT re-run `yeet reply` (would repost); post-denied carries the
+    whole-command retry. Artifacts at packet root (`.beep/yeet/`) so both
+    parties address the same paths — the cross-branch shared drafts path
+    is flagged to the fleet scope. >100-comment threads warn by PRRT_ id.
+47. **Monitor + integration calls — RATIFIED.** sweep/merge/reply are
+    porcelain flag-bag runners, NOT `YeetRunMode` members — modes would
+    drag attempt-journal/verdict/turbo-plan machinery through unreachable
+    `$match` arms and hijack `--plan`. `readOnlyRunContext` extraction:
+    porcelain never pays `collectTurboPlanSnapshot`. `MergeOutcome` stays
+    stdout-only (its embedded sweep report IS persisted); a
+    machine-readable merge trace waits for a consumer. The fallow "never
+    reads a half-truth" posture is ratified as NARROWED by the C4 fix:
+    defects among FRESH envelopes suppress that run's advisory read;
+    stale/mode-mismatched envelopes self-heal silently (ledger #55).
+    The `tooling-schema-first` lane failure (11 findings, lane absent from
+    the composite battery) is attributed INHERITED — pre-existing on
+    main, not PR-E's to fix. Rerun-teaching parity: `yeet status`'s
+    `--failed` suggestion is made job-scoped in the fix wave so no yeet
+    surface teaches what another bans.
+48. **Fix-wave re-verify rulings (2026-08-05, run wf_7d56b3bb-e06;
+    7/7 findings mutation-proven fixed, full battery green 69/1036).**
+    (a) `yeet reply` preflight failure (nothing attempted) writes the
+    all-failed report AND exits nonzero — the report is the accounting,
+    the exit code is the verdict, so `beep yeet reply && ...` never
+    proceeds past a run that posted zero replies. Per-draft failures keep
+    exit 0: the batch ran and the report is authoritative. Sweep's exit-0
+    needs-operator posture is unchanged — its denials are per-step,
+    planned-for outcomes (#53a), a different class from a run-level
+    precondition failure. (b) Rerun-budget key collision direction
+    ratified: name-keying can only UNDER-spend (a shard family shares one
+    allowance; the unrerun shard surfaces to the operator with its id) —
+    a bound; id-keying over-spends without limit because each rerun mints
+    fresh job ids. Under-spend is the safe failure direction. (c) The
+    merge loop (`--until-merged`) writes no verdict artifact — accepted:
+    it terminates in MERGED→sweep or CLOSED, and merge-readiness lands on
+    `status.json` + stdout; the verdict record rides plain `monitor` and
+    `publish --monitor`. (d) Known-unpinned, fast-follow: the
+    `mergeReady` Ref-update wiring in `runMonitorMode` /
+    `runPublishMonitorAndResult` survives deletion with the suite green —
+    pinning needs a stubbed-snapshot integration test (ledger #66 family);
+    the reshaped rerun teaching got its producer pin in-session
+    (`yeetRerunJobListingCommand` / `yeetRerunDecisionText` + fixture
+    cleanup, banned form now absent from the test corpus). (e)
+    `YeetMergeReady` coherence filter enforces consistency, NOT reporting
+    precedence (`failing` stays independently meaningful) — disclosed in
+    the class Gotchas.

--- a/goals/speed-loop/research/OPPORTUNITIES.md
+++ b/goals/speed-loop/research/OPPORTUNITIES.md
@@ -596,3 +596,180 @@ audited), #50 (ratcheted-advisory contract). All 55 items now covered.
     skip with a note), never exit 1. Candidate vehicle: PR-E rider (it's the
     yeet surface); also a #50 exhibit — the failure output taught neither
     the fix nor the one command to run.
+
+61. **Yeet publish flag-path regression matrix.** (From the #551 monitor
+    regression, found by beep-effect5 tripping it publishing PR #562.)
+    `publish`'s terminal behavior differs per flag combination (default
+    `--message`, `--monitor`, `--fast --monitor`, `--start-pr-early`,
+    `--staged-only`), and #551 shipped green on the author's combination
+    (`--fast --monitor`) while breaking the default path for every other
+    checkout — the exit-1-on-success went unnoticed for a day because this
+    session also ships `--fast --monitor`. A stubbed-step test matrix
+    asserting exit code + terminal phase behavior for each supported flag
+    combination makes "green on my flags" insufficient to ship. Vehicle:
+    PR-E rider (the tests colocate with the publish/monitor code being
+    rebuilt there); the decision-39 regression test is its first row.
+62. **merge_group parity for required security gates.** Under merge_group
+    events commitlint depth degrades to one commit (check.yml:599-609) and
+    gitleaks runs `-1` with the base-pinned scanner-config hardening
+    bypassed (:657-681) — both required gates pass vacuously. Gate
+    contracts must hold under every trigger event, independent of whether
+    #22 merge queue is ever adopted. Vehicle: small hosted-CI PR; natural
+    rider on PR-G parity work.
+
+63. **Effect v4 `A.filterMap` takes `Result`, not `Option` — a wave-scale
+    trap.** Three independent hits in one build wave (Sweep ×2, Reply ×1):
+    the v3 muscle-memory shape compiles into silently-empty arrays under
+    vitest (one suite went 31/32 green while broken — vitest does not
+    typecheck) and tsgo rejects it with a TS2375
+    `exactOptionalPropertyTypes` wall that names neither `filterMap` nor
+    the fix. Correct v4 shape: `A.map(...)` + `A.getSomes`. Actions:
+    effect-v4-imports skill note; memory line (done); candidate upstream
+    `effect(outdatedApi)`-style one-liner diagnostic (the plugin already
+    special-cases `Effect.iterate`). Wave law: run the tsgo overlay BEFORE
+    the test pass — a green vitest run is not evidence of v4 API shape.
+64. **Wave gate attribution and own-scope gates.** One worktree, four
+    agents: concurrent full-package `vitest run` has no lock (two runs
+    contended and both starved, ~15 min no output); failures in a full run
+    include other agents' mid-edit files (two agents each burned two full
+    runs distinguishing "mine" from "someone else's half-written file");
+    no streaming totals when redirected, so alive-vs-hung needs `pgrep`.
+    Actions: wave-brief law "own test files during the loop, one full
+    package run at integration"; a `beep test` lane wrapper with an
+    advisory lock that attaches to an in-flight run instead of starting a
+    second; per-suite progress lines for background monitorability;
+    file-scoped verdicts derived from wave-manifest claim globs (#46/#41
+    kin, #49's missing gate-attribution half).
+65. **Budget/dedupe keys must be built from fields documented stable
+    across retries (.patterns/ law).** The merge-loop rerun budget keyed
+    on `${headSha}#${databaseId}` — but job databaseIds are per-attempt
+    records, so the budget reset itself on every rerun (unbounded reruns
+    at one SHA; caught by adversarial verify, fixed to key on `job.name`).
+    The class is mechanically detectable whenever the schema carries a
+    stable sibling of the unstable field.
+66. **Writer-level artifact coverage + mechanical S.encode-law
+    enforcement.** All four PR-E artifact producers were initially tested
+    only at the codec layer — reverting the writer fix left 1004 tests
+    green (the codec is the layer that was never broken). Fix wave adds
+    per-writer round-trips. Remaining: three yeet writers still on
+    schema-agnostic `renderJson` (pr-closeout.json — now READ by the
+    greptileScore path, proof lock/state ×2, quality issue index); no live
+    Option bug today, but the first `OptionFromOptionalKey` field on
+    `PrCloseoutReport` reproduces the verdict bug on a hotter path. Widget:
+    a lint — "`writeTextFile` whose payload derives from a decoded
+    `S.Class` must flow through a `JsonStringCodec`" — plus routing the
+    three stragglers. #34 family, fast-follow PR.
+67. **Adversarial-review harness (`beep review claims` + `beep yeet
+    diff`).** Both reviewers hand-built evidence bundles (grep sweeps for
+    `--failed`/`git add -A`/`--force`/`.git` probes, `git show
+    origin/main:` for new-vs-preexisting attribution), and both hit `git
+    diff origin/main...HEAD` returning EMPTY on uncommitted work — an
+    agent trusting the prompt's diff command would have reported HOLDS on
+    a 2,500-line change it never read. Widgets: a claims→evidence-bundle
+    command with pre-existing-vs-new attribution; a `yeet diff` that
+    unions staged + unstaged + untracked against the merge base; a
+    prompt-side `status --porcelain -uall` sanity check before any
+    review-by-diff (decision 42c's law, same reason).
+68. **Binding-contract block colocated with schemas.** The sweep
+    implementer spent ~20 minutes cross-referencing GRILL-DECISIONS 14(b)
+    (the -D trio), ledger #39 (FF-refusal evidence), decision 36 (worktree
+    law), and the step-id set that lives only in `Sweep.schemas.ts` JSDoc.
+    A one-paragraph block colocated with the schema naming which decisions
+    constrain it removes the scavenger hunt. #50 teach family.
+69. **Fixture corpus for hosted CI payloads (`test/fixtures/gh/`).** The
+    monitor classifier's `<job>\t<step>\t<timestamp>` shapes and
+    `--log-failed` output were hand-authored from memory; one captured
+    payload per fingerprint class + one genuine red + one bot review body
+    per bot makes every future classifier change provable instead of
+    plausible. #47's `beep ci logs` is the harvesting tool.
+70. **Append-optional lint (#34) must distinguish artifact schemas from
+    input DTOs.** `buildYeetVerdict` takes a positional object literal, so
+    adding a field as `S.OptionFromOptionalKey` (the artifact law) BREAKS
+    every call site while `S.optional` does not — on input DTOs the law
+    would cause exactly the failure it exists to prevent. The lint needs
+    the schemaVersion-literal discriminator (artifact) vs constructor-input
+    shape (DTO) built in.
+
+PR-E build-wave reflection harvest (2026-08-05, #54 ritual; 7 agents,
+run wf_da334d69-0b9): new items #63–70 above. Evidence mapped onto
+existing items — #43/#19: the brief's overlay recipe was broken as
+written (missing `"rootDir": "."` → TS6059 ×65) and the shared
+`tsconfig.overlay.json` filename collided (one agent deleted another's
+mid-typecheck; a third created a content-identical sibling to avoid
+exactly that) — the generator must emit per-scope overlays into
+gitignored `.beep/overlays/` and the fix must reach the wave-brief
+template; #49: test-kit barrels and overlays need shared-bucket manifest
+entries like changesets/lockfile (every engine agent must append one line
+to the same 45-line barrel — the hottest conflict in the wave), and the
+drift detector must run DURING the wave to help the integrator, not
+after; #52: "both gates green" (vitest+tsgo) let 19 biome + 6
+schema-first + 6 tsdoc failures land on the integrator — the brief must
+emit the complete per-package gate set (`bunx biome check --write` costs
+~10s per agent); #50: the brief contained a nonexistent command (`beep
+lint effect-fn`) whose args fell through to the full repo lint battery —
+minutes of misleading failures; `beep lint`/`beep laws` should reject
+unknown trailing args; #59 shipped: status threads now carry author,
+excerpt, path, line, and commentDatabaseId.
+
+71. **Mutation proof as a first-class gate.** Two of seven "fixed"
+    findings in the PR-E fix wave (`mergeReady` threading, rerun-teaching
+    reshape) survived full reversion with the entire suite green — both
+    fixers reported FIXED in good faith; only the re-verifier's
+    revert-and-rerun caught it (~15s per finding). Widget: a `beep`
+    quality lane that takes a finding's changed expression, neuters it,
+    and asserts some named test goes red — converting "I wrote a test"
+    into "I wrote a test that binds". Same family as the memory'd
+    vacuous-test-pattern; review-checklist line meanwhile: "if the fix is
+    a write, name the test that reads it back."
+72. **Yeet test-kit import tax: 224s of a 278s full run is imports.** The
+    53-line `export *` barrel pulls ~17k lines of source into every test
+    file; 69 files × barrel import = 6:1 import-to-execution ratio, the
+    single largest wall-clock tax on every fix loop (and the reason
+    single-file runs still cost ~5s each). Candidates: per-domain
+    test-kit splits (sweep/reply/monitor/status), and a shared
+    `stubSpawnerLayer(table)` in `@beep/test-utils` — four packages
+    hand-roll the same ~35-line ChildProcessSpawner stub today, and the
+    fix wave copy-pasted it twice more because file ownership forbade a
+    shared helper.
+
+PR-E fix-wave reflection harvest (2026-08-05, #54 ritual; 5 agents, run
+wf_7d56b3bb-e06): new items #71–72 above. Also: adversarial-review
+findings should anchor on SYMBOL NAMES, not line numbers — three of four
+line anchors handed to one fixer were stale/wrong the moment a concurrent
+fixer edited above them (#67 rider); the `zsh -ic` wrapper emits ~12
+lines of gitstatus/zle noise per gate call across every agent (a
+mise-only non-interactive shim would pay for itself in one wave); the
+overlay-tsconfig ritual should be one command (`beep quality typecheck
+--isolated`, #43 rider) — five agents hand-wrote the same JSON with a
+load-bearing `rootDir` and a cleanup obligation; `SchemaUtils.
+withConstantDefault` cannot type a boolean default (literal-widening
+trap — `withConstantDefault<boolean>(false)` is the workaround, worth a
+JSDoc gotcha); test-harness laws (`provideScopedLayer` never
+`Effect.provide(Layer)` under strictEffectProvide; `Effect.fn`-wrapped
+temp-dir helpers) are discoverable only by reading neighbors — one
+paragraph in the effect-first skill closes it; fixture builders for
+filename-addressed artifacts must derive filenames from the producer
+helper (the fallow fix's discriminating test was unwritable until the
+builder was refactored); nonzero-exit probes are the same inference gap
+as truncated probes in the sweep's certainty model (named follow-up:
+generalize `*ProbeTruncated` to `!probeSucceeded`, ~10 lines); JSDoc
+example import paths are not reachability proof — docgen validating that
+each example's import specifier resolves would catch stale examples
+generally.
+
+Fleet handoff #2 (2026-08-05; beep-effect5
+explorations/fleet-coordination/research/HANDOFF-2-pre-push-and-guard.md,
+PR #562; GRILL-DECISIONS.md #39–44): #551 monitor regression → PR-E triage
+must-fix (decision 39; Mode B specimen → #61); pre-push wiring → PR-G with
+the reuse marker riding earlyPushStep, passthrough consumer, caller-aware
+failure text, blocking-vs-advisory + emergency-push carve-out queued for
+grill #5 (decision 40); Q7 staleness guard sequenced behind the #21/#25
+comparison under the fleet's measure-first law (decision 41); decision-36
+worktree refinements — `-name .git -prune`, FETCH_HEAD via
+`--git-common-dir`, `status --porcelain -uall` — become sweep-engine triage
+audit items (decision 42); PR-I awareness surfaces build on
+`hookSpecificOutput.additionalContext`, plain hook stdout being a silent
+no-op outside UserPromptSubmit/UserPromptExpansion/SessionStart (decision
+43); merge_group vacuous gates → #62 and
+`strict_required_status_checks_policy` re-opened at its true ~8 runs/day
+cost (decision 44).

--- a/goals/speed-loop/research/PR-E-TRIAGE.md
+++ b/goals/speed-loop/research/PR-E-TRIAGE.md
@@ -1,0 +1,52 @@
+# PR-E integration triage checklist
+
+Durable checklist for the post-workflow triage pass on `feat/merge-loop`
+(power outages have eaten this session twice; the list lives on disk).
+Work through after the PR-E workflow (`wf_da334d69-0b9`) completes and
+before `yeet publish`.
+
+## Must-fix (block publish)
+
+- [x] **#551 monitor regression (GRILL-DECISIONS #39).** FIXED +
+      mutation-proven (re-verify: neutering the guard fails both tests in
+      `test/yeet-monitor-phase-empty.test.ts` with the literal production
+      error). #61's first matrix row exists.
+- [x] **Sweep-engine audit against decision 42.** Verified by adversarial
+      review + orchestrator read: (1) no find-based `.git` probes exist —
+      detection is `git worktree list --porcelain` (claim 2 HOLDS);
+      (2) `FETCH_HEAD` is never read — sweep uses `fetch --prune` +
+      `merge --ff-only refs/remotes/...`; (3) sweep's `status --porcelain`
+      is a clean/dirty BOOLEAN (any output = dirty), not a change-surface
+      count, so `-uall` is not load-bearing there — 42(c) applies to
+      future change-surface consumers.
+- [x] **Adversarial verify findings.** ALL FIXED — re-verify verdict 7/7
+      mutation-proven, full battery green (69 files / 1036 tests, tsgo
+      clean, biome clean, schema-first 0, effect-fn 0, previously-HOLDING
+      contracts intact). Re-verify's three follow-ups closed by the
+      orchestrator in-session: reply preflight now writes the report AND
+      exits nonzero (decision 48a, test flipped); rerun teaching pinned
+      at the producer (`yeetRerunJobListingCommand`/`yeetRerunDecisionText`
+      exported + tested; banned `--failed` literals purged from fixtures).
+      Known-unpinned fast-follow: `mergeReady` Ref-update wiring
+      (decision 48d, ledger #66/#71). Inherited-only:
+      `tooling-schema-first` lane (11 findings pre-existing on main).
+      renderJson stragglers deferred to fast-follow (ledger #66).
+
+## Riders (in-scope for PR-E, do before publish if cheap)
+
+- [~] **#61 flag-path matrix**: decision-39 row in fix wave; fuller matrix
+      (`--fast --monitor`, `--start-pr-early`, `--staged-only`) only if
+      the wave's writer-test helper makes it cheap — else fast-follow.
+- [x] **#54 reflection harvest.** Done — ledger #63–70 + evidence block
+      (OPPORTUNITIES.md), ratifications as GRILL-DECISIONS #45–47.
+
+## Publish notes
+
+- Publish WITH `--monitor` (the regression-free path) regardless of the
+  decision-39 fix landing — belt and suspenders.
+- Docs riding this branch: GRILL-DECISIONS.md #39–44, OPPORTUNITIES.md
+  #61–62 + handoff-2 disposition block, this file. Decide at publish time
+  whether they ride PR-E (packet-state-flip norm) or split docs-only.
+- Fleet relay-back owed to beep-effect5 (via operator): decisions 39–44
+  ack + the earlyPushStep ruling (marker rides it; grill #5 takes
+  blocking-vs-advisory + emergency-push carve-out).

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -269,7 +269,10 @@ const { githubCheckLaneWaves } = githubCheckLanePlan;
 
 const ignoredTestDirectoryNames = ["node_modules", "dist", "coverage", "tmp"] as const;
 const ignoredTestPathSegments = ["/test/fixtures/"] as const;
-const testSearchRoots = ["apps", "packages", "tooling", "infra"] as const;
+// No `tooling` root: tooling workspaces live under `packages/tooling/*`, which
+// the `packages` root already walks. A top-level `tooling/` directory has never
+// existed in this repo, so the entry only cost a wasted existence probe.
+const testSearchRoots = ["apps", "packages", "infra"] as const;
 const moduleTagScannedRoots = [".patterns", "apps", "packages", "tooling"] as const;
 const moduleTagScannedExtensions = [".hbs", ".md", ".ts", ".tsx"] as const;
 const effectDiagnosticsDirectiveScannedRoots = ["apps", "packages", "tooling", "infra"] as const;

--- a/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
@@ -16,6 +16,7 @@ import {
 } from "./internal/FallowFeedback.ts";
 import { runYeet } from "./internal/Handler.ts";
 import { DEFAULT_YEET_PACKET_DIR, YeetProofTier } from "./internal/Planner.ts";
+import { runYeetMerge, runYeetMergeLoop, runYeetReplyPass, runYeetSweep } from "./internal/Porcelain.ts";
 import { YeetRunOptions } from "./Yeet.schemas.ts";
 import type { YeetRunMode } from "./internal/Planner.ts";
 
@@ -55,6 +56,12 @@ const startPrEarlyFlag = Flag.boolean("start-pr-early").pipe(
 
 const monitorFlag = Flag.boolean("monitor").pipe(
   Flag.withDescription("Monitor hosted PR checks after publish instead of stopping at push")
+);
+
+const untilMergedFlag = Flag.boolean("until-merged").pipe(
+  Flag.withDescription(
+    "Keep monitoring across pushes until the PR merges or closes, rerunning known-flake jobs once per job per head SHA and sweeping the clone on merge"
+  )
 );
 
 const summaryFlag = Flag.boolean("summary").pipe(
@@ -225,6 +232,19 @@ const publishFlags = {
 const monitorFlags = {
   ...sharedFlags,
   summary: summaryFlag,
+  untilMerged: untilMergedFlag,
+} as const;
+
+const porcelainFlags = {
+  base: baseFlag,
+  head: headFlag,
+  packetDir: packetDirFlag,
+} as const;
+
+const sweepFlags = {
+  ...porcelainFlags,
+  json: jsonFlag,
+  plan: planFlag,
 } as const;
 
 const closeoutFlags = {
@@ -327,8 +347,20 @@ const yeetPublishCommand = Command.make("publish", publishFlags, (options) => ru
   Command.withDescription("Commit reviewed staged changes, prove the commit, then push")
 );
 
-const yeetMonitorCommand = Command.make("monitor", monitorFlags, (options) => runYeetMode("monitor", options)).pipe(
-  Command.withDescription("Monitor hosted PR checks for the current branch")
+const yeetMonitorCommand = Command.make("monitor", monitorFlags, ({ untilMerged, ...options }) =>
+  untilMerged && !options.plan ? runYeetMergeLoop(options) : runYeetMode("monitor", options)
+).pipe(Command.withDescription("Monitor hosted PR checks for the current branch"));
+
+const yeetSweepCommand = Command.make("sweep", sweepFlags, (options) => runYeetSweep(options)).pipe(
+  Command.withDescription("Reset the clone after a merge: prune refs, fast-forward main, delete merged branches")
+);
+
+const yeetMergeCommand = Command.make("merge", porcelainFlags, (options) => runYeetMerge(options)).pipe(
+  Command.withDescription("Squash-merge this branch's pull request, confirm MERGED, then sweep the clone")
+);
+
+const yeetReplyCommand = Command.make("reply", porcelainFlags, (options) => runYeetReplyPass(options)).pipe(
+  Command.withDescription("Post and resolve the drafted review-thread replies for this branch's pull request")
 );
 
 const yeetCloseoutCommand = Command.make("closeout", closeoutFlags, (options) => runYeetMode("closeout", options)).pipe(
@@ -405,6 +437,9 @@ export const yeetCommand = Command.make("yeet", publishFlags, (options) => runYe
     yeetMonitorCommand,
     yeetCloseoutCommand,
     yeetStatusCommand,
+    yeetSweepCommand,
+    yeetMergeCommand,
+    yeetReplyCommand,
     yeetPrePushHookCommand,
     yeetFallowFeedbackCommand,
     yeetFallowFixtureCheckCommand,

--- a/packages/tooling/tool/cli/src/commands/Yeet/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/index.ts
@@ -19,14 +19,23 @@ export { YeetRunMode } from "./internal/Planner.ts";
  * @since 0.0.0
  */
 export {
+  collectRemoteWorkflowRuns,
   collectYeetStatus,
+  deriveYeetMergeReady,
+  GhStatusWorkflowRun,
+  renderYeetReviewThreadBlock,
   renderYeetStatusSummary,
   writeYeetStatusSnapshot,
   YeetStatusArtifact,
   YeetStatusArtifactState,
   YeetStatusRemote,
+  YeetStatusReviewThread,
   YeetStatusSnapshot,
+  YeetStatusSnapshotJson,
   YeetStatusWorktree,
+  yeetRerunDecisionText,
+  yeetRerunJobListingCommand,
+  yeetReviewThreadExcerpt,
   yeetStatusNextCommandForTesting,
   yeetStatusPathForTesting,
 } from "./internal/Status.ts";

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/FallowFeedback.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/FallowFeedback.ts
@@ -8,6 +8,7 @@
 import { resolvePathWithinRoot } from "@beep/file-processing/PathSafety";
 import { $RepoCliId } from "@beep/identity/packages";
 import { findRepoRoot } from "@beep/repo-utils";
+import { LiteralKit } from "@beep/schema";
 import { decodeJsoncTextAs } from "@beep/schema/Jsonc";
 import { Console, Context, DateTime, Effect, FileSystem, Layer, Order, Path, pipe } from "effect";
 import * as A from "effect/Array";
@@ -66,6 +67,49 @@ class FallowFixtureDocument extends S.Class<FallowFixtureDocument>($I`FallowFixt
   },
   $I.annote("FallowFixtureDocument", {
     description: "Checked-in Fallow report envelope fixture document.",
+  })
+) {}
+
+// `.beep/fallow` is gitignored, regenerable state. An advisory phase must never
+// fail a publish over it, so the two envelope defects that are pure leftovers —
+// envelopes written before this Yeet run started, and advisory-named envelopes
+// produced in check mode — are purged and the phase skips (decision 25 / ledger
+// #55). Leftover classification therefore runs BEFORE every hard-failing check,
+// and those checks only ever see the envelopes that survive the purge: a stale
+// or check-mode envelope that also disagrees with its feature family is still
+// just leftover state. Everything else (a surviving fresh envelope whose
+// findings disagree with its feature family, unreadable or undecodable
+// envelopes) is a producer bug in current-run output rather than stale state:
+// those still surface, each carrying this one-command remedy.
+const FALLOW_ENVELOPE_PURGE_REMEDY = "rm -rf .beep/fallow";
+
+const withPurgeRemedy = (message: string): string => `${message}\nRemedy: ${FALLOW_ENVELOPE_PURGE_REMEDY}`;
+
+const FallowEnvelopeDefectKind = LiteralKit(["mode-mismatch", "stale"]).pipe(
+  $I.annoteSchema("FallowEnvelopeDefectKind", {
+    description: "Self-healable Fallow advisory envelope defect kind: regenerable leftovers, never a run failure.",
+  })
+);
+
+class FallowEnvelopeEntry extends S.Class<FallowEnvelopeEntry>($I`FallowEnvelopeEntry`)(
+  {
+    envelope: FallowEnvelope,
+    filePath: S.String,
+  },
+  $I.annote("FallowEnvelopeEntry", {
+    description: "One decoded Fallow envelope paired with the file it was read from.",
+  })
+) {}
+
+class FallowEnvelopeDefect extends S.Class<FallowEnvelopeDefect>($I`FallowEnvelopeDefect`)(
+  {
+    detail: S.String,
+    filePath: S.String,
+    kind: FallowEnvelopeDefectKind,
+    subcommand: FallowFeatureFamily,
+  },
+  $I.annote("FallowEnvelopeDefect", {
+    description: "One purgeable Fallow advisory envelope file plus why it is unusable for the current Yeet run.",
   })
 ) {}
 
@@ -281,15 +325,11 @@ const issueIndexFromEnvelopes = (envelopes: ReadonlyArray<FallowEnvelope>, advis
     )
   );
 
-const assertAdvisoryEnvelopes = Effect.fn("YeetFallowFeedback.assertAdvisoryEnvelopes")(function* (
-  envelopes: ReadonlyArray<FallowEnvelope>,
-  advisory: boolean,
-  runStartedAt?: string
-): Effect.fn.Return<void, YeetCommandError> {
-  // Reject self-contradictory payloads up front: a successful envelope's findings
-  // must share its subcommand feature family, otherwise the issue id (derived from
-  // the subcommand) and category/message (derived from the finding) would disagree.
-  const inconsistentRefs = pipe(
+// Reject self-contradictory payloads: a successful envelope's findings must share
+// its subcommand feature family, otherwise the issue id (derived from the
+// subcommand) and category/message (derived from the finding) would disagree.
+const familyMismatchRefs = (envelopes: ReadonlyArray<FallowEnvelope>): ReadonlyArray<string> =>
+  pipe(
     envelopes,
     A.filter(
       (envelope) =>
@@ -298,6 +338,12 @@ const assertAdvisoryEnvelopes = Effect.fn("YeetFallowFeedback.assertAdvisoryEnve
     ),
     A.map((envelope) => envelope.reportPath)
   );
+
+const assertAdvisoryEnvelopes = Effect.fn("YeetFallowFeedback.assertAdvisoryEnvelopes")(function* (
+  envelopes: ReadonlyArray<FallowEnvelope>,
+  advisory: boolean
+): Effect.fn.Return<void, YeetCommandError> {
+  const inconsistentRefs = familyMismatchRefs(envelopes);
   if (!A.isReadonlyArrayEmpty(inconsistentRefs)) {
     return yield* YeetCommandError.make({
       message: `Fallow advisory feedback received envelope(s) whose findings disagree with the subcommand feature family: ${A.join(inconsistentRefs, ", ")}`,
@@ -318,41 +364,119 @@ const assertAdvisoryEnvelopes = Effect.fn("YeetFallowFeedback.assertAdvisoryEnve
       exitCode: 1,
     });
   }
-  const startedAtMillis = pipe(
-    O.fromUndefinedOr(runStartedAt),
-    O.flatMap(DateTime.make),
-    O.map(DateTime.toEpochMillis)
-  );
-  const staleRefs = pipe(
-    startedAtMillis,
-    O.map((startedAt) =>
-      pipe(
-        envelopes,
-        A.filter((envelope) =>
-          pipe(
-            DateTime.make(envelope.generatedAt),
-            O.match({ onNone: () => true, onSome: (generatedAt) => DateTime.toEpochMillis(generatedAt) < startedAt })
-          )
-        ),
-        A.map((envelope) => `${envelope.subcommand} (${envelope.generatedAt})`)
-      )
-    ),
-    O.getOrElse(A.empty<string>)
-  );
-  if (!A.isReadonlyArrayEmpty(staleRefs)) {
-    return yield* YeetCommandError.make({
-      message: `Fallow advisory feedback rejected envelope(s) older than the Yeet run start ${runStartedAt}: ${A.join(staleRefs, ", ")}`,
-      exitCode: 1,
-    });
-  }
 });
+
+// The on-disk advisory phase keeps the same contract check, but teaches the
+// remedy: a mismatched envelope on disk is regenerable, so the operator (or
+// agent) never has to rediscover `rm -rf .beep/fallow` from a 2026-06 memory.
+const assertEnvelopeFamilyConsistency = Effect.fn("YeetFallowFeedback.assertEnvelopeFamilyConsistency")(function* (
+  envelopes: ReadonlyArray<FallowEnvelope>
+): Effect.fn.Return<void, YeetCommandError> {
+  const inconsistentRefs = familyMismatchRefs(envelopes);
+  if (A.isReadonlyArrayEmpty(inconsistentRefs)) {
+    return;
+  }
+  return yield* YeetCommandError.make({
+    command: FALLOW_ENVELOPE_PURGE_REMEDY,
+    message: withPurgeRemedy(
+      `Fallow advisory feedback received envelope(s) whose findings disagree with the subcommand feature family: ${A.join(inconsistentRefs, ", ")}`
+    ),
+    exitCode: 1,
+  });
+});
+
+const runStartMillis = (runStartedAt: string | undefined): O.Option<number> =>
+  pipe(O.fromUndefinedOr(runStartedAt), O.flatMap(DateTime.make), O.map(DateTime.toEpochMillis));
+
+// An envelope with an unparseable `generatedAt` cannot be proven fresh, so it is
+// treated as stale rather than trusted.
+const envelopeIsStale = (envelope: FallowEnvelope, startedAtMillis: number): boolean =>
+  pipe(
+    DateTime.make(envelope.generatedAt),
+    O.match({
+      onNone: () => true,
+      onSome: (generatedAt) => DateTime.toEpochMillis(generatedAt) < startedAtMillis,
+    })
+  );
+
+const envelopeDefect = (
+  entry: FallowEnvelopeEntry,
+  startedAtMillis: O.Option<number>
+): O.Option<FallowEnvelopeDefect> =>
+  entry.envelope.advisory
+    ? pipe(
+        startedAtMillis,
+        O.filter((startedAt) => envelopeIsStale(entry.envelope, startedAt)),
+        O.as(
+          FallowEnvelopeDefect.make({
+            detail: `generated ${entry.envelope.generatedAt}, older than the Yeet run start`,
+            filePath: entry.filePath,
+            kind: "stale",
+            subcommand: entry.envelope.subcommand,
+          })
+        )
+      )
+    : O.some(
+        FallowEnvelopeDefect.make({
+          detail: `advisory-named envelope was produced in check mode (${entry.envelope.reportPath})`,
+          filePath: entry.filePath,
+          kind: "mode-mismatch",
+          subcommand: entry.envelope.subcommand,
+        })
+      );
+
+const selfHealableDefects = (
+  entries: ReadonlyArray<FallowEnvelopeEntry>,
+  startedAtMillis: O.Option<number>
+): ReadonlyArray<FallowEnvelopeDefect> => A.getSomes(A.map(entries, (entry) => envelopeDefect(entry, startedAtMillis)));
+
+// The complement of `selfHealableDefects`: the envelopes that are not purgeable
+// leftovers, so they are the only ones a hard-failing consistency check may read.
+const survivingEnvelopes = (
+  entries: ReadonlyArray<FallowEnvelopeEntry>,
+  startedAtMillis: O.Option<number>
+): ReadonlyArray<FallowEnvelope> =>
+  pipe(
+    entries,
+    A.filter((entry) => O.isNone(envelopeDefect(entry, startedAtMillis))),
+    A.map((entry) => entry.envelope)
+  );
+
+const purgeEnvelopeFile = Effect.fn("YeetFallowFeedback.purgeEnvelopeFile")(function* (
+  defect: FallowEnvelopeDefect
+): Effect.fn.Return<O.Option<string>, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  // A delete that fails is reported in the skip note, never raised: the phase is
+  // advisory and the next run re-attempts the purge.
+  return yield* fs.remove(defect.filePath, { force: true }).pipe(
+    Effect.as(O.none<string>()),
+    Effect.orElseSucceed(() => O.some(defect.filePath))
+  );
+});
+
+const purgeNoteLines = (
+  defects: ReadonlyArray<FallowEnvelopeDefect>,
+  unpurged: ReadonlyArray<string>
+): ReadonlyArray<string> => [
+  `[yeet] advisory feedback skipped: stale envelopes purged (${A.length(defects)})`,
+  ...A.map(defects, (defect) => `[yeet]   - ${defect.subcommand} (${defect.kind}): ${defect.detail}`),
+  ...(A.isReadonlyArrayEmpty(unpurged)
+    ? []
+    : [`[yeet]   ! could not delete: ${A.join(unpurged, ", ")}`, `[yeet]   Remedy: ${FALLOW_ENVELOPE_PURGE_REMEDY}`]),
+  "[yeet] .beep/fallow is gitignored, regenerable state; the next fallow run rewrites these envelopes.",
+];
 
 const readEnvelopeFile = Effect.fn("YeetFallowFeedback.readEnvelopeFile")(function* (
   filePath: string
 ): Effect.fn.Return<FallowEnvelope, YeetCommandError, FileSystem.FileSystem> {
   const text = yield* readFileText(filePath);
   return yield* decodeFallowEnvelopeJson(text).pipe(
-    Effect.mapError(YeetCommandError.new(`Failed to decode Fallow envelope "${filePath}".`, { file: filePath }))
+    Effect.mapError(
+      YeetCommandError.new(withPurgeRemedy(`Failed to decode Fallow envelope "${filePath}".`), {
+        command: FALLOW_ENVELOPE_PURGE_REMEDY,
+        file: filePath,
+      })
+    )
   );
 });
 
@@ -371,7 +495,8 @@ const envelopePaths = Effect.fn("YeetFallowFeedback.envelopePaths")(function* (
         ? Effect.succeed(A.empty<string>())
         : Effect.fail(
             YeetCommandError.make({
-              message: `Failed to read Fallow envelope directory "${absoluteFromPath}".`,
+              command: FALLOW_ENVELOPE_PURGE_REMEDY,
+              message: withPurgeRemedy(`Failed to read Fallow envelope directory "${absoluteFromPath}".`),
               file: absoluteFromPath,
               cause: error,
             })
@@ -389,26 +514,41 @@ const envelopePaths = Effect.fn("YeetFallowFeedback.envelopePaths")(function* (
 const spaceValues = (value: string): ReadonlyArray<string> =>
   pipe(Str.split(value, " "), A.map(Str.trim), A.filter(Str.isNonEmpty));
 
-const readEnvelopesFromDirectory = Effect.fn("YeetFallowFeedback.readEnvelopesFromDirectory")(function* (
+const readEnvelopeEntries = Effect.fn("YeetFallowFeedback.readEnvelopeEntries")(function* (
   fromPath: string
-): Effect.fn.Return<ReadonlyArray<FallowEnvelope>, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+): Effect.fn.Return<ReadonlyArray<FallowEnvelopeEntry>, YeetCommandError, FileSystem.FileSystem | Path.Path> {
   const paths = yield* envelopePaths(fromPath);
-  return yield* Effect.forEach(paths, readEnvelopeFile, { concurrency: 1 });
+  return yield* Effect.forEach(
+    paths,
+    (filePath) =>
+      readEnvelopeFile(filePath).pipe(Effect.map((envelope) => FallowEnvelopeEntry.make({ envelope, filePath }))),
+    { concurrency: 1 }
+  );
 });
-
-const feedbackEnvelopes = (
-  envelopes: ReadonlyArray<FallowEnvelope>,
-  advisory: boolean
-): ReadonlyArray<FallowEnvelope> =>
-  advisory
-    ? pipe(
-        envelopes,
-        A.filter((envelope) => envelope.advisory)
-      )
-    : envelopes;
 
 /**
  * Convert Fallow advisory envelopes from a directory into a Yeet issue index.
+ *
+ * **Details**
+ *
+ * In advisory mode the phase self-heals rather than failing the run: envelopes
+ * left over from an earlier Yeet run (stale) and advisory-named envelopes that
+ * were produced in check mode (mode-mismatched) are deleted, an empty issue
+ * index is emitted so downstream consumers see the same state as an absent
+ * `.beep/fallow`, and the run continues with a skip note on stdout — which the
+ * step recorder captures into the run verdict.
+ *
+ * **Gotchas**
+ *
+ * Self-heal covers regenerable leftovers only. Envelope contract violations and
+ * unreadable/undecodable envelopes still fail, each printing the exact
+ * `rm -rf .beep/fallow` remedy.
+ *
+ * Order matters: leftovers are classified and purged first, and the feature
+ * family consistency check reads only the envelopes that survive that purge. A
+ * stale or check-mode envelope that also disagrees with its feature family is
+ * regenerable state and self-heals; the same disagreement on a surviving fresh
+ * envelope is current-run producer output and still fails with exit code 1.
  *
  * @category commands
  * @since 0.0.0
@@ -419,11 +559,32 @@ export const runYeetFallowFeedback = Effect.fn("YeetFallowFeedback.runYeetFallow
   readonly from: string;
   readonly runStartedAt?: string;
 }): Effect.fn.Return<void, YeetCommandError, FileSystem.FileSystem | Path.Path> {
-  const envelopes = yield* readEnvelopesFromDirectory(options.from);
-  const selectedEnvelopes = feedbackEnvelopes(envelopes, options.advisory);
-  yield* assertAdvisoryEnvelopes(selectedEnvelopes, options.advisory, options.runStartedAt);
-  const index = issueIndexFromEnvelopes(selectedEnvelopes, options.advisory);
-  yield* writeQualityIssueIndex(options.emit, index);
+  const entries = yield* readEnvelopeEntries(options.from);
+  if (!options.advisory) {
+    const envelopes = A.map(entries, (entry) => entry.envelope);
+    yield* assertAdvisoryEnvelopes(envelopes, false);
+    yield* writeQualityIssueIndex(options.emit, issueIndexFromEnvelopes(envelopes, false));
+    yield* Console.log(`[yeet] Fallow advisory issue index written to ${options.emit}`);
+    return;
+  }
+  // Classify and purge regenerable leftovers before any hard-failing check, then
+  // check only the survivors (decision 25 / ledger #55): a stale or check-mode
+  // envelope is never allowed to fail the publish, whatever else it carries.
+  const startedAtMillis = runStartMillis(options.runStartedAt);
+  const defects = selfHealableDefects(entries, startedAtMillis);
+  const surviving = survivingEnvelopes(entries, startedAtMillis);
+  if (!A.isReadonlyArrayEmpty(defects)) {
+    const unpurged = A.getSomes(yield* Effect.forEach(defects, purgeEnvelopeFile, { concurrency: 1 }));
+    // Emit the same index an absent `.beep/fallow` produces so a downstream
+    // consumer never reads a half-truth built from a partially stale directory.
+    yield* writeQualityIssueIndex(options.emit, issueIndexFromEnvelopes(A.empty<FallowEnvelope>(), true));
+    yield* Console.log(A.join(purgeNoteLines(defects, unpurged), "\n"));
+    // Leftovers are healed; a family mismatch left on an envelope that survived
+    // the purge is a producer bug in current-run output, so it still fails.
+    return yield* assertEnvelopeFamilyConsistency(surviving);
+  }
+  yield* assertEnvelopeFamilyConsistency(surviving);
+  yield* writeQualityIssueIndex(options.emit, issueIndexFromEnvelopes(surviving, true));
   yield* Console.log(`[yeet] Fallow advisory issue index written to ${options.emit}`);
 });
 

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
@@ -93,17 +93,78 @@ import { ensurePullRequest } from "./PullRequest.ts";
 import { buildQualityIssueIndex } from "./QualityIssueIndex.ts";
 import { collectYeetStatus, renderYeetStatusSummary, writeYeetStatusSnapshot } from "./Status.ts";
 import { collectTurboPlanSnapshot } from "./TurboQuery.ts";
-import { buildYeetVerdict, YeetExecutedStep } from "./Verdict.ts";
+import { buildYeetVerdict, YeetExecutedStep, YeetVerdictJson } from "./Verdict.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { RepoRunPlan } from "../../../internal/repo-run/index.ts";
 import type { FlakeQuarantineIncident } from "../../Quality/internal/FlakeQuarantine.ts";
 import type { YeetRunOptions, YeetRunResult } from "../Yeet.schemas.ts";
 import type { YeetStatusSnapshot } from "./Status.ts";
-import type { YeetBaseFreshness, YeetStashState } from "./Verdict.ts";
+import type { YeetBaseFreshness, YeetMergeReady, YeetStashState } from "./Verdict.ts";
 
 export { defaultYeetRunOptions } from "../Yeet.schemas.ts";
 
 const $I = $RepoCliId.create("commands/Yeet/internal/Handler");
+
+/**
+ * The three repository coordinates every yeet run context needs before any
+ * turbo work is planned. Structural on purpose: each caller passes its own
+ * parsed flag bag rather than importing a shared option type.
+ */
+interface YeetContextCoordinates {
+  readonly base: string;
+  readonly head: string;
+  readonly packetDir: string;
+}
+
+const readOnlyRunContext = (repoRoot: string, branch: string, options: YeetContextCoordinates): RepoRunContext =>
+  RepoRunContext.make({
+    repoRoot,
+    cwd: process.cwd(),
+    base: options.base,
+    head: options.head,
+    branch,
+    packetDir: options.packetDir,
+    originalArgv: [],
+    turbo: emptyTurboPlanSnapshot([]),
+  });
+
+/**
+ * Hydrate a run context for commands that read the clone instead of planning
+ * turbo work.
+ *
+ * **Details**
+ *
+ * The porcelain subcommands — sweep, merge, reply, and the merge loop — need the
+ * repo root, the checked-out branch, and the packet directory, and nothing else.
+ * Skipping {@link collectTurboPlanSnapshot} keeps them off the `turbo run --dry`
+ * critical path, which is the whole reason they feel instant next to a publish.
+ *
+ * **Example** (Hydrate a read-only context)
+ *
+ * ```ts
+ * import { hydrateYeetReadOnlyContext } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(hydrateYeetReadOnlyContext)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Base ref, head ref, and packet directory for the run.
+ * @returns Run context carrying an empty turbo snapshot.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const hydrateYeetReadOnlyContext = Effect.fn("Yeet.hydrateYeetReadOnlyContext")(function* (
+  options: YeetContextCoordinates
+): Effect.fn.Return<
+  RepoRunContext,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const repoRoot = yield* findRepoRoot().pipe(Effect.mapError(YeetCommandError.new("Failed to locate repo root.")));
+  const branch = yield* currentYeetBranch(repoRoot);
+  return readOnlyRunContext(repoRoot, branch, options);
+});
 
 /**
  * Hydrate a shared yeet run context from repository state.
@@ -132,32 +193,14 @@ export const hydrateYeetRunContext = Effect.fn("Yeet.hydrateYeetRunContext")(fun
   const repoRoot = yield* findRepoRoot().pipe(Effect.mapError(YeetCommandError.new("Failed to locate repo root.")));
   const branch = yield* currentYeetBranch(repoRoot);
   if (options.mode === "pre-push-hook") {
-    return RepoRunContext.make({
-      repoRoot,
-      cwd: process.cwd(),
-      base: options.base,
-      head: options.head,
-      branch,
-      packetDir: options.packetDir,
-      originalArgv: [],
-      turbo: emptyTurboPlanSnapshot([]),
-    });
+    return readOnlyRunContext(repoRoot, branch, options);
   }
 
   if (options.mode === "status") {
     if (options.remote) {
       yield* refreshBaseRef(repoRoot, options.base);
     }
-    return RepoRunContext.make({
-      repoRoot,
-      cwd: process.cwd(),
-      base: options.base,
-      head: options.head,
-      branch,
-      packetDir: options.packetDir,
-      originalArgv: [],
-      turbo: emptyTurboPlanSnapshot([]),
-    });
+    return readOnlyRunContext(repoRoot, branch, options);
   }
 
   if (!options.plan) {
@@ -448,7 +491,7 @@ const runPublishMode = Effect.fn("Yeet.runPublishMode")(function* (
       yield* writeVerifiedState(plan.context, "full", fullSteps);
       yield* validatePostCommitProofDidNotChangeWorktree(plan.context, postCommitProofChangedAfterEarlyPushMessage);
 
-      return yield* runPublishMonitorAndResult(plan.context, monitorSteps, recorder, skipCommit);
+      return yield* runPublishMonitorAndResult(plan.context, monitorSteps, recorder, extras, skipCommit);
     }
 
     const preflightSteps = A.filter(publishSteps, (step) => step.id === HEAD_INSTALL_PREFLIGHT_STEP_ID);
@@ -493,7 +536,7 @@ const runPublishMode = Effect.fn("Yeet.runPublishMode")(function* (
       );
     }
 
-    return yield* runPublishMonitorAndResult(plan.context, monitorSteps, recorder, skipCommit);
+    return yield* runPublishMonitorAndResult(plan.context, monitorSteps, recorder, extras, skipCommit);
   });
 
   return yield* pipe(
@@ -554,7 +597,8 @@ const runPrePushHookMode = Effect.fn("Yeet.runPrePushHookMode")(function* (
 const runMonitorMode = Effect.fn("Yeet.runMonitorMode")(function* (
   context: RepoRunContext,
   monitorSteps: ReadonlyArray<RepoPlanStep>,
-  recorder: Ref.Ref<ReadonlyArray<YeetExecutedStep>>
+  recorder: Ref.Ref<ReadonlyArray<YeetExecutedStep>>,
+  extras: Ref.Ref<YeetVerdictExtras>
 ): Effect.fn.Return<
   YeetRunResult,
   YeetCommandError,
@@ -564,6 +608,7 @@ const runMonitorMode = Effect.fn("Yeet.runMonitorMode")(function* (
     Effect.catch((error) => failWithRerunGuidance(context, error))
   );
   const snapshot = yield* printOperatorStatusSummary(context, true);
+  yield* Ref.update(extras, (state) => ({ ...state, mergeReady: snapshot.mergeReady }));
   yield* assertNoUnresolvedReviewThreads(snapshot);
   return yield* emptyPlanResult(context);
 });
@@ -627,6 +672,14 @@ const runMonitorPhase = Effect.fn("Yeet.runMonitorPhase")(function* (
   YeetCommandError,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
+  // The planner emits monitor steps only under `--monitor`, so every other
+  // publish arrives here with an empty list. Falling through decoded the absent
+  // PR context and failed the whole run with "Failed to decode pull request
+  // number for yeet monitor" *after* a full success; an empty monitor phase is
+  // a no-op by contract.
+  if (A.isReadonlyArrayEmpty(monitorSteps)) {
+    return;
+  }
   const contextSteps = A.filter(monitorSteps, (step) => step.id === "monitor:01-pr-context");
   const checkSteps = A.filter(monitorSteps, (step) => step.id === "monitor:02-pr-checks-watch");
   const contextResults = yield* runPhase(context, contextSteps, recorder);
@@ -653,6 +706,7 @@ const runPublishMonitorAndResult = Effect.fn("Yeet.runPublishMonitorAndResult")(
   context: RepoRunContext,
   monitorSteps: ReadonlyArray<RepoPlanStep>,
   recorder: Ref.Ref<ReadonlyArray<YeetExecutedStep>>,
+  extras: Ref.Ref<YeetVerdictExtras>,
   skipCommit: boolean
 ): Effect.fn.Return<
   YeetRunResult,
@@ -664,10 +718,27 @@ const runPublishMonitorAndResult = Effect.fn("Yeet.runPublishMonitorAndResult")(
   );
   if (!A.isReadonlyArrayEmpty(monitorSteps)) {
     const snapshot = yield* printOperatorStatusSummary(context, true);
+    yield* Ref.update(extras, (state) => ({ ...state, mergeReady: snapshot.mergeReady }));
     yield* assertNoUnresolvedReviewThreads(snapshot);
   }
   return yield* publishResult(context, !skipCommit);
 });
+
+/**
+ * Run the monitor phase in isolation.
+ *
+ * @category testing
+ * @since 0.0.0
+ */
+export const runMonitorPhaseForTesting = runMonitorPhase;
+
+/**
+ * Run the publish tail — monitor phase, operator summary, and run result.
+ *
+ * @category testing
+ * @since 0.0.0
+ */
+export const runPublishMonitorAndResultForTesting = runPublishMonitorAndResult;
 
 const runStatusMode = Effect.fn("Yeet.runStatusMode")(function* (
   context: RepoRunContext,
@@ -736,6 +807,7 @@ const runCloseoutMode = Effect.fn("Yeet.runCloseoutMode")(function* (
 
 type YeetVerdictExtras = {
   readonly baseFreshness: O.Option<YeetBaseFreshness>;
+  readonly mergeReady: O.Option<YeetMergeReady>;
   readonly stash: O.Option<YeetStashState>;
 };
 
@@ -836,6 +908,10 @@ const writeRunVerdict = Effect.fn("Yeet.writeRunVerdict")(function* (
     indexPath: O.getOrUndefined(indexPath),
     message,
     mode: options.mode,
+    // Only the publish/monitor paths observe a live status snapshot, so runs
+    // that never read the pull request omit the key rather than asserting an
+    // unknown merge readiness.
+    mergeReady: O.getOrUndefined(extraState.mergeReady),
     outcome,
     packetPaths: pipe(
       artifacts,
@@ -849,7 +925,13 @@ const writeRunVerdict = Effect.fn("Yeet.writeRunVerdict")(function* (
     failureKind: outcome === "failure" ? (O.isSome(failedExecution) ? "step-exit" : "handler-error") : undefined,
   });
   const verdictPath = yield* runOutputPathForContext(plan.context, "verdict.json");
-  yield* writeTextFile(verdictPath, `${yield* renderJson(verdict)}\n`);
+  // Encode through the verdict's own schema codec: a generic JSON render of the
+  // decoded instance writes Option fields as `{"_id":"Option",...}`, which the
+  // status reader then rejects as "verdict artifact could not be decoded".
+  const verdictJson = yield* YeetVerdictJson.encode(verdict).pipe(
+    Effect.mapError(YeetCommandError.new("Failed to encode the yeet verdict artifact."))
+  );
+  yield* writeTextFile(verdictPath, `${verdictJson}\n`);
   yield* appendYeetAttemptJournalEvent(
     plan.context,
     YeetAttemptFinished.make({
@@ -862,6 +944,22 @@ const writeRunVerdict = Effect.fn("Yeet.writeRunVerdict")(function* (
   );
   yield* Console.log(`[yeet] verdict written to ${verdictPath}`);
 });
+
+/**
+ * Verdict facts collected outside the step recorder during one run.
+ *
+ * @category testing
+ * @since 0.0.0
+ */
+export type YeetVerdictExtrasForTesting = YeetVerdictExtras;
+
+/**
+ * Write the run verdict artifact and append its attempt-journal record.
+ *
+ * @category testing
+ * @since 0.0.0
+ */
+export const writeRunVerdictForTesting = writeRunVerdict;
 
 const runPlanExecution = Effect.fn("Yeet.runPlanExecution")(function* (
   plan: RepoRunPlan,
@@ -906,7 +1004,11 @@ const runPlanExecution = Effect.fn("Yeet.runPlanExecution")(function* (
   const monitorSteps = A.filter(executionSteps, (step) => step.phase === "monitor");
 
   const recorder = yield* Ref.make<ReadonlyArray<YeetExecutedStep>>(A.empty());
-  const extras = yield* Ref.make<YeetVerdictExtras>({ baseFreshness: O.none(), stash: O.none() });
+  const extras = yield* Ref.make<YeetVerdictExtras>({
+    baseFreshness: O.none(),
+    mergeReady: O.none(),
+    stash: O.none(),
+  });
 
   const execution = Effect.gen(function* () {
     const prepareResults = yield* runPhase(plan.context, prepareSteps, recorder);
@@ -935,7 +1037,7 @@ const runPlanExecution = Effect.fn("Yeet.runPlanExecution")(function* (
           recorder,
           extras
         ),
-      monitor: () => runMonitorMode(plan.context, monitorSteps, recorder),
+      monitor: () => runMonitorMode(plan.context, monitorSteps, recorder, extras),
       closeout: () => runCloseoutMode(plan.context, options),
       status: () => runStatusMode(plan.context, options),
       "pre-push-hook": () => runPrePushHookMode(plan.context),

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Merge.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Merge.ts
@@ -1,0 +1,245 @@
+/**
+ * Operator-authorized squash-merge porcelain with the workspace sweep as its tail.
+ *
+ * {@link mergePr} exists because `gh pr merge --squash --delete-branch` conflates
+ * two operations with different failure modes. On 2026-08-04 the API merge of
+ * #551 succeeded and the CLI's own local cleanup then failed —
+ * `'main' is already used by worktree at …` — so the command exited nonzero,
+ * looked like a failed merge, and silently abandoned the remote branch deletion.
+ * This porcelain splits them: merge WITHOUT `--delete-branch`, confirm `MERGED`
+ * from the API, and only then hand the whole cleanup sequence to the
+ * worktree-aware sweep.
+ *
+ * **Details**
+ *
+ * Nothing in this repository calls {@link mergePr}. It is an explicitly-run,
+ * operator-authorized action: the sweep is safe to auto-run on a merged-PR
+ * detection, but merging is a decision, not a step, and no monitor loop, closeout
+ * path, or publish flow may reach it.
+ *
+ * **Gotchas**
+ *
+ * The `MERGED` confirmation is a bounded poll rather than a single read, because
+ * `gh pr merge` returns as soon as GitHub accepts the request while the pull
+ * request's own state settles a moment later. Exhausting the budget is an error,
+ * not a silent pass — an unconfirmed merge must never be followed by branch
+ * deletion.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { guardLiteralArg } from "@beep/repo-utils";
+import { Duration, Effect, Schedule } from "effect";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { GhPrView, ghOutput } from "../../../internal/github/index.ts";
+import { runRepoCommandCapture } from "../../../internal/repo-run/index.ts";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import { SweepReport } from "./Sweep.schemas.ts";
+import { executeSweep } from "./Sweep.ts";
+import type { FileSystem, Path } from "effect";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Merge");
+
+const mergedState = "MERGED";
+const pullRequestViewFields = "number,headRefName,state,headRefOid";
+
+/**
+ * Bounded-poll settings for the post-merge `MERGED` confirmation.
+ */
+interface MergePrOptions {
+  /** Extra confirmation reads after the first one. */
+  readonly pollAttempts: number;
+  /** Delay between confirmation reads. */
+  readonly pollInterval: Duration.Input;
+}
+
+/**
+ * The default confirmation budget: ten extra reads, three seconds apart.
+ *
+ * **Example** (Read the default budget)
+ *
+ * ```ts
+ * import { defaultMergePrOptions } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(defaultMergePrOptions.pollAttempts)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const defaultMergePrOptions: MergePrOptions = {
+  pollAttempts: 10,
+  pollInterval: Duration.seconds(3),
+};
+
+/**
+ * What one operator-authorized merge did, and what the sweep tail found afterwards.
+ *
+ * **Example** (Report a merged pull request)
+ *
+ * ```ts
+ * import { MergeOutcome, SweepPlan, SweepReport } from "@beep/repo-cli/test/Yeet"
+ *
+ * const outcome = MergeOutcome.make({
+ *   pullRequestNumber: 559,
+ *   state: "MERGED",
+ *   sweep: SweepReport.make({
+ *     schemaVersion: "yeet-sweep-report/v1",
+ *     plan: SweepPlan.make({
+ *       schemaVersion: "yeet-sweep-plan/v1",
+ *       createdAt: "2026-08-04T00:00:00.000Z",
+ *       branch: "feat/merge-loop",
+ *       steps: [],
+ *     }),
+ *     steps: [],
+ *     startedAt: "2026-08-04T00:00:00.000Z",
+ *     endedAt: "2026-08-04T00:00:01.000Z",
+ *   }),
+ * })
+ * console.log(outcome.pullRequestNumber)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class MergeOutcome extends S.Class<MergeOutcome>($I`MergeOutcome`)(
+  {
+    pullRequestNumber: S.Finite,
+    state: S.NonEmptyString,
+    sweep: SweepReport,
+  },
+  $I.annote("MergeOutcome", {
+    description: "Result of one operator-authorized squash merge and the workspace sweep that followed it.",
+  })
+) {}
+
+const decodePullRequestView = S.decodeUnknownEffect(S.fromJsonString(GhPrView));
+
+const readPullRequest = Effect.fn("Yeet.readMergePullRequest")(function* (
+  context: RepoRunContext,
+  selector: string
+): Effect.fn.Return<GhPrView, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const output = yield* ghOutput({
+    args: ["pr", "view", selector, "--json", pullRequestViewFields],
+    cwd: context.repoRoot,
+    label: `gh pr view ${selector}`,
+    onFailure: (failure) =>
+      YeetCommandError.make({
+        message: `Failed to read pull request "${selector}" (${failure._tag}).`,
+        command: failure.command,
+        exitCode: 1,
+      }),
+  });
+  return yield* decodePullRequestView(output).pipe(
+    Effect.mapError(YeetCommandError.new(`Failed to decode gh pr view JSON for "${selector}".`))
+  );
+});
+
+const confirmMerged = Effect.fn("Yeet.confirmPullRequestMerged")(function* (
+  context: RepoRunContext,
+  pullRequestNumber: number
+): Effect.fn.Return<GhPrView, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const view = yield* readPullRequest(context, `${pullRequestNumber}`);
+  if (view.state !== mergedState) {
+    return yield* YeetCommandError.make({
+      message: `pull request #${pullRequestNumber} reports state ${view.state}, not ${mergedState}.`,
+      command: `gh pr view ${pullRequestNumber} --json ${pullRequestViewFields}`,
+      exitCode: 1,
+    });
+  }
+  return view;
+});
+
+/**
+ * Squash-merge the current branch's pull request, confirm it, then sweep the clone.
+ *
+ * **Details**
+ *
+ * Three phases, in order and never reordered: `gh pr merge <number> --squash`
+ * without `--delete-branch`; a bounded poll until the API reports `MERGED`; then
+ * {@link executeSweep}, which owns every ref update and deletion under its own
+ * worktree-aware safety rails. A merge that cannot be confirmed fails here, so no
+ * deletion is ever attempted against an unconfirmed merge.
+ *
+ * **Gotchas**
+ *
+ * Never wire this into an automatic path. Monitor's merged-PR detection may run
+ * the sweep; only a human may run the merge.
+ *
+ * **Example** (Build the merge effect)
+ *
+ * ```ts
+ * import { mergePr } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(mergePr)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the repo root and the branch to merge.
+ * @param options - Confirmation poll budget; defaults to {@link defaultMergePrOptions}.
+ * @returns The merged pull request number, its confirmed state, and the sweep report.
+ * @category workflows
+ * @since 0.0.0
+ */
+export const mergePr = Effect.fn("Yeet.mergePr")(function* (
+  context: RepoRunContext,
+  options: MergePrOptions = defaultMergePrOptions
+): Effect.fn.Return<
+  MergeOutcome,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const branch = yield* guardLiteralArg(context.branch).pipe(
+    Effect.mapError(
+      YeetCommandError.new(`yeet merge refuses an option-like branch name "${context.branch}".`, {
+        command: "gh pr view",
+        exitCode: 1,
+      })
+    )
+  );
+  const view = yield* readPullRequest(context, branch);
+  if (view.headRefName !== context.branch) {
+    return yield* YeetCommandError.make({
+      message: `yeet merge expected PR head "${context.branch}" but gh reported "${view.headRefName}".`,
+      command: `gh pr view ${context.branch} --json ${pullRequestViewFields}`,
+      exitCode: 1,
+    });
+  }
+  if (view.state !== "OPEN") {
+    return yield* YeetCommandError.make({
+      message: `yeet merge requires an open pull request; #${view.number} is ${view.state}.`,
+      command: `gh pr view ${context.branch} --json ${pullRequestViewFields}`,
+      exitCode: 1,
+    });
+  }
+
+  const mergeCommand = `gh pr merge ${view.number} --squash`;
+  const merge = yield* runRepoCommandCapture(
+    "gh",
+    ["pr", "merge", `${view.number}`, "--squash"],
+    context.repoRoot
+  ).pipe(Effect.mapError(YeetCommandError.new(`Failed to run ${mergeCommand}.`)));
+  if (merge.exitCode !== 0) {
+    return yield* YeetCommandError.make({
+      message: `${mergeCommand} failed:\n${Str.trim(merge.output)}`,
+      command: mergeCommand,
+      exitCode: merge.exitCode,
+    });
+  }
+
+  const confirmed = yield* confirmMerged(context, view.number).pipe(
+    Effect.retry({ times: options.pollAttempts, schedule: Schedule.spaced(options.pollInterval) })
+  );
+
+  return MergeOutcome.make({
+    pullRequestNumber: confirmed.number,
+    state: confirmed.state,
+    sweep: yield* executeSweep(context),
+  });
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorComments.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorComments.ts
@@ -312,12 +312,37 @@ export const normalizeYeetMonitorReviewCommentForTesting = normalizeReviewCommen
  */
 export const normalizeYeetMonitorIssueCommentForTesting = normalizeIssueComment;
 
-const excerpt = (body: string): string => {
+/**
+ * Collapse whitespace in a comment body and bound its length for one line.
+ *
+ * **Details**
+ *
+ * Terminal control sequences are stripped before the whitespace collapse, so a
+ * hostile comment body cannot smuggle escape codes into operator terminals.
+ * Shared with `yeet status` thread triage, which strips bot badge markup first
+ * and then bounds the surviving first line here — so both operator surfaces
+ * sanitize and truncate identically instead of drifting apart.
+ *
+ * **Example** (Bound a long body)
+ *
+ * ```ts
+ * import { yeetCommentExcerpt } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(yeetCommentExcerpt("please  add\na regression test", 12))
+ * ```
+ *
+ * @param body - Raw comment text.
+ * @param maxLength - Maximum characters before an ellipsis is appended.
+ * @returns The single-line, bounded, control-sequence-free excerpt.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const yeetCommentExcerpt = (body: string, maxLength: number): string => {
   const normalized = pipe(body, stripTerminalControlSequences, Str.replace(/\s+/gu, " "), Str.trim);
-  return Str.length(normalized) <= commentExcerptLength
-    ? normalized
-    : `${pipe(normalized, Str.takeLeft(commentExcerptLength))}…`;
+  return Str.length(normalized) <= maxLength ? normalized : `${pipe(normalized, Str.takeLeft(maxLength))}…`;
 };
+
+const excerpt = (body: string): string => yeetCommentExcerpt(body, commentExcerptLength);
 
 /**
  * Render a new pull request comment in Yeet monitor's compact operator format.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorLoop.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorLoop.ts
@@ -1,0 +1,803 @@
+/**
+ * The `yeet monitor --until-merged` merge loop.
+ *
+ * Plain `yeet monitor` watches one head SHA and exits on the first red, so every
+ * fix wave costs the operator a manual re-arm. The merge loop instead follows
+ * the pull request itself: it re-reads status each poll, picks up whatever head
+ * SHA the branch now carries, and only stops when the PR reaches a terminal
+ * state — `MERGED` (which hands off to the post-merge sweep), `CLOSED`, or an
+ * operator interrupt.
+ *
+ * **Details**
+ *
+ * A red wave is triaged, not surrendered to. Each failed job's failing-step log
+ * is matched against the two flake fingerprints this repo has evidence for —
+ * the no-location TS2589 native-compiler flake (detection reused verbatim from
+ * `commands/Quality/internal/FlakeQuarantine`) and the CI-timeout class — and a
+ * match buys exactly one rerun per job per head SHA. Anything else is reported
+ * as "needs code fix" and the loop keeps following, so the operator sees the
+ * classification instead of a dead session.
+ *
+ * **Gotchas**
+ *
+ * Reruns go through `gh run rerun --job <databaseId>`, never
+ * `gh run rerun --failed`. `--failed` reruns *every* failed job in the workflow
+ * run, which re-executes genuine reds coexisting with the flake and silently
+ * spends a budget that is defined per job — the bound would stop being a bound.
+ *
+ * The budget is in-memory and keyed by `(headSha, jobName)`, so a new push
+ * earns a fresh rerun allowance by construction and a resumed session starts
+ * from zero. That is deliberate: the budget exists to stop this loop from
+ * spinning, not to be a durable ledger.
+ *
+ * The key uses the job *name*, never the `databaseId`, because a job record is
+ * per-attempt: rerunning creates a new workflow-run attempt whose jobs carry
+ * fresh ids. Keying on the id would make every rerun's own output miss the
+ * budget it just spent, and the bound would be unbounded. The executed command
+ * still addresses the id — execution is attempt-scoped, only the idempotency
+ * key is not.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit, SchemaUtils } from "@beep/schema";
+import { Console, Duration, Effect, flow, HashSet, Match, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { runRepoCommandCapture } from "../../../internal/repo-run/index.ts";
+import { detectNoLocationTs2589Flake } from "../../Quality/internal/FlakeQuarantine.ts";
+import {
+  collectRemoteWorkflowRuns,
+  collectYeetStatus,
+  renderYeetStatusSummary,
+  writeYeetStatusSnapshot,
+} from "./Status.ts";
+import { executeSweep } from "./Sweep.ts";
+import type { FileSystem, Path } from "effect";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
+import type { YeetCommandError } from "../Yeet.errors.ts";
+import type { YeetStatusSnapshot } from "./Status.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/MonitorLoop");
+
+const mergeLoopPollInterval = Duration.seconds(30);
+
+/**
+ * Environment-only failure signatures the merge loop is allowed to rerun.
+ *
+ * **Details**
+ *
+ * Both members are evidence-backed classes, not guesses. `ts2589-no-location`
+ * is the Effect-patched native compiler counting instantiations across parallel
+ * checker threads and tipping a near-ceiling package over the limit — it emits
+ * `error TS2589` with no file location and never reproduces standalone.
+ * `ci-timeout` is a heavy or property-based suite exceeding a runner limit that
+ * it clears locally in seconds.
+ *
+ * Anything outside this domain is a code failure by default. Widening it is a
+ * decision, not a convenience: every member is a licence to spend a rerun.
+ *
+ * **Example** (List the fingerprinted flake classes)
+ *
+ * ```ts
+ * import { YeetMonitorFlakeClass } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetMonitorFlakeClass.Options)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetMonitorFlakeClass = LiteralKit(["ts2589-no-location", "ci-timeout"]).pipe(
+  $I.annoteSchema("YeetMonitorFlakeClass", {
+    title: "Yeet Monitor Flake Class",
+    description: "One environment-only failure signature the merge loop may rerun once per job per head SHA.",
+  })
+);
+
+/**
+ * Environment-only failure signatures the merge loop is allowed to rerun.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetMonitorFlakeClass = typeof YeetMonitorFlakeClass.Type;
+
+/**
+ * Terminal pull request states that end a merge loop.
+ *
+ * **Example** (List the terminal states)
+ *
+ * ```ts
+ * import { YeetMonitorTerminalState } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetMonitorTerminalState.Options)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetMonitorTerminalState = LiteralKit(["merged", "closed"]).pipe(
+  $I.annoteSchema("YeetMonitorTerminalState", {
+    title: "Yeet Monitor Terminal State",
+    description: "Pull request state that ends the merge loop.",
+  })
+);
+
+/**
+ * Terminal pull request states that end a merge loop.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetMonitorTerminalState = typeof YeetMonitorTerminalState.Type;
+
+const GITHUB_LOG_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z ?/u;
+const GITHUB_LOG_COMMAND_MARKER_PATTERN = /^##\[[a-z]+\] ?/u;
+const GITHUB_LOG_JOB_STEP_PREFIX_PATTERN = /^[^\t]*\t[^\t]*\t/u;
+
+const CI_TIMEOUT_PATTERNS: ReadonlyArray<RegExp> = [
+  /has exceeded the maximum execution time/u,
+  /The action '[^']*' has timed out/u,
+  /Test timed out in \d+\s*ms/u,
+  /Hook timed out in \d+\s*ms/u,
+  /timed out after \d+\s*(?:ms|s|m|seconds?|minutes?)/u,
+];
+
+const stripGithubLogPrefix: (line: string) => string = flow(
+  Str.replace(GITHUB_LOG_JOB_STEP_PREFIX_PATTERN, ""),
+  Str.replace(GITHUB_LOG_TIMESTAMP_PATTERN, ""),
+  Str.replace(GITHUB_LOG_COMMAND_MARKER_PATTERN, "")
+);
+
+/**
+ * Strip GitHub Actions log decoration so a job log reads like local output.
+ *
+ * **Details**
+ *
+ * `gh run view --log` prefixes every line with `<job>\t<step>\t`, a UTC
+ * timestamp, and sometimes a `##[error]` workflow-command marker. Left in
+ * place they defeat the Turbo `<package>:<task>: ` prefix match the TS2589
+ * detector relies on, which downgrades a quarantinable flake into an
+ * unrecognised diagnostic.
+ *
+ * **Example** (Normalize one decorated line)
+ *
+ * ```ts
+ * import { stripYeetMonitorLogDecoration } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(stripYeetMonitorLogDecoration("2026-08-04T12:00:00.1234567Z ##[error]boom"))
+ * ```
+ *
+ * @param log - Raw job log text as returned by `gh run view --log-failed`.
+ * @returns The same log with per-line GitHub decoration removed.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const stripYeetMonitorLogDecoration = (log: string): string =>
+  pipe(Str.split(/\r?\n/u)(log), A.map(stripGithubLogPrefix), A.join("\n"));
+
+/**
+ * Classify a failed job's log against the merge loop's flake fingerprints.
+ *
+ * **Details**
+ *
+ * The TS2589 arm delegates to the quality lane's
+ * `detectNoLocationTs2589Flake`, so the strictness rules stay defined in one
+ * place: every TS2589 line must be attributed to a Turbo task, no other TS
+ * diagnostic may appear, and Turbo's `Failed:` footer must agree.
+ *
+ * **Gotchas**
+ *
+ * Returning `None` is the safe answer and the caller must treat it as "needs
+ * code fix". A truncated log capture must never reach here — the TS2589 rules
+ * include "no other diagnostic *anywhere* in the output", which a truncated
+ * capture cannot establish.
+ *
+ * **Example** (Recognize a timed-out suite)
+ *
+ * ```ts
+ * import { detectYeetMonitorFlakeClass } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(detectYeetMonitorFlakeClass("Test timed out in 5000ms"))
+ * ```
+ *
+ * @param log - Failing-step log for one job.
+ * @returns The matched flake class, or `None` when the failure is not one.
+ * @category detection
+ * @since 0.0.0
+ */
+export const detectYeetMonitorFlakeClass = (log: string): O.Option<YeetMonitorFlakeClass> => {
+  const normalized = stripYeetMonitorLogDecoration(log);
+  if (O.isSome(detectNoLocationTs2589Flake(normalized))) {
+    return O.some(YeetMonitorFlakeClass.Enum["ts2589-no-location"]);
+  }
+  return A.some(CI_TIMEOUT_PATTERNS, (pattern) => pattern.test(normalized))
+    ? O.some(YeetMonitorFlakeClass.Enum["ci-timeout"])
+    : O.none();
+};
+
+/**
+ * A failed hosted job, already classified against the flake fingerprints.
+ *
+ * **Example** (Describe an unclassified red job)
+ *
+ * ```ts
+ * import { YeetMonitorFailedJob } from "@beep/repo-cli/test/Yeet"
+ *
+ * const job = YeetMonitorFailedJob.make({ databaseId: 991, name: "Check" })
+ * console.log(job.flakeClass)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMonitorFailedJob extends S.Class<YeetMonitorFailedJob>($I`YeetMonitorFailedJob`)(
+  {
+    databaseId: S.Finite,
+    name: S.String,
+    flakeClass: YeetMonitorFlakeClass.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+  },
+  $I.annote("YeetMonitorFailedJob", {
+    description: "One failed hosted job paired with the flake class its log matched, if any.",
+  })
+) {}
+
+/**
+ * A job the loop will rerun once, having matched a flake fingerprint.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMonitorRerunJob extends S.Class<YeetMonitorRerunJob>($I`YeetMonitorRerunJob`)(
+  {
+    status: S.tag("rerun"),
+    databaseId: S.Finite,
+    name: S.String,
+    flakeClass: YeetMonitorFlakeClass,
+    command: S.NonEmptyString,
+  },
+  $I.annote("YeetMonitorRerunJob", {
+    description: "A flake-matching job the merge loop reruns once for this head SHA.",
+  })
+) {}
+
+/**
+ * A job that matched a fingerprint but already spent its rerun on this SHA.
+ *
+ * **Details**
+ *
+ * A second identical failure at the same SHA is evidence against the
+ * environment-only reading: the loop reports it and stops paying for it.
+ * "Identical" is judged by job name, so the rerun's own attempt — a fresh
+ * `databaseId` for the same logical job — lands here rather than buying
+ * another allowance.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMonitorRerunSpent extends S.Class<YeetMonitorRerunSpent>($I`YeetMonitorRerunSpent`)(
+  {
+    status: S.tag("rerun-spent"),
+    databaseId: S.Finite,
+    name: S.String,
+    flakeClass: YeetMonitorFlakeClass,
+  },
+  $I.annote("YeetMonitorRerunSpent", {
+    description: "A flake-matching job whose one rerun for this head SHA is already spent.",
+  })
+) {}
+
+/**
+ * A red job whose log matched no fingerprint: the branch needs a code fix.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMonitorNeedsCodeFix extends S.Class<YeetMonitorNeedsCodeFix>($I`YeetMonitorNeedsCodeFix`)(
+  {
+    status: S.tag("needs-code-fix"),
+    databaseId: S.Finite,
+    name: S.String,
+  },
+  $I.annote("YeetMonitorNeedsCodeFix", {
+    description: "A red job the merge loop refuses to rerun because its failure matched no known flake class.",
+  })
+) {}
+
+/**
+ * What the merge loop decided about one red job.
+ *
+ * **Example** (Decode a needs-code-fix decision)
+ *
+ * ```ts
+ * import { YeetMonitorJobDecision } from "@beep/repo-cli/test/Yeet"
+ * import * as S from "effect/Schema"
+ *
+ * const decoded = S.decodeUnknownOption(YeetMonitorJobDecision)({
+ *   status: "needs-code-fix",
+ *   databaseId: 991,
+ *   name: "Check",
+ * })
+ * console.log(decoded)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetMonitorJobDecision = S.Union([
+  YeetMonitorRerunJob,
+  YeetMonitorRerunSpent,
+  YeetMonitorNeedsCodeFix,
+]).pipe(
+  S.toTaggedUnion("status"),
+  $I.annoteSchema("YeetMonitorJobDecision", {
+    description: "What the merge loop decided about one red hosted job.",
+  })
+);
+
+/**
+ * What the merge loop decided about one red job.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetMonitorJobDecision = typeof YeetMonitorJobDecision.Type;
+
+/**
+ * The set of `(head SHA, job name)` pairs whose single rerun is already spent.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type YeetMonitorRerunBudget = HashSet.HashSet<string>;
+
+/**
+ * A merge loop that has spent no reruns yet.
+ *
+ * **Example** (Start a fresh budget)
+ *
+ * ```ts
+ * import { emptyYeetMonitorRerunBudget } from "@beep/repo-cli/test/Yeet"
+ * import { HashSet } from "effect"
+ *
+ * console.log(HashSet.size(emptyYeetMonitorRerunBudget))
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const emptyYeetMonitorRerunBudget: YeetMonitorRerunBudget = HashSet.empty<string>();
+
+/**
+ * Build the budget key that scopes one rerun to one job at one head SHA.
+ *
+ * **Details**
+ *
+ * The job identity in the key is `job.name`, not `job.databaseId`, because
+ * GitHub job records are per-attempt. `gh run rerun --job <id>` creates a new
+ * attempt of the workflow run, and the next `gh run view --json jobs` returns
+ * the same logical job under a *new* `databaseId`. Keyed on the id, the very
+ * failure a rerun produced would miss the budget entry that rerun spent, and
+ * the loop could rerun the same job forever at one head SHA. The name is the
+ * identifier stable across attempts, so it is what bounds the allowance.
+ *
+ * **Gotchas**
+ *
+ * Matrix jobs sharing a `name` collide into one allowance — deliberately
+ * chosen: a collision under-spends (one rerun covers the shard family) whereas
+ * an id-key over-spends without limit, and only one of those two failure
+ * directions is a bound.
+ *
+ * **Example** (Key one job at one SHA)
+ *
+ * ```ts
+ * import { yeetMonitorRerunKey } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(yeetMonitorRerunKey("abc123", "Check"))
+ * ```
+ *
+ * @param headSha - Head SHA the failing job ran against.
+ * @param jobName - GitHub job `name`, stable across workflow-run attempts.
+ * @returns The budget key for that pair.
+ * @category constructors
+ * @since 0.0.0
+ */
+export const yeetMonitorRerunKey = (headSha: string, jobName: string): string => `${headSha}#${jobName}`;
+
+/**
+ * Build the job-scoped rerun command for one failing job.
+ *
+ * **Gotchas**
+ *
+ * Job-scoped on purpose. `gh run rerun <runId> --failed` reruns every failed
+ * job in the run, so a genuine red sharing the run with a flake would be
+ * re-executed as a side effect of the flake's allowance.
+ *
+ * **Example** (Build the job-scoped rerun)
+ *
+ * ```ts
+ * import { yeetMonitorRerunCommand } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(yeetMonitorRerunCommand(991))
+ * ```
+ *
+ * @param databaseId - GitHub job `databaseId` to rerun.
+ * @returns The `gh run rerun --job` invocation.
+ * @category constructors
+ * @since 0.0.0
+ */
+export const yeetMonitorRerunCommand = (databaseId: number): string => `gh run rerun --job ${databaseId}`;
+
+/**
+ * A batch of job decisions paired with the budget they left behind.
+ */
+interface YeetMonitorRerunPlan {
+  readonly budget: YeetMonitorRerunBudget;
+  readonly decisions: ReadonlyArray<YeetMonitorJobDecision>;
+}
+
+/**
+ * Decide, for every red job at one head SHA, whether to rerun it.
+ *
+ * **Details**
+ *
+ * The one pure decision in the merge loop, and the reason "one rerun per job
+ * per SHA" is a property rather than a hope: the returned budget is the input
+ * budget plus every key this call approved, so feeding it back is the only way
+ * to keep looping and a second call over the same SHA and job name can only
+ * return `rerun-spent`.
+ *
+ * **Gotchas**
+ *
+ * The budget key is `(headSha, job.name)`, so the refusal holds across the new
+ * `databaseId` the rerun's own attempt produces — see `yeetMonitorRerunKey`.
+ * The approved `command` still targets `job.databaseId`, which is the only
+ * thing `gh run rerun --job` can address.
+ *
+ * **Example** (Approve one rerun, then refuse the second)
+ *
+ * ```ts
+ * import { emptyYeetMonitorRerunBudget, planYeetMonitorReruns, YeetMonitorFailedJob } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const job = YeetMonitorFailedJob.make({ databaseId: 991, name: "Check", flakeClass: O.some("ci-timeout") })
+ * const first = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [job])
+ * const second = planYeetMonitorReruns(first.budget, "abc123", [job])
+ * console.log(second.decisions[0]?.status)
+ * ```
+ *
+ * @param budget - Reruns already spent in this session.
+ * @param headSha - Head SHA the red jobs ran against.
+ * @param jobs - Classified red jobs for that SHA.
+ * @returns One decision per job plus the budget after the batch.
+ * @category planning
+ * @since 0.0.0
+ */
+export const planYeetMonitorReruns = (
+  budget: YeetMonitorRerunBudget,
+  headSha: string,
+  jobs: ReadonlyArray<YeetMonitorFailedJob>
+): YeetMonitorRerunPlan =>
+  A.reduce(jobs, { budget, decisions: A.empty<YeetMonitorJobDecision>() }, (plan, job) =>
+    O.match(job.flakeClass, {
+      onNone: () => ({
+        budget: plan.budget,
+        decisions: A.append(
+          plan.decisions,
+          YeetMonitorNeedsCodeFix.make({ databaseId: job.databaseId, name: job.name })
+        ),
+      }),
+      onSome: (flakeClass) => {
+        const key = yeetMonitorRerunKey(headSha, job.name);
+        return HashSet.has(plan.budget, key)
+          ? {
+              budget: plan.budget,
+              decisions: A.append(
+                plan.decisions,
+                YeetMonitorRerunSpent.make({ databaseId: job.databaseId, flakeClass, name: job.name })
+              ),
+            }
+          : {
+              budget: HashSet.add(plan.budget, key),
+              decisions: A.append(
+                plan.decisions,
+                YeetMonitorRerunJob.make({
+                  command: yeetMonitorRerunCommand(job.databaseId),
+                  databaseId: job.databaseId,
+                  flakeClass,
+                  name: job.name,
+                })
+              ),
+            };
+      },
+    })
+  );
+
+/**
+ * Render one merge-loop job decision as an operator line.
+ *
+ * **Example** (Render a refused red)
+ *
+ * ```ts
+ * import { renderYeetMonitorJobDecision, YeetMonitorNeedsCodeFix } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(renderYeetMonitorJobDecision(YeetMonitorNeedsCodeFix.make({ databaseId: 991, name: "Check" })))
+ * ```
+ *
+ * @param decision - The decision to render.
+ * @returns A single-line operator string.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetMonitorJobDecision = (decision: YeetMonitorJobDecision): string =>
+  Match.value(decision).pipe(
+    Match.discriminatorsExhaustive("status")({
+      rerun: (value) =>
+        `[yeet] ${value.name}: ${value.flakeClass} flake fingerprint matched; rerunning once -> ${value.command}`,
+      "rerun-spent": (value) =>
+        `[yeet] ${value.name}: ${value.flakeClass} matched again at this SHA; rerun budget spent, needs attention`,
+      "needs-code-fix": (value) => `[yeet] ${value.name}: red with no known flake fingerprint; needs code fix`,
+    })
+  );
+
+/**
+ * Read the terminal merge-loop state out of a `gh pr view` state string.
+ *
+ * **Example** (Recognize a merged pull request)
+ *
+ * ```ts
+ * import { yeetMonitorTerminalState } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * console.log(yeetMonitorTerminalState(O.some("MERGED")))
+ * ```
+ *
+ * @param state - `gh pr view --json state` value, when it was read.
+ * @returns The terminal state, or `None` while the pull request is still open.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const yeetMonitorTerminalState = (state: O.Option<string>): O.Option<YeetMonitorTerminalState> =>
+  pipe(
+    state,
+    O.map(Str.toUpperCase),
+    O.flatMap((value) =>
+      value === "MERGED"
+        ? O.some(YeetMonitorTerminalState.Enum.merged)
+        : value === "CLOSED"
+          ? O.some(YeetMonitorTerminalState.Enum.closed)
+          : O.none()
+    )
+  );
+
+class GhMonitorJob extends S.Class<GhMonitorJob>($I`GhMonitorJob`)(
+  {
+    conclusion: S.NullOr(S.String),
+    databaseId: S.Finite,
+    name: S.String,
+    status: S.String,
+  },
+  $I.annote("GhMonitorJob", { description: "One job of a workflow run as returned by gh run view --json jobs." })
+) {}
+
+class GhMonitorRunJobs extends S.Class<GhMonitorRunJobs>($I`GhMonitorRunJobs`)(
+  { jobs: S.Array(GhMonitorJob) },
+  $I.annote("GhMonitorRunJobs", { description: "Job list of one workflow run used by the yeet merge loop." })
+) {}
+
+const decodeGhMonitorRunJobs = S.decodeUnknownEffect(S.fromJsonString(GhMonitorRunJobs));
+
+const jobIsRed = (job: GhMonitorJob): boolean =>
+  pipe(
+    O.fromNullishOr(job.conclusion),
+    O.map(Str.toLowerCase),
+    O.exists((conclusion) => A.contains(["failure", "timed_out", "cancelled"], conclusion))
+  );
+
+const runJobs = Effect.fn("YeetMonitorLoop.runJobs")(function* (
+  context: RepoRunContext,
+  runDatabaseId: number
+): Effect.fn.Return<ReadonlyArray<GhMonitorJob>, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const result = yield* runRepoCommandCapture(
+    "gh",
+    ["run", "view", `${runDatabaseId}`, "--json", "jobs"],
+    context.repoRoot
+  ).pipe(Effect.orElseSucceed(() => ({ exitCode: 1, output: Str.empty, truncated: false })));
+  if (result.exitCode !== 0 || result.truncated) {
+    return A.empty();
+  }
+  return yield* decodeGhMonitorRunJobs(result.output).pipe(
+    Effect.map((payload) => payload.jobs),
+    Effect.orElseSucceed(A.empty<GhMonitorJob>)
+  );
+});
+
+/**
+ * Fetch and classify one failed job's failing-step log.
+ *
+ * `--log-failed` rather than `--log`: only the failing steps are relevant, and
+ * a whole-job log routinely overruns the repo-run capture bound. A truncated or
+ * unavailable capture yields `None`, which the planner reads as "needs code
+ * fix" — the conservative direction.
+ */
+const classifyJob = Effect.fn("YeetMonitorLoop.classifyJob")(function* (
+  context: RepoRunContext,
+  job: GhMonitorJob
+): Effect.fn.Return<YeetMonitorFailedJob, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const result = yield* runRepoCommandCapture(
+    "gh",
+    ["run", "view", "--job", `${job.databaseId}`, "--log-failed"],
+    context.repoRoot
+  ).pipe(Effect.orElseSucceed(() => ({ exitCode: 1, output: Str.empty, truncated: false })));
+  const flakeClass = result.exitCode === 0 && !result.truncated ? detectYeetMonitorFlakeClass(result.output) : O.none();
+  return YeetMonitorFailedJob.make({ databaseId: job.databaseId, flakeClass, name: job.name });
+});
+
+const collectFailedJobs = Effect.fn("YeetMonitorLoop.collectFailedJobs")(function* (
+  context: RepoRunContext,
+  headSha: string
+): Effect.fn.Return<ReadonlyArray<YeetMonitorFailedJob>, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const runs = yield* collectRemoteWorkflowRuns(context);
+  const redRuns = A.filter(runs, (run) => run.headSha === headSha && run.conclusion === "failure");
+  const jobs = yield* Effect.forEach(redRuns, (run) => runJobs(context, run.databaseId), { concurrency: 2 });
+  return yield* Effect.forEach(pipe(jobs, A.flatten, A.filter(jobIsRed)), (job) => classifyJob(context, job), {
+    concurrency: 2,
+  });
+});
+
+const rerunJob = Effect.fn("YeetMonitorLoop.rerunJob")(function* (
+  context: RepoRunContext,
+  databaseId: number
+): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const result = yield* runRepoCommandCapture("gh", ["run", "rerun", "--job", `${databaseId}`], context.repoRoot).pipe(
+    Effect.orElseSucceed(() => ({ exitCode: 1, output: Str.empty, truncated: false }))
+  );
+  if (result.exitCode !== 0) {
+    yield* Console.log(`[yeet] rerun of job ${databaseId} was rejected; leaving it red for the operator`);
+  }
+});
+
+const applyDecision = Effect.fn("YeetMonitorLoop.applyDecision")(function* (
+  context: RepoRunContext,
+  decision: YeetMonitorJobDecision
+): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
+  yield* Console.log(renderYeetMonitorJobDecision(decision));
+  if (decision.status === "rerun") {
+    yield* rerunJob(context, decision.databaseId);
+  }
+});
+
+/**
+ * Options for one `yeet monitor --until-merged` session.
+ *
+ * **Details**
+ *
+ * `onMerged` defaults to `executeSweep` from `internal/Sweep.ts` — the merged
+ * path is the sweep, not a variant of it. The seam exists so a test can drive
+ * the merged branch of the loop without a real clone to sweep, and so an
+ * operator-authorized wrapper can substitute a plan-only run.
+ */
+interface YeetMonitorUntilMergedOptions {
+  readonly onMerged?:
+    | ((
+        context: RepoRunContext
+      ) => Effect.Effect<
+        unknown,
+        YeetCommandError,
+        FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+      >)
+    | undefined;
+  readonly pollInterval?: Duration.Duration | undefined;
+}
+
+const renderMergeReadyGate = (snapshot: YeetStatusSnapshot): string =>
+  pipe(
+    snapshot.mergeReady,
+    O.match({
+      onNone: () => "[yeet] merge readiness is unknown; the PR could not be read",
+      onSome: (mergeReady) =>
+        O.match(mergeReady.failing, {
+          onNone: () => "[yeet] merge-ready: every hard criterion is green; awaiting the operator's merge",
+          onSome: (failing) => `[yeet] not merge-ready: blocked on ${failing}`,
+        }),
+    })
+  );
+
+const pollUntilMerged = Effect.fn("YeetMonitorLoop.poll")(function* (
+  context: RepoRunContext,
+  options: YeetMonitorUntilMergedOptions,
+  budget: YeetMonitorRerunBudget
+): Effect.fn.Return<
+  { readonly budget: YeetMonitorRerunBudget; readonly terminal: O.Option<YeetMonitorTerminalState> },
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const snapshot = yield* collectYeetStatus(context, true);
+  yield* writeYeetStatusSnapshot(snapshot);
+  yield* Console.log(renderYeetStatusSummary(snapshot));
+  const terminal = yeetMonitorTerminalState(O.fromUndefinedOr(snapshot.remote.state));
+  if (O.exists(terminal, (state) => state === YeetMonitorTerminalState.Enum.merged)) {
+    yield* Console.log("[yeet] pull request is MERGED; running the post-merge workspace sweep");
+    yield* O.getOrElse(O.fromNullishOr(options.onMerged), () => executeSweep)(context);
+    return { budget, terminal };
+  }
+  if (O.isSome(terminal)) {
+    yield* Console.log("[yeet] pull request is CLOSED without merging; ending the merge loop");
+    return { budget, terminal };
+  }
+  yield* Console.log(renderMergeReadyGate(snapshot));
+  const headSha = snapshot.remote.headSha;
+  const failingCheckCount = O.getOrElse(O.fromUndefinedOr(snapshot.remote.failingCheckCount), () => 0);
+  if (failingCheckCount === 0 || O.isNone(headSha)) {
+    return { budget, terminal };
+  }
+  const failedJobs = yield* collectFailedJobs(context, headSha.value);
+  const plan = planYeetMonitorReruns(budget, headSha.value, failedJobs);
+  yield* Effect.forEach(plan.decisions, (decision) => applyDecision(context, decision), { concurrency: 1 });
+  return { budget: plan.budget, terminal };
+});
+
+/**
+ * Follow a pull request through its fix waves until it merges or closes.
+ *
+ * **When to use**
+ *
+ * Behind `yeet monitor --until-merged`, when the operator wants one session to
+ * babysit the whole treadmill instead of re-arming a fresh monitor after every
+ * push.
+ *
+ * **Details**
+ *
+ * Each poll re-reads `yeet status --remote`, so a push landing mid-session is
+ * picked up without restarting: the new head SHA simply becomes the budget
+ * scope for the next red wave. The loop ends on `MERGED` (after the sweep it was
+ * handed), on `CLOSED`, or when the operator interrupts the fiber.
+ *
+ * **Example** (Reference the merge loop)
+ *
+ * ```ts
+ * import { runYeetMonitorUntilMerged } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(runYeetMonitorUntilMerged)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param context - Yeet run context for the branch being followed.
+ * @param options - Post-merge sweep seam and optional poll interval.
+ * @returns The terminal state that ended the loop.
+ * @category streams
+ * @since 0.0.0
+ */
+export const runYeetMonitorUntilMerged = Effect.fn("Yeet.runMonitorUntilMerged")(function* (
+  context: RepoRunContext,
+  options: YeetMonitorUntilMergedOptions
+): Effect.fn.Return<
+  YeetMonitorTerminalState,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const interval = O.getOrElse(O.fromNullishOr(options.pollInterval), () => mergeLoopPollInterval);
+  const followFrom = (
+    budget: YeetMonitorRerunBudget
+  ): Effect.Effect<
+    YeetMonitorTerminalState,
+    YeetCommandError,
+    FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+  > =>
+    pollUntilMerged(context, options, budget).pipe(
+      Effect.flatMap((next) =>
+        O.match(next.terminal, {
+          onNone: () => Effect.sleep(interval).pipe(Effect.andThen(Effect.suspend(() => followFrom(next.budget)))),
+          onSome: Effect.succeed,
+        })
+      )
+    );
+  return yield* followFrom(emptyYeetMonitorRerunBudget);
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts
@@ -1,0 +1,222 @@
+/**
+ * Command-layer runners for the merge-loop porcelain: `yeet sweep`,
+ * `yeet merge`, `yeet reply`, and `yeet monitor --until-merged`.
+ *
+ * **Details**
+ *
+ * Each engine — {@link executeSweep}, {@link mergePr}, {@link runYeetReply},
+ * {@link runYeetMonitorUntilMerged} — takes a hydrated `RepoRunContext` and
+ * knows nothing about flags. This module is the seam that turns parsed flag
+ * values into that context and renders the result for the operator, so
+ * `Yeet.command.ts` stays a declaration of the CLI surface rather than a place
+ * where behavior accumulates.
+ *
+ * **Gotchas**
+ *
+ * `runYeetMerge` is the only runner here that writes to a pull request, and it
+ * exists solely so a human can type it. Nothing in this repository may call it
+ * from a monitor, closeout, or publish path — the sweep is safe to automate on a
+ * merged-PR detection, the merge itself never is.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { Console, Effect } from "effect";
+import * as A from "effect/Array";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import { hydrateYeetReadOnlyContext } from "./Handler.ts";
+import { mergePr } from "./Merge.ts";
+import { runYeetMonitorUntilMerged } from "./MonitorLoop.ts";
+import { runYeetReply } from "./Reply.ts";
+import { SweepPlanJson, SweepReportJson } from "./Sweep.schemas.ts";
+import { executeSweep, planSweep, renderSweepReport } from "./Sweep.ts";
+import type { FileSystem, Path } from "effect";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { YeetMonitorTerminalState } from "./MonitorLoop.ts";
+import type { SweepPlan, SweepPlanStep, SweepReport } from "./Sweep.schemas.ts";
+
+/**
+ * The parsed flag values every merge-loop subcommand accepts, matching the
+ * coordinates `hydrateYeetReadOnlyContext` needs.
+ */
+interface YeetPorcelainOptions {
+  readonly base: string;
+  readonly head: string;
+  readonly packetDir: string;
+}
+
+/**
+ * Parsed `yeet sweep` flag values. `plan` is the dry run — observe the clone,
+ * build the plan, print it, execute nothing — and `json` selects the artifact
+ * codec instead of the operator text, for both the plan and the report.
+ */
+interface YeetSweepOptions extends YeetPorcelainOptions {
+  readonly json: boolean;
+  readonly plan: boolean;
+}
+
+const encodeSweepPlan = (plan: SweepPlan): Effect.Effect<string, YeetCommandError> =>
+  SweepPlanJson.encode(plan).pipe(Effect.mapError(YeetCommandError.new("Failed to encode the yeet sweep plan.")));
+
+const encodeSweepReport = (report: SweepReport): Effect.Effect<string, YeetCommandError> =>
+  SweepReportJson.encode(report).pipe(Effect.mapError(YeetCommandError.new("Failed to encode the yeet sweep report.")));
+
+const renderSweepPlanStep = (planStep: SweepPlanStep): ReadonlyArray<string> => [
+  `  ${planStep.id}: ${planStep.action}${planStep.requiresOperator ? " (needs operator)" : ""}`,
+  ...A.map(
+    planStep.preconditions,
+    (precondition) => `    ${precondition.satisfied ? "ok" : "unmet"}: ${precondition.description}`
+  ),
+];
+
+const renderSweepPlan = (plan: SweepPlan): string =>
+  A.join([`[yeet] sweep plan ${plan.branch} (dry run)`, ...A.flatMap(plan.steps, renderSweepPlanStep)], "\n");
+
+/**
+ * Run one post-merge workspace sweep, or print the plan it would run.
+ *
+ * **Details**
+ *
+ * A sweep never fails on a step: every outcome is recorded, `needs-operator`
+ * outcomes are batched into a handoff block, and the command exits 0 whether the
+ * clone was already clean or every step skipped. That is the point — "merged,
+ * cleanup skipped: reason" is a success, not a red run.
+ *
+ * **Example** (Build the sweep runner effect)
+ *
+ * ```ts
+ * import { runYeetSweep } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(runYeetSweep)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Parsed `yeet sweep` flag values.
+ * @returns Void once the plan or the executed report has been printed.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetSweep = Effect.fn("Yeet.runSweepCommand")(function* (
+  options: YeetSweepOptions
+): Effect.fn.Return<
+  void,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const context = yield* hydrateYeetReadOnlyContext(options);
+  if (options.plan) {
+    const plan = yield* planSweep(context);
+    yield* Console.log(options.json ? yield* encodeSweepPlan(plan) : renderSweepPlan(plan));
+    return;
+  }
+  const report = yield* executeSweep(context);
+  yield* Console.log(options.json ? yield* encodeSweepReport(report) : renderSweepReport(report));
+});
+
+/**
+ * Squash-merge the current branch's pull request, then sweep the clone.
+ *
+ * **Gotchas**
+ *
+ * Operator-authorized only. The merge is a decision, not a step: no monitor
+ * loop, closeout path, or publish flow may reach this runner.
+ *
+ * **Example** (Build the merge runner effect)
+ *
+ * ```ts
+ * import { runYeetMerge } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(runYeetMerge)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Parsed `yeet merge` flag values.
+ * @returns Void once the merge and its sweep tail have been printed.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetMerge = Effect.fn("Yeet.runMergeCommand")(function* (
+  options: YeetPorcelainOptions
+): Effect.fn.Return<
+  void,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const outcome = yield* mergePr(yield* hydrateYeetReadOnlyContext(options));
+  yield* Console.log(`[yeet] pull request #${outcome.pullRequestNumber} is ${outcome.state}`);
+  yield* Console.log(renderSweepReport(outcome.sweep));
+});
+
+/**
+ * Post and resolve the drafted review-thread replies for the current branch.
+ *
+ * **Details**
+ *
+ * The drafts artifact names its own pull request, so either party — the agent
+ * that wrote the drafts or the operator whose auth may post them — can run this
+ * from any worktree. Every draft gets its turn: a denied scope or a deleted
+ * thread becomes that draft's outcome, never an aborted pass.
+ *
+ * **Example** (Build the reply runner effect)
+ *
+ * ```ts
+ * import { runYeetReplyPass } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(runYeetReplyPass)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Parsed `yeet reply` flag values.
+ * @returns Void once every draft outcome has been recorded and reported.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetReplyPass = Effect.fn("Yeet.runReplyCommand")(function* (
+  options: YeetPorcelainOptions
+): Effect.fn.Return<
+  void,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  yield* runYeetReply(yield* hydrateYeetReadOnlyContext(options));
+});
+
+/**
+ * Follow the current branch's pull request through its fix waves until it
+ * merges or closes.
+ *
+ * **Details**
+ *
+ * This is `yeet monitor --until-merged`. Plain `yeet monitor` exits on the first
+ * red wave and has to be re-armed after every push; the loop re-reads status
+ * each poll instead, so a mid-session push simply becomes the next budget scope,
+ * and the merged path ends in the workspace sweep.
+ *
+ * **Example** (Build the merge-loop runner effect)
+ *
+ * ```ts
+ * import { runYeetMergeLoop } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(runYeetMergeLoop)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Parsed `yeet monitor` flag values.
+ * @returns The terminal state that ended the loop.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetMergeLoop = Effect.fn("Yeet.runMergeLoopCommand")(function* (
+  options: YeetPorcelainOptions
+): Effect.fn.Return<
+  YeetMonitorTerminalState,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  return yield* runYeetMonitorUntilMerged(yield* hydrateYeetReadOnlyContext(options), {});
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.schemas.ts
@@ -1,0 +1,364 @@
+/**
+ * Schema-first draft and report documents for auditable PR review-thread replies.
+ *
+ * Agents verify review findings but cannot post the reply that closes the
+ * thread, so fixes end as paste-these-drafts handoffs and the "comments
+ * resolved" merge criterion stays open by hand. These schemas make the handoff
+ * a document: {@link ReplyDrafts} is written by whoever did the work, validated
+ * against the live threads, then posted and resolved through the operator's own
+ * `gh` auth, producing a {@link ReplyReport}.
+ *
+ * **Details**
+ *
+ * A draft names its target either way GitHub exposes one — the GraphQL review
+ * thread id (`PRRT_…`) or the numeric REST comment id — because the two live on
+ * different surfaces: `yeet status` lists thread ids, while a review comment
+ * URL and the REST API speak comment ids. Requiring the caller to translate is
+ * what forced the hand-mapping pass this schema exists to remove, so
+ * {@link ReplyDraft} accepts either and the resolver does the mapping.
+ *
+ * Both artifacts are written through their `S.encode`-backed JSON codecs
+ * ({@link ReplyDraftsJson}, {@link ReplyReportJson}); a decoded instance must
+ * never reach `JSON.stringify`, which would leak `Option` runtime objects.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit, SchemaUtils } from "@beep/schema";
+import { Effect } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Reply.schemas");
+
+const REVIEW_THREAD_ID_PREFIX = "PRRT_";
+
+/**
+ * A GitHub GraphQL pull request review thread id.
+ *
+ * **Details**
+ *
+ * GraphQL node ids for review threads are prefixed `PRRT_`; the prefix check is
+ * what lets a draft that pasted a review *comment* id (`PRRC_…`) or a bare
+ * number into the wrong field fail at decode instead of at the mutation.
+ *
+ * **Example** (Decode a thread id)
+ *
+ * ```ts
+ * import { ReplyThreadId } from "@beep/repo-cli/test/Yeet"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.decodeUnknownOption(ReplyThreadId)("PRRT_kwDOA"))
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const ReplyThreadId = S.NonEmptyString.check(S.isStartsWith(REVIEW_THREAD_ID_PREFIX)).pipe(
+  $I.annoteSchema("ReplyThreadId", {
+    title: "Reply Thread Id",
+    description: "GitHub GraphQL pull request review thread id.",
+  })
+);
+
+/**
+ * A GitHub GraphQL pull request review thread id.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ReplyThreadId = typeof ReplyThreadId.Type;
+
+/**
+ * A GitHub REST pull request review comment id.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const ReplyCommentId = S.Int.check(S.isGreaterThan(0)).pipe(
+  $I.annoteSchema("ReplyCommentId", {
+    title: "Reply Comment Id",
+    description: "GitHub REST pull request review comment id.",
+  })
+);
+
+/**
+ * A GitHub REST pull request review comment id.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ReplyCommentId = typeof ReplyCommentId.Type;
+
+/**
+ * A GitHub pull request number.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const ReplyPullRequestNumber = S.Int.check(S.isGreaterThan(0)).pipe(
+  $I.annoteSchema("ReplyPullRequestNumber", {
+    title: "Reply Pull Request Number",
+    description: "Pull request the reply drafts and report belong to.",
+  })
+);
+
+/**
+ * A GitHub pull request number.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ReplyPullRequestNumber = typeof ReplyPullRequestNumber.Type;
+
+const replyTargetFields = {
+  threadId: ReplyThreadId.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+  commentId: ReplyCommentId.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+} satisfies S.Struct.Fields;
+
+/**
+ * Cross-field requirement that a reply target names at least one live handle.
+ *
+ * Both id fields are optional because either alone identifies the thread, but a
+ * record carrying neither is not a reply to anything — it would decode cleanly
+ * and then fail at the API with no way to attribute the mistake back to the
+ * draft that caused it. Making the empty target undecodable pushes the failure
+ * to the file the human wrote, and reports it at the `threadId` path since that
+ * is the handle `yeet status` prints.
+ */
+const ReplyTargetPresenceCheck = S.makeFilter(
+  (target: { readonly threadId: O.Option<ReplyThreadId>; readonly commentId: O.Option<ReplyCommentId> }) =>
+    O.isSome(target.threadId) || O.isSome(target.commentId)
+      ? undefined
+      : {
+          path: ["threadId"],
+          issue: "A reply target must carry a GraphQL thread id (PRRT_...) or a numeric REST comment id.",
+        },
+  {
+    identifier: $I`ReplyTargetPresenceCheck`,
+    title: "Reply target presence",
+    description: "A reply target must carry a GraphQL thread id or a numeric REST comment id.",
+  }
+);
+
+/**
+ * One drafted reply to a pull request review thread.
+ *
+ * **Details**
+ *
+ * `resolve` defaults to `true` on both construction and decoding: the reason to
+ * post a reply on a review thread is to close it, so a hand-written drafts file
+ * that omits the key gets the intended behaviour, and opting out is explicit.
+ *
+ * **Example** (Draft a reply against a thread id)
+ *
+ * ```ts
+ * import { ReplyDraft } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const draft = ReplyDraft.make({
+ *   threadId: O.some("PRRT_kwDOA"),
+ *   body: "Fixed in 0123456: the writer now encodes through the schema codec.",
+ * })
+ * console.log(draft.resolve)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplyDraft extends S.Class<ReplyDraft>($I`ReplyDraft`)(
+  S.Struct({
+    ...replyTargetFields,
+    body: S.NonEmptyString,
+    resolve: S.Boolean.pipe(
+      S.withConstructorDefault(Effect.succeed(true)),
+      S.withDecodingDefault(Effect.succeed(true))
+    ),
+  }).pipe(S.check(ReplyTargetPresenceCheck)),
+  $I.annote("ReplyDraft", {
+    description: "One drafted reply to a pull request review thread, targeted by thread id or comment id.",
+  })
+) {}
+
+/**
+ * The drafted replies for one pull request.
+ *
+ * **Example** (Construct an empty drafts artifact)
+ *
+ * ```ts
+ * import { ReplyDrafts } from "@beep/repo-cli/test/Yeet"
+ *
+ * const drafts = ReplyDrafts.make({
+ *   schemaVersion: "yeet-reply-drafts/v1",
+ *   prNumber: 558,
+ *   drafts: [],
+ * })
+ * console.log(drafts.prNumber)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplyDrafts extends S.Class<ReplyDrafts>($I`ReplyDrafts`)(
+  {
+    schemaVersion: S.Literal("yeet-reply-drafts/v1"),
+    prNumber: ReplyPullRequestNumber,
+    drafts: S.Array(ReplyDraft),
+  },
+  $I.annote("ReplyDrafts", {
+    description: "Drafted review-thread replies for one pull request, pending post and resolve.",
+  })
+) {}
+
+/**
+ * What became of one drafted reply.
+ *
+ * **Details**
+ *
+ * `posted` means the reply landed but the thread was left open (either the
+ * draft opted out of resolving, or resolution is not available on that thread);
+ * `resolved` means it landed and the thread was closed; `stale` means the live
+ * thread was already resolved upstream, so nothing was written; `failed` means
+ * the attempt was rejected or could not be made at all.
+ *
+ * **Gotchas**
+ *
+ * `stale` is narrower than "the thread moved on". An `isOutdated` thread is not
+ * stale: its diff hunk moved, but the thread is still open and still counts
+ * against the "threads resolved" merge criterion, so it is written like any
+ * other. A handle matching no live thread is `failed`, not `stale` — the draft
+ * names something that does not exist, which is an operator mistake worth
+ * surfacing rather than a no-op worth accepting.
+ *
+ * **Example** (List the reply outcome statuses)
+ *
+ * ```ts
+ * import { ReplyOutcomeStatus } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(ReplyOutcomeStatus.Options)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const ReplyOutcomeStatus = LiteralKit(["posted", "resolved", "stale", "failed"]).pipe(
+  $I.annoteSchema("ReplyOutcomeStatus", {
+    title: "Reply Outcome Status",
+    description: "What became of one drafted reply.",
+  })
+);
+
+/**
+ * What became of one drafted reply.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ReplyOutcomeStatus = typeof ReplyOutcomeStatus.Type;
+
+/**
+ * One drafted reply paired with what the run did about it.
+ *
+ * **Example** (Record a stale draft)
+ *
+ * ```ts
+ * import { ReplyDraftOutcome } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const outcome = ReplyDraftOutcome.make({
+ *   threadId: O.some("PRRT_kwDOA"),
+ *   status: "stale",
+ *   detail: "thread was already resolved upstream",
+ * })
+ * console.log(outcome.status)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplyDraftOutcome extends S.Class<ReplyDraftOutcome>($I`ReplyDraftOutcome`)(
+  S.Struct({
+    ...replyTargetFields,
+    status: ReplyOutcomeStatus,
+    detail: S.NonEmptyString,
+  }).pipe(S.check(ReplyTargetPresenceCheck)),
+  $I.annote("ReplyDraftOutcome", {
+    description: "One drafted reply paired with what the reply run did about it.",
+  })
+) {}
+
+/**
+ * The result document for one reply run.
+ *
+ * **Example** (Construct an empty reply report)
+ *
+ * ```ts
+ * import { ReplyReport } from "@beep/repo-cli/test/Yeet"
+ *
+ * const report = ReplyReport.make({
+ *   schemaVersion: "yeet-reply-report/v1",
+ *   prNumber: 558,
+ *   createdAt: "2026-08-04T00:00:00.000Z",
+ *   outcomes: [],
+ * })
+ * console.log(report.outcomes.length)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplyReport extends S.Class<ReplyReport>($I`ReplyReport`)(
+  {
+    schemaVersion: S.Literal("yeet-reply-report/v1"),
+    prNumber: ReplyPullRequestNumber,
+    createdAt: S.String,
+    outcomes: S.Array(ReplyDraftOutcome),
+  },
+  $I.annote("ReplyReport", {
+    description: "Result document for one reply run: every drafted reply paired with its outcome.",
+  })
+) {}
+
+/**
+ * JSON-string codec for the reply drafts artifact.
+ *
+ * **Example** (Encode an empty drafts artifact)
+ *
+ * ```ts
+ * import { ReplyDrafts, ReplyDraftsJson } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const drafts = ReplyDrafts.make({ schemaVersion: "yeet-reply-drafts/v1", prNumber: 558, drafts: [] })
+ * console.log(Effect.runSync(ReplyDraftsJson.encode(drafts)))
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const ReplyDraftsJson = JsonStringCodec(ReplyDrafts);
+
+/**
+ * JSON-string codec for the reply report artifact.
+ *
+ * **Example** (Encode an empty reply report)
+ *
+ * ```ts
+ * import { ReplyReport, ReplyReportJson } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const report = ReplyReport.make({
+ *   schemaVersion: "yeet-reply-report/v1",
+ *   prNumber: 558,
+ *   createdAt: "2026-08-04T00:00:00.000Z",
+ *   outcomes: [],
+ * })
+ * console.log(Effect.runSync(ReplyReportJson.encode(report)))
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const ReplyReportJson = JsonStringCodec(ReplyReport);

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.ts
@@ -1,0 +1,1007 @@
+/**
+ * Reply engine: validate drafted review-thread replies against live GitHub
+ * state, post them, resolve the threads, and record what happened.
+ *
+ * The drafts artifact ({@link ReplyDrafts}) is written by whoever verified the
+ * review findings; this module is the half that touches GitHub, and it is
+ * designed so *either party* can run it. An agent whose session denies the
+ * write scope produces the same validated plan and the same report — every
+ * draft it could not write lands as a `failed` outcome carrying the exact
+ * command the operator re-runs. A permission wall is data in the report, never
+ * a thrown crash that loses the other drafts' results, and that holds whether
+ * the wall arrives on the reply mutation or on the read that precedes it.
+ *
+ * **Details**
+ *
+ * Drafts name a thread either way GitHub exposes one: the GraphQL thread id
+ * (`PRRT_…`) that `yeet status` prints, or the numeric REST comment id in a
+ * review-comment URL (`…#discussion_r<id>`). Mapping the second to the first is
+ * what forced the hand-mapping pass this engine exists to remove, so one
+ * `reviewThreads` query per pull request fetches every thread with its
+ * comments' `databaseId`, and {@link findReplyThread} resolves either handle
+ * against that one snapshot — no per-draft REST round trip.
+ *
+ * Classification is pure ({@link planReplyActions}) and separated from
+ * execution: a thread that is already resolved settles as `stale` without a
+ * write, an id that matches no live thread settles as `failed` with a detail
+ * naming both handles, and only surviving drafts become
+ * {@link ReplyPostAction}s. That split is what makes the interesting behaviour
+ * testable without a network.
+ *
+ * **Gotchas**
+ *
+ * An `isOutdated` thread is deliberately *not* stale. Outdated only means the
+ * diff moved under the comment; the thread is still open and still counts
+ * against the "threads resolved" merge criterion, so skipping it would leave
+ * the merge blocked — the opposite of this engine's purpose.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { Console, DateTime, Effect, FileSystem, HashSet, Match, Path, pipe, Result } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import {
+  collectTruncatableThreadPages,
+  GhPageInfo,
+  ghGraphqlPage,
+  ghOutput,
+  nextCursor,
+} from "../../../internal/github/index.ts";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import { artifactDirForContext } from "./ArtifactPaths.ts";
+import { decodeGhRepoView } from "./closeout/Gh.schemas.ts";
+import { REPLY_THREAD_MUTATION, RESOLVE_THREAD_MUTATION } from "./closeout/WritePlan.ts";
+import { writeTextFile } from "./IssueArtifacts.ts";
+import { ReplyDraft, ReplyDraftOutcome, ReplyDraftsJson, ReplyReport, ReplyReportJson } from "./Reply.schemas.ts";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { GhCommandFailure } from "../../../internal/github/index.ts";
+import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
+import type { GhRepoView } from "./closeout/Gh.schemas.ts";
+import type { ReplyDrafts, ReplyOutcomeStatus } from "./Reply.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Reply");
+
+const REPLY_FAILURE_DETAIL_MAX_CHARS = 240;
+
+/**
+ * File name of the reply drafts artifact inside the Yeet packet directory.
+ *
+ * **Example** (Name the drafts artifact)
+ *
+ * ```ts
+ * import { REPLY_DRAFTS_FILE_NAME } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(`.beep/yeet/${REPLY_DRAFTS_FILE_NAME}`)
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const REPLY_DRAFTS_FILE_NAME = "reply-drafts.json";
+
+/**
+ * File name of the reply report artifact inside the Yeet packet directory.
+ *
+ * **Example** (Name the report artifact)
+ *
+ * ```ts
+ * import { REPLY_REPORT_FILE_NAME } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(`.beep/yeet/${REPLY_REPORT_FILE_NAME}`)
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const REPLY_REPORT_FILE_NAME = "reply-report.json";
+
+/**
+ * Command that re-runs the whole reply pass.
+ *
+ * **Details**
+ *
+ * Quoted in `failed` details for drafts where nothing was written, because the
+ * drafts file is untouched by a failed run: re-running it is the retry. It is
+ * deliberately *not* quoted when a reply posted and only the resolve failed —
+ * re-running would post the body a second time.
+ *
+ * **Example** (Print the retry command)
+ *
+ * ```ts
+ * import { REPLY_RERUN_COMMAND } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(REPLY_RERUN_COMMAND)
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const REPLY_RERUN_COMMAND = "bun run beep yeet reply";
+
+/**
+ * GraphQL query paginating a pull request's review threads with the numeric
+ * `databaseId` of every thread comment.
+ *
+ * **Details**
+ *
+ * `databaseId` is the REST comment id, and it is the only field that joins the
+ * two id surfaces a draft may use. Requesting it here is what lets one query
+ * per pull request serve both validation and comment-id resolution.
+ *
+ * **Example** (Confirm the join field is requested)
+ *
+ * ```ts
+ * import { replyReviewThreadsPageQuery } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(replyReviewThreadsPageQuery.includes("databaseId")) // true
+ * ```
+ *
+ * @category queries
+ * @since 0.0.0
+ */
+export const replyReviewThreadsPageQuery = `
+query YeetReplyReviewThreads($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 100) {
+            pageInfo { hasNextPage endCursor }
+            nodes { id databaseId }
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+/**
+ * One comment inside a live review thread, carrying both id surfaces.
+ *
+ * **Example** (Describe a thread comment)
+ *
+ * ```ts
+ * import { ReplyThreadComment } from "@beep/repo-cli/test/Yeet"
+ *
+ * const comment = ReplyThreadComment.make({ databaseId: 2284119001, id: "PRRC_kwDOA" })
+ * console.log(comment.databaseId)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplyThreadComment extends S.Class<ReplyThreadComment>($I`ReplyThreadComment`)(
+  {
+    databaseId: S.NullOr(S.Finite),
+    id: S.String,
+  },
+  $I.annote("ReplyThreadComment", {
+    description: "Review thread comment carrying the GraphQL node id and the numeric REST database id.",
+  })
+) {}
+
+/**
+ * Paginated comments nested under a live review thread.
+ *
+ * **Example** (Describe an empty comment page)
+ *
+ * ```ts
+ * import { ReplyThreadCommentConnection } from "@beep/repo-cli/test/Yeet"
+ *
+ * const connection = ReplyThreadCommentConnection.make({
+ *   nodes: [],
+ *   pageInfo: { endCursor: null, hasNextPage: false },
+ * })
+ * console.log(connection.nodes.length)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplyThreadCommentConnection extends S.Class<ReplyThreadCommentConnection>(
+  $I`ReplyThreadCommentConnection`
+)(
+  {
+    nodes: S.Array(ReplyThreadComment),
+    pageInfo: GhPageInfo,
+  },
+  $I.annote("ReplyThreadCommentConnection", {
+    description: "Comment connection nested under a live pull request review thread.",
+  })
+) {}
+
+/**
+ * A live pull request review thread as the reply engine sees it.
+ *
+ * **Details**
+ *
+ * `id` stays a plain string rather than `ReplyThreadId`: it is GitHub's own
+ * value, not human-typed draft input, so re-validating its prefix would only
+ * add a construction-time throw on a payload the engine cannot influence. The
+ * `PRRT_` check belongs on the drafts side, where a paste error is real.
+ *
+ * **Example** (Describe an unresolved thread)
+ *
+ * ```ts
+ * import { ReplyLiveThread, ReplyThreadCommentConnection } from "@beep/repo-cli/test/Yeet"
+ *
+ * const thread = ReplyLiveThread.make({
+ *   comments: ReplyThreadCommentConnection.make({
+ *     nodes: [],
+ *     pageInfo: { endCursor: null, hasNextPage: false },
+ *   }),
+ *   id: "PRRT_kwDOA",
+ *   isOutdated: false,
+ *   isResolved: false,
+ *   line: 42,
+ *   path: "src/file.ts",
+ * })
+ * console.log(thread.isResolved)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplyLiveThread extends S.Class<ReplyLiveThread>($I`ReplyLiveThread`)(
+  {
+    comments: ReplyThreadCommentConnection,
+    id: S.String,
+    isOutdated: S.Boolean,
+    isResolved: S.Boolean,
+    line: S.NullOr(S.Finite),
+    path: S.NullOr(S.String),
+  },
+  $I.annote("ReplyLiveThread", {
+    description: "Live pull request review thread inspected before a drafted reply is written.",
+  })
+) {}
+
+const ReplyLiveThreadConnection = S.Struct({
+  nodes: S.Array(ReplyLiveThread),
+  pageInfo: GhPageInfo,
+});
+
+const ReplyReviewThreadsDocument = S.Struct({
+  data: S.Struct({
+    repository: S.Struct({
+      pullRequest: S.Struct({
+        reviewThreads: ReplyLiveThreadConnection,
+      }),
+    }),
+  }),
+});
+
+const decodeReplyReviewThreadsDocument = S.decodeUnknownEffect(S.fromJsonString(ReplyReviewThreadsDocument));
+
+/**
+ * A drafted reply that survived validation and is ready to write.
+ *
+ * **Example** (Describe a ready reply)
+ *
+ * ```ts
+ * import { ReplyDraft, ReplyPostAction } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const action = ReplyPostAction.make({
+ *   draft: ReplyDraft.make({ threadId: O.some("PRRT_kwDOA"), body: "Fixed in 0123456." }),
+ *   threadId: "PRRT_kwDOA",
+ * })
+ * console.log(action.threadId)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplyPostAction extends S.TaggedClass<ReplyPostAction>($I`ReplyPostAction`)(
+  "post",
+  {
+    draft: ReplyDraft,
+    threadId: S.NonEmptyString,
+  },
+  $I.annote("ReplyPostAction", {
+    description: "Drafted reply resolved to a live, unresolved review thread and ready to write.",
+  })
+) {}
+
+/**
+ * A drafted reply decided without touching GitHub.
+ *
+ * **Example** (Describe a stale draft)
+ *
+ * ```ts
+ * import { ReplyDraftOutcome, ReplySettledAction } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const action = ReplySettledAction.make({
+ *   outcome: ReplyDraftOutcome.make({
+ *     threadId: O.some("PRRT_kwDOA"),
+ *     status: "stale",
+ *     detail: "thread was already resolved upstream",
+ *   }),
+ * })
+ * console.log(action.outcome.status)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ReplySettledAction extends S.TaggedClass<ReplySettledAction>($I`ReplySettledAction`)(
+  "settled",
+  {
+    outcome: ReplyDraftOutcome,
+  },
+  $I.annote("ReplySettledAction", {
+    description: "Drafted reply whose outcome was decided during validation, before any write.",
+  })
+) {}
+
+/**
+ * What the reply run will do about one drafted reply.
+ *
+ * **Example** (Decode a settled action)
+ *
+ * ```ts
+ * import { ReplyAction } from "@beep/repo-cli/test/Yeet"
+ * import * as S from "effect/Schema"
+ *
+ * const decoded = S.decodeUnknownOption(ReplyAction)({
+ *   _tag: "settled",
+ *   outcome: { threadId: "PRRT_kwDOA", status: "stale", detail: "already resolved" },
+ * })
+ * console.log(decoded)
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ReplyAction = S.Union([ReplyPostAction, ReplySettledAction]).pipe(
+  $I.annoteSchema("ReplyAction", {
+    description: "Write or settled decision taken for one drafted review-thread reply.",
+  })
+);
+
+/**
+ * What the reply run will do about one drafted reply.
+ *
+ * @see {@link ReplyAction} for the runtime schema and its variants.
+ * @category models
+ * @since 0.0.0
+ */
+export type ReplyAction = typeof ReplyAction.Type;
+
+const compactWhitespace = (value: string): string => pipe(value, Str.replace(/\s+/gu, " "), Str.trim);
+
+const excerpt = (value: string): string => {
+  const normalized = compactWhitespace(value);
+  return Str.length(normalized) <= REPLY_FAILURE_DETAIL_MAX_CHARS
+    ? normalized
+    : `${pipe(normalized, Str.takeLeft(REPLY_FAILURE_DETAIL_MAX_CHARS))}…`;
+};
+
+const threadLocation = (thread: ReplyLiveThread): string =>
+  pipe(
+    O.fromNullishOr(thread.path),
+    O.map((path) =>
+      pipe(
+        O.fromNullishOr(thread.line),
+        O.match({
+          onNone: () => path,
+          onSome: (line) => `${path}:${line}`,
+        })
+      )
+    ),
+    O.getOrElse(() => "unknown file")
+  );
+
+const draftTargetLabel = (draft: ReplyDraft): string =>
+  pipe(
+    [
+      ...pipe(
+        draft.threadId,
+        O.map((threadId) => `thread id ${threadId}`),
+        O.toArray
+      ),
+      ...pipe(
+        draft.commentId,
+        O.map((commentId) => `comment id ${commentId}`),
+        O.toArray
+      ),
+    ],
+    A.join(" / ")
+  );
+
+const settledAction = (
+  draft: ReplyDraft,
+  threadId: O.Option<string>,
+  status: ReplyOutcomeStatus,
+  detail: string
+): ReplySettledAction =>
+  ReplySettledAction.make({
+    outcome: ReplyDraftOutcome.make({
+      commentId: draft.commentId,
+      detail,
+      status,
+      threadId: O.orElse(threadId, () => draft.threadId),
+    }),
+  });
+
+/**
+ * Resolve one draft against a snapshot of live review threads, by GraphQL
+ * thread id first and by numeric REST comment id second.
+ *
+ * **Details**
+ *
+ * The comment-id path is the mapping this engine owns: GitHub exposes the REST
+ * comment id as `databaseId` on the thread's comments, so a draft written
+ * straight off a review-comment URL resolves without the caller ever seeing a
+ * `PRRT_` id. A draft carrying both handles prefers the thread id and falls
+ * back to the comment id, so one stale handle does not sink a locatable draft.
+ *
+ * **Example** (Resolve a draft by its REST comment id)
+ *
+ * ```ts
+ * import { findReplyThread, ReplyDraft, ReplyLiveThread, ReplyThreadComment, ReplyThreadCommentConnection } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const thread = ReplyLiveThread.make({
+ *   comments: ReplyThreadCommentConnection.make({
+ *     nodes: [ReplyThreadComment.make({ databaseId: 2284119001, id: "PRRC_kwDOA" })],
+ *     pageInfo: { endCursor: null, hasNextPage: false },
+ *   }),
+ *   id: "PRRT_kwDOA",
+ *   isOutdated: false,
+ *   isResolved: false,
+ *   line: 42,
+ *   path: "src/file.ts",
+ * })
+ * const draft = ReplyDraft.make({ commentId: O.some(2284119001), body: "Fixed." })
+ * console.log(O.map(findReplyThread([thread], draft), (found) => found.id))
+ * ```
+ *
+ * @param threads - Live review threads collected for the pull request.
+ * @param draft - Drafted reply naming a thread id, a comment id, or both.
+ * @returns The matching live thread, or `None` when no thread carries either handle.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const findReplyThread = (
+  threads: ReadonlyArray<ReplyLiveThread>,
+  draft: ReplyDraft
+): O.Option<ReplyLiveThread> =>
+  pipe(
+    draft.threadId,
+    O.flatMap((threadId) => A.findFirst(threads, (thread) => thread.id === threadId)),
+    O.orElse(() =>
+      pipe(
+        draft.commentId,
+        O.flatMap((commentId) =>
+          A.findFirst(threads, (thread) => A.some(thread.comments.nodes, (comment) => comment.databaseId === commentId))
+        )
+      )
+    )
+  );
+
+const classifyReplyDraft = (
+  prNumber: number,
+  threads: ReadonlyArray<ReplyLiveThread>,
+  claimedThreadIds: HashSet.HashSet<string>,
+  draft: ReplyDraft
+): ReplyAction =>
+  pipe(
+    findReplyThread(threads, draft),
+    O.match({
+      onNone: () =>
+        settledAction(
+          draft,
+          O.none(),
+          "failed",
+          `no live review thread on pull request #${prNumber} matches ${draftTargetLabel(draft)}; thread ids come from "yeet status" and comment ids from the review comment URL (#discussion_r<id>)`
+        ),
+      onSome: (thread) => {
+        if (HashSet.has(claimedThreadIds, thread.id)) {
+          return settledAction(
+            draft,
+            O.some(thread.id),
+            "failed",
+            `review thread ${thread.id} (${threadLocation(thread)}) is already targeted by an earlier draft in this file; merge the two bodies into one draft`
+          );
+        }
+        if (thread.isResolved) {
+          return settledAction(
+            draft,
+            O.some(thread.id),
+            "stale",
+            `review thread ${thread.id} (${threadLocation(thread)}) is already resolved upstream; nothing was posted`
+          );
+        }
+        return ReplyPostAction.make({ draft, threadId: thread.id });
+      },
+    })
+  );
+
+/**
+ * Classify every drafted reply against a snapshot of live review threads.
+ *
+ * **Details**
+ *
+ * Pure and total: each draft yields exactly one action in file order, so the
+ * report always accounts for every line the human wrote. A thread already
+ * resolved upstream settles as `stale`, an unmatched handle settles as
+ * `failed`, and a thread already claimed by an earlier draft in the same file
+ * settles as `failed` too — posting twice to one thread is the failure mode a
+ * hand-written drafts file actually produces, and a single live snapshot
+ * cannot see the first write.
+ *
+ * **Example** (Plan a drafts file against one open thread)
+ *
+ * ```ts
+ * import { planReplyActions, ReplyDraft, ReplyDrafts, ReplyLiveThread, ReplyThreadCommentConnection } from "@beep/repo-cli/test/Yeet"
+ * import * as A from "effect/Array"
+ * import * as O from "effect/Option"
+ *
+ * const thread = ReplyLiveThread.make({
+ *   comments: ReplyThreadCommentConnection.make({
+ *     nodes: [],
+ *     pageInfo: { endCursor: null, hasNextPage: false },
+ *   }),
+ *   id: "PRRT_kwDOA",
+ *   isOutdated: false,
+ *   isResolved: false,
+ *   line: 42,
+ *   path: "src/file.ts",
+ * })
+ * const drafts = ReplyDrafts.make({
+ *   schemaVersion: "yeet-reply-drafts/v1",
+ *   prNumber: 558,
+ *   drafts: [ReplyDraft.make({ threadId: O.some("PRRT_kwDOA"), body: "Fixed." })],
+ * })
+ * console.log(A.map(planReplyActions(drafts, [thread]), (action) => action._tag))
+ * ```
+ *
+ * @param drafts - Decoded drafts artifact for one pull request.
+ * @param threads - Live review threads collected for that pull request.
+ * @returns One action per draft, in drafts-file order.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const planReplyActions = (
+  drafts: ReplyDrafts,
+  threads: ReadonlyArray<ReplyLiveThread>
+): ReadonlyArray<ReplyAction> =>
+  A.reduce(drafts.drafts, { actions: A.empty<ReplyAction>(), claimed: HashSet.empty<string>() }, (state, draft) => {
+    const action = classifyReplyDraft(drafts.prNumber, threads, state.claimed, draft);
+    return {
+      actions: [...state.actions, action],
+      claimed: action._tag === "post" ? HashSet.add(state.claimed, action.threadId) : state.claimed,
+    };
+  }).actions;
+
+/**
+ * The single `gh` command that resolves one review thread.
+ *
+ * **Details**
+ *
+ * Quoted in the report whenever a reply posted but resolving it did not — the
+ * body is already on GitHub, so the retry must be resolve-only. Being
+ * body-free it stays a one-line copy-paste for whoever holds the write scope.
+ *
+ * **Example** (Render the resolve retry)
+ *
+ * ```ts
+ * import { replyResolveRetryCommand } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(replyResolveRetryCommand("PRRT_kwDOA").includes("resolveReviewThread")) // true
+ * ```
+ *
+ * @param threadId - GraphQL id of the thread left open.
+ * @returns A copy-pasteable `gh api graphql` resolve command.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const replyResolveRetryCommand = (threadId: string): string =>
+  `gh api graphql -f 'query=${RESOLVE_THREAD_MUTATION}' -f threadId=${threadId}`;
+
+const replyGhFailure = (failure: GhCommandFailure): YeetCommandError =>
+  Match.value(failure).pipe(
+    Match.tags({
+      spawn: (spawnFailure) =>
+        YeetCommandError.make({
+          cause: spawnFailure.cause,
+          command: spawnFailure.command,
+          exitCode: 1,
+          message: `${spawnFailure.label} could not be started; check that the GitHub CLI is installed and authenticated.`,
+        }),
+      "nonzero-exit": (exitFailure) =>
+        YeetCommandError.make({
+          command: exitFailure.command,
+          exitCode: exitFailure.exitCode,
+          message: `${exitFailure.label} failed with exit code ${exitFailure.exitCode}: ${excerpt(exitFailure.output)}`,
+        }),
+      truncated: (truncatedFailure) =>
+        YeetCommandError.make({
+          command: truncatedFailure.command,
+          exitCode: 1,
+          message: `${truncatedFailure.label} output exceeded the repo-run capture limit.`,
+        }),
+    }),
+    Match.exhaustive
+  );
+
+const replyGhOutput = (
+  context: RepoRunContext,
+  args: ReadonlyArray<string>,
+  label: string
+): Effect.Effect<string, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> =>
+  ghOutput({ args, cwd: context.repoRoot, label, onFailure: replyGhFailure });
+
+/**
+ * Resolve the reply drafts artifact path for a repo run context.
+ *
+ * **Example** (Locate the drafts artifact)
+ *
+ * ```ts
+ * import { replyDraftsPathForContext } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(Effect.succeed(replyDraftsPathForContext))) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the Yeet packet directory.
+ * @returns Absolute path to `reply-drafts.json`.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const replyDraftsPathForContext = Effect.fn("Yeet.replyDraftsPathForContext")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<string, never, Path.Path> {
+  const path = yield* Path.Path;
+  const artifactDir = yield* artifactDirForContext(context);
+  return path.join(artifactDir, REPLY_DRAFTS_FILE_NAME);
+});
+
+/**
+ * Resolve the reply report artifact path for a repo run context.
+ *
+ * **Example** (Locate the report artifact)
+ *
+ * ```ts
+ * import { replyReportPathForContext } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(Effect.succeed(replyReportPathForContext))) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the Yeet packet directory.
+ * @returns Absolute path to `reply-report.json`.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const replyReportPathForContext = Effect.fn("Yeet.replyReportPathForContext")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<string, never, Path.Path> {
+  const path = yield* Path.Path;
+  const artifactDir = yield* artifactDirForContext(context);
+  return path.join(artifactDir, REPLY_REPORT_FILE_NAME);
+});
+
+/**
+ * Load and decode the reply drafts artifact.
+ *
+ * **Details**
+ *
+ * A missing file and a malformed file are different operator mistakes, so they
+ * fail with different messages; both name the absolute path, since the party
+ * running the command is often not the party that wrote the drafts.
+ *
+ * **Example** (Build the drafts loader effect)
+ *
+ * ```ts
+ * import { loadReplyDrafts, RepoRunContext } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const context = RepoRunContext.make({
+ *   base: "origin/main",
+ *   branch: "feat/merge-loop",
+ *   cwd: ".",
+ *   head: "HEAD",
+ *   originalArgv: [],
+ *   packetDir: ".beep/yeet",
+ *   repoRoot: ".",
+ *   turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+ * })
+ * console.log(Effect.isEffect(loadReplyDrafts(context))) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the Yeet packet directory.
+ * @returns The decoded drafts artifact.
+ * @category queries
+ * @since 0.0.0
+ */
+export const loadReplyDrafts = Effect.fn("Yeet.loadReplyDrafts")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<ReplyDrafts, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const draftsPath = yield* replyDraftsPathForContext(context);
+  const exists = yield* fs.exists(draftsPath).pipe(Effect.orElseSucceed(() => false));
+  if (!exists) {
+    return yield* YeetCommandError.make({
+      file: draftsPath,
+      message: `No reply drafts at "${draftsPath}". Write one drafts file with schemaVersion "yeet-reply-drafts/v1", the pull request number, and a body per review thread.`,
+    });
+  }
+  const text = yield* fs
+    .readFileString(draftsPath)
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to read "${draftsPath}".`, { file: draftsPath })));
+  return yield* ReplyDraftsJson.decode(text).pipe(
+    Effect.mapError(
+      YeetCommandError.new(
+        `Failed to decode "${draftsPath}"; every draft needs a non-empty body and either a PRRT_ thread id or a numeric comment id.`,
+        { file: draftsPath }
+      )
+    )
+  );
+});
+
+const collectReplyThreads = (
+  context: RepoRunContext,
+  repo: GhRepoView,
+  prNumber: number
+): Effect.Effect<ReadonlyArray<ReplyLiveThread>, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> =>
+  collectTruncatableThreadPages({
+    advance: (pageInfo) =>
+      nextCursor({
+        label: "pull request review threads",
+        onMissingCursor: (missingLabel) =>
+          YeetCommandError.make({
+            command: "gh api graphql",
+            exitCode: 1,
+            message: `${missingLabel} reported another GraphQL page without an end cursor.`,
+          }),
+        pageInfo,
+      }),
+    fetchPage: (cursor) =>
+      ghGraphqlPage({
+        cursor,
+        cwd: context.repoRoot,
+        label: "gh api graphql reply review threads",
+        name: repo.name,
+        number: prNumber,
+        onFailure: replyGhFailure,
+        owner: repo.owner.login,
+        query: replyReviewThreadsPageQuery,
+      }).pipe(
+        Effect.flatMap((output) =>
+          decodeReplyReviewThreadsDocument(output).pipe(
+            // fallow-ignore-next-line code-duplication -- reply and closeout configure the shared internal/github thread-page collector with isomorphic decode pipelines over distinct schemas; the loop itself is extracted
+            Effect.mapError(YeetCommandError.new("Failed to decode the reply review threads GraphQL JSON."))
+          )
+        ),
+        Effect.map((document) => document.data.repository.pullRequest.reviewThreads)
+      ),
+    truncationWarning: (threadIds) =>
+      `Review thread(s) ${A.join(threadIds, ", ")} have more than 100 comments; yeet reply reads only the first 100 per thread, so a comment id beyond that page will not resolve. Target those threads by PRRT_ thread id.`,
+  });
+
+const performReplyPost = Effect.fnUntraced(function* (
+  context: RepoRunContext,
+  action: ReplyPostAction
+): Effect.fn.Return<ReplyDraftOutcome, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const target = { commentId: action.draft.commentId, threadId: O.some(action.threadId) };
+  const posted = yield* Effect.result(
+    replyGhOutput(
+      context,
+      [
+        "api",
+        "graphql",
+        "-f",
+        `query=${REPLY_THREAD_MUTATION}`,
+        "-f",
+        `threadId=${action.threadId}`,
+        "-f",
+        `body=${action.draft.body}`,
+      ],
+      "gh api graphql (reply)"
+    )
+  );
+  if (Result.isFailure(posted)) {
+    return ReplyDraftOutcome.make({
+      ...target,
+      detail: `${posted.failure.message} Nothing was posted; retry with: ${REPLY_RERUN_COMMAND}`,
+      status: "failed",
+    });
+  }
+  if (!action.draft.resolve) {
+    return ReplyDraftOutcome.make({
+      ...target,
+      detail: "reply posted; the draft opted out of resolving the thread",
+      status: "posted",
+    });
+  }
+  const resolved = yield* Effect.result(
+    replyGhOutput(
+      context,
+      ["api", "graphql", "-f", `query=${RESOLVE_THREAD_MUTATION}`, "-f", `threadId=${action.threadId}`],
+      "gh api graphql (resolve)"
+    )
+  );
+  if (Result.isFailure(resolved)) {
+    return ReplyDraftOutcome.make({
+      ...target,
+      detail: `reply posted, but resolving the thread failed: ${resolved.failure.message} Do not re-run "${REPLY_RERUN_COMMAND}" — it would post the body again; resolve with: ${replyResolveRetryCommand(action.threadId)}`,
+      status: "failed",
+    });
+  }
+  return ReplyDraftOutcome.make({
+    ...target,
+    detail: "reply posted and thread resolved",
+    status: "resolved",
+  });
+});
+
+const executeReplyAction = (
+  context: RepoRunContext,
+  action: ReplyAction
+): Effect.Effect<ReplyDraftOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  Match.value(action).pipe(
+    Match.tags({
+      post: (post) => performReplyPost(context, post),
+      settled: (settled) => Effect.succeed(settled.outcome),
+    }),
+    Match.exhaustive
+  );
+
+const countStatus = (outcomes: ReadonlyArray<ReplyDraftOutcome>, status: ReplyOutcomeStatus): number =>
+  A.length(A.filter(outcomes, (outcome) => outcome.status === status));
+
+const replyPreflight = Effect.fn("Yeet.replyPreflight")(function* (
+  context: RepoRunContext,
+  prNumber: number
+): Effect.fn.Return<ReadonlyArray<ReplyLiveThread>, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const repo = yield* replyGhOutput(context, ["repo", "view", "--json", "owner,name"], "gh repo view").pipe(
+    Effect.flatMap((output) =>
+      decodeGhRepoView(output).pipe(Effect.mapError(YeetCommandError.new("Failed to decode gh repo view JSON.")))
+    )
+  );
+  return yield* collectReplyThreads(context, repo, prNumber);
+});
+
+/**
+ * Settle every loaded draft against a preflight failure, so a wall hit before
+ * the first write is reported exactly like a wall hit during one.
+ *
+ * @param drafts - The loaded drafts artifact whose drafts get failure outcomes.
+ * @param failure - The preflight failure carried into every outcome's detail.
+ * @returns One `failed` outcome per draft, each naming the whole-run retry.
+ */
+const preflightFailureOutcomes = (drafts: ReplyDrafts, failure: YeetCommandError): ReadonlyArray<ReplyDraftOutcome> =>
+  A.map(drafts.drafts, (draft) =>
+    ReplyDraftOutcome.make({
+      commentId: draft.commentId,
+      detail: `${failure.message} Nothing was posted for any draft; retry the whole run with: ${REPLY_RERUN_COMMAND}`,
+      status: "failed",
+      threadId: draft.threadId,
+    })
+  );
+
+/**
+ * Run one reply pass: load the drafts, validate them against live review
+ * threads, write the survivors, and record every outcome.
+ *
+ * **Details**
+ *
+ * The pull request number comes from the drafts artifact rather than the
+ * checked-out branch, so the operator can execute an agent's drafts from any
+ * worktree. Writes run one at a time and never fail the run: a denied scope,
+ * a deleted thread, or a rate limit becomes that draft's `failed` outcome with
+ * the retry command, and the remaining drafts still get their turn. The report
+ * is written through {@link ReplyReportJson} so `Option` fields encode as
+ * omitted keys rather than runtime objects.
+ *
+ * The preflight — `gh repo view` plus the paginated `reviewThreads` query — is
+ * held to a stronger contract. A denied repo read, a denied thread page, or a
+ * page that reports another page without a cursor settles *every* loaded draft
+ * as `failed` carrying that failure's text and the whole-run retry command,
+ * writes the report, and then fails the run. A drafts file is a batch of work
+ * someone did; losing the whole batch to a thrown error with no artifact is the
+ * failure mode this command exists to remove — but a pass that posted nothing
+ * is not a success either. The report is the accounting; the exit code is the
+ * verdict, so a `beep yeet reply && ...` chain never proceeds past a run that
+ * wrote zero replies.
+ *
+ * **Gotchas**
+ *
+ * Per-draft failures exit 0 — the batch ran and the report is authoritative.
+ * Only the preflight (nothing attempted) fails the run, and with no drafts
+ * loaded it fails without a report: there is no outcome to attach the failure
+ * to, so an exit-0 empty report would be a silent green.
+ *
+ * **Example** (Build the reply run effect)
+ *
+ * ```ts
+ * import { RepoRunContext, runYeetReply } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const context = RepoRunContext.make({
+ *   base: "origin/main",
+ *   branch: "feat/merge-loop",
+ *   cwd: ".",
+ *   head: "HEAD",
+ *   originalArgv: [],
+ *   packetDir: ".beep/yeet",
+ *   repoRoot: ".",
+ *   turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+ * })
+ * console.log(Effect.isEffect(runYeetReply(context))) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the repo root and packet directory.
+ * @returns The written reply report.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetReply = Effect.fn("Yeet.runReply")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<
+  ReplyReport,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const drafts = yield* loadReplyDrafts(context);
+  const preflight = yield* Effect.result(replyPreflight(context, drafts.prNumber));
+  if (Result.isFailure(preflight) && A.isReadonlyArrayEmpty(drafts.drafts)) {
+    return yield* preflight.failure;
+  }
+  const outcomes = Result.isSuccess(preflight)
+    ? yield* Effect.forEach(
+        planReplyActions(drafts, preflight.success),
+        (action) => executeReplyAction(context, action),
+        { concurrency: 1 }
+      )
+    : preflightFailureOutcomes(drafts, preflight.failure);
+  yield* Effect.forEach(
+    outcomes,
+    (outcome) =>
+      Console.log(
+        `[yeet] reply ${outcome.status} ${O.getOrElse(outcome.threadId, () => `comment ${O.getOrElse(O.map(outcome.commentId, String), () => "?")}`)}: ${outcome.detail}`
+      ),
+    { concurrency: 1 }
+  );
+
+  const createdAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  const report = ReplyReport.make({
+    createdAt,
+    outcomes,
+    prNumber: drafts.prNumber,
+    schemaVersion: "yeet-reply-report/v1",
+  });
+  const reportPath = yield* replyReportPathForContext(context);
+  const reportJson = yield* ReplyReportJson.encode(report).pipe(
+    Effect.mapError(YeetCommandError.new("Failed to encode the yeet reply report artifact."))
+  );
+  yield* writeTextFile(reportPath, `${reportJson}\n`);
+  yield* Console.log(
+    `[yeet] reply report written to ${reportPath} (${countStatus(outcomes, "resolved")} resolved, ${countStatus(outcomes, "posted")} posted, ${countStatus(outcomes, "stale")} stale, ${countStatus(outcomes, "failed")} failed)`
+  );
+  if (Result.isFailure(preflight)) {
+    return yield* YeetCommandError.make({
+      cause: preflight.failure,
+      exitCode: 1,
+      file: reportPath,
+      message: `yeet reply preflight failed before any draft could be posted; every draft is settled as failed in ${reportPath}. ${preflight.failure.message}`,
+    });
+  }
+
+  return report;
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Status.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Status.ts
@@ -6,22 +6,25 @@
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
-import { LiteralKit } from "@beep/schema";
+import { LiteralKit, SchemaUtils } from "@beep/schema";
 import * as O from "@beep/utils/Option";
 import { DateTime, Effect, FileSystem, flow, Order, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
+import { GhActor } from "../../../internal/github/index.ts";
 import { runRepoCommandCapture } from "../../../internal/repo-run/index.ts";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
 import { runArtifactPathForContext, runIdForContext } from "./ArtifactPaths.ts";
 import { PrCloseoutReport } from "./Closeout.ts";
-import { YeetVerdict } from "./Verdict.ts";
+import { yeetCommentExcerpt } from "./MonitorComments.ts";
+import { YeetMergeReady, YeetMergeReadyCriteria, YeetMergeReadyCriterion, YeetVerdict } from "./Verdict.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
 
 const $I = $RepoCliId.create("commands/Yeet/internal/Status");
-const encodeJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
+const threadExcerptLength = 140;
 
 /**
  * Status of an optional Yeet artifact read.
@@ -107,9 +110,56 @@ export class YeetStatusArtifact extends S.Class<YeetStatusArtifact>($I`YeetStatu
     outcome: S.optionalKey(S.String),
     repairCommand: S.optionalKey(S.String),
     schemaVersion: S.optionalKey(S.String),
+    greptileScore: S.String.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
   },
   $I.annote("YeetStatusArtifact", {
     description: "Compact summary for a Yeet artifact read by status.",
+  })
+) {}
+
+/**
+ * One unresolved review thread, carried with enough context to triage it.
+ *
+ * **Details**
+ *
+ * Status used to list threads as bare GraphQL node ids plus a file path, which
+ * is the least actionable form of the data: triaging a wave meant a second REST
+ * pass and hand-mapping thread ids to comment ids by file. Author, first-line
+ * excerpt, and the numeric REST `commentDatabaseId` are exactly the fields that
+ * turn the listing into something a reply drafts file can be written from
+ * directly — `yeet reply` accepts either identifier.
+ *
+ * **Example** (Describe one unresolved thread)
+ *
+ * ```ts
+ * import { YeetStatusReviewThread } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const thread = YeetStatusReviewThread.make({
+ *   threadId: "PRRT_kwDO",
+ *   author: "greptile-apps[bot]",
+ *   excerpt: "logic: the rerun budget never resets across SHAs",
+ *   path: O.some("src/commands/Yeet/internal/MonitorLoop.ts"),
+ *   line: O.some(88),
+ *   commentDatabaseId: O.some(2412551122),
+ * })
+ * console.log(thread.author)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetStatusReviewThread extends S.Class<YeetStatusReviewThread>($I`YeetStatusReviewThread`)(
+  {
+    threadId: S.String,
+    author: S.String,
+    excerpt: S.String,
+    path: S.String.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+    line: S.Finite.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+    commentDatabaseId: S.Finite.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+  },
+  $I.annote("YeetStatusReviewThread", {
+    description: "One unresolved pull request review thread with the context needed to triage and reply to it.",
   })
 ) {}
 
@@ -142,6 +192,8 @@ export class YeetStatusRemote extends S.Class<YeetStatusRemote>($I`YeetStatusRem
     pendingCheckCount: S.optionalKey(S.Finite),
     unresolvedReviewThreadCount: S.optionalKey(S.Finite),
     unresolvedReviewThreads: S.Array(S.String).pipe(S.optionalKey),
+    unresolvedThreads: S.Array(YeetStatusReviewThread).pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+    headSha: S.String.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
     rerunFailedCommand: S.optionalKey(S.String),
     rerunFailedDecision: S.optionalKey(S.String),
     reviewDecision: S.optionalKey(S.String),
@@ -195,11 +247,35 @@ export class YeetStatusSnapshot extends S.Class<YeetStatusSnapshot>($I`YeetStatu
     statusPath: S.String,
     verdict: YeetStatusArtifact,
     worktree: YeetStatusWorktree,
+    mergeReady: YeetMergeReady.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
   },
   $I.annote("YeetStatusSnapshot", {
     description: "Machine-readable status snapshot emitted by yeet status.",
   })
 ) {}
+
+/**
+ * JSON-string codec for the `status.json` artifact.
+ *
+ * **Gotchas**
+ *
+ * The status writer must go through this codec. Rendering the decoded snapshot
+ * with a generic JSON encoder serializes `Option` fields as their runtime shape
+ * (`{"_id":"Option","_tag":"Some","value":…}`), producing an artifact that no
+ * longer decodes — the same trap the verdict artifact already fell into.
+ *
+ * **Example** (Encode a snapshot)
+ *
+ * ```ts
+ * import { YeetStatusSnapshotJson } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(typeof YeetStatusSnapshotJson.encode)
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const YeetStatusSnapshotJson = JsonStringCodec(YeetStatusSnapshot);
 
 class GhStatusPullRequest extends S.Class<GhStatusPullRequest>($I`GhStatusPullRequest`)(
   {
@@ -218,15 +294,37 @@ class GhStatusPullRequest extends S.Class<GhStatusPullRequest>($I`GhStatusPullRe
   })
 ) {}
 
+class GhStatusThreadComment extends S.Class<GhStatusThreadComment>($I`GhStatusThreadComment`)(
+  {
+    author: S.NullOr(GhActor),
+    body: S.NullOr(S.String),
+    databaseId: S.NullOr(S.Finite),
+  },
+  $I.annote("GhStatusThreadComment", {
+    description: "The opening comment of a review thread, used for status thread triage.",
+  })
+) {}
+
+class GhStatusThreadCommentConnection extends S.Class<GhStatusThreadCommentConnection>(
+  $I`GhStatusThreadCommentConnection`
+)(
+  { nodes: S.Array(GhStatusThreadComment) },
+  $I.annote("GhStatusThreadCommentConnection", {
+    description: "First-comment connection of a review thread returned by Yeet remote status.",
+  })
+) {}
+
 class GhStatusReviewThread extends S.Class<GhStatusReviewThread>($I`GhStatusReviewThread`)(
   {
     id: S.String,
     isResolved: S.Boolean,
     isOutdated: S.Boolean,
     path: S.NullOr(S.String),
+    line: S.NullOr(S.Finite),
+    comments: GhStatusThreadCommentConnection,
   },
   $I.annote("GhStatusReviewThread", {
-    description: "Minimal review-thread identity used by Yeet remote status.",
+    description: "Review-thread identity plus opening-comment triage context used by Yeet remote status.",
   })
 ) {}
 
@@ -261,7 +359,28 @@ class GhStatusReviewThreadsDocument extends S.Class<GhStatusReviewThreadsDocumen
   $I.annote("GhStatusReviewThreadsDocument", { description: "GraphQL review-thread status document." })
 ) {}
 
-class GhStatusWorkflowRun extends S.Class<GhStatusWorkflowRun>($I`GhStatusWorkflowRun`)(
+/**
+ * A branch workflow run as returned by `gh run list`.
+ *
+ * **Example** (Construct a workflow run row)
+ *
+ * ```ts
+ * import { GhStatusWorkflowRun } from "@beep/repo-cli/test/Yeet"
+ *
+ * const run = GhStatusWorkflowRun.make({
+ *   conclusion: "failure",
+ *   databaseId: 42,
+ *   headSha: "abc123",
+ *   name: "check",
+ *   status: "completed",
+ * })
+ * console.log(run.conclusion)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GhStatusWorkflowRun extends S.Class<GhStatusWorkflowRun>($I`GhStatusWorkflowRun`)(
   {
     conclusion: S.NullOr(S.String),
     databaseId: S.Finite,
@@ -289,7 +408,7 @@ const decodeGhStatusPullRequest = S.decodeUnknownEffect(S.fromJsonString(GhStatu
 const decodeGhStatusReviewThreads = S.decodeUnknownEffect(S.fromJsonString(GhStatusReviewThreadsDocument));
 const decodeGhStatusWorkflowRuns = S.decodeUnknownEffect(S.fromJsonString(S.Array(GhStatusWorkflowRun)));
 const reviewThreadsQuery =
-  "query($id:ID!){node(id:$id){... on PullRequest{reviewThreads(first:100){nodes{id isResolved isOutdated path} pageInfo{hasNextPage}}}}}";
+  "query($id:ID!){node(id:$id){... on PullRequest{reviewThreads(first:100){nodes{id isResolved isOutdated path line comments(first:1){nodes{author{login} body databaseId}}} pageInfo{hasNextPage}}}}}";
 const decodeGhStatusChecks = S.decodeUnknownEffect(S.fromJsonString(S.Array(GhStatusCheck)));
 
 const sortedUniquePaths: (paths: ReadonlyArray<string>) => ReadonlyArray<string> = flow(
@@ -397,6 +516,7 @@ const artifactFromCloseout = (path: string, report: PrCloseoutReport): YeetStatu
     path,
     schemaVersion: report.schemaVersion,
     state: "present",
+    greptileScore: O.fromUndefinedOr(report.greptile.score),
   });
 
 const readJsonArtifact = Effect.fn("YeetStatus.readJsonArtifact")(function* <Value>(
@@ -503,7 +623,29 @@ const collectRemoteReviewThreads = Effect.fn("YeetStatus.collectRemoteReviewThre
   );
 });
 
-const collectRemoteWorkflowRuns = Effect.fn("YeetStatus.collectRemoteWorkflowRuns")(function* (
+/**
+ * Fetch the branch's recent workflow runs, tolerating any `gh` failure.
+ *
+ * **Details**
+ *
+ * Shared with the `--until-merged` merge loop, which needs the same run list to
+ * find the failed runs at the current head SHA before drilling into their jobs.
+ *
+ * **Example** (Reference the workflow-run collector)
+ *
+ * ```ts
+ * import { collectRemoteWorkflowRuns } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(Effect.succeed(collectRemoteWorkflowRuns))) // true
+ * ```
+ *
+ * @param context - Yeet run context naming the branch and repo root.
+ * @returns The branch's most recent workflow runs, or an empty list.
+ * @category diagnostics
+ * @since 0.0.0
+ */
+export const collectRemoteWorkflowRuns = Effect.fn("YeetStatus.collectRemoteWorkflowRuns")(function* (
   context: RepoRunContext
 ): Effect.fn.Return<ReadonlyArray<GhStatusWorkflowRun>, never, ChildProcessSpawner.ChildProcessSpawner> {
   const result = yield* runRepoCommandCapture(
@@ -517,11 +659,130 @@ const collectRemoteWorkflowRuns = Effect.fn("YeetStatus.collectRemoteWorkflowRun
   return yield* decodeGhStatusWorkflowRuns(result.output).pipe(Effect.orElseSucceed(A.empty<GhStatusWorkflowRun>));
 });
 
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/gu;
+const MARKDOWN_IMAGE_PATTERN = /!\[[^\]]*\]\([^)]*\)/gu;
+const HTML_TAG_PATTERN = /<[^>]*>/gu;
+const MARKDOWN_LINK_PATTERN = /\[([^\]]*)\]\([^)]*\)/gu;
+const MARKDOWN_LINE_PREFIX_PATTERN = /^[\s>#*\-+]+/u;
+const MARKDOWN_EMPHASIS_PATTERN = /[*_`]/gu;
+
+/**
+ * Reduce a review-comment body to one plain first line.
+ *
+ * **Details**
+ *
+ * Bot review bodies open with machine markers rather than prose — an HTML
+ * comment, a shields.io severity badge image, then bolded category text — so a
+ * naive first line is empty or a URL. Stripping comments, images, tags, and
+ * link syntax first makes the first non-empty line the sentence a human would
+ * read.
+ *
+ * **Example** (Strip a badge-prefixed bot comment)
+ *
+ * ```ts
+ * import { yeetReviewThreadExcerpt } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(yeetReviewThreadExcerpt("<!-- greptile -->\n![](https://img/badge.svg) **logic**: off by one"))
+ * ```
+ *
+ * @param body - Raw review-comment markdown.
+ * @returns A single-line, badge-free excerpt bounded for operator output.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const yeetReviewThreadExcerpt = (body: string): string =>
+  pipe(
+    body,
+    Str.replace(HTML_COMMENT_PATTERN, " "),
+    Str.replace(MARKDOWN_IMAGE_PATTERN, " "),
+    Str.replace(HTML_TAG_PATTERN, " "),
+    Str.replace(MARKDOWN_LINK_PATTERN, "$1"),
+    Str.split(/\r?\n/u),
+    A.map(flow(Str.replace(MARKDOWN_LINE_PREFIX_PATTERN, ""), Str.replace(MARKDOWN_EMPHASIS_PATTERN, ""), Str.trim)),
+    A.findFirst(Str.isNonEmpty),
+    O.map((line) => yeetCommentExcerpt(line, threadExcerptLength)),
+    O.getOrElse(() => "(no comment body)")
+  );
+
+const reviewThreadTriage = (thread: GhStatusReviewThread): YeetStatusReviewThread => {
+  const opening = A.head(thread.comments.nodes);
+  return YeetStatusReviewThread.make({
+    threadId: thread.id,
+    author: pipe(
+      opening,
+      O.flatMap((comment) => O.fromNullishOr(comment.author)),
+      O.map((author) => author.login),
+      O.getOrElse(() => "unknown")
+    ),
+    excerpt: pipe(
+      opening,
+      O.flatMap((comment) => O.fromNullishOr(comment.body)),
+      O.map(yeetReviewThreadExcerpt),
+      O.getOrElse(() => "(no comment body)")
+    ),
+    path: O.fromNullishOr(thread.path),
+    line: O.fromNullishOr(thread.line),
+    commentDatabaseId: pipe(
+      opening,
+      O.flatMap((comment) => O.fromNullishOr(comment.databaseId))
+    ),
+  });
+};
+
 const skippedRemote = YeetStatusRemote.make({
   available: false,
   checked: false,
   detail: "pass --remote to include live GitHub PR data",
 });
+
+/**
+ * Build the read-only failed-job listing suggested when a same-SHA red run is
+ * rerunnable.
+ *
+ * **Details**
+ *
+ * Job-scoped on purpose, matching the merge loop's rerun command. A run-level
+ * `--failed` rerun re-executes every failed job in the run, so a genuine red
+ * sharing the run with a flake gets re-run as a side effect of the flake —
+ * the exact behaviour the merge loop bans. Status has only the run-level
+ * record at this seam, so it suggests the listing that surfaces
+ * each failed job's `databaseId` and lets the decision text name the
+ * job-scoped rerun form.
+ *
+ * **Example** (Suggest the failed-job listing for a run)
+ *
+ * ```ts
+ * import { yeetRerunJobListingCommand } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(yeetRerunJobListingCommand(123).startsWith("gh run view 123")) // true
+ * ```
+ *
+ * @param runId - Workflow run database id from `gh run list`.
+ * @returns The read-only `gh run view` job listing command.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const yeetRerunJobListingCommand = (runId: number): string =>
+  `gh run view ${runId} --json jobs --jq '.jobs[] | select(.conclusion == "failure") | [.databaseId, .name] | @tsv'`;
+
+/**
+ * Render the same-SHA rerun decision line that teaches the job-scoped form.
+ *
+ * **Example** (Name the job-scoped rerun for a red run)
+ *
+ * ```ts
+ * import { yeetRerunDecisionText } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(yeetRerunDecisionText("check").includes("--job")) // true
+ * ```
+ *
+ * @param runName - Workflow run name from `gh run list`.
+ * @returns Operator guidance naming `gh run rerun --job`, never `--failed`.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const yeetRerunDecisionText = (runName: string): string =>
+  `same-SHA red detected for ${runName}; rerun one job with \`gh run rerun --job <databaseId>\`, never \`--failed\``;
 
 const collectRemoteStatus = Effect.fn("YeetStatus.collectRemoteStatus")(function* (
   context: RepoRunContext,
@@ -554,9 +815,10 @@ const collectRemoteStatus = Effect.fn("YeetStatus.collectRemoteStatus")(function
   );
   const checks = yield* collectRemoteChecks(context);
   const reviewThreads = yield* collectRemoteReviewThreads(context, view.id);
-  const unresolvedThreads = A.filter(reviewThreads.nodes, (thread) => !thread.isResolved);
+  const unresolved = A.filter(reviewThreads.nodes, (thread) => !thread.isResolved);
+  const unresolvedThreads = A.map(unresolved, reviewThreadTriage);
   const unresolvedReviewThreads = [
-    ...A.map(unresolvedThreads, (thread) => `${thread.id}${thread.path === null ? "" : ` (${thread.path})`}`),
+    ...A.map(unresolved, (thread) => `${thread.id}${thread.path === null ? "" : ` (${thread.path})`}`),
     ...(reviewThreads.pageInfo.hasNextPage ? ["additional review threads omitted after the first 100"] : []),
   ];
   const checkCount = pipe(checks, O.map(A.length));
@@ -580,10 +842,10 @@ const collectRemoteStatus = Effect.fn("YeetStatus.collectRemoteStatus")(function
     A.findFirst((run) => run.headSha === view.headRefOid && run.conclusion === "failure"),
     O.filter(() => hasFailingCheck)
   );
-  const rerunFailedCommand = O.map(rerunnableFailedRun, (run) => `gh run rerun ${run.databaseId} --failed`);
+  const rerunFailedCommand = O.map(rerunnableFailedRun, (run) => yeetRerunJobListingCommand(run.databaseId));
   const rerunFailedDecision = pipe(
     rerunnableFailedRun,
-    O.map((run) => `same-SHA red detected for ${run.name}; suggest rerun-failed before pushing`),
+    O.map((run) => yeetRerunDecisionText(run.name)),
     O.orElse(() => O.some("no same-SHA failed workflow rerun is currently indicated"))
   );
   return YeetStatusRemote.make({
@@ -596,6 +858,8 @@ const collectRemoteStatus = Effect.fn("YeetStatus.collectRemoteStatus")(function
     url: view.url,
     unresolvedReviewThreadCount: A.length(unresolvedReviewThreads),
     unresolvedReviewThreads,
+    unresolvedThreads: O.some(unresolvedThreads),
+    headSha: O.some(view.headRefOid),
     ...O.getSomesStruct({
       checkCount,
       failingCheckCount,
@@ -620,19 +884,98 @@ const CLOSEOUT_COMMAND =
   "run `bun run beep yeet closeout --summary --require-greptile-score 5/5 --require-greptile-issues 0 --require-review-comments 0`";
 const VERIFY_OR_REMOTE_COMMAND = "run `bun run beep yeet verify` or pass `--remote` for PR status";
 
-const remoteIsMergeReady = (closeout: YeetStatusArtifact, remote: YeetStatusRemote): boolean =>
-  remote.unresolvedReviewThreadCount === 0 &&
+const checksAreGreen = (remote: YeetStatusRemote): boolean =>
+  pipe(
+    O.fromUndefinedOr(remote.checkCount),
+    O.exists(() => (remote.failingCheckCount ?? 0) === 0 && (remote.pendingCheckCount ?? 0) === 0)
+  );
+
+const threadsAreResolved = (closeout: YeetStatusArtifact, remote: YeetStatusRemote): boolean =>
+  (remote.unresolvedReviewThreadCount ?? 0) === 0 &&
   pipe(
     O.fromUndefinedOr(closeout.issueCount),
     O.exists((count) => count === 0)
   );
+
+/**
+ * Fold the merge protocol's three surfaces into one merge-readiness verdict.
+ *
+ * **Details**
+ *
+ * Status already fetches everything the protocol asks a human to read, so the
+ * only thing missing was a name for the answer. `checks-green` and
+ * `threads-resolved` are the hard criteria and are reported in that order —
+ * a red pipeline is the blocker worth acting on first even when threads are
+ * also open. The Greptile score rides along as display-only: it is a target the
+ * operator judges, not a gate this verdict enforces.
+ *
+ * **Gotchas**
+ *
+ * Returns `None` when the pull request was not read at all (`yeet status`
+ * without `--remote`, or no PR for the branch). Unknown is not the same as
+ * blocked, and callers that flatten it to `false` would announce a failing
+ * criterion that was never observed. Unread *checks*, by contrast, are treated
+ * as not-green: the criterion is hard, so absence of proof blocks.
+ *
+ * **Example** (Name the blocking criterion)
+ *
+ * ```ts
+ * import { deriveYeetMergeReady, YeetStatusArtifact, YeetStatusRemote } from "@beep/repo-cli/test/Yeet"
+ *
+ * const mergeReady = deriveYeetMergeReady(
+ *   YeetStatusArtifact.make({ detail: "closed", issueCount: 0, path: "pr-closeout.json", state: "present" }),
+ *   YeetStatusRemote.make({
+ *     available: true,
+ *     checked: true,
+ *     detail: "PR #42 OPEN",
+ *     checkCount: 24,
+ *     failingCheckCount: 1,
+ *     pendingCheckCount: 0,
+ *     unresolvedReviewThreadCount: 0,
+ *   })
+ * )
+ * console.log(mergeReady)
+ * ```
+ *
+ * @param closeout - Closeout artifact summary for the branch.
+ * @param remote - Live pull request summary, checked or not.
+ * @returns The merge-readiness verdict, or `None` when the PR was not read.
+ * @category diagnostics
+ * @since 0.0.0
+ */
+export const deriveYeetMergeReady = (
+  closeout: YeetStatusArtifact,
+  remote: YeetStatusRemote
+): O.Option<YeetMergeReady> => {
+  if (!remote.checked || !remote.available) {
+    return O.none();
+  }
+  const checksGreen = checksAreGreen(remote);
+  const threadsResolved = threadsAreResolved(closeout, remote);
+  const failing = !checksGreen
+    ? O.some(YeetMergeReadyCriterion.Enum["checks-green"])
+    : threadsResolved
+      ? O.none<YeetMergeReadyCriterion>()
+      : O.some(YeetMergeReadyCriterion.Enum["threads-resolved"]);
+  return O.some(
+    YeetMergeReady.make({
+      ready: O.isNone(failing),
+      failing,
+      criteria: YeetMergeReadyCriteria.make({
+        checksGreen,
+        threadsResolved,
+        greptileScore: closeout.greptileScore,
+      }),
+    })
+  );
+};
 
 const nextCommandForRemote = (
   verdict: YeetStatusArtifact,
   closeout: YeetStatusArtifact,
   remote: YeetStatusRemote
 ): string => {
-  if (remoteIsMergeReady(closeout, remote)) {
+  if (O.exists(deriveYeetMergeReady(closeout, remote), (mergeReady) => mergeReady.ready)) {
     return MERGE_READY_COMMAND;
   }
   if (remote.rerunFailedCommand !== undefined && verdict.outcome === "success") {
@@ -709,6 +1052,7 @@ export const collectYeetStatus = Effect.fn("YeetStatus.collectYeetStatus")(funct
     statusPath,
     verdict,
     worktree,
+    mergeReady: deriveYeetMergeReady(closeout, remoteStatus),
   });
 });
 
@@ -720,14 +1064,80 @@ const renderCheckLine = (remote: YeetStatusRemote): string =>
     ? `checks: ${remote.checkCount} total, ${remote.failingCheckCount ?? 0} failing, ${remote.pendingCheckCount ?? 0} pending`
     : "checks: not checked";
 
-const renderReviewThreadLine = (remote: YeetStatusRemote): string => {
+const renderThreadTriageLine = (thread: YeetStatusReviewThread): string => {
+  const location = pipe(
+    thread.path,
+    O.map((path) => ` ${path}${O.match(thread.line, { onNone: () => Str.empty, onSome: (line) => `:${line}` })}`),
+    O.getOrElse(() => Str.empty)
+  );
+  const commentId = O.match(thread.commentDatabaseId, {
+    onNone: () => Str.empty,
+    onSome: (id) => ` comment ${id}`,
+  });
+  return `  - ${thread.threadId}${commentId}${location} @${thread.author}: ${thread.excerpt}`;
+};
+
+/**
+ * Render the unresolved-thread block of a status summary.
+ *
+ * **Details**
+ *
+ * When triage context is available each thread gets its own line carrying the
+ * GraphQL thread id, the REST comment `databaseId`, the location, the author,
+ * and a plain first-line excerpt — the exact columns a reply drafts file needs.
+ * Snapshots written before that context existed fall back to the original
+ * inline id list rather than losing the count.
+ *
+ * **Example** (Render an unchecked remote)
+ *
+ * ```ts
+ * import { renderYeetReviewThreadBlock, YeetStatusRemote } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(renderYeetReviewThreadBlock(
+ *   YeetStatusRemote.make({ available: false, checked: false, detail: "pass --remote" })
+ * ))
+ * ```
+ *
+ * @param remote - Live pull request summary, checked or not.
+ * @returns The `review threads:` line plus one indented line per thread.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetReviewThreadBlock = (remote: YeetStatusRemote): string => {
   if (!remote.checked || !remote.available) {
     return "review threads: not checked";
   }
-  const threads = remote.unresolvedReviewThreads ?? A.empty<string>();
-  const listed = A.isReadonlyArrayNonEmpty(threads) ? ` -> ${A.join(threads, ", ")}` : Str.empty;
-  return `review threads: ${remote.unresolvedReviewThreadCount ?? 0} unresolved${listed}`;
+  const header = `review threads: ${remote.unresolvedReviewThreadCount ?? 0} unresolved`;
+  return pipe(
+    remote.unresolvedThreads,
+    O.filter(A.isReadonlyArrayNonEmpty),
+    O.match({
+      onNone: () => {
+        const threads = remote.unresolvedReviewThreads ?? A.empty<string>();
+        return A.isReadonlyArrayNonEmpty(threads) ? `${header} -> ${A.join(threads, ", ")}` : header;
+      },
+      onSome: (threads) => A.join([header, ...A.map(threads, renderThreadTriageLine)], "\n"),
+    })
+  );
 };
+
+const renderMergeReadyLine = (snapshot: YeetStatusSnapshot): string =>
+  pipe(
+    snapshot.mergeReady,
+    O.match({
+      onNone: () => "merge-ready: not checked",
+      onSome: (mergeReady) => {
+        const greptile = O.match(mergeReady.criteria.greptileScore, {
+          onNone: () => Str.empty,
+          onSome: (score) => ` (greptile ${score})`,
+        });
+        return O.match(mergeReady.failing, {
+          onNone: () => `merge-ready: yes${greptile}`,
+          onSome: (failing) => `merge-ready: no, blocked on ${failing}${greptile}`,
+        });
+      },
+    })
+  );
 
 /**
  * Render a concise human-readable Yeet status block.
@@ -770,7 +1180,8 @@ export const renderYeetStatusSummary = (snapshot: YeetStatusSnapshot): string =>
       `- closeout: ${snapshot.closeout.detail}`,
       `- remote: ${snapshot.remote.checked ? snapshot.remote.detail : "remote not checked"}`,
       `- ${renderCheckLine(snapshot.remote)}`,
-      `- ${renderReviewThreadLine(snapshot.remote)}`,
+      `- ${renderYeetReviewThreadBlock(snapshot.remote)}`,
+      `- ${renderMergeReadyLine(snapshot)}`,
       `- rerun-failed: ${snapshot.remote.rerunFailedDecision ?? "not checked"}`,
       `- status artifact: ${snapshot.statusPath}`,
       `- next: ${snapshot.nextCommand}`,
@@ -799,7 +1210,7 @@ export const writeYeetStatusSnapshot = Effect.fn("YeetStatus.writeYeetStatusSnap
 ): Effect.fn.Return<void, YeetCommandError, FileSystem.FileSystem | Path.Path> {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const json = yield* encodeJson(snapshot).pipe(
+  const json = yield* YeetStatusSnapshotJson.encode(snapshot).pipe(
     Effect.mapError(YeetCommandError.new("Failed to encode yeet status JSON."))
   );
   yield* fs

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.schemas.ts
@@ -1,0 +1,410 @@
+/**
+ * Schema-first plan and report documents for the post-merge workspace sweep.
+ *
+ * After a merge lands through the gh CLI the local clone is left stale and the
+ * next yeet run pays for it: the feature branch lingers, origin refs are
+ * unpruned, local `main` is behind (stale base → rebase treadmill), and a
+ * lockfile-moving `main` leaves `node_modules` phantom-failing. The sweep is
+ * the tail that returns the clone to a ready state.
+ *
+ * Two documents model it. {@link SweepPlan} is the dry-run: every step it would
+ * take, the git facts it observed, and whether the step needs a human. Running
+ * it produces a {@link SweepReport}: the same plan echoed verbatim plus one
+ * outcome per step. Both carry a `schemaVersion` literal and are written
+ * through their `S.encode`-backed JSON codecs ({@link SweepPlanJson},
+ * {@link SweepReportJson}) — never `JSON.stringify` over a decoded instance,
+ * which leaks `Option` runtime objects into the artifact.
+ *
+ * **Details**
+ *
+ * The sweep never fails. A precondition it cannot satisfy — a dirty worktree, a
+ * branch checked out elsewhere, an unpushed commit — is reported as a skip or
+ * an operator handoff, so "merged, cleanup skipped: reason" is a success. That
+ * is why {@link SweepStepOutcome} has no failure member: unmerged local work is
+ * sacred and the sweep would rather report than destroy.
+ *
+ * **Gotchas**
+ *
+ * Worktree detection must go through `git rev-parse --git-dir` or
+ * `git worktree list`. A `[ -d "$dir/.git" ]` probe silently skips linked
+ * worktrees, where `.git` is a FILE — the exact miss that would let a
+ * "no worktree holds this branch" precondition read satisfied while a linked
+ * worktree has it checked out. Truncated probe output is the same miss by
+ * another route: a cut-off `git worktree list --porcelain` parses to zero
+ * worktrees, so the planner records the truncation as its own unsatisfied
+ * {@link SweepPrecondition} rather than letting it read as an observed fact.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit, SchemaUtils } from "@beep/schema";
+import * as S from "effect/Schema";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Sweep.schemas");
+
+/**
+ * The fixed set of steps a workspace sweep may take, in execution order.
+ *
+ * **Details**
+ *
+ * `fetch-prune` refreshes origin and drops deleted remote refs; `ff-main`
+ * fast-forwards local `main` (via `git fetch origin main:main` when `main` is
+ * not checked out anywhere); `delete-local-branch` and `delete-remote-branch`
+ * retire the merged feature branch; `lockfile-install` runs `bun install` when
+ * the `main` update moved `bun.lock`; `end-state` records where the sweep left
+ * the clone.
+ *
+ * **Example** (List the sweep step ids)
+ *
+ * ```ts
+ * import { SweepStepId } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(SweepStepId.Options)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const SweepStepId = LiteralKit([
+  "fetch-prune",
+  "ff-main",
+  "delete-local-branch",
+  "delete-remote-branch",
+  "lockfile-install",
+  "end-state",
+]).pipe(
+  $I.annoteSchema("SweepStepId", {
+    title: "Sweep Step Id",
+    description: "One step of the post-merge workspace sweep.",
+  })
+);
+
+/**
+ * The fixed set of steps a workspace sweep may take.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type SweepStepId = typeof SweepStepId.Type;
+
+/**
+ * One git fact the planner observed, paired with whether it holds.
+ *
+ * **Details**
+ *
+ * Preconditions are recorded as observations rather than prose so a `--plan`
+ * dry-run explains itself: an unsatisfied precondition is the reason its step
+ * will skip or hand off, and `requiresOperator` on the step is derivable from
+ * the set rather than asserted independently.
+ *
+ * **Example** (Record an observed precondition)
+ *
+ * ```ts
+ * import { SweepPrecondition } from "@beep/repo-cli/test/Yeet"
+ *
+ * const observed = SweepPrecondition.make({
+ *   description: "no worktree holds branch feat/merge-loop",
+ *   satisfied: false,
+ * })
+ * console.log(observed.satisfied)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepPrecondition extends S.Class<SweepPrecondition>($I`SweepPrecondition`)(
+  {
+    description: S.NonEmptyString,
+    satisfied: S.Boolean,
+  },
+  $I.annote("SweepPrecondition", {
+    description: "One git fact observed while planning a sweep step, paired with whether it holds.",
+  })
+) {}
+
+/**
+ * One planned sweep step with the action it would take and the facts behind it.
+ *
+ * **Example** (Plan the local branch deletion)
+ *
+ * ```ts
+ * import { SweepPlanStep, SweepPrecondition } from "@beep/repo-cli/test/Yeet"
+ *
+ * const step = SweepPlanStep.make({
+ *   id: "delete-local-branch",
+ *   action: "git branch -d feat/merge-loop",
+ *   preconditions: [SweepPrecondition.make({ description: "branch is merged into origin/main", satisfied: true })],
+ *   requiresOperator: false,
+ * })
+ * console.log(step.id)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepPlanStep extends S.Class<SweepPlanStep>($I`SweepPlanStep`)(
+  {
+    id: SweepStepId,
+    action: S.NonEmptyString,
+    preconditions: S.Array(SweepPrecondition),
+    requiresOperator: S.Boolean,
+  },
+  $I.annote("SweepPlanStep", {
+    description: "One planned sweep step with its action, observed preconditions, and operator requirement.",
+  })
+) {}
+
+/**
+ * The dry-run document for one workspace sweep.
+ *
+ * **Example** (Construct an empty sweep plan)
+ *
+ * ```ts
+ * import { SweepPlan } from "@beep/repo-cli/test/Yeet"
+ *
+ * const plan = SweepPlan.make({
+ *   schemaVersion: "yeet-sweep-plan/v1",
+ *   createdAt: "2026-08-04T00:00:00.000Z",
+ *   branch: "feat/merge-loop",
+ *   steps: [],
+ * })
+ * console.log(plan.branch)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepPlan extends S.Class<SweepPlan>($I`SweepPlan`)(
+  {
+    schemaVersion: S.Literal("yeet-sweep-plan/v1"),
+    createdAt: S.String,
+    branch: S.String,
+    steps: S.Array(SweepPlanStep),
+  },
+  $I.annote("SweepPlan", {
+    description: "Dry-run plan for one post-merge workspace sweep.",
+  })
+) {}
+
+/**
+ * A sweep step that ran its action.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepStepExecuted extends S.Class<SweepStepExecuted>($I`SweepStepExecuted`)(
+  {
+    status: S.tag("executed"),
+    detail: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+  },
+  $I.annote("SweepStepExecuted", {
+    description: "A sweep step that ran its action.",
+  })
+) {}
+
+/**
+ * A sweep step deliberately not taken, with the precondition that blocked it.
+ *
+ * **Details**
+ *
+ * A skip is a success, not a failure: the clone is simply less clean than it
+ * could have been, and the reason names what a human would have to change.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepStepSkipped extends S.Class<SweepStepSkipped>($I`SweepStepSkipped`)(
+  {
+    status: S.tag("skipped"),
+    reason: S.NonEmptyString,
+  },
+  $I.annote("SweepStepSkipped", {
+    description: "A sweep step deliberately not taken, carrying the reason it was skipped.",
+  })
+) {}
+
+/**
+ * A sweep step the tool refuses to take on its own, handed to the operator.
+ *
+ * **Details**
+ *
+ * Distinct from a skip: the work still wants doing, but authority for it rests
+ * with the human, so the outcome carries the exact command to run.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepStepNeedsOperator extends S.Class<SweepStepNeedsOperator>($I`SweepStepNeedsOperator`)(
+  {
+    status: S.tag("needs-operator"),
+    reason: S.NonEmptyString,
+    operatorCommand: S.NonEmptyString,
+  },
+  $I.annote("SweepStepNeedsOperator", {
+    description: "A sweep step handed to the operator, carrying the reason and the exact command to run.",
+  })
+) {}
+
+/**
+ * What became of one sweep step: executed, skipped, or handed to the operator.
+ *
+ * **Example** (Decode a skipped outcome)
+ *
+ * ```ts
+ * import { SweepStepOutcome } from "@beep/repo-cli/test/Yeet"
+ * import * as S from "effect/Schema"
+ *
+ * const decoded = S.decodeUnknownOption(SweepStepOutcome)({
+ *   status: "skipped",
+ *   reason: "worktree is dirty",
+ * })
+ * console.log(decoded)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const SweepStepOutcome = S.Union([SweepStepExecuted, SweepStepSkipped, SweepStepNeedsOperator]).pipe(
+  S.toTaggedUnion("status"),
+  $I.annoteSchema("SweepStepOutcome", {
+    description: "What became of one sweep step: executed, skipped, or handed to the operator.",
+  })
+);
+
+/**
+ * What became of one sweep step.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type SweepStepOutcome = typeof SweepStepOutcome.Type;
+
+/**
+ * One executed plan step paired with its outcome.
+ *
+ * **Example** (Record a skipped step)
+ *
+ * ```ts
+ * import { SweepReportStep, SweepStepSkipped } from "@beep/repo-cli/test/Yeet"
+ *
+ * const step = SweepReportStep.make({
+ *   id: "ff-main",
+ *   outcome: SweepStepSkipped.make({ reason: "main is checked out in another worktree" }),
+ * })
+ * console.log(step.outcome.status)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepReportStep extends S.Class<SweepReportStep>($I`SweepReportStep`)(
+  {
+    id: SweepStepId,
+    outcome: SweepStepOutcome,
+    durationMs: S.Finite.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+  },
+  $I.annote("SweepReportStep", {
+    description: "One planned sweep step paired with the outcome of attempting it.",
+  })
+) {}
+
+/**
+ * The result document for one executed workspace sweep.
+ *
+ * **Details**
+ *
+ * The plan is echoed in full rather than referenced by path so the report is a
+ * self-contained audit record: a reader can see which facts were observed at
+ * plan time and what the run then did about them, without a second file that
+ * may have been overwritten by the next sweep.
+ *
+ * **Example** (Construct an empty sweep report)
+ *
+ * ```ts
+ * import { SweepPlan, SweepReport } from "@beep/repo-cli/test/Yeet"
+ *
+ * const report = SweepReport.make({
+ *   schemaVersion: "yeet-sweep-report/v1",
+ *   plan: SweepPlan.make({
+ *     schemaVersion: "yeet-sweep-plan/v1",
+ *     createdAt: "2026-08-04T00:00:00.000Z",
+ *     branch: "feat/merge-loop",
+ *     steps: [],
+ *   }),
+ *   steps: [],
+ *   startedAt: "2026-08-04T00:00:00.000Z",
+ *   endedAt: "2026-08-04T00:00:01.000Z",
+ * })
+ * console.log(report.plan.branch)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepReport extends S.Class<SweepReport>($I`SweepReport`)(
+  {
+    schemaVersion: S.Literal("yeet-sweep-report/v1"),
+    plan: SweepPlan,
+    steps: S.Array(SweepReportStep),
+    startedAt: S.String,
+    endedAt: S.String,
+  },
+  $I.annote("SweepReport", {
+    description: "Result document for one executed post-merge workspace sweep, echoing the plan it ran.",
+  })
+) {}
+
+/**
+ * JSON-string codec for the sweep plan artifact.
+ *
+ * **Example** (Round-trip an empty plan)
+ *
+ * ```ts
+ * import { SweepPlan, SweepPlanJson } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const plan = SweepPlan.make({
+ *   schemaVersion: "yeet-sweep-plan/v1",
+ *   createdAt: "2026-08-04T00:00:00.000Z",
+ *   branch: "feat/merge-loop",
+ *   steps: [],
+ * })
+ * console.log(Effect.runSync(SweepPlanJson.encode(plan)))
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const SweepPlanJson = JsonStringCodec(SweepPlan);
+
+/**
+ * JSON-string codec for the sweep report artifact.
+ *
+ * **Example** (Encode a report)
+ *
+ * ```ts
+ * import { SweepPlan, SweepReport, SweepReportJson } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const report = SweepReport.make({
+ *   schemaVersion: "yeet-sweep-report/v1",
+ *   plan: SweepPlan.make({
+ *     schemaVersion: "yeet-sweep-plan/v1",
+ *     createdAt: "2026-08-04T00:00:00.000Z",
+ *     branch: "feat/merge-loop",
+ *     steps: [],
+ *   }),
+ *   steps: [],
+ *   startedAt: "2026-08-04T00:00:00.000Z",
+ *   endedAt: "2026-08-04T00:00:01.000Z",
+ * })
+ * console.log(Effect.runSync(SweepReportJson.encode(report)))
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const SweepReportJson = JsonStringCodec(SweepReport);

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
@@ -1,0 +1,946 @@
+/**
+ * Post-merge workspace sweep: observe the clone, plan the cleanup, run it.
+ *
+ * The sweep is the tail that returns a clone to a ready state after a merge
+ * lands. It is split into three pieces so the interesting half is testable
+ * without a git fixture: {@link observeSweepGitState} performs every read-only
+ * git and `gh` probe, {@link buildSweepPlan} is a pure function from those
+ * observations to a {@link SweepPlan}, and {@link executeSweep} threads the two
+ * together, runs the plan, and writes a {@link SweepReport}.
+ *
+ * **Details**
+ *
+ * Every planned step carries the preconditions that must hold for its action.
+ * The executor's rule is one line: a step whose preconditions all hold runs its
+ * action; any unsatisfied precondition is a skip whose reason names the facts
+ * that blocked it. That is why the plan is worth reading — `--plan` output is a
+ * complete explanation of what the sweep will and will not do, before it does
+ * anything.
+ *
+ * The sweep never fails on a step. A dirty worktree, a branch checked out
+ * elsewhere, a local tip that has moved past the merged pull request head — each
+ * is reported, never overridden, because unpushed local work is sacred. "Merged,
+ * cleanup skipped: reason" is a success. The only outcome that asks for a human
+ * is `needs-operator`, raised when an action is refused by authority rather than
+ * by safety (a denied remote ref deletion), and it carries the exact command so
+ * handoffs batch instead of arriving one failure at a time.
+ *
+ * **Gotchas**
+ *
+ * Worktree detection goes through `git worktree list --porcelain`, never a
+ * `[ -d "$dir/.git" ]` probe: `.git` is a FILE in a linked worktree, so the
+ * directory test silently reports "no worktree holds this branch" while a linked
+ * worktree has it checked out — precisely the case the force-deletion contract
+ * exists to prevent.
+ *
+ * A probe whose captured output was truncated is UNKNOWN, never "no rows". A
+ * truncated `git worktree list --porcelain` would otherwise read as "no worktree
+ * holds this branch" — the same silent miss with a different cause — so
+ * truncation forces the facts it feeds to their conservative value (branch held,
+ * worktree dirty) and the blocked step's reason names the truncated command
+ * instead of a fact nobody observed.
+ *
+ * The pull request is only trusted once its head branch is confirmed to be the
+ * branch being swept. `gh pr view <branch>` resolves a pull request by more than
+ * an exact head match, so anchoring the MERGED-gated deletions to an unverified
+ * pull request would let another branch's merge authorize this branch's
+ * force-deletion.
+ *
+ * `delete-local-branch` is planned before `end-state`, so a sweep run from the
+ * merged branch's own worktree skips the deletion ("no worktree holds
+ * `<branch>`" fails) and then leaves the clone on `main`. Re-running the sweep
+ * completes the deletion. Moving HEAD first would mean mutating the worktree
+ * before the plan's safety facts were acted on, which the rails forbid.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { guardLiteralArg } from "@beep/repo-utils";
+import { SchemaUtils } from "@beep/schema";
+import { Clock, DateTime, Effect, Path, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { GhPrView, ghOutput } from "../../../internal/github/index.ts";
+import { runRepoCommandCapture, safeOriginBranchFromBase } from "../../../internal/repo-run/index.ts";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import { artifactDirForContext } from "./ArtifactPaths.ts";
+import { optionFromNonEmpty } from "./GitExec.ts";
+import { writeTextFile } from "./IssueArtifacts.ts";
+import {
+  SweepPlan,
+  SweepPlanStep,
+  SweepPrecondition,
+  SweepReport,
+  SweepReportJson,
+  SweepReportStep,
+  SweepStepExecuted,
+  SweepStepId,
+  SweepStepNeedsOperator,
+  SweepStepOutcome,
+  SweepStepSkipped,
+} from "./Sweep.schemas.ts";
+import type { FileSystem } from "effect";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Sweep");
+
+const sweepReportFileName = "sweep-report.json";
+
+const permissionDenialMarkers = [
+  "permission denied",
+  "permission to",
+  "denied to",
+  "403",
+  "not authorized",
+  "protected branch",
+  "pre-receive hook declined",
+  "refusing to allow",
+] as const;
+
+/**
+ * The git and GitHub facts one sweep is planned from.
+ *
+ * **Details**
+ *
+ * This record is the seam between the world and the planner: everything
+ * {@link buildSweepPlan} needs, and nothing it can observe for itself. Splitting
+ * it out is what makes the deletion contract testable — a force-deletion
+ * precondition is falsified by constructing a state, not by staging a repository.
+ *
+ * "Elsewhere" in `mainCheckedOutElsewhere` and `branchCheckedOutElsewhere` means
+ * a worktree other than the one being swept; whether the sweeping worktree holds
+ * a branch is read off `headBranch`, so the two facts together answer "does any
+ * worktree hold it".
+ *
+ * `pullRequestHeadBranch` is kept rather than discarded because a pull request
+ * only speaks for this sweep when its head is this branch; the deletion steps
+ * check it, so a pull request `gh` resolved by some other route cannot authorize
+ * deleting a branch it never belonged to.
+ *
+ * **Gotchas**
+ *
+ * `statusProbeTruncated` and `worktreeProbeTruncated` are the "this fact is
+ * unknown" carriers. When either is true the boolean it feeds is already forced
+ * to its conservative value here, so a reader of the raw facts is safe too; the
+ * flag exists so the plan can name the truncated command as the blocker instead
+ * of asserting a worktree state nobody observed.
+ *
+ * **Example** (Describe a merged branch that is safe to delete)
+ *
+ * ```ts
+ * import { SweepGitState } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const state = SweepGitState.make({
+ *   branch: "feat/merge-loop",
+ *   mainBranch: "main",
+ *   headBranch: "main",
+ *   worktreeDirty: false,
+ *   mainCheckedOutElsewhere: false,
+ *   branchCheckedOutElsewhere: false,
+ *   branchMergedIntoBase: false,
+ *   lockfileMovedOnMainUpdate: true,
+ *   statusProbeTruncated: false,
+ *   worktreeProbeTruncated: false,
+ *   localTip: O.some("aaaa1111"),
+ *   remoteTip: O.some("aaaa1111"),
+ *   pullRequestState: O.some("MERGED"),
+ *   pullRequestHeadBranch: O.some("feat/merge-loop"),
+ *   pullRequestHeadOid: O.some("aaaa1111"),
+ * })
+ * console.log(state.branch)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SweepGitState extends S.Class<SweepGitState>($I`SweepGitState`)(
+  {
+    branch: S.NonEmptyString,
+    mainBranch: S.NonEmptyString,
+    headBranch: S.NonEmptyString,
+    worktreeDirty: S.Boolean,
+    mainCheckedOutElsewhere: S.Boolean,
+    branchCheckedOutElsewhere: S.Boolean,
+    branchMergedIntoBase: S.Boolean,
+    lockfileMovedOnMainUpdate: S.Boolean,
+    statusProbeTruncated: S.Boolean,
+    worktreeProbeTruncated: S.Boolean,
+    localTip: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+    remoteTip: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+    pullRequestState: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+    pullRequestHeadBranch: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+    pullRequestHeadOid: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+  },
+  $I.annote("SweepGitState", {
+    description: "Read-only git and GitHub facts one post-merge workspace sweep is planned from.",
+  })
+) {}
+
+const precondition = (description: string, satisfied: boolean): SweepPrecondition =>
+  SweepPrecondition.make({ description, satisfied });
+
+const unsatisfied = (preconditions: ReadonlyArray<SweepPrecondition>): ReadonlyArray<SweepPrecondition> =>
+  A.filter(preconditions, (observed) => !observed.satisfied);
+
+/**
+ * The preconditions blocking a planned step, empty when the step will run.
+ *
+ * **Details**
+ *
+ * This is the executor's whole decision rule, exposed so a `--plan` renderer and
+ * the run itself agree by construction: a step with no blockers executes its
+ * action, and any blocker becomes the skip reason verbatim.
+ *
+ * **Example** (Read the blockers off a planned step)
+ *
+ * ```ts
+ * import { sweepStepBlockers, SweepPlanStep, SweepPrecondition } from "@beep/repo-cli/test/Yeet"
+ *
+ * const blockers = sweepStepBlockers(
+ *   SweepPlanStep.make({
+ *     id: "delete-local-branch",
+ *     action: "git branch -D feat/merge-loop",
+ *     preconditions: [SweepPrecondition.make({ description: "worktree is clean", satisfied: false })],
+ *     requiresOperator: false,
+ *   })
+ * )
+ * console.log(blockers.length)
+ * ```
+ *
+ * @param planStep - Planned sweep step to inspect.
+ * @returns Every unsatisfied precondition, in plan order.
+ * @category planning
+ * @since 0.0.0
+ */
+export const sweepStepBlockers = (planStep: SweepPlanStep): ReadonlyArray<SweepPrecondition> =>
+  unsatisfied(planStep.preconditions);
+
+const statusProbeCommand = "git status --porcelain";
+
+const worktreeProbeCommand = "git worktree list --porcelain";
+
+const optionText = (value: O.Option<string>): string => O.getOrElse(value, () => "<absent>");
+
+const holdsBranch = (held: boolean, headBranch: string, branch: string): boolean => held || headBranch === branch;
+
+const pullRequestIsMerged = (state: SweepGitState): boolean =>
+  O.exists(state.pullRequestState, (value) => value === "MERGED");
+
+const truncatedProbePrecondition = (command: string): SweepPrecondition =>
+  precondition(`${command} output was not truncated`, false);
+
+/**
+ * A truncated probe leaves the fact unknown, so the blocker names the command
+ * whose output was cut instead of a worktree state nobody observed.
+ *
+ * @param state - Observed git state carrying the probe-truncation flags.
+ * @returns The clean-worktree precondition, or the truncation blocker.
+ */
+const cleanWorktreePrecondition = (state: SweepGitState): SweepPrecondition =>
+  state.statusProbeTruncated
+    ? truncatedProbePrecondition(statusProbeCommand)
+    : precondition("worktree is clean", !state.worktreeDirty);
+
+const mainFreePrecondition = (state: SweepGitState): SweepPrecondition =>
+  state.worktreeProbeTruncated
+    ? truncatedProbePrecondition(worktreeProbeCommand)
+    : precondition(`${state.mainBranch} is not checked out in another worktree`, !state.mainCheckedOutElsewhere);
+
+const branchFreePrecondition = (state: SweepGitState): SweepPrecondition =>
+  state.worktreeProbeTruncated
+    ? truncatedProbePrecondition(worktreeProbeCommand)
+    : precondition(
+        `no worktree holds ${state.branch}`,
+        !holdsBranch(state.branchCheckedOutElsewhere, state.headBranch, state.branch)
+      );
+
+/**
+ * The pull request `gh` resolved is only this branch's pull request when its
+ * head branch says so; every MERGED-gated step carries this check.
+ *
+ * @param state - Observed git state carrying the resolved PR's head branch.
+ * @returns A precondition holding only when the PR's head equals the branch.
+ */
+const pullRequestIdentityPrecondition = (state: SweepGitState): SweepPrecondition =>
+  precondition(
+    `pull request head branch ${optionText(state.pullRequestHeadBranch)} is ${state.branch}`,
+    O.exists(state.pullRequestHeadBranch, (head) => head === state.branch)
+  );
+
+const tipsMatch = (left: O.Option<string>, right: O.Option<string>): boolean =>
+  O.isSome(left) && O.isSome(right) && left.value === right.value;
+
+const fetchPrunePlanStep = (): SweepPlanStep =>
+  SweepPlanStep.make({
+    id: "fetch-prune",
+    action: "git fetch --prune origin",
+    preconditions: [],
+    requiresOperator: false,
+  });
+
+const ffMainPlanStep = (state: SweepGitState): SweepPlanStep =>
+  state.headBranch === state.mainBranch
+    ? SweepPlanStep.make({
+        id: "ff-main",
+        action: `git merge --ff-only refs/remotes/origin/${state.mainBranch}`,
+        preconditions: [cleanWorktreePrecondition(state)],
+        requiresOperator: false,
+      })
+    : SweepPlanStep.make({
+        id: "ff-main",
+        action: `git fetch origin ${state.mainBranch}:${state.mainBranch}`,
+        preconditions: [mainFreePrecondition(state)],
+        requiresOperator: false,
+      });
+
+const deleteLocalBranchPlanStep = (state: SweepGitState): SweepPlanStep => {
+  const shared = [
+    precondition(`local branch ${state.branch} exists`, O.isSome(state.localTip)),
+    precondition(`pull request for ${state.branch} is MERGED`, pullRequestIsMerged(state)),
+    pullRequestIdentityPrecondition(state),
+    branchFreePrecondition(state),
+  ];
+  return state.branchMergedIntoBase
+    ? SweepPlanStep.make({
+        id: "delete-local-branch",
+        action: `git branch -d ${state.branch}`,
+        preconditions: A.append(
+          shared,
+          precondition(`${state.branch} is an ancestor of origin/${state.mainBranch}`, true)
+        ),
+        requiresOperator: false,
+      })
+    : SweepPlanStep.make({
+        id: "delete-local-branch",
+        action: `git branch -D ${state.branch}`,
+        preconditions: A.append(
+          shared,
+          precondition(
+            `local tip ${optionText(state.localTip)} equals pull request head ${optionText(state.pullRequestHeadOid)}`,
+            tipsMatch(state.localTip, state.pullRequestHeadOid)
+          )
+        ),
+        requiresOperator: false,
+      });
+};
+
+const deleteRemoteBranchPlanStep = (state: SweepGitState): SweepPlanStep => {
+  const preconditions = [
+    precondition(`remote branch origin/${state.branch} exists`, O.isSome(state.remoteTip)),
+    precondition(`pull request for ${state.branch} is MERGED`, pullRequestIsMerged(state)),
+    pullRequestIdentityPrecondition(state),
+    precondition(
+      `remote tip ${optionText(state.remoteTip)} equals pull request head ${optionText(state.pullRequestHeadOid)}`,
+      tipsMatch(state.remoteTip, state.pullRequestHeadOid)
+    ),
+  ];
+  return SweepPlanStep.make({
+    id: "delete-remote-branch",
+    action: `git push origin --delete ${state.branch}`,
+    preconditions,
+    requiresOperator: A.isReadonlyArrayEmpty(unsatisfied(preconditions)),
+  });
+};
+
+const lockfileInstallPlanStep = (state: SweepGitState): SweepPlanStep =>
+  SweepPlanStep.make({
+    id: "lockfile-install",
+    action: "bun install",
+    preconditions: [
+      precondition(`bun.lock moved in the ${state.mainBranch} update`, state.lockfileMovedOnMainUpdate),
+      cleanWorktreePrecondition(state),
+    ],
+    requiresOperator: false,
+  });
+
+const endStatePlanStep = (state: SweepGitState): SweepPlanStep =>
+  SweepPlanStep.make({
+    id: "end-state",
+    action: `git switch ${state.mainBranch}`,
+    preconditions:
+      state.headBranch === state.mainBranch ? [] : [cleanWorktreePrecondition(state), mainFreePrecondition(state)],
+    requiresOperator: false,
+  });
+
+/**
+ * Turn observed git state into the plan a sweep would execute.
+ *
+ * **Details**
+ *
+ * Pure: the same state and timestamp always produce the same plan, which is what
+ * makes the branch-deletion contract testable without a repository fixture.
+ *
+ * `requiresOperator` is derived, never asserted. It is true only for a remote ref
+ * deletion whose preconditions all hold, because that is the one action the
+ * running session may lack authority for; flagging it at plan time lets `--plan`
+ * output batch the operator handoff instead of discovering the denial mid-run.
+ * Safety blockers — a tip mismatch, a dirty worktree, a branch held by a worktree
+ * — never become handoffs, because performing them anyway would destroy work.
+ *
+ * **Gotchas**
+ *
+ * The `-d` and `-D` variants of `delete-local-branch` carry different
+ * precondition sets on purpose. `-d` leans on git's own ancestry check, so it
+ * records the ancestry fact and stops. `-D` overrides that check, so it demands
+ * the full review-hardened set: the pull request is MERGED, the pull request's
+ * head branch is this branch, the local tip still equals the pull request's
+ * recorded head (a post-merge push makes MERGED stale), and no worktree holds the
+ * branch.
+ *
+ * A worktree fact the observer could not read — a truncated
+ * `git worktree list --porcelain` or `git status --porcelain` — is not silently
+ * treated as "nothing found". The step blocks, and its blocker names the
+ * truncated command rather than claiming a worktree state.
+ *
+ * **Example** (Plan a sweep for a squash-merged branch)
+ *
+ * ```ts
+ * import { buildSweepPlan, SweepGitState } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const plan = buildSweepPlan(
+ *   SweepGitState.make({
+ *     branch: "feat/merge-loop",
+ *     mainBranch: "main",
+ *     headBranch: "main",
+ *     worktreeDirty: false,
+ *     mainCheckedOutElsewhere: false,
+ *     branchCheckedOutElsewhere: false,
+ *     branchMergedIntoBase: false,
+ *     lockfileMovedOnMainUpdate: false,
+ *     statusProbeTruncated: false,
+ *     worktreeProbeTruncated: false,
+ *     localTip: O.some("aaaa1111"),
+ *     remoteTip: O.some("aaaa1111"),
+ *     pullRequestState: O.some("MERGED"),
+ *     pullRequestHeadBranch: O.some("feat/merge-loop"),
+ *     pullRequestHeadOid: O.some("aaaa1111"),
+ *   }),
+ *   "2026-08-04T00:00:00.000Z"
+ * )
+ * console.log(plan.steps.length)
+ * ```
+ *
+ * @param state - Observed git and GitHub facts for the branch being swept.
+ * @param createdAt - ISO timestamp recorded on the plan.
+ * @returns The ordered plan, one step per {@link SweepStepId}.
+ * @category planning
+ * @since 0.0.0
+ */
+export const buildSweepPlan = (state: SweepGitState, createdAt: string): SweepPlan =>
+  SweepPlan.make({
+    schemaVersion: "yeet-sweep-plan/v1",
+    createdAt,
+    branch: state.branch,
+    steps: [
+      fetchPrunePlanStep(),
+      ffMainPlanStep(state),
+      deleteLocalBranchPlanStep(state),
+      deleteRemoteBranchPlanStep(state),
+      lockfileInstallPlanStep(state),
+      endStatePlanStep(state),
+    ],
+  });
+
+type CommandProbe = {
+  readonly exitCode: number;
+  readonly output: string;
+  readonly truncated: boolean;
+};
+
+type WorktreeEntry = {
+  readonly path: string;
+  readonly branch: O.Option<string>;
+};
+
+const captureCommand = (
+  command: string,
+  args: ReadonlyArray<string>,
+  cwd: string
+): Effect.Effect<CommandProbe, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  runRepoCommandCapture(command, args, cwd).pipe(
+    Effect.map(
+      (result): CommandProbe => ({
+        exitCode: result.exitCode,
+        output: Str.trim(result.output),
+        truncated: result.truncated,
+      })
+    ),
+    Effect.orElseSucceed((): CommandProbe => ({ exitCode: 1, output: "", truncated: false }))
+  );
+
+const captureGit = (
+  cwd: string,
+  args: ReadonlyArray<string>
+): Effect.Effect<CommandProbe, never, ChildProcessSpawner.ChildProcessSpawner> => captureCommand("git", args, cwd);
+
+const firstLine = (text: string): string =>
+  pipe(
+    Str.split(text, "\n"),
+    A.map(Str.trim),
+    A.findFirst(Str.isNonEmpty),
+    O.getOrElse(() => "no output")
+  );
+
+const probeFailureText = (probe: CommandProbe): string => firstLine(probe.output);
+
+const valueAfter = (prefix: string, line: string): string => Str.trim(Str.slice(Str.length(prefix))(line));
+
+const parseWorktreeList = (output: string): ReadonlyArray<WorktreeEntry> =>
+  pipe(
+    Str.split(output, "\n\n"),
+    A.map((block) => {
+      const lines = pipe(Str.split(block, "\n"), A.map(Str.trim), A.filter(Str.isNonEmpty));
+      return pipe(
+        A.findFirst(lines, Str.startsWith("worktree ")),
+        O.map(
+          (line): WorktreeEntry => ({
+            path: valueAfter("worktree ", line),
+            branch: pipe(
+              A.findFirst(lines, Str.startsWith("branch refs/heads/")),
+              O.map((branchLine) => valueAfter("branch refs/heads/", branchLine))
+            ),
+          })
+        )
+      );
+    }),
+    A.getSomes
+  );
+
+const heldByOtherWorktree = (worktrees: ReadonlyArray<WorktreeEntry>, branch: string, selfPath: string): boolean =>
+  A.some(worktrees, (entry) => entry.path !== selfPath && O.exists(entry.branch, (held) => held === branch));
+
+const observeSha = (
+  cwd: string,
+  ref: string
+): Effect.Effect<O.Option<string>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  captureGit(cwd, ["rev-parse", "--verify", "--quiet", ref]).pipe(
+    Effect.map((probe) => (probe.exitCode === 0 ? optionFromNonEmpty(probe.output) : O.none<string>()))
+  );
+
+const decodePullRequestView = S.decodeUnknownOption(S.fromJsonString(GhPrView));
+
+const observePullRequest = Effect.fn("Yeet.observeSweepPullRequest")(function* (
+  context: RepoRunContext,
+  branch: string
+): Effect.fn.Return<O.Option<GhPrView>, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const output = yield* ghOutput({
+    args: ["pr", "view", branch, "--json", "number,headRefName,state,headRefOid"],
+    cwd: context.repoRoot,
+    label: `gh pr view ${branch}`,
+    onFailure: (failure) => failure,
+  }).pipe(
+    Effect.map(O.some),
+    Effect.orElseSucceed(() => O.none<string>())
+  );
+  return O.flatMap(output, decodePullRequestView);
+});
+
+const mainBranchFromContext = (context: RepoRunContext): string =>
+  pipe(
+    safeOriginBranchFromBase(context.base),
+    O.getOrElse(() => "main")
+  );
+
+const refuseUnsafeName = (value: string, role: string) =>
+  guardLiteralArg(value).pipe(
+    Effect.mapError(
+      YeetCommandError.new(`yeet sweep refuses an option-like ${role} name "${value}".`, {
+        command: "git",
+        exitCode: 1,
+      })
+    )
+  );
+
+/**
+ * Probe the clone for every fact {@link buildSweepPlan} needs.
+ *
+ * **Details**
+ *
+ * Read-only by construction: `rev-parse`, `status --porcelain`,
+ * `worktree list --porcelain`, `merge-base --is-ancestor`, a `bun.lock` diff
+ * between local and remote `main`, and one `gh pr view`. Individual probes are
+ * failure-tolerant — a missing ref or an absent pull request reads as `None`,
+ * not as an error — so planning still succeeds in a half-configured clone and
+ * the plan simply reports more unsatisfied preconditions.
+ *
+ * **Gotchas**
+ *
+ * The branch and base names are pushed through `guardLiteralArg` before they
+ * reach any argv, so an option-like branch name fails the sweep outright instead
+ * of becoming a git flag. That refusal is the one way sweep planning errors.
+ *
+ * Failure-tolerant is not the same as optimistic. A truncated `status` or
+ * `worktree list` capture is recorded as such and the fact it feeds is forced to
+ * its conservative value — dirty worktree, branch held — because "the output was
+ * cut off" and "the branch is free" are the same bytes to a parser and only one
+ * of them is safe to force-delete against.
+ *
+ * **Example** (Observe the current clone)
+ *
+ * ```ts
+ * import { observeSweepGitState } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(observeSweepGitState)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the repo root, branch, and base ref.
+ * @returns The observed git and GitHub facts for the branch being swept.
+ * @category planning
+ * @since 0.0.0
+ */
+export const observeSweepGitState = Effect.fn("Yeet.observeSweepGitState")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<SweepGitState, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const branch = yield* refuseUnsafeName(context.branch, "branch");
+  const mainBranch = yield* refuseUnsafeName(mainBranchFromContext(context), "base branch");
+  const repoRoot = context.repoRoot;
+
+  const head = yield* captureGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const status = yield* captureGit(repoRoot, ["status", "--porcelain"]);
+  const toplevel = yield* captureGit(repoRoot, ["rev-parse", "--show-toplevel"]);
+  const worktreeList = yield* captureGit(repoRoot, ["worktree", "list", "--porcelain"]);
+  const localTip = yield* observeSha(repoRoot, `refs/heads/${branch}`);
+  const remoteTip = yield* observeSha(repoRoot, `refs/remotes/origin/${branch}`);
+  const ancestry = yield* captureGit(repoRoot, [
+    "merge-base",
+    "--is-ancestor",
+    `refs/heads/${branch}`,
+    `refs/remotes/origin/${mainBranch}`,
+  ]);
+  const lockfile = yield* captureGit(repoRoot, [
+    "diff",
+    "--name-only",
+    `refs/heads/${mainBranch}..refs/remotes/origin/${mainBranch}`,
+    "--",
+    "bun.lock",
+  ]);
+  const pullRequest = yield* observePullRequest(context, branch);
+
+  const worktrees = parseWorktreeList(worktreeList.output);
+  return SweepGitState.make({
+    branch,
+    mainBranch,
+    headBranch: pipe(
+      optionFromNonEmpty(head.output),
+      O.getOrElse(() => "HEAD")
+    ),
+    worktreeDirty: status.truncated || (status.exitCode === 0 && Str.isNonEmpty(status.output)),
+    mainCheckedOutElsewhere: worktreeList.truncated || heldByOtherWorktree(worktrees, mainBranch, toplevel.output),
+    branchCheckedOutElsewhere: worktreeList.truncated || heldByOtherWorktree(worktrees, branch, toplevel.output),
+    branchMergedIntoBase: ancestry.exitCode === 0 && O.isSome(localTip),
+    lockfileMovedOnMainUpdate: lockfile.exitCode === 0 && Str.isNonEmpty(lockfile.output),
+    statusProbeTruncated: status.truncated,
+    worktreeProbeTruncated: worktreeList.truncated,
+    localTip,
+    remoteTip,
+    pullRequestState: O.flatMap(pullRequest, (view) => optionFromNonEmpty(view.state)),
+    pullRequestHeadBranch: O.flatMap(pullRequest, (view) => optionFromNonEmpty(view.headRefName)),
+    pullRequestHeadOid: O.flatMap(pullRequest, (view) =>
+      O.flatMap(O.fromNullishOr(view.headRefOid), optionFromNonEmpty)
+    ),
+  });
+});
+
+/**
+ * Observe the clone and build the plan without executing anything.
+ *
+ * **Details**
+ *
+ * This is `--plan` mode. The caller renders the returned plan through
+ * `SweepPlanJson.encode` — the plan is a document, so it crosses any boundary
+ * through its codec rather than `JSON.stringify`.
+ *
+ * **Example** (Build a dry-run plan)
+ *
+ * ```ts
+ * import { planSweep } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(planSweep)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the repo root, branch, and base ref.
+ * @returns The plan the sweep would execute against the observed clone.
+ * @category planning
+ * @since 0.0.0
+ */
+export const planSweep = Effect.fn("Yeet.planSweep")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<SweepPlan, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const createdAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  return buildSweepPlan(yield* observeSweepGitState(context), createdAt);
+});
+
+const isPermissionDenial = (output: string): boolean => {
+  const lowered = Str.toLowerCase(output);
+  return A.some(permissionDenialMarkers, (marker) => Str.includes(marker)(lowered));
+};
+
+const executedFrom = (probe: CommandProbe): SweepStepOutcome =>
+  SweepStepExecuted.make({ detail: optionFromNonEmpty(probe.output) });
+
+const skippedFromFailure = (action: string, probe: CommandProbe): SweepStepOutcome =>
+  SweepStepSkipped.make({
+    reason: `${action} failed (exit ${probe.exitCode}): ${probeFailureText(probe)}`,
+  });
+
+const runCommandStep = (
+  command: string,
+  args: ReadonlyArray<string>,
+  cwd: string,
+  action: string
+): Effect.Effect<SweepStepOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  captureCommand(command, args, cwd).pipe(
+    Effect.map((probe) => (probe.exitCode === 0 ? executedFrom(probe) : skippedFromFailure(action, probe)))
+  );
+
+const runRemoteDeletionStep = (
+  state: SweepGitState,
+  cwd: string,
+  action: string
+): Effect.Effect<SweepStepOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  captureGit(cwd, ["push", "origin", "--delete", state.branch]).pipe(
+    Effect.map((probe) => {
+      if (probe.exitCode === 0) {
+        return executedFrom(probe);
+      }
+      if (isPermissionDenial(probe.output)) {
+        return SweepStepNeedsOperator.make({
+          reason: `deleting origin/${state.branch} was denied by permission: ${probeFailureText(probe)}`,
+          operatorCommand: action,
+        });
+      }
+      return skippedFromFailure(action, probe);
+    })
+  );
+
+const runEndStateStep = (
+  state: SweepGitState,
+  cwd: string,
+  action: string
+): Effect.Effect<SweepStepOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  state.headBranch === state.mainBranch
+    ? Effect.succeed(SweepStepExecuted.make({ detail: O.some(`already on ${state.mainBranch}`) }))
+    : captureGit(cwd, ["switch", state.mainBranch]).pipe(
+        Effect.map((probe) =>
+          probe.exitCode === 0
+            ? SweepStepExecuted.make({ detail: O.some(`switched to ${state.mainBranch}`) })
+            : skippedFromFailure(action, probe)
+        )
+      );
+
+const performSweepStep = (
+  context: RepoRunContext,
+  state: SweepGitState,
+  planStep: SweepPlanStep
+): Effect.Effect<SweepStepOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  SweepStepId.$match(planStep.id, {
+    "fetch-prune": () => runCommandStep("git", ["fetch", "--prune", "origin"], context.repoRoot, planStep.action),
+    "ff-main": () =>
+      state.headBranch === state.mainBranch
+        ? runCommandStep(
+            "git",
+            ["merge", "--ff-only", `refs/remotes/origin/${state.mainBranch}`],
+            context.repoRoot,
+            planStep.action
+          )
+        : runCommandStep(
+            "git",
+            ["fetch", "origin", `${state.mainBranch}:${state.mainBranch}`],
+            context.repoRoot,
+            planStep.action
+          ),
+    "delete-local-branch": () =>
+      runCommandStep(
+        "git",
+        ["branch", state.branchMergedIntoBase ? "-d" : "-D", state.branch],
+        context.repoRoot,
+        planStep.action
+      ),
+    "delete-remote-branch": () => runRemoteDeletionStep(state, context.repoRoot, planStep.action),
+    "lockfile-install": () => runCommandStep("bun", ["install"], context.repoRoot, planStep.action),
+    "end-state": () => runEndStateStep(state, context.repoRoot, planStep.action),
+  });
+
+const runSweepStep = Effect.fn("Yeet.runSweepStep")(function* (
+  context: RepoRunContext,
+  state: SweepGitState,
+  planStep: SweepPlanStep
+): Effect.fn.Return<SweepReportStep, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const startedAt = yield* Clock.currentTimeMillis;
+  const blocked = sweepStepBlockers(planStep);
+  const outcome = A.isReadonlyArrayEmpty(blocked)
+    ? yield* performSweepStep(context, state, planStep)
+    : SweepStepSkipped.make({
+        reason: `blocked: ${A.join(
+          A.map(blocked, (observed) => observed.description),
+          "; "
+        )}`,
+      });
+  const endedAt = yield* Clock.currentTimeMillis;
+  return SweepReportStep.make({ id: planStep.id, outcome, durationMs: O.some(endedAt - startedAt) });
+});
+
+/**
+ * Resolve the sweep report artifact path for a repo run context.
+ *
+ * **Example** (Resolve the report path)
+ *
+ * ```ts
+ * import { sweepReportPath } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(sweepReportPath)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the artifact directory.
+ * @returns Absolute path to `.beep/yeet/sweep-report.json`.
+ * @category artifacts
+ * @since 0.0.0
+ */
+export const sweepReportPath = Effect.fn("Yeet.sweepReportPath")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<string, never, Path.Path> {
+  const path = yield* Path.Path;
+  return path.join(yield* artifactDirForContext(context), sweepReportFileName);
+});
+
+/**
+ * Observe, plan, execute, and record one post-merge workspace sweep.
+ *
+ * **Details**
+ *
+ * Steps run in {@link SweepStepId} order and each produces exactly one outcome.
+ * No step outcome fails the sweep: the returned {@link SweepReport} is the whole
+ * result, and a caller that renders it exits 0 whether every step ran, every step
+ * skipped, or a remote deletion needs the operator. The report is written to
+ * `.beep/yeet/sweep-report.json` through {@link SweepReportJson} so the artifact
+ * is encoded rather than stringified.
+ *
+ * **Gotchas**
+ *
+ * The sweep still errors on one thing: an option-like branch or base name, which
+ * is refused before any argv is built. That is a refusal to plan, not a failed
+ * step, so it has no place in the report.
+ *
+ * **Example** (Run the sweep)
+ *
+ * ```ts
+ * import { executeSweep } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(executeSweep)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the repo root, branch, base, and artifact directory.
+ * @returns The executed sweep report, already persisted.
+ * @category workflows
+ * @since 0.0.0
+ */
+export const executeSweep = Effect.fn("Yeet.executeSweep")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<
+  SweepReport,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const startedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  const state = yield* observeSweepGitState(context);
+  const plan = buildSweepPlan(state, startedAt);
+  const steps = yield* Effect.forEach(plan.steps, (planStep) => runSweepStep(context, state, planStep));
+  const endedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  const report = SweepReport.make({
+    schemaVersion: "yeet-sweep-report/v1",
+    plan,
+    steps,
+    startedAt,
+    endedAt,
+  });
+  const encoded = yield* SweepReportJson.encode(report).pipe(
+    Effect.mapError(YeetCommandError.new("Failed to encode the yeet sweep report."))
+  );
+  yield* writeTextFile(yield* sweepReportPath(context), encoded);
+  return report;
+});
+
+const outcomeSummary = (outcome: SweepStepOutcome): string =>
+  SweepStepOutcome.match(outcome, {
+    executed: (executed) =>
+      `executed${pipe(
+        executed.detail,
+        O.map((detail) => `: ${firstLine(detail)}`),
+        O.getOrElse(() => "")
+      )}`,
+    skipped: (skipped) => `skipped: ${skipped.reason}`,
+    "needs-operator": (handoff) => `needs-operator: ${handoff.reason}`,
+  });
+
+const operatorCommands = (report: SweepReport): ReadonlyArray<string> =>
+  pipe(
+    A.map(report.steps, (step) =>
+      step.outcome.status === "needs-operator" ? O.some(step.outcome.operatorCommand) : O.none<string>()
+    ),
+    A.getSomes
+  );
+
+/**
+ * Render a sweep report as operator-facing text with a batched handoff block.
+ *
+ * **Details**
+ *
+ * The trailing block exists because discovering permission boundaries one failed
+ * command at a time is the friction this command was built to remove: every
+ * `needs-operator` outcome contributes its exact command, so the human runs them
+ * as one batch.
+ *
+ * **Example** (Render an empty report)
+ *
+ * ```ts
+ * import { renderSweepReport, SweepPlan, SweepReport } from "@beep/repo-cli/test/Yeet"
+ *
+ * const rendered = renderSweepReport(
+ *   SweepReport.make({
+ *     schemaVersion: "yeet-sweep-report/v1",
+ *     plan: SweepPlan.make({
+ *       schemaVersion: "yeet-sweep-plan/v1",
+ *       createdAt: "2026-08-04T00:00:00.000Z",
+ *       branch: "feat/merge-loop",
+ *       steps: [],
+ *     }),
+ *     steps: [],
+ *     startedAt: "2026-08-04T00:00:00.000Z",
+ *     endedAt: "2026-08-04T00:00:01.000Z",
+ *   })
+ * )
+ * console.log(rendered)
+ * ```
+ *
+ * @param report - Executed sweep report to render.
+ * @returns Multi-line operator summary, ending with the handoff block when one is needed.
+ * @category rendering
+ * @since 0.0.0
+ */
+export const renderSweepReport = (report: SweepReport): string => {
+  const header = `[yeet] sweep ${report.plan.branch}`;
+  const lines = A.map(report.steps, (step) => `  ${step.id}: ${outcomeSummary(step.outcome)}`);
+  const handoff = operatorCommands(report);
+  const handoffLines = A.isReadonlyArrayEmpty(handoff)
+    ? A.empty<string>()
+    : [
+        `  operator handoff (${handoff.length} command(s) only you can run):`,
+        ...A.map(handoff, (command) => `    ${command}`),
+      ];
+  return A.join([header, ...lines, ...handoffLines], "\n");
+};

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
@@ -59,7 +59,7 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { guardLiteralArg } from "@beep/repo-utils";
 import { SchemaUtils } from "@beep/schema";
-import { Clock, DateTime, Effect, Path, pipe } from "effect";
+import { Clock, DateTime, Effect, flow, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -124,10 +124,11 @@ const permissionDenialMarkers = [
  *
  * **Gotchas**
  *
- * `statusProbeTruncated` and `worktreeProbeTruncated` are the "this fact is
- * unknown" carriers. When either is true the boolean it feeds is already forced
+ * `statusProbeUnreliable` and `worktreeProbeUnreliable` are the "this fact is
+ * unknown" carriers, set when the probe failed, exited nonzero, or overran the
+ * capture bound. When either is true the boolean it feeds is already forced
  * to its conservative value here, so a reader of the raw facts is safe too; the
- * flag exists so the plan can name the truncated command as the blocker instead
+ * flag exists so the plan can name the unreadable command as the blocker instead
  * of asserting a worktree state nobody observed.
  *
  * **Example** (Describe a merged branch that is safe to delete)
@@ -145,8 +146,8 @@ const permissionDenialMarkers = [
  *   branchCheckedOutElsewhere: false,
  *   branchMergedIntoBase: false,
  *   lockfileMovedOnMainUpdate: true,
- *   statusProbeTruncated: false,
- *   worktreeProbeTruncated: false,
+ *   statusProbeUnreliable: false,
+ *   worktreeProbeUnreliable: false,
  *   localTip: O.some("aaaa1111"),
  *   remoteTip: O.some("aaaa1111"),
  *   pullRequestState: O.some("MERGED"),
@@ -169,8 +170,8 @@ export class SweepGitState extends S.Class<SweepGitState>($I`SweepGitState`)(
     branchCheckedOutElsewhere: S.Boolean,
     branchMergedIntoBase: S.Boolean,
     lockfileMovedOnMainUpdate: S.Boolean,
-    statusProbeTruncated: S.Boolean,
-    worktreeProbeTruncated: S.Boolean,
+    statusProbeUnreliable: S.Boolean,
+    worktreeProbeUnreliable: S.Boolean,
     localTip: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
     remoteTip: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
     pullRequestState: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
@@ -232,8 +233,8 @@ const holdsBranch = (held: boolean, headBranch: string, branch: string): boolean
 const pullRequestIsMerged = (state: SweepGitState): boolean =>
   O.exists(state.pullRequestState, (value) => value === "MERGED");
 
-const truncatedProbePrecondition = (command: string): SweepPrecondition =>
-  precondition(`${command} output was not truncated`, false);
+const unreliableProbePrecondition = (command: string): SweepPrecondition =>
+  precondition(`${command} succeeded without truncation`, false);
 
 /**
  * A truncated probe leaves the fact unknown, so the blocker names the command
@@ -243,18 +244,18 @@ const truncatedProbePrecondition = (command: string): SweepPrecondition =>
  * @returns The clean-worktree precondition, or the truncation blocker.
  */
 const cleanWorktreePrecondition = (state: SweepGitState): SweepPrecondition =>
-  state.statusProbeTruncated
-    ? truncatedProbePrecondition(statusProbeCommand)
+  state.statusProbeUnreliable
+    ? unreliableProbePrecondition(statusProbeCommand)
     : precondition("worktree is clean", !state.worktreeDirty);
 
 const mainFreePrecondition = (state: SweepGitState): SweepPrecondition =>
-  state.worktreeProbeTruncated
-    ? truncatedProbePrecondition(worktreeProbeCommand)
+  state.worktreeProbeUnreliable
+    ? unreliableProbePrecondition(worktreeProbeCommand)
     : precondition(`${state.mainBranch} is not checked out in another worktree`, !state.mainCheckedOutElsewhere);
 
 const branchFreePrecondition = (state: SweepGitState): SweepPrecondition =>
-  state.worktreeProbeTruncated
-    ? truncatedProbePrecondition(worktreeProbeCommand)
+  state.worktreeProbeUnreliable
+    ? unreliableProbePrecondition(worktreeProbeCommand)
     : precondition(
         `no worktree holds ${state.branch}`,
         !holdsBranch(state.branchCheckedOutElsewhere, state.headBranch, state.branch)
@@ -414,8 +415,8 @@ const endStatePlanStep = (state: SweepGitState): SweepPlanStep =>
  *     branchCheckedOutElsewhere: false,
  *     branchMergedIntoBase: false,
  *     lockfileMovedOnMainUpdate: false,
- *     statusProbeTruncated: false,
- *     worktreeProbeTruncated: false,
+ *     statusProbeUnreliable: false,
+ *     worktreeProbeUnreliable: false,
  *     localTip: O.some("aaaa1111"),
  *     remoteTip: O.some("aaaa1111"),
  *     pullRequestState: O.some("MERGED"),
@@ -474,6 +475,11 @@ const captureCommand = (
     ),
     Effect.orElseSucceed((): CommandProbe => ({ exitCode: 1, output: "", truncated: false }))
   );
+
+// A probe that failed to spawn, exited nonzero, or overran the capture bound
+// proves nothing about the fact it was asked for; "empty output" and "the
+// worktree is clean" are the same bytes, and only one is safe to delete against.
+const probeUnreliable = (probe: CommandProbe): boolean => probe.truncated || probe.exitCode !== 0;
 
 const captureGit = (
   cwd: string,
@@ -576,11 +582,11 @@ const refuseUnsafeName = (value: string, role: string) =>
  * reach any argv, so an option-like branch name fails the sweep outright instead
  * of becoming a git flag. That refusal is the one way sweep planning errors.
  *
- * Failure-tolerant is not the same as optimistic. A truncated `status` or
- * `worktree list` capture is recorded as such and the fact it feeds is forced to
- * its conservative value — dirty worktree, branch held — because "the output was
- * cut off" and "the branch is free" are the same bytes to a parser and only one
- * of them is safe to force-delete against.
+ * Failure-tolerant is not the same as optimistic. A `status` or `worktree list`
+ * probe that failed, exited nonzero, or overran the capture bound is recorded as
+ * unreliable and the fact it feeds is forced to its conservative value — dirty
+ * worktree, branch held — because "no output" and "the branch is free" are the
+ * same bytes to a parser and only one of them is safe to force-delete against.
  *
  * **Example** (Observe the current clone)
  *
@@ -633,13 +639,14 @@ export const observeSweepGitState = Effect.fn("Yeet.observeSweepGitState")(funct
       optionFromNonEmpty(head.output),
       O.getOrElse(() => "HEAD")
     ),
-    worktreeDirty: status.truncated || (status.exitCode === 0 && Str.isNonEmpty(status.output)),
-    mainCheckedOutElsewhere: worktreeList.truncated || heldByOtherWorktree(worktrees, mainBranch, toplevel.output),
-    branchCheckedOutElsewhere: worktreeList.truncated || heldByOtherWorktree(worktrees, branch, toplevel.output),
+    worktreeDirty: probeUnreliable(status) || Str.isNonEmpty(status.output),
+    mainCheckedOutElsewhere:
+      probeUnreliable(worktreeList) || heldByOtherWorktree(worktrees, mainBranch, toplevel.output),
+    branchCheckedOutElsewhere: probeUnreliable(worktreeList) || heldByOtherWorktree(worktrees, branch, toplevel.output),
     branchMergedIntoBase: ancestry.exitCode === 0 && O.isSome(localTip),
     lockfileMovedOnMainUpdate: lockfile.exitCode === 0 && Str.isNonEmpty(lockfile.output),
-    statusProbeTruncated: status.truncated,
-    worktreeProbeTruncated: worktreeList.truncated,
+    statusProbeUnreliable: probeUnreliable(status),
+    worktreeProbeUnreliable: probeUnreliable(worktreeList),
     localTip,
     remoteTip,
     pullRequestState: O.flatMap(pullRequest, (view) => optionFromNonEmpty(view.state)),
@@ -724,6 +731,112 @@ const runRemoteDeletionStep = (
     })
   );
 
+/**
+ * Re-verify that the local branch tip still matches the planned observation
+ * immediately before deletion.
+ *
+ * **Details**
+ *
+ * The plan's deletion preconditions were proven against a snapshot; a commit
+ * landing on the branch between observation and execution would make that
+ * proof stale, and deleting would orphan the new commit. `None` means the tip
+ * is unchanged and deletion may proceed; `Some(reason)` names the drift.
+ *
+ * **Example** (Refuse a moved tip)
+ *
+ * ```ts
+ * import { revalidateLocalDeletion } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(revalidateLocalDeletion)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param cwd - Repository root the tip is re-read from.
+ * @param state - Planned sweep state carrying the observed local tip.
+ * @returns `None` when the tip is unchanged; `Some(skip reason)` on drift.
+ * @category planning
+ * @since 0.0.0
+ */
+export const revalidateLocalDeletion = (
+  cwd: string,
+  state: SweepGitState
+): Effect.Effect<O.Option<string>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  observeSha(cwd, `refs/heads/${state.branch}`).pipe(
+    Effect.map((fresh) =>
+      tipsMatch(fresh, state.localTip)
+        ? O.none<string>()
+        : O.some(
+            `refs/heads/${state.branch} moved since planning (planned ${optionText(state.localTip)}, now ${optionText(fresh)})`
+          )
+    )
+  );
+
+/**
+ * Re-verify against the live remote that `origin/<branch>` still points at the
+ * planned tip immediately before remote deletion.
+ *
+ * **Details**
+ *
+ * The planned remote tip came from the local remote-tracking ref; a push landing
+ * after observation would advance the real remote while the tracking ref stays
+ * stale, and deleting would make the new commit unreachable from that ref. This
+ * asks the server directly via `git ls-remote origin refs/heads/<branch>` — an
+ * unreadable answer or any drift refuses the deletion.
+ *
+ * **Example** (Refuse when the remote cannot be re-verified)
+ *
+ * ```ts
+ * import { revalidateRemoteDeletion } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(revalidateRemoteDeletion)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param cwd - Repository root the `ls-remote` runs from.
+ * @param state - Planned sweep state carrying the observed remote tip.
+ * @returns `None` when the live tip matches the plan; `Some(skip reason)` otherwise.
+ * @category planning
+ * @since 0.0.0
+ */
+export const revalidateRemoteDeletion = (
+  cwd: string,
+  state: SweepGitState
+): Effect.Effect<O.Option<string>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  captureGit(cwd, ["ls-remote", "origin", `refs/heads/${state.branch}`]).pipe(
+    Effect.map((probe) => {
+      if (probeUnreliable(probe)) {
+        return O.some(`could not re-verify origin/${state.branch} before deletion: ${probeFailureText(probe)}`);
+      }
+      const fresh = pipe(
+        optionFromNonEmpty(probe.output),
+        O.flatMap((line) => pipe(Str.split(line, "\t"), A.head, O.flatMap(flow(Str.trim, optionFromNonEmpty))))
+      );
+      if (O.isNone(fresh)) {
+        return O.some(`origin/${state.branch} no longer exists; nothing to delete`);
+      }
+      return tipsMatch(fresh, state.remoteTip)
+        ? O.none<string>()
+        : O.some(
+            `origin/${state.branch} moved since planning (planned ${optionText(state.remoteTip)}, now ${optionText(fresh)})`
+          );
+    })
+  );
+
+const guardedDeletion = (
+  revalidate: Effect.Effect<O.Option<string>, never, ChildProcessSpawner.ChildProcessSpawner>,
+  runDeletion: Effect.Effect<SweepStepOutcome, never, ChildProcessSpawner.ChildProcessSpawner>
+): Effect.Effect<SweepStepOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  revalidate.pipe(
+    Effect.flatMap(
+      O.match({
+        onNone: () => runDeletion,
+        onSome: (reason) => Effect.succeed<SweepStepOutcome>(SweepStepSkipped.make({ reason })),
+      })
+    )
+  );
+
 const runEndStateStep = (
   state: SweepGitState,
   cwd: string,
@@ -761,13 +874,20 @@ const performSweepStep = (
             planStep.action
           ),
     "delete-local-branch": () =>
-      runCommandStep(
-        "git",
-        ["branch", state.branchMergedIntoBase ? "-d" : "-D", state.branch],
-        context.repoRoot,
-        planStep.action
+      guardedDeletion(
+        revalidateLocalDeletion(context.repoRoot, state),
+        runCommandStep(
+          "git",
+          ["branch", state.branchMergedIntoBase ? "-d" : "-D", state.branch],
+          context.repoRoot,
+          planStep.action
+        )
       ),
-    "delete-remote-branch": () => runRemoteDeletionStep(state, context.repoRoot, planStep.action),
+    "delete-remote-branch": () =>
+      guardedDeletion(
+        revalidateRemoteDeletion(context.repoRoot, state),
+        runRemoteDeletionStep(state, context.repoRoot, planStep.action)
+      ),
     "lockfile-install": () => runCommandStep("bun", ["install"], context.repoRoot, planStep.action),
     "end-state": () => runEndStateStep(state, context.repoRoot, planStep.action),
   });

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Verdict.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Verdict.ts
@@ -180,6 +180,166 @@ export const YeetFailureKind = LiteralKit(["step-exit", "handler-error"]).pipe(
 );
 
 /**
+ * One hard criterion of the merge protocol, named when it is the blocker.
+ *
+ * **Details**
+ *
+ * Only the two hard criteria appear here. The Greptile score is a displayed
+ * target rather than a gate, so it is carried on
+ * {@link YeetMergeReadyCriteria} for the operator to read and can never be the
+ * value of {@link YeetMergeReady.failing}.
+ *
+ * **Example** (List the merge-ready criteria)
+ *
+ * ```ts
+ * import { YeetMergeReadyCriterion } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetMergeReadyCriterion.Options)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetMergeReadyCriterion = LiteralKit(["checks-green", "threads-resolved"]).pipe(
+  $I.annoteSchema("YeetMergeReadyCriterion", {
+    title: "Yeet Merge Ready Criterion",
+    description: "One hard criterion of the merge protocol.",
+  })
+);
+
+/**
+ * One hard criterion of the merge protocol.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetMergeReadyCriterion = typeof YeetMergeReadyCriterion.Type;
+
+/**
+ * The observed state of each merge-protocol criterion.
+ *
+ * **Example** (Construct merge-ready criteria)
+ *
+ * ```ts
+ * import { YeetMergeReadyCriteria } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const criteria = YeetMergeReadyCriteria.make({
+ *   checksGreen: true,
+ *   threadsResolved: false,
+ *   greptileScore: O.some("5/5"),
+ * })
+ * console.log(criteria.checksGreen)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMergeReadyCriteria extends S.Class<YeetMergeReadyCriteria>($I`YeetMergeReadyCriteria`)(
+  {
+    checksGreen: S.Boolean,
+    threadsResolved: S.Boolean,
+    greptileScore: S.String.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+  },
+  $I.annote("YeetMergeReadyCriteria", {
+    description: "Observed state of each merge-protocol criterion; the Greptile score is display-only.",
+  })
+) {}
+
+const mergeReadyCriterionHolds = (criteria: YeetMergeReadyCriteria, criterion: YeetMergeReadyCriterion): boolean =>
+  YeetMergeReadyCriterion.$match(criterion, {
+    "checks-green": () => criteria.checksGreen,
+    "threads-resolved": () => criteria.threadsResolved,
+  });
+
+/**
+ * Cross-field requirement that the three merge-readiness surfaces agree.
+ *
+ * `ready`, `failing`, and `criteria` restate one fact three ways, so without a
+ * filter a document could decode cleanly while carrying
+ * `{"ready":true,"failing":"checks-green"}` — an answer and its own refutation.
+ * Whoever read the field they trusted would act on the wrong one, and nothing
+ * would attribute the contradiction back to the writer that produced it. The
+ * issue is reported at `failing` because that is the field an operator reads to
+ * decide what to do next.
+ */
+const YeetMergeReadyCoherenceCheck = S.makeFilter(
+  (value: {
+    readonly ready: boolean;
+    readonly failing: O.Option<YeetMergeReadyCriterion>;
+    readonly criteria: YeetMergeReadyCriteria;
+  }) =>
+    O.match(value.failing, {
+      onNone: () =>
+        value.ready && value.criteria.checksGreen && value.criteria.threadsResolved
+          ? undefined
+          : {
+              path: ["failing"],
+              issue:
+                "A merge-ready verdict naming no failing criterion must be ready with every hard criterion satisfied.",
+            },
+      onSome: (criterion) =>
+        !value.ready && !mergeReadyCriterionHolds(value.criteria, criterion)
+          ? undefined
+          : {
+              path: ["failing"],
+              issue: `A merge-ready verdict blocked on ${criterion} must not be ready and must record ${criterion} as unsatisfied.`,
+            },
+    }),
+  {
+    identifier: $I`YeetMergeReadyCoherenceCheck`,
+    title: "Yeet merge readiness coherence",
+    description: "Merge readiness must agree with the named blocking criterion and the observed criteria.",
+  }
+);
+
+/**
+ * Merge readiness as data: the verdict plus the criterion that blocks it.
+ *
+ * **Details**
+ *
+ * The merge protocol is otherwise enforced by a human reading three surfaces
+ * that status and monitor already fetch. Folding them into one record with a
+ * named blocker is what lets `--until-merged` decide without re-deriving the
+ * protocol at every call site.
+ *
+ * **Gotchas**
+ *
+ * The three fields are mutually derivable, so a cross-field check makes an
+ * incoherent record undecodable rather than merely wrong: `ready` is true
+ * exactly when `failing` is `None` and both hard criteria hold, and a named
+ * `failing` criterion must be the one recorded as unsatisfied. The Greptile
+ * score is display-only and is not part of the check.
+ *
+ * **Example** (Construct a blocked merge-ready verdict)
+ *
+ * ```ts
+ * import { YeetMergeReady, YeetMergeReadyCriteria } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const mergeReady = YeetMergeReady.make({
+ *   ready: false,
+ *   failing: O.some("threads-resolved"),
+ *   criteria: YeetMergeReadyCriteria.make({ checksGreen: true, threadsResolved: false }),
+ * })
+ * console.log(mergeReady.ready)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMergeReady extends S.Class<YeetMergeReady>($I`YeetMergeReady`)(
+  S.Struct({
+    ready: S.Boolean,
+    failing: YeetMergeReadyCriterion.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
+    criteria: YeetMergeReadyCriteria,
+  }).pipe(S.check(YeetMergeReadyCoherenceCheck)),
+  $I.annote("YeetMergeReady", {
+    description: "Merge readiness as data, naming the criterion that blocks the merge when one does.",
+  })
+) {}
+
+/**
  * Machine-readable verdict for one yeet run.
  *
  * **Gotchas**
@@ -249,11 +409,55 @@ export class YeetVerdict extends S.Class<YeetVerdict>($I`YeetVerdict`)(
     flakeQuarantine: FlakeQuarantineIncident.pipe(S.Array, S.optionalKey),
     failedStepId: S.optionalKey(S.String),
     failureKind: YeetFailureKind.pipe(S.optionalKey),
+    mergeReady: YeetMergeReady.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
   },
   $I.annote("YeetVerdict", {
     description: "Machine-readable verdict for one yeet run, including per-lane repair commands.",
   })
 ) {}
+
+/**
+ * JSON-string codec for the `verdict.json` artifact.
+ *
+ * **Gotchas**
+ *
+ * Every writer of the verdict artifact must go through this codec. Rendering a
+ * decoded {@link YeetVerdict} with a generic JSON encoder serializes its
+ * `Option` fields as their runtime representation
+ * (`{"_id":"Option","_tag":"Some","value":…}`), which no longer decodes — the
+ * failure surfaces much later as `verdict artifact could not be decoded` from
+ * `yeet status`, with nothing pointing back at the writer.
+ *
+ * **Example** (Round-trip a verdict)
+ *
+ * ```ts
+ * import { YeetVerdict, YeetVerdictJson } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ * import * as O from "effect/Option"
+ *
+ * const verdict = YeetVerdict.make({
+ *   schemaVersion: "yeet-verdict/v2",
+ *   attemptId: O.some("550e8400-e29b-41d4-a716-446655440000"),
+ *   base: "origin/main",
+ *   branch: "feature",
+ *   committed: false,
+ *   createdAt: "2026-06-11T00:00:00.000Z",
+ *   head: "HEAD",
+ *   lanes: [],
+ *   message: "yeet verification proof passed.",
+ *   mode: "verify",
+ *   outcome: "success",
+ *   packetPaths: [],
+ *   pushed: false,
+ *   runId: "feature",
+ * })
+ * console.log(Effect.runSync(YeetVerdictJson.encode(verdict)))
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const YeetVerdictJson = JsonStringCodec(YeetVerdict);
 
 /**
  * One executed plan step paired with its run result.
@@ -363,6 +567,7 @@ export class BuildYeetVerdictInput extends S.Class<BuildYeetVerdictInput>($I`Bui
     stash: S.optional(YeetStashState),
     failedStepId: S.optional(S.String),
     failureKind: S.optional(YeetFailureKind),
+    mergeReady: S.optional(YeetMergeReady),
   },
   $I.annote("BuildYeetVerdictInput", {
     description: "Run identity, outcome, planned steps, and executed results used to build the run verdict.",
@@ -452,6 +657,7 @@ export const buildYeetVerdict = (input: BuildYeetVerdictInput): YeetVerdict => {
     startedAt: input.startedAt,
     endedAt: input.endedAt,
     elapsedMs: input.elapsedMs,
+    mergeReady: O.fromUndefinedOr(input.mergeReady),
     ...O.getSomesStruct({
       indexPath: O.fromUndefinedOr(input.indexPath),
       baseFreshness: O.fromUndefinedOr(input.baseFreshness),

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/closeout/GhCollect.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/closeout/GhCollect.ts
@@ -9,7 +9,7 @@ import { O } from "@beep/utils";
 import { Effect } from "effect";
 import * as A from "effect/Array";
 import { pipe } from "effect/Function";
-import { GhPageInfo, ghOutput } from "../../../../internal/github/index.ts";
+import { collectTruncatableThreadPages, GhPageInfo, ghOutput } from "../../../../internal/github/index.ts";
 import { YeetCommandError } from "../../Yeet.errors.ts";
 import { PrCloseoutWriteAction } from "./Closeout.schemas.ts";
 import {
@@ -38,12 +38,8 @@ type CloseoutWriteIntent = ReturnType<typeof closeoutWritePlan>["intents"][numbe
 /**
  * Run a GitHub CLI command with Yeet closeout error normalization.
  *
- * @param context - Repo context whose root becomes the GitHub CLI working
- * directory.
- * @param args - GitHub CLI arguments excluding the `gh` executable.
- * @param label - Human-readable label included in closeout errors.
- * @returns Captured stdout when the command succeeds.
- * @example
+ * **Example** (Read repository coordinates for closeout)
+ *
  * ```ts
  * import { Effect } from "effect"
  * import { closeoutGhOutput, RepoRunContext } from "@beep/repo-cli/test/Yeet"
@@ -63,6 +59,12 @@ type CloseoutWriteIntent = ReturnType<typeof closeoutWritePlan>["intents"][numbe
  *   Effect.map((output) => output.length)
  * )
  * ```
+ *
+ * @param context - Repo context whose root becomes the GitHub CLI working
+ * directory.
+ * @param args - GitHub CLI arguments excluding the `gh` executable.
+ * @param label - Human-readable label included in closeout errors.
+ * @returns Captured stdout when the command succeeds.
  * @category clients
  * @since 0.0.0
  */
@@ -175,49 +177,25 @@ const collectCommentPages = Effect.fn("YeetCloseout.collectCommentPages")(functi
   return comments;
 });
 
-const collectReviewThreadPages = Effect.fn("YeetCloseout.collectReviewThreadPages")(function* (
+const collectReviewThreadPages = (
   context: RepoRunContext,
   repo: GhRepoView,
   pr: GhPrView
-): Effect.fn.Return<ReadonlyArray<GhReviewThread>, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
-  let cursor = O.none<string>();
-  let threads: ReadonlyArray<GhReviewThread> = [];
-  let hasNextPage = true;
-
-  while (hasNextPage) {
-    const page = yield* ghGraphqlPage(
-      context,
-      repo,
-      pr,
-      reviewThreadsPageQuery,
-      cursor,
-      "gh api graphql review threads"
-    ).pipe(
-      Effect.flatMap((output) =>
-        decodeGhReviewThreadsDocument(output).pipe(
-          Effect.mapError(YeetCommandError.new("Failed to decode PR closeout review threads GraphQL JSON."))
-        )
+): Effect.Effect<ReadonlyArray<GhReviewThread>, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> =>
+  collectTruncatableThreadPages({
+    advance: (pageInfo) => nextCursor("pull request review threads", pageInfo),
+    fetchPage: (cursor) =>
+      ghGraphqlPage(context, repo, pr, reviewThreadsPageQuery, cursor, "gh api graphql review threads").pipe(
+        Effect.flatMap((output) =>
+          decodeGhReviewThreadsDocument(output).pipe(
+            Effect.mapError(YeetCommandError.new("Failed to decode PR closeout review threads GraphQL JSON."))
+          )
+        ),
+        Effect.map((document) => document.data.repository.pullRequest.reviewThreads)
       ),
-      Effect.map((document) => document.data.repository.pullRequest.reviewThreads)
-    );
-    const truncatedThreadIds = pipe(
-      page.nodes,
-      A.filter((thread) => thread.comments.pageInfo.hasNextPage),
-      A.map((thread) => thread.id)
-    );
-    if (A.isReadonlyArrayNonEmpty(truncatedThreadIds)) {
-      yield* Effect.logWarning(
-        `Review thread(s) ${A.join(truncatedThreadIds, ", ")} have more than 100 comments; Yeet closeout inspects only the first 100 nested comments per thread. Untrusted comment volume cannot block closeout.`
-      );
-    }
-
-    threads = [...threads, ...page.nodes];
-    cursor = yield* nextCursor("pull request review threads", page.pageInfo);
-    hasNextPage = O.isSome(cursor);
-  }
-
-  return threads;
-});
+    truncationWarning: (threadIds) =>
+      `Review thread(s) ${A.join(threadIds, ", ")} have more than 100 comments; Yeet closeout inspects only the first 100 nested comments per thread. Untrusted comment volume cannot block closeout.`,
+  });
 
 const collectReviewPages = Effect.fn("YeetCloseout.collectReviewPages")(function* (
   context: RepoRunContext,
@@ -259,10 +237,8 @@ const collectReviewPages = Effect.fn("YeetCloseout.collectReviewPages")(function
 /**
  * Collect the pull request, comments, review threads, and reviews for closeout.
  *
- * @param context - Repo context whose branch and repository are inspected with
- * GitHub CLI.
- * @returns Closeout payload plus the `gh pr view` metadata used to fetch it.
- * @example
+ * **Example** (Fetch the closeout payload for the current branch)
+ *
  * ```ts
  * import { Effect } from "effect"
  * import { collectPrCloseoutPayload, RepoRunContext } from "@beep/repo-cli/test/Yeet"
@@ -280,6 +256,10 @@ const collectReviewPages = Effect.fn("YeetCloseout.collectReviewPages")(function
  *
  * const prNumber = collectPrCloseoutPayload(context).pipe(Effect.map((payload) => payload.pr.number))
  * ```
+ *
+ * @param context - Repo context whose branch and repository are inspected with
+ * GitHub CLI.
+ * @returns Closeout payload plus the `gh pr view` metadata used to fetch it.
  * @category queries
  * @since 0.0.0
  */
@@ -319,10 +299,8 @@ export const collectPrCloseoutPayload = Effect.fn("YeetCloseout.collectPrCloseou
 /**
  * Execute explicit closeout writes such as replies and thread resolutions.
  *
- * @param context - Repo context whose repository receives the GraphQL writes.
- * @param intents - Planned write intents produced by closeout write planning.
- * @returns One successful write action record for each performed intent.
- * @example
+ * **Example** (Resolve one review thread during closeout)
+ *
  * ```ts
  * import { Effect } from "effect"
  * import * as O from "effect/Option"
@@ -343,6 +321,10 @@ export const collectPrCloseoutPayload = Effect.fn("YeetCloseout.collectPrCloseou
  *   { body: O.none(), kind: "resolve", threadId: "PRRT_example" }
  * ]).pipe(Effect.map((written) => written.length))
  * ```
+ *
+ * @param context - Repo context whose repository receives the GraphQL writes.
+ * @param intents - Planned write intents produced by closeout write planning.
+ * @returns One successful write action record for each performed intent.
  * @category commands
  * @since 0.0.0
  */

--- a/packages/tooling/tool/cli/src/internal/github/GhCommand.ts
+++ b/packages/tooling/tool/cli/src/internal/github/GhCommand.ts
@@ -30,13 +30,15 @@ import type { GhPageInfo } from "./GhSchema.ts";
  * exit code and captured output; `truncated` reports that captured output
  * overflowed the repo-run capture bound.
  *
- * @example
+ * **Example** (Classify a truncated capture)
+ *
  * ```ts
  * import type { GhCommandFailure } from "@beep/repo-cli/internal/github"
  *
  * const failure: GhCommandFailure = { _tag: "truncated", label: "gh pr view", command: "gh pr view" }
  * console.log(failure._tag)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -69,9 +71,8 @@ export interface GhOutputOptions<E> {
  * Run `gh` with captured output, returning stdout on success and mapping a spawn
  * failure, nonzero exit, or truncated capture into the caller's error.
  *
- * @param options - Command args, working directory, label, and error mapper.
- * @returns The captured stdout on a clean, non-truncated zero-exit run.
- * @example
+ * **Example** (Fetch PR facts with a caller-owned error)
+ *
  * ```ts
  * import { ghOutput } from "@beep/repo-cli/internal/github"
  * import { Effect } from "effect"
@@ -84,6 +85,9 @@ export interface GhOutputOptions<E> {
  * })
  * console.log(Effect.isEffect(program))
  * ```
+ *
+ * @param options - Command args, working directory, label, and error mapper.
+ * @returns The captured stdout on a clean, non-truncated zero-exit run.
  * @category execution
  * @since 0.0.0
  */
@@ -113,9 +117,8 @@ export const ghOutput = Effect.fn("GhCommand.ghOutput")(function* <E>(options: G
  * Build the `-F cursor=<value>` argument pair for a GraphQL page request, or an
  * empty argument list when there is no cursor.
  *
- * @param cursor - The page cursor, if any.
- * @returns The `gh api graphql` cursor argument fragment.
- * @example
+ * **Example** (Render cursor arguments for both cases)
+ *
  * ```ts
  * import { cursorArgs } from "@beep/repo-cli/internal/github"
  * import * as O from "effect/Option"
@@ -123,6 +126,9 @@ export const ghOutput = Effect.fn("GhCommand.ghOutput")(function* <E>(options: G
  * console.log(cursorArgs(O.some("abc")))
  * console.log(cursorArgs(O.none()))
  * ```
+ *
+ * @param cursor - The page cursor, if any.
+ * @returns The `gh api graphql` cursor argument fragment.
  * @category execution
  * @since 0.0.0
  */
@@ -133,9 +139,8 @@ export const cursorArgs = (cursor: O.Option<string>): ReadonlyArray<string> =>
  * Resolve the next page cursor from GraphQL page info, failing when another page
  * is reported without an end cursor.
  *
- * @param options - Page info, a label for error text, and the missing-cursor mapper.
- * @returns `Some(cursor)` for a further page, `None` when pagination is complete.
- * @example
+ * **Example** (Finish pagination on the last page)
+ *
  * ```ts
  * import { GhPageInfo, nextCursor } from "@beep/repo-cli/internal/github"
  * import { Effect } from "effect"
@@ -148,6 +153,9 @@ export const cursorArgs = (cursor: O.Option<string>): ReadonlyArray<string> =>
  * })
  * console.log(O.isNone(Effect.runSync(done)))
  * ```
+ *
+ * @param options - Page info, a label for error text, and the missing-cursor mapper.
+ * @returns `Some(cursor)` for a further page, `None` when pagination is complete.
  * @category execution
  * @since 0.0.0
  */
@@ -188,9 +196,8 @@ export interface GhGraphqlPageOptions<E> {
  * Fetch one `gh api graphql` page for a pull request, threading `owner`, `name`,
  * `number`, and the optional cursor into the query variables.
  *
- * @param options - Repository coordinates, GraphQL query, cursor, and error mapper.
- * @returns The raw GraphQL response body on success.
- * @example
+ * **Example** (Request the first page of a PR query)
+ *
  * ```ts
  * import { ghGraphqlPage } from "@beep/repo-cli/internal/github"
  * import { Effect } from "effect"
@@ -208,6 +215,9 @@ export interface GhGraphqlPageOptions<E> {
  * })
  * console.log(Effect.isEffect(program))
  * ```
+ *
+ * @param options - Repository coordinates, GraphQL query, cursor, and error mapper.
+ * @returns The raw GraphQL response body on success.
  * @category execution
  * @since 0.0.0
  */
@@ -232,3 +242,82 @@ export const ghGraphqlPage = <E>(
     label: options.label,
     onFailure: options.onFailure,
   });
+
+/** A review-thread node whose nested comment connection can report truncation. */
+interface GhTruncatableThread {
+  readonly comments: { readonly pageInfo: GhPageInfo };
+  readonly id: string;
+}
+
+/**
+ * Options for {@link collectTruncatableThreadPages}.
+ *
+ * @typeParam T - Thread node type carried by each page.
+ * @typeParam E - Caller-owned error for page fetches and cursor advancement.
+ * @typeParam R - Requirements of the page fetch.
+ * @category models
+ * @since 0.0.0
+ */
+export interface CollectTruncatableThreadPagesOptions<T extends GhTruncatableThread, E, R> {
+  readonly advance: (pageInfo: GhPageInfo) => Effect.Effect<O.Option<string>, E>;
+  readonly fetchPage: (
+    cursor: O.Option<string>
+  ) => Effect.Effect<{ readonly nodes: ReadonlyArray<T>; readonly pageInfo: GhPageInfo }, E, R>;
+  readonly truncationWarning: (threadIds: ReadonlyArray<string>) => string;
+}
+
+/**
+ * Collect every page of a review-thread connection, warning once per page about
+ * threads whose nested comment connection is truncated.
+ *
+ * **Details**
+ *
+ * Both the closeout collector and the reply engine paginate the same
+ * `reviewThreads` shape and must warn when a thread carries more than one
+ * nested comment page; this owns that loop once, parameterized by the page
+ * fetch, the cursor advance, and the caller's warning text.
+ *
+ * **Example** (Collect a single closed page)
+ *
+ * ```ts
+ * import { collectTruncatableThreadPages, GhPageInfo } from "@beep/repo-cli/internal/github"
+ * import { Effect } from "effect"
+ * import * as O from "effect/Option"
+ *
+ * const program = collectTruncatableThreadPages({
+ *   advance: () => Effect.succeed(O.none()),
+ *   fetchPage: () =>
+ *     Effect.succeed({ nodes: [], pageInfo: GhPageInfo.make({ endCursor: null, hasNextPage: false }) }),
+ *   truncationWarning: (ids) => `truncated: ${ids.length}`
+ * })
+ * console.log(Effect.isEffect(program))
+ * ```
+ *
+ * @param options - Page fetch, cursor advance, and truncation-warning text.
+ * @returns Every thread node across all pages, in page order.
+ * @category execution
+ * @since 0.0.0
+ */
+export const collectTruncatableThreadPages = <T extends GhTruncatableThread, E, R>(
+  options: CollectTruncatableThreadPagesOptions<T, E, R>
+): Effect.Effect<ReadonlyArray<T>, E, R> => {
+  const go = (cursor: O.Option<string>, collected: ReadonlyArray<T>): Effect.Effect<ReadonlyArray<T>, E, R> =>
+    options.fetchPage(cursor).pipe(
+      Effect.flatMap((page) => {
+        const truncatedThreadIds = pipe(
+          page.nodes,
+          A.filter((thread) => thread.comments.pageInfo.hasNextPage),
+          A.map((thread) => thread.id)
+        );
+        const warn = A.isReadonlyArrayNonEmpty(truncatedThreadIds)
+          ? Effect.logWarning(options.truncationWarning(truncatedThreadIds))
+          : Effect.void;
+        const threads = [...collected, ...page.nodes];
+        return warn.pipe(
+          Effect.andThen(options.advance(page.pageInfo)),
+          Effect.flatMap((next) => (O.isSome(next) ? go(next, threads) : Effect.succeed(threads)))
+        );
+      })
+    );
+  return go(O.none(), A.empty<T>());
+};

--- a/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
@@ -6,6 +6,7 @@
  */
 
 export * from "@beep/repo-cli/commands/Yeet/index";
+export * from "../commands/Yeet/internal/ArtifactPaths.ts";
 export * from "../commands/Yeet/internal/AttemptJournal.ts";
 export * from "../commands/Yeet/internal/Closeout.ts";
 export * from "../commands/Yeet/internal/closeout/Closeout.schemas.ts";
@@ -32,12 +33,19 @@ export * from "../commands/Yeet/internal/Handler.ts";
 export * from "../commands/Yeet/internal/IssueArtifacts.ts";
 export * from "../commands/Yeet/internal/IssueClassification.ts";
 export * from "../commands/Yeet/internal/IssueParser.ts";
+export * from "../commands/Yeet/internal/Merge.ts";
 export * from "../commands/Yeet/internal/MonitorComments.ts";
+export * from "../commands/Yeet/internal/MonitorLoop.ts";
 export * from "../commands/Yeet/internal/Planner.ts";
+export * from "../commands/Yeet/internal/Porcelain.ts";
 export * from "../commands/Yeet/internal/ProofState.ts";
 export * from "../commands/Yeet/internal/PublishScope.ts";
 export * from "../commands/Yeet/internal/PullRequest.ts";
 export * from "../commands/Yeet/internal/QualityIssueIndex.ts";
+export * from "../commands/Yeet/internal/Reply.schemas.ts";
+export * from "../commands/Yeet/internal/Reply.ts";
+export * from "../commands/Yeet/internal/Sweep.schemas.ts";
+export * from "../commands/Yeet/internal/Sweep.ts";
 export * from "../commands/Yeet/internal/TurboQuery.ts";
 export * from "../commands/Yeet/internal/Verdict.ts";
 export * from "../commands/Yeet/Yeet.render.ts";

--- a/packages/tooling/tool/cli/test/yeet-artifact-writers.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-artifact-writers.test.ts
@@ -1,0 +1,210 @@
+import {
+  defaultYeetRunOptions,
+  RepoRunContext,
+  RepoRunPlan,
+  runArtifactPathForContext,
+  TurboPlanSnapshot,
+  writeRunVerdictForTesting,
+  writeYeetStatusSnapshot,
+  YeetAttemptStarted,
+  YeetMergeReady,
+  YeetMergeReadyCriteria,
+  YeetStatusArtifact,
+  YeetStatusRemote,
+  YeetStatusSnapshot,
+  YeetStatusSnapshotJson,
+  YeetStatusWorktree,
+  YeetVerdictJson,
+} from "@beep/repo-cli/test/Yeet";
+import { UUID } from "@beep/schema/String";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, Path, Ref } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import type { YeetExecutedStep, YeetVerdictExtrasForTesting } from "@beep/repo-cli/test/Yeet";
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+const withTempDirectory = <Result, Error, Requirements>(
+  use: (tmpDir: string) => Effect.Effect<Result, Error, Requirements>
+) =>
+  Effect.acquireUseRelease(
+    Effect.flatMap(FileSystem.FileSystem, (fs) => fs.makeTempDirectory()),
+    use,
+    (tmpDir) => Effect.flatMap(FileSystem.FileSystem, (fs) => fs.remove(tmpDir, { recursive: true }).pipe(Effect.orDie))
+  ).pipe(provideScopedLayer(PlatformLayer));
+
+const attemptId = S.decodeUnknownSync(UUID)("550e8400-e29b-41d4-a716-446655440000");
+
+const contextForRoot = (repoRoot: string): RepoRunContext =>
+  RepoRunContext.make({
+    repoRoot,
+    cwd: repoRoot,
+    base: "origin/main",
+    head: "HEAD",
+    branch: "feat/merge-loop",
+    packetDir: ".beep/yeet",
+    originalArgv: [],
+    turbo: TurboPlanSnapshot.make({ graphHealthStatus: "ok", graphHealthWarnings: [], packages: [], tasks: [] }),
+  });
+
+const attemptFor = (context: RepoRunContext): YeetAttemptStarted =>
+  YeetAttemptStarted.make({
+    schemaVersion: "yeet-attempt-journal/v1",
+    _tag: "attempt-started",
+    attemptId,
+    runId: "feat_merge-loop",
+    branch: context.branch,
+    base: context.base,
+    head: context.head,
+    mode: "publish",
+    startedAt: "2026-08-04T00:00:00.000Z",
+  });
+
+const blockedMergeReady = YeetMergeReady.make({
+  ready: false,
+  failing: O.some("threads-resolved"),
+  criteria: YeetMergeReadyCriteria.make({
+    checksGreen: true,
+    threadsResolved: false,
+    greptileScore: O.some("5/5"),
+  }),
+});
+
+const extrasWith = (mergeReady: O.Option<YeetMergeReady>): YeetVerdictExtrasForTesting => ({
+  baseFreshness: O.none(),
+  mergeReady,
+  stash: O.none(),
+});
+
+// Resolved through the same path helper the writer uses, so the bytes read back
+// are the bytes `yeet status` would later decode.
+const readVerdictArtifact = Effect.fnUntraced(function* (context: RepoRunContext) {
+  const fs = yield* FileSystem.FileSystem;
+  const verdictPath = yield* runArtifactPathForContext(context, "verdict.json");
+  return { text: yield* fs.readFileString(verdictPath), verdictPath } as const;
+});
+
+// The artifact producers were covered only at the codec layer, so reverting a
+// writer to a generic JSON render left every test green while `yeet status`
+// could no longer decode what the writer had emitted. These assert the bytes
+// that actually landed on disk.
+describe("writeRunVerdict", () => {
+  it.effect("writes a verdict file that decodes back through YeetVerdictJson", () =>
+    withTempDirectory(
+      Effect.fnUntraced(function* (tmpDir) {
+        const context = contextForRoot(tmpDir);
+        const plan = RepoRunPlan.make({ context, steps: A.empty() });
+        const recorder = yield* Ref.make<ReadonlyArray<YeetExecutedStep>>(A.empty());
+        const extras = yield* Ref.make<YeetVerdictExtrasForTesting>(extrasWith(O.some(blockedMergeReady)));
+
+        yield* writeRunVerdictForTesting(
+          plan,
+          defaultYeetRunOptions({ mode: "publish" }),
+          attemptFor(context),
+          0,
+          recorder,
+          extras,
+          "success",
+          "yeet publish succeeded.",
+          O.none()
+        );
+
+        const { text } = yield* readVerdictArtifact(context);
+        expect(text).not.toContain('"_id":"Option"');
+
+        const decoded = yield* YeetVerdictJson.decode(text);
+        expect(decoded.outcome).toBe("success");
+        expect(decoded.mode).toBe("publish");
+        expect(decoded.attemptId).toStrictEqual(O.some(attemptId));
+        // Threaded from the status snapshot the publish/monitor path read.
+        expect(O.flatMap(decoded.mergeReady, (value) => value.failing)).toStrictEqual(O.some("threads-resolved"));
+      })
+    )
+  );
+
+  it.effect("omits merge readiness from the artifact when no status snapshot was read", () =>
+    withTempDirectory(
+      Effect.fnUntraced(function* (tmpDir) {
+        const context = contextForRoot(tmpDir);
+        const plan = RepoRunPlan.make({ context, steps: A.empty() });
+        const recorder = yield* Ref.make<ReadonlyArray<YeetExecutedStep>>(A.empty());
+        const extras = yield* Ref.make<YeetVerdictExtrasForTesting>(extrasWith(O.none()));
+
+        yield* writeRunVerdictForTesting(
+          plan,
+          defaultYeetRunOptions({ mode: "verify" }),
+          attemptFor(context),
+          0,
+          recorder,
+          extras,
+          "success",
+          "yeet verify succeeded.",
+          O.none()
+        );
+
+        const { text } = yield* readVerdictArtifact(context);
+        expect(text).not.toContain("mergeReady");
+
+        const decoded = yield* YeetVerdictJson.decode(text);
+        expect(decoded.mergeReady).toStrictEqual(O.none());
+      })
+    )
+  );
+});
+
+describe("writeYeetStatusSnapshot", () => {
+  it.effect("writes a status file that decodes back through YeetStatusSnapshotJson", () =>
+    withTempDirectory(
+      Effect.fnUntraced(function* (tmpDir) {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const statusPath = path.join(tmpDir, ".beep", "yeet", "runs", "feat_merge-loop", "status.json");
+        const closeout = YeetStatusArtifact.make({
+          detail: "PR #560",
+          issueCount: 0,
+          path: "pr-closeout.json",
+          state: "present",
+          greptileScore: O.some("5/5"),
+        });
+        const snapshot = YeetStatusSnapshot.make({
+          base: "origin/main",
+          branch: "feat/merge-loop",
+          closeout,
+          createdAt: "2026-08-04T00:00:00.000Z",
+          head: "HEAD",
+          nextCommand: "bun run beep yeet closeout --summary",
+          remote: YeetStatusRemote.make({
+            available: true,
+            checked: true,
+            detail: "PR #560 OPEN",
+            checkCount: 24,
+            failingCheckCount: 0,
+            pendingCheckCount: 0,
+            unresolvedReviewThreadCount: 1,
+          }),
+          runId: "feat_merge-loop",
+          schemaVersion: "yeet-status/v1",
+          statusPath,
+          verdict: YeetStatusArtifact.make({ detail: "publish success", path: "verdict.json", state: "present" }),
+          worktree: YeetStatusWorktree.make({ clean: true, staged: 0, unstaged: 0, untracked: 0 }),
+          mergeReady: O.some(blockedMergeReady),
+        });
+
+        yield* writeYeetStatusSnapshot(snapshot);
+
+        const text = yield* fs.readFileString(statusPath);
+        expect(text).not.toContain('"_id":"Option"');
+
+        const decoded = yield* YeetStatusSnapshotJson.decode(text);
+        expect(decoded.statusPath).toBe(statusPath);
+        expect(O.flatMap(decoded.mergeReady, (value) => value.failing)).toStrictEqual(O.some("threads-resolved"));
+        expect(O.flatMap(decoded.mergeReady, (value) => value.criteria.greptileScore)).toStrictEqual(O.some("5/5"));
+      })
+    )
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-command-wiring.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-command-wiring.test.ts
@@ -1,0 +1,35 @@
+import { yeetCommand } from "@beep/repo-cli/commands/Yeet";
+import { describe, expect, it } from "@effect/vitest";
+import * as A from "effect/Array";
+
+/**
+ * Every subcommand name registered under `beep yeet`, flattened across the
+ * subcommand groups the CLI builder produces.
+ */
+const subcommandNames: ReadonlyArray<string> = A.flatMap(yeetCommand.subcommands, (group) =>
+  A.map(group.commands, (command) => command.name)
+);
+
+const findSubcommand = (name: string) =>
+  A.findFirst(
+    A.flatMap(yeetCommand.subcommands, (group) => group.commands),
+    (command) => command.name === name
+  );
+
+describe("yeet merge-loop command wiring", () => {
+  it.each(["sweep", "merge", "reply"])("registers the %s subcommand", (name) => {
+    expect(subcommandNames).toContain(name);
+  });
+
+  it.each(["sweep", "merge", "reply"])("describes the %s subcommand in help output", (name) => {
+    const command = findSubcommand(name);
+    expect(command._tag).toBe("Some");
+    expect(command._tag === "Some" ? command.value.description : undefined).toEqual(expect.any(String));
+  });
+
+  it("keeps the pre-existing subcommands registered", () => {
+    expect(subcommandNames).toEqual(
+      expect.arrayContaining(["verify", "repair", "publish", "monitor", "closeout", "status"])
+    );
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet-fallow-self-heal.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-fallow-self-heal.test.ts
@@ -1,0 +1,389 @@
+import {
+  FallowReportFinding,
+  FallowReportOk,
+  FallowReportPayload,
+  FindingAttributionSummary,
+  fallowEnvelopeFileName,
+} from "@beep/repo-cli/test/Quality";
+import {
+  FallowFeedbackAllowedRoot,
+  QualityIssueIndex,
+  runYeetFallowFeedbackForTesting,
+} from "@beep/repo-cli/test/Yeet";
+import { NonNegativeInt } from "@beep/schema";
+import { provideScopedLayer } from "@beep/test-utils";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import * as A from "effect/Array";
+import { pipe } from "effect/Function";
+import * as O from "effect/Option";
+import * as P from "effect/Predicate";
+import * as S from "effect/Schema";
+import * as TestConsole from "effect/testing/TestConsole";
+
+const TestLayer = Layer.mergeAll(NodeServices.layer, TestConsole.layer);
+const encodeJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
+const decodeQualityIssueIndex = S.decodeUnknownEffect(S.fromJsonString(QualityIssueIndex));
+
+const RUN_STARTED_AT = "2026-06-16T00:00:00.000Z";
+const BEFORE_RUN_START = "2026-06-15T00:00:00.000Z";
+const AFTER_RUN_START = "2026-06-16T00:00:01.000Z";
+
+const withTempDirectory = <Result, Error, Requirements>(
+  use: (tmpDir: string) => Effect.Effect<Result, Error, Requirements>
+) =>
+  Effect.acquireUseRelease(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      return yield* fs.makeTempDirectory();
+    }),
+    use,
+    (tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.remove(tmpDir, { recursive: true });
+      })
+  ).pipe(provideScopedLayer(TestLayer));
+
+// An ok envelope for one feature family whose finding family agrees with its
+// subcommand unless `findingFamily` deliberately breaks the producer contract.
+const okEnvelope = (options: {
+  readonly advisory: boolean;
+  readonly feature?: "audit" | "health";
+  readonly findingFamily?: "audit" | "health";
+  readonly generatedAt: string;
+}): FallowReportOk => {
+  const feature = options.feature ?? "health";
+  return FallowReportOk.make({
+    schemaVersion: "fallow-report-envelope/v1",
+    toolVersion: "fallow-test",
+    command: `beep quality fallow ${feature}`,
+    subcommand: feature,
+    baseRef: "origin/main",
+    generatedAt: options.generatedAt,
+    advisory: options.advisory,
+    dirtyWorktree: false,
+    reportPath: `.beep/fallow/${feature}.json`,
+    rawOutputRef: `.beep/fallow/raw/${feature}.json`,
+    attributionKinds: ["inherited-adjacent"],
+    findingAttributionSummary: FindingAttributionSummary.make({
+      introduced: NonNegativeInt.make(0),
+      inheritedAdjacent: NonNegativeInt.make(1),
+      notApplicable: NonNegativeInt.make(0),
+    }),
+    status: "ok",
+    exitStatus: NonNegativeInt.make(0),
+    report: FallowReportPayload.make({
+      findingCount: NonNegativeInt.make(1),
+      findings: [
+        FallowReportFinding.make({
+          attribution: "inherited-adjacent",
+          blocking: false,
+          featureFamily: options.findingFamily ?? feature,
+          id: `${feature}-advisory`,
+          parser: `fallow/${feature}/v1`,
+          sourceRef: `packages/example/src/${feature}.ts`,
+          subCategory: `fallow:${feature}:fixture`,
+        }),
+      ],
+    }),
+  });
+};
+
+const writeEnvelopeText = Effect.fn("YeetFallowSelfHealTest.writeEnvelopeText")(function* (
+  fromDir: string,
+  text: string,
+  fileName = fallowEnvelopeFileName("health", true)
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  yield* fs.makeDirectory(fromDir, { recursive: true });
+  const filePath = path.join(fromDir, fileName);
+  yield* fs.writeFileString(filePath, `${text}\n`);
+  return filePath;
+});
+
+// Always written to the advisory-named file for its family: a check-mode envelope
+// sitting under an advisory name is exactly the mode-mismatch defect under test.
+const writeEnvelope = Effect.fn("YeetFallowSelfHealTest.writeEnvelope")(function* (
+  fromDir: string,
+  envelope: FallowReportOk
+) {
+  return yield* writeEnvelopeText(
+    fromDir,
+    yield* encodeJson(envelope),
+    fallowEnvelopeFileName(envelope.subcommand, true)
+  );
+});
+
+const consoleText = Effect.fn("YeetFallowSelfHealTest.consoleText")(function* () {
+  return pipe(yield* TestConsole.logLines, A.filter(P.isString), A.join("\n"));
+});
+
+describe("yeet fallow advisory self-heal", () => {
+  it.effect("purges stale advisory envelopes, skips the phase, and exits 0", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        const envelopePath = yield* writeEnvelope(
+          fromDir,
+          okEnvelope({ advisory: true, generatedAt: BEFORE_RUN_START })
+        );
+
+        yield* runYeetFallowFeedbackForTesting({
+          advisory: true,
+          emit: emitPath,
+          from: fromDir,
+          runStartedAt: RUN_STARTED_AT,
+        }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)));
+
+        expect(yield* fs.exists(envelopePath)).toBe(false);
+
+        const index = yield* decodeQualityIssueIndex(yield* fs.readFileString(emitPath));
+        expect(index.issues).toEqual([]);
+        expect(index.packages).toEqual([]);
+
+        const output = yield* consoleText();
+        expect(output).toContain("advisory feedback skipped: stale envelopes purged (1)");
+        expect(output).toContain("health (stale)");
+        expect(output).toContain("older than the Yeet run start");
+        expect(output).toContain("regenerable state");
+      })
+    )
+  );
+
+  it.effect("purges advisory-named envelopes that were produced in check mode", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        const envelopePath = yield* writeEnvelope(
+          fromDir,
+          okEnvelope({ advisory: false, generatedAt: AFTER_RUN_START })
+        );
+
+        yield* runYeetFallowFeedbackForTesting({
+          advisory: true,
+          emit: emitPath,
+          from: fromDir,
+          runStartedAt: RUN_STARTED_AT,
+        }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)));
+
+        expect(yield* fs.exists(envelopePath)).toBe(false);
+
+        const index = yield* decodeQualityIssueIndex(yield* fs.readFileString(emitPath));
+        expect(index.issues).toEqual([]);
+
+        const output = yield* consoleText();
+        expect(output).toContain("advisory feedback skipped: stale envelopes purged (1)");
+        expect(output).toContain("health (mode-mismatch)");
+      })
+    )
+  );
+
+  it.effect("keeps fresh advisory envelopes and emits their findings", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        const envelopePath = yield* writeEnvelope(
+          fromDir,
+          okEnvelope({ advisory: true, generatedAt: AFTER_RUN_START })
+        );
+
+        yield* runYeetFallowFeedbackForTesting({
+          advisory: true,
+          emit: emitPath,
+          from: fromDir,
+          runStartedAt: RUN_STARTED_AT,
+        }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)));
+
+        expect(yield* fs.exists(envelopePath)).toBe(true);
+
+        const index = yield* decodeQualityIssueIndex(yield* fs.readFileString(emitPath));
+        expect(index.issues).toHaveLength(1);
+        expect(index.issues[0]).toMatchObject({ blocking: false, id: "fallow:health:health-advisory" });
+
+        const output = yield* consoleText();
+        expect(output).toContain("Fallow advisory issue index written to");
+        expect(output).not.toContain("advisory feedback skipped");
+      })
+    )
+  );
+
+  it.effect("treats an envelope with an unparseable generatedAt as stale", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        const envelopePath = yield* writeEnvelope(
+          fromDir,
+          okEnvelope({ advisory: true, generatedAt: "not-a-timestamp" })
+        );
+
+        yield* runYeetFallowFeedbackForTesting({
+          advisory: true,
+          emit: emitPath,
+          from: fromDir,
+          runStartedAt: RUN_STARTED_AT,
+        }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)));
+
+        expect(yield* fs.exists(envelopePath)).toBe(false);
+        expect(yield* consoleText()).toContain("health (stale)");
+      })
+    )
+  );
+
+  it.effect("leaves envelopes untouched when the run start is unknown", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        const envelopePath = yield* writeEnvelope(
+          fromDir,
+          okEnvelope({ advisory: true, generatedAt: BEFORE_RUN_START })
+        );
+
+        yield* runYeetFallowFeedbackForTesting({ advisory: true, emit: emitPath, from: fromDir }).pipe(
+          Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir))
+        );
+
+        expect(yield* fs.exists(envelopePath)).toBe(true);
+        const index = yield* decodeQualityIssueIndex(yield* fs.readFileString(emitPath));
+        expect(index.issues).toHaveLength(1);
+      })
+    )
+  );
+
+  it.effect("fails an undecodable envelope with the one-command remedy", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        yield* writeEnvelopeText(fromDir, "{ not json");
+
+        const error = yield* runYeetFallowFeedbackForTesting({
+          advisory: true,
+          emit: emitPath,
+          from: fromDir,
+          runStartedAt: RUN_STARTED_AT,
+        }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)), Effect.flip);
+
+        expect(error.message).toContain("Failed to decode Fallow envelope");
+        expect(error.message).toContain("Remedy: rm -rf .beep/fallow");
+        expect(error.command).toBe("rm -rf .beep/fallow");
+      })
+    )
+  );
+
+  // Ledger #55 / decision 25: staleness is decided before any contract check, so a
+  // leftover envelope self-heals no matter what else it carries. Nothing about a
+  // pre-run-start envelope may fail the publish.
+  it.effect("self-heals a stale envelope that also disagrees with its feature family", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        const envelopePath = yield* writeEnvelope(
+          fromDir,
+          okEnvelope({ advisory: true, findingFamily: "audit", generatedAt: BEFORE_RUN_START })
+        );
+
+        yield* runYeetFallowFeedbackForTesting({
+          advisory: true,
+          emit: emitPath,
+          from: fromDir,
+          runStartedAt: RUN_STARTED_AT,
+        }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)));
+
+        expect(yield* fs.exists(envelopePath)).toBe(false);
+
+        const index = yield* decodeQualityIssueIndex(yield* fs.readFileString(emitPath));
+        expect(index.issues).toEqual([]);
+
+        const output = yield* consoleText();
+        expect(output).toContain("advisory feedback skipped: stale envelopes purged (1)");
+        expect(output).toContain("health (stale)");
+        expect(output).not.toContain("disagree with the subcommand feature family");
+      })
+    )
+  );
+
+  it.effect("fails a fresh envelope whose findings disagree with its feature family", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        const envelopePath = yield* writeEnvelope(
+          fromDir,
+          okEnvelope({ advisory: true, findingFamily: "audit", generatedAt: AFTER_RUN_START })
+        );
+
+        const error = yield* runYeetFallowFeedbackForTesting({
+          advisory: true,
+          emit: emitPath,
+          from: fromDir,
+          runStartedAt: RUN_STARTED_AT,
+        }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)), Effect.flip);
+
+        expect(error.message).toContain("disagree with the subcommand feature family");
+        expect(error.message).toContain("Remedy: rm -rf .beep/fallow");
+        expect(error.command).toBe("rm -rf .beep/fallow");
+        expect(error.exitCode).toBe(1);
+        // Current-run producer output, not regenerable leftover state, so the
+        // envelope survives for inspection instead of being silently purged.
+        expect(yield* fs.exists(envelopePath)).toBe(true);
+      })
+    )
+  );
+
+  it.effect("heals leftovers first, then still fails a surviving fresh family mismatch", () =>
+    withTempDirectory((tmpDir) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fromDir = path.join(tmpDir, ".beep", "fallow");
+        const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+        const stalePath = yield* writeEnvelope(fromDir, okEnvelope({ advisory: true, generatedAt: BEFORE_RUN_START }));
+        const freshPath = yield* writeEnvelope(
+          fromDir,
+          okEnvelope({ advisory: true, feature: "audit", findingFamily: "health", generatedAt: AFTER_RUN_START })
+        );
+
+        const error = yield* runYeetFallowFeedbackForTesting({
+          advisory: true,
+          emit: emitPath,
+          from: fromDir,
+          runStartedAt: RUN_STARTED_AT,
+        }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)), Effect.flip);
+
+        expect(yield* fs.exists(stalePath)).toBe(false);
+        expect(yield* fs.exists(freshPath)).toBe(true);
+        expect(error.message).toContain(".beep/fallow/audit.json");
+
+        // The purge note and the absent-directory index are still emitted, so no
+        // downstream consumer can read a half-truth built from the stale file.
+        const index = yield* decodeQualityIssueIndex(yield* fs.readFileString(emitPath));
+        expect(index.issues).toEqual([]);
+        expect(yield* consoleText()).toContain("health (stale)");
+      })
+    )
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-merge-ready-coherence.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-merge-ready-coherence.test.ts
@@ -1,0 +1,139 @@
+import { YeetMergeReady, YeetMergeReadyCriteria, YeetVerdictJson } from "@beep/repo-cli/test/Yeet";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+
+const decodeMergeReady = S.decodeUnknownEffect(YeetMergeReady);
+
+// A verdict document whose only variable part is the merge-readiness record, so
+// a decode failure can only come from the cross-field check.
+const verdictJsonWithMergeReady = (mergeReady: string): string =>
+  [
+    '{"schemaVersion":"yeet-verdict/v2","base":"origin/main","branch":"feat/merge-loop","committed":true,',
+    '"createdAt":"2026-08-04T00:00:05.000Z","failurePolicy":"fail-fast","head":"HEAD","lanes":[],',
+    '"message":"yeet publish proof passed.","mode":"publish","outcome":"success","packetPaths":[],',
+    `"pushed":true,"runId":"feat_merge-loop","mergeReady":${mergeReady}}`,
+  ].join("");
+
+describe("YeetMergeReady coherence", () => {
+  it.effect("decodes a blocked record whose named criterion is the unsatisfied one", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decodeMergeReady({
+        ready: false,
+        failing: "checks-green",
+        criteria: { checksGreen: false, threadsResolved: true },
+      });
+
+      expect(decoded.ready).toBe(false);
+      expect(decoded.failing).toStrictEqual(O.some("checks-green"));
+    })
+  );
+
+  it.effect("decodes a ready record naming no criterion with both criteria satisfied", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decodeMergeReady({
+        ready: true,
+        criteria: { checksGreen: true, threadsResolved: true, greptileScore: "5/5" },
+      });
+
+      expect(decoded.ready).toBe(true);
+      expect(decoded.failing).toStrictEqual(O.none());
+      expect(decoded.criteria.greptileScore).toStrictEqual(O.some("5/5"));
+    })
+  );
+
+  // The exact document the review named: `ready` and `failing` are an answer and
+  // its own refutation, and whichever field a reader trusted decided the merge.
+  it.effect("rejects a record that is ready and also names a blocking criterion", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeMergeReady({
+          ready: true,
+          failing: "checks-green",
+          criteria: { checksGreen: false, threadsResolved: true },
+        })
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+
+  it.effect("rejects a record blocked on a criterion its own criteria report as satisfied", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeMergeReady({
+          ready: false,
+          failing: "threads-resolved",
+          criteria: { checksGreen: true, threadsResolved: true },
+        })
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+
+  it.effect("rejects a not-ready record that names no blocking criterion", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeMergeReady({
+          ready: false,
+          criteria: { checksGreen: true, threadsResolved: true },
+        })
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+
+  it.effect("rejects a ready record whose criteria are not all satisfied", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeMergeReady({
+          ready: true,
+          criteria: { checksGreen: true, threadsResolved: false },
+        })
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+
+  it("keeps the coherent constructor path working", () => {
+    const mergeReady = YeetMergeReady.make({
+      ready: false,
+      failing: O.some("threads-resolved"),
+      criteria: YeetMergeReadyCriteria.make({ checksGreen: true, threadsResolved: false }),
+    });
+
+    expect(mergeReady.failing).toStrictEqual(O.some("threads-resolved"));
+  });
+});
+
+describe("YeetVerdictJson merge-readiness coherence", () => {
+  it.effect("decodes a verdict carrying a coherent merge-ready record", () =>
+    Effect.gen(function* () {
+      const decoded = yield* YeetVerdictJson.decode(
+        verdictJsonWithMergeReady(
+          '{"ready":false,"failing":"checks-green","criteria":{"checksGreen":false,"threadsResolved":true}}'
+        )
+      );
+
+      expect(O.flatMap(decoded.mergeReady, (value) => value.failing)).toStrictEqual(O.some("checks-green"));
+    })
+  );
+
+  it.effect("rejects a verdict artifact whose merge-ready record contradicts itself", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        YeetVerdictJson.decode(
+          verdictJsonWithMergeReady(
+            '{"ready":true,"failing":"checks-green","criteria":{"checksGreen":false,"threadsResolved":true}}'
+          )
+        )
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-monitor-loop.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-monitor-loop.test.ts
@@ -1,0 +1,197 @@
+import {
+  detectYeetMonitorFlakeClass,
+  emptyYeetMonitorRerunBudget,
+  planYeetMonitorReruns,
+  renderYeetMonitorJobDecision,
+  stripYeetMonitorLogDecoration,
+  YeetMonitorFailedJob,
+  yeetMonitorRerunCommand,
+  yeetMonitorRerunKey,
+  yeetMonitorTerminalState,
+} from "@beep/repo-cli/test/Yeet";
+import { A } from "@beep/utils";
+import { describe, expect, it } from "@effect/vitest";
+import { HashSet } from "effect";
+import * as O from "effect/Option";
+
+// `gh run view --job <id> --log-failed` emits `<job>\t<step>\t<timestamp> <line>`
+// and sometimes an `##[error]` workflow-command marker. These fixtures keep that
+// decoration so the detectors are exercised on the shape they actually receive.
+const ghLog = (jobName: string, stepName: string, lines: ReadonlyArray<string>): string =>
+  A.join(
+    A.map(
+      lines,
+      (line, index) => `${jobName}\t${stepName}\t2026-08-04T12:00:${`${index}`.padStart(2, "0")}.1234567Z ${line}`
+    ),
+    "\n"
+  );
+
+const ts2589FlakeLog = ghLog("Check", "Run bun run check", [
+  "##[group]Run bun run check",
+  "@beep/box:build: error TS2589: Type instantiation is excessively deep and possibly infinite.",
+  "Failed:    @beep/box#build",
+]);
+
+const locatedTs2589Log = ghLog("Check", "Run bun run check", [
+  "@beep/box:build: src/Box.ts(12,3): error TS2589: Type instantiation is excessively deep and possibly infinite.",
+  "Failed:    @beep/box#build",
+]);
+
+const genuineTypeErrorLog = ghLog("Check", "Run bun run check", [
+  "@beep/ui:check: src/Panel.tsx(3,5): error TS2322: Type 'string' is not assignable to type 'number'.",
+  "Failed:    @beep/ui#check",
+]);
+
+const suiteTimeoutLog = ghLog("Test Unit", "Run vitest", [
+  "FAIL packages/ontology/use-cases/test/SchemaParity.test.ts",
+  "Error: Test timed out in 30000ms.",
+]);
+
+const jobTimeoutLog = ghLog("Test Unit", "Complete job", [
+  "##[error]The job running on runner ubuntu-latest has exceeded the maximum execution time of 60 minutes.",
+]);
+
+const cancelledSiblingLog = ghLog("Test Unit", "Run vitest", ["##[error]The operation was canceled."]);
+
+const failedJob = (databaseId: number, name: string, flakeClass: O.Option<"ts2589-no-location" | "ci-timeout">) =>
+  YeetMonitorFailedJob.make({ databaseId, name, flakeClass });
+
+describe("yeet monitor flake fingerprints", () => {
+  it("strips the job, step, timestamp, and workflow-command decoration from a log line", () => {
+    expect(stripYeetMonitorLogDecoration("Check\tRun bun\t2026-08-04T12:00:00.1234567Z ##[error]boom")).toBe("boom");
+  });
+
+  it("recognizes the no-location TS2589 signature through GitHub log decoration", () => {
+    expect(detectYeetMonitorFlakeClass(ts2589FlakeLog)).toStrictEqual(O.some("ts2589-no-location"));
+  });
+
+  it("refuses a TS2589 that carries a file location", () => {
+    // A located TS2589 is a real depth problem in a real file, not the
+    // scheduling-dependent instantiation-count flake.
+    expect(detectYeetMonitorFlakeClass(locatedTs2589Log)).toStrictEqual(O.none());
+  });
+
+  it("refuses an ordinary type error", () => {
+    expect(detectYeetMonitorFlakeClass(genuineTypeErrorLog)).toStrictEqual(O.none());
+  });
+
+  it("recognizes both suite-level and job-level timeouts", () => {
+    expect(detectYeetMonitorFlakeClass(suiteTimeoutLog)).toStrictEqual(O.some("ci-timeout"));
+    expect(detectYeetMonitorFlakeClass(jobTimeoutLog)).toStrictEqual(O.some("ci-timeout"));
+  });
+
+  it("refuses a bare cancellation", () => {
+    // A job cancelled because a sibling failed carries no timeout evidence;
+    // classifying it would spend a rerun on a fail-fast side effect.
+    expect(detectYeetMonitorFlakeClass(cancelledSiblingLog)).toStrictEqual(O.none());
+  });
+});
+
+describe("yeet monitor rerun budget", () => {
+  it("approves the first rerun and refuses the second for the same job at the same SHA", () => {
+    const job = failedJob(991, "Check", O.some("ts2589-no-location"));
+    const first = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [job]);
+    const second = planYeetMonitorReruns(first.budget, "abc123", [job]);
+
+    expect(first.decisions).toHaveLength(1);
+    expect(first.decisions[0]?.status).toBe("rerun");
+    expect(second.decisions[0]?.status).toBe("rerun-spent");
+  });
+
+  it("scopes the rerun command to the job so coexisting genuine reds are never re-executed", () => {
+    const plan = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [
+      failedJob(991, "Check", O.some("ci-timeout")),
+    ]);
+    const decision = plan.decisions[0];
+
+    expect(decision?.status).toBe("rerun");
+    expect(decision?.status === "rerun" ? decision.command : "").toBe("gh run rerun --job 991");
+    expect(decision?.status === "rerun" ? decision.command : "").not.toContain("--failed");
+  });
+
+  it("refuses the rerun's own attempt, which reports the same job under a new databaseId", () => {
+    // `gh run rerun --job <id>` starts a new workflow-run attempt, and job
+    // records are per-attempt: the same logical job comes back with a fresh
+    // `databaseId` at the unchanged head SHA. Keyed on the id the budget would
+    // miss here and approve reruns forever, so the key is the job name.
+    const firstAttempt = failedJob(991, "Check", O.some("ts2589-no-location"));
+    const secondAttempt = failedJob(1042, "Check", O.some("ts2589-no-location"));
+    const first = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [firstAttempt]);
+    const second = planYeetMonitorReruns(first.budget, "abc123", [secondAttempt]);
+
+    expect(first.decisions[0]?.status).toBe("rerun");
+    expect(second.decisions[0]?.status).toBe("rerun-spent");
+    // The refusal still names the id it saw, so the operator can find the job.
+    expect(second.decisions[0]?.databaseId).toBe(1042);
+    expect(HashSet.size(second.budget)).toBe(1);
+  });
+
+  it("keeps distinct job names on separate allowances across attempts", () => {
+    // Name-keying must not over-collapse: a different red job at the same SHA
+    // still gets its own single rerun even when its id happens to be adjacent.
+    const first = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [
+      failedJob(991, "Check", O.some("ts2589-no-location")),
+    ]);
+    const second = planYeetMonitorReruns(first.budget, "abc123", [failedJob(1042, "Test Unit", O.some("ci-timeout"))]);
+
+    expect(second.decisions[0]?.status).toBe("rerun");
+    expect(HashSet.size(second.budget)).toBe(2);
+  });
+
+  it("spends one rerun per job rather than one per wave", () => {
+    const plan = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [
+      failedJob(991, "Check", O.some("ts2589-no-location")),
+      failedJob(992, "Test Unit", O.some("ci-timeout")),
+    ]);
+
+    expect(A.map(plan.decisions, (decision) => decision.status)).toStrictEqual(["rerun", "rerun"]);
+  });
+
+  it("grants a fresh allowance to the same job after a new head SHA lands", () => {
+    const job = failedJob(991, "Check", O.some("ci-timeout"));
+    const spent = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [job]);
+    const afterPush = planYeetMonitorReruns(spent.budget, "def456", [job]);
+
+    expect(afterPush.decisions[0]?.status).toBe("rerun");
+  });
+
+  it("reports an unfingerprinted red as needing a code fix and never spends budget on it", () => {
+    const job = failedJob(993, "Check", O.none());
+    const first = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [job]);
+    const second = planYeetMonitorReruns(first.budget, "abc123", [job]);
+
+    expect(first.decisions[0]?.status).toBe("needs-code-fix");
+    expect(second.decisions[0]?.status).toBe("needs-code-fix");
+    expect(first.budget).toStrictEqual(emptyYeetMonitorRerunBudget);
+  });
+
+  it("keys the budget on the SHA and job name while the command stays id-scoped", () => {
+    // Idempotency key and execution target are deliberately different
+    // identifiers: the name survives a rerun's new attempt, the id is the only
+    // thing `gh run rerun --job` accepts.
+    expect(yeetMonitorRerunKey("abc123", "Check")).toBe("abc123#Check");
+    expect(yeetMonitorRerunKey("abc123", "Check")).not.toContain("991");
+    expect(yeetMonitorRerunCommand(991)).toBe("gh run rerun --job 991");
+  });
+});
+
+describe("yeet monitor loop control", () => {
+  it("reads the terminal state out of a gh pr view state string", () => {
+    expect(yeetMonitorTerminalState(O.some("MERGED"))).toStrictEqual(O.some("merged"));
+    expect(yeetMonitorTerminalState(O.some("closed"))).toStrictEqual(O.some("closed"));
+    expect(yeetMonitorTerminalState(O.some("OPEN"))).toStrictEqual(O.none());
+    expect(yeetMonitorTerminalState(O.none())).toStrictEqual(O.none());
+  });
+
+  it("renders each decision so the operator sees the classification, not a bare exit", () => {
+    const plan = planYeetMonitorReruns(emptyYeetMonitorRerunBudget, "abc123", [
+      failedJob(991, "Check", O.some("ts2589-no-location")),
+      failedJob(993, "Coverage", O.none()),
+    ]);
+    const rendered = A.map(plan.decisions, renderYeetMonitorJobDecision);
+
+    expect(rendered[0]).toContain("ts2589-no-location flake fingerprint matched");
+    expect(rendered[0]).toContain("gh run rerun --job 991");
+    expect(rendered[1]).toContain("needs code fix");
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet-monitor-phase-empty.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-monitor-phase-empty.test.ts
@@ -1,0 +1,70 @@
+import {
+  RepoRunContext,
+  runMonitorPhaseForTesting,
+  runPublishMonitorAndResultForTesting,
+  TurboPlanSnapshot,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import { NodeChildProcessSpawner } from "@effect/platform-node";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Ref } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import type { YeetExecutedStep, YeetVerdictExtrasForTesting } from "@beep/repo-cli/test/Yeet";
+
+const PlatformLayer = NodeChildProcessSpawner.layer.pipe(
+  Layer.provideMerge(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer))
+);
+
+const context = RepoRunContext.make({
+  repoRoot: "/repo",
+  cwd: "/repo",
+  base: "origin/main",
+  head: "HEAD",
+  branch: "feat/merge-loop",
+  packetDir: ".beep/yeet",
+  originalArgv: [],
+  turbo: TurboPlanSnapshot.make({ graphHealthStatus: "ok", graphHealthWarnings: [], packages: [], tasks: [] }),
+});
+
+const emptyExtras: YeetVerdictExtrasForTesting = {
+  baseFreshness: O.none(),
+  mergeReady: O.none(),
+  stash: O.none(),
+};
+
+// Regression for the publish-without---monitor P0: the planner emits monitor
+// steps only under `--monitor`, so every other publish reached the monitor
+// phase with an empty step list. The phase decoded the (absent) PR context
+// anyway and failed with "Failed to decode pull request number for yeet
+// monitor" AFTER the run had fully succeeded, so `yeet publish` exited 1 on
+// green. An empty monitor phase must be a no-op.
+describe("yeet monitor phase with no planned steps", () => {
+  it.effect("completes without decoding a pull request and runs no step", () =>
+    Effect.gen(function* () {
+      const recorder = yield* Ref.make<ReadonlyArray<YeetExecutedStep>>(A.empty());
+
+      yield* runMonitorPhaseForTesting(context, A.empty(), recorder, "yeet publish monitor phase failed.");
+
+      expect(yield* Ref.get(recorder)).toStrictEqual(A.empty());
+    }).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.effect("returns the publish result and leaves merge readiness unobserved", () =>
+    Effect.gen(function* () {
+      const recorder = yield* Ref.make<ReadonlyArray<YeetExecutedStep>>(A.empty());
+      const extras = yield* Ref.make<YeetVerdictExtrasForTesting>(emptyExtras);
+
+      const result = yield* runPublishMonitorAndResultForTesting(context, A.empty(), recorder, extras, false);
+
+      expect(result.committed).toBe(true);
+      expect(result.pushed).toBe(true);
+      expect(yield* Ref.get(recorder)).toStrictEqual(A.empty());
+      // No status snapshot was read, so the verdict must omit mergeReady rather
+      // than assert an unobserved answer.
+      expect((yield* Ref.get(extras)).mergeReady).toStrictEqual(O.none());
+    }).pipe(provideScopedLayer(PlatformLayer))
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-reply-engine.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-reply-engine.test.ts
@@ -1,0 +1,425 @@
+import {
+  findReplyThread,
+  planReplyActions,
+  REPLY_DRAFTS_FILE_NAME,
+  REPLY_REPORT_FILE_NAME,
+  REPLY_RERUN_COMMAND,
+  ReplyDraft,
+  ReplyDrafts,
+  ReplyDraftsJson,
+  ReplyLiveThread,
+  ReplyReport,
+  ReplyReportJson,
+  ReplyThreadComment,
+  ReplyThreadCommentConnection,
+  RepoRunContext,
+  replyDraftsPathForContext,
+  replyReportPathForContext,
+  replyResolveRetryCommand,
+  replyReviewThreadsPageQuery,
+  runYeetReply,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, pipe, Result, Sink, Stream } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import type { ReplyAction, ReplyDraftOutcome } from "@beep/repo-cli/test/Yeet";
+
+const OPEN_COMMENT_ID = 2_284_119_001;
+const RESOLVED_COMMENT_ID = 2_284_119_002;
+const OUTDATED_COMMENT_ID = 2_284_119_003;
+const UNKNOWN_COMMENT_ID = 2_284_119_999;
+
+const closedPageInfo = { endCursor: null, hasNextPage: false };
+
+const openThread = ReplyLiveThread.make({
+  comments: ReplyThreadCommentConnection.make({
+    nodes: [ReplyThreadComment.make({ databaseId: OPEN_COMMENT_ID, id: "PRRC_open" })],
+    pageInfo: closedPageInfo,
+  }),
+  id: "PRRT_open",
+  isOutdated: false,
+  isResolved: false,
+  line: 42,
+  path: "src/commands/Yeet/internal/Reply.ts",
+});
+
+const resolvedThread = ReplyLiveThread.make({
+  comments: ReplyThreadCommentConnection.make({
+    nodes: [ReplyThreadComment.make({ databaseId: RESOLVED_COMMENT_ID, id: "PRRC_resolved" })],
+    pageInfo: closedPageInfo,
+  }),
+  id: "PRRT_resolved",
+  isOutdated: false,
+  isResolved: true,
+  line: 7,
+  path: "src/commands/Yeet/internal/Verdict.ts",
+});
+
+// A thread whose diff hunk moved: still open, still counts against the
+// "threads resolved" merge criterion, and its only comment predates the
+// databaseId field being requested.
+const outdatedThread = ReplyLiveThread.make({
+  comments: ReplyThreadCommentConnection.make({
+    nodes: [
+      ReplyThreadComment.make({ databaseId: null, id: "PRRC_outdated_legacy" }),
+      ReplyThreadComment.make({ databaseId: OUTDATED_COMMENT_ID, id: "PRRC_outdated" }),
+    ],
+    pageInfo: closedPageInfo,
+  }),
+  id: "PRRT_outdated",
+  isOutdated: true,
+  isResolved: false,
+  line: null,
+  path: null,
+});
+
+const liveThreads = [openThread, resolvedThread, outdatedThread];
+
+const draftsOf = (drafts: ReadonlyArray<ReplyDraft>): ReplyDrafts =>
+  ReplyDrafts.make({ schemaVersion: "yeet-reply-drafts/v1", prNumber: 558, drafts });
+
+const postThreadIds = (actions: ReadonlyArray<ReplyAction>): ReadonlyArray<string> =>
+  A.filterMap(actions, (action) => (action._tag === "post" ? Result.succeed(action.threadId) : Result.failVoid));
+
+const settledOutcomes = (actions: ReadonlyArray<ReplyAction>): ReadonlyArray<ReplyDraftOutcome> =>
+  A.filterMap(actions, (action) => (action._tag === "settled" ? Result.succeed(action.outcome) : Result.failVoid));
+
+describe("findReplyThread", () => {
+  it("matches a draft that names the GraphQL thread id", () => {
+    const draft = ReplyDraft.make({ threadId: O.some("PRRT_resolved"), body: "ack" });
+    expect(O.map(findReplyThread(liveThreads, draft), (thread) => thread.id)).toEqual(O.some("PRRT_resolved"));
+  });
+
+  it("maps a REST comment id onto its thread through the comment databaseId", () => {
+    const draft = ReplyDraft.make({ commentId: O.some(OPEN_COMMENT_ID), body: "ack" });
+    expect(O.map(findReplyThread(liveThreads, draft), (thread) => thread.id)).toEqual(O.some("PRRT_open"));
+  });
+
+  it("prefers the thread id when a draft carries both handles", () => {
+    const draft = ReplyDraft.make({
+      threadId: O.some("PRRT_resolved"),
+      commentId: O.some(OPEN_COMMENT_ID),
+      body: "ack",
+    });
+    expect(O.map(findReplyThread(liveThreads, draft), (thread) => thread.id)).toEqual(O.some("PRRT_resolved"));
+  });
+
+  it("falls back to the comment id when the named thread id is not live", () => {
+    const draft = ReplyDraft.make({
+      threadId: O.some("PRRT_gone"),
+      commentId: O.some(OPEN_COMMENT_ID),
+      body: "ack",
+    });
+    expect(O.map(findReplyThread(liveThreads, draft), (thread) => thread.id)).toEqual(O.some("PRRT_open"));
+  });
+
+  it("returns None for a comment id no live thread carries", () => {
+    const draft = ReplyDraft.make({ commentId: O.some(UNKNOWN_COMMENT_ID), body: "ack" });
+    expect(findReplyThread(liveThreads, draft)).toEqual(O.none());
+  });
+
+  it("skips comments whose databaseId is absent instead of matching them", () => {
+    const draft = ReplyDraft.make({ commentId: O.some(OUTDATED_COMMENT_ID), body: "ack" });
+    expect(O.map(findReplyThread(liveThreads, draft), (thread) => thread.id)).toEqual(O.some("PRRT_outdated"));
+  });
+});
+
+describe("planReplyActions", () => {
+  it("plans a write for a live, unresolved thread named by thread id", () => {
+    const actions = planReplyActions(
+      draftsOf([ReplyDraft.make({ threadId: O.some("PRRT_open"), body: "Fixed in 0123456." })]),
+      liveThreads
+    );
+    expect(A.map(actions, (action) => action._tag)).toEqual(["post"]);
+    expect(postThreadIds(actions)).toEqual(["PRRT_open"]);
+  });
+
+  it("plans a write for a comment-id draft, resolving it to the thread id", () => {
+    const actions = planReplyActions(
+      draftsOf([ReplyDraft.make({ commentId: O.some(OPEN_COMMENT_ID), body: "Fixed in 0123456." })]),
+      liveThreads
+    );
+    expect(postThreadIds(actions)).toEqual(["PRRT_open"]);
+  });
+
+  it("still plans a write for an outdated but unresolved thread", () => {
+    const actions = planReplyActions(
+      draftsOf([ReplyDraft.make({ threadId: O.some("PRRT_outdated"), body: "Fixed in 0123456." })]),
+      liveThreads
+    );
+    expect(postThreadIds(actions)).toEqual(["PRRT_outdated"]);
+  });
+
+  it("plans a write regardless of the draft's resolve flag", () => {
+    const actions = planReplyActions(
+      draftsOf([ReplyDraft.make({ threadId: O.some("PRRT_open"), body: "Not a defect.", resolve: false })]),
+      liveThreads
+    );
+    expect(postThreadIds(actions)).toEqual(["PRRT_open"]);
+  });
+
+  it("settles an already-resolved thread as stale, naming its location", () => {
+    const [outcome] = settledOutcomes(
+      planReplyActions(draftsOf([ReplyDraft.make({ threadId: O.some("PRRT_resolved"), body: "ack" })]), liveThreads)
+    );
+    expect(outcome?.status).toBe("stale");
+    expect(outcome?.threadId).toEqual(O.some("PRRT_resolved"));
+    expect(outcome?.detail).toContain("already resolved upstream");
+    expect(outcome?.detail).toContain("src/commands/Yeet/internal/Verdict.ts:7");
+  });
+
+  it("settles an unknown thread id as failed and quotes the handle", () => {
+    const [outcome] = settledOutcomes(
+      planReplyActions(draftsOf([ReplyDraft.make({ threadId: O.some("PRRT_gone"), body: "ack" })]), liveThreads)
+    );
+    expect(outcome?.status).toBe("failed");
+    expect(outcome?.threadId).toEqual(O.some("PRRT_gone"));
+    expect(outcome?.detail).toContain("thread id PRRT_gone");
+    expect(outcome?.detail).toContain("pull request #558");
+  });
+
+  it("settles an unknown comment id as failed and keeps the comment id for triage", () => {
+    const [outcome] = settledOutcomes(
+      planReplyActions(draftsOf([ReplyDraft.make({ commentId: O.some(UNKNOWN_COMMENT_ID), body: "ack" })]), liveThreads)
+    );
+    expect(outcome?.status).toBe("failed");
+    expect(outcome?.threadId).toEqual(O.none());
+    expect(outcome?.commentId).toEqual(O.some(UNKNOWN_COMMENT_ID));
+    expect(outcome?.detail).toContain(`comment id ${UNKNOWN_COMMENT_ID}`);
+  });
+
+  it("names both handles when a draft carrying both matches nothing", () => {
+    const [outcome] = settledOutcomes(
+      planReplyActions(
+        draftsOf([
+          ReplyDraft.make({ threadId: O.some("PRRT_gone"), commentId: O.some(UNKNOWN_COMMENT_ID), body: "ack" }),
+        ]),
+        liveThreads
+      )
+    );
+    expect(outcome?.detail).toContain("thread id PRRT_gone / comment id");
+  });
+
+  it("fails the second draft that targets a thread an earlier draft already claimed", () => {
+    const actions = planReplyActions(
+      draftsOf([
+        ReplyDraft.make({ threadId: O.some("PRRT_open"), body: "first" }),
+        ReplyDraft.make({ commentId: O.some(OPEN_COMMENT_ID), body: "second" }),
+      ]),
+      liveThreads
+    );
+    expect(A.map(actions, (action) => action._tag)).toEqual(["post", "settled"]);
+    const [outcome] = settledOutcomes(actions);
+    expect(outcome?.status).toBe("failed");
+    expect(outcome?.detail).toContain("already targeted by an earlier draft");
+    expect(outcome?.commentId).toEqual(O.some(OPEN_COMMENT_ID));
+    expect(outcome?.threadId).toEqual(O.some("PRRT_open"));
+  });
+
+  it("emits exactly one action per draft, in drafts-file order", () => {
+    const actions = planReplyActions(
+      draftsOf([
+        ReplyDraft.make({ threadId: O.some("PRRT_resolved"), body: "stale one" }),
+        ReplyDraft.make({ threadId: O.some("PRRT_open"), body: "live one" }),
+        ReplyDraft.make({ threadId: O.some("PRRT_gone"), body: "unknown one" }),
+      ]),
+      liveThreads
+    );
+    expect(A.map(actions, (action) => action._tag)).toEqual(["settled", "post", "settled"]);
+  });
+
+  it("plans everything as failed when the live snapshot is empty", () => {
+    const actions = planReplyActions(
+      draftsOf([ReplyDraft.make({ threadId: O.some("PRRT_open"), body: "ack" })]),
+      A.empty<ReplyLiveThread>()
+    );
+    expect(A.map(settledOutcomes(actions), (outcome) => outcome.status)).toEqual(["failed"]);
+  });
+
+  it.effect("produces settled outcomes that round-trip through the report codec", () =>
+    Effect.gen(function* () {
+      const outcomes = settledOutcomes(
+        planReplyActions(
+          draftsOf([
+            ReplyDraft.make({ threadId: O.some("PRRT_resolved"), body: "stale one" }),
+            ReplyDraft.make({ commentId: O.some(UNKNOWN_COMMENT_ID), body: "unknown one" }),
+          ]),
+          liveThreads
+        )
+      );
+      const report = ReplyReport.make({
+        schemaVersion: "yeet-reply-report/v1",
+        prNumber: 558,
+        createdAt: "2026-08-05T00:00:00.000Z",
+        outcomes,
+      });
+      const text = yield* ReplyReportJson.encode(report);
+      expect(text).not.toContain('"_id":"Option"');
+      expect(yield* ReplyReportJson.decode(text)).toEqual(report);
+    })
+  );
+});
+
+const encoder = new TextEncoder();
+
+type CommandStub = {
+  readonly exitCode: number;
+  readonly output: string;
+};
+
+const ok = (output: string): CommandStub => ({ exitCode: 0, output });
+
+const stubHandle = (stub: CommandStub) =>
+  ChildProcessSpawner.makeHandle({
+    all: Stream.make(encoder.encode(stub.output)),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(stub.exitCode)),
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    pid: ChildProcessSpawner.ProcessId(1),
+    stderr: Stream.empty,
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(stub.output)),
+    unref: Effect.succeed(Effect.void),
+  });
+
+/** A spawner answering by command-line marker; unlisted commands succeed empty. */
+const stubSpawnerLayer = (stubs: ReadonlyArray<readonly [string, CommandStub]>) =>
+  Layer.effect(
+    ChildProcessSpawner.ChildProcessSpawner,
+    Effect.succeed(
+      ChildProcessSpawner.make((command) =>
+        ChildProcess.isStandardCommand(command)
+          ? Effect.succeed(
+              stubHandle(
+                pipe(
+                  A.findFirst(stubs, ([marker]) =>
+                    Str.includes(marker)(A.join([command.command, ...command.args], " "))
+                  ),
+                  O.match({ onNone: () => ok(""), onSome: ([, stub]) => stub })
+                )
+              )
+            )
+          : Effect.die("the reply engine never spawns a piped command")
+      )
+    )
+  );
+
+const repoViewJson = `{"name":"beep-effect","owner":{"login":"YeeBois"}}`;
+
+const reviewThreadsJson = `{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[{"id":"PRRT_open","isResolved":false,"isOutdated":false,"path":"src/commands/Yeet/internal/Reply.ts","line":42,"comments":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[{"id":"PRRC_open","databaseId":${OPEN_COMMENT_ID}}]}},{"id":"PRRT_resolved","isResolved":true,"isOutdated":false,"path":"src/commands/Yeet/internal/Verdict.ts","line":7,"comments":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[{"id":"PRRC_resolved","databaseId":${RESOLVED_COMMENT_ID}}]}}]}}}}}`;
+
+const replyContext = (root: string): RepoRunContext =>
+  RepoRunContext.make({
+    base: "origin/main",
+    branch: "feat/merge-loop",
+    cwd: root,
+    head: "HEAD",
+    originalArgv: [],
+    packetDir: root,
+    repoRoot: root,
+    turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+  });
+
+const writeDrafts = Effect.fnUntraced(function* (context: RepoRunContext, drafts: ReplyDrafts) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.writeFileString(yield* replyDraftsPathForContext(context), yield* ReplyDraftsJson.encode(drafts));
+});
+
+const withTempDirectory = Effect.fn("withTempDirectory")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+const replyTestLayer = (stubs: ReadonlyArray<readonly [string, CommandStub]>) =>
+  Layer.mergeAll(NodeFileSystem.layer, NodePath.layer, stubSpawnerLayer(stubs));
+
+const deniedRepoViewStubs: ReadonlyArray<readonly [string, CommandStub]> = [
+  ["gh repo view", { exitCode: 1, output: "gh: authentication required" }],
+];
+
+const liveThreadStubs: ReadonlyArray<readonly [string, CommandStub]> = [
+  ["gh repo view", ok(repoViewJson)],
+  ["YeetReplyReviewThreads", ok(reviewThreadsJson)],
+];
+
+describe("runYeetReply", () => {
+  const twoDrafts = draftsOf([
+    ReplyDraft.make({ threadId: O.some("PRRT_open"), body: "Fixed in 0123456." }),
+    ReplyDraft.make({ commentId: O.some(RESOLVED_COMMENT_ID), body: "Already handled." }),
+  ]);
+
+  it.effect("settles every loaded draft when the preflight repo read fails, then fails the run", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = replyContext(root);
+        yield* writeDrafts(context, twoDrafts);
+
+        const error = yield* Effect.flip(runYeetReply(context));
+        expect(error.message).toContain("preflight failed before any draft could be posted");
+        expect(error.exitCode).toBe(1);
+
+        const fs = yield* FileSystem.FileSystem;
+        const reportPath = yield* replyReportPathForContext(context);
+        expect(error.file).toBe(reportPath);
+        const written = yield* fs.readFileString(reportPath);
+        const report = yield* ReplyReportJson.decode(written);
+        expect(A.map(report.outcomes, (outcome) => outcome.status)).toEqual(["failed", "failed"]);
+        expect(A.map(report.outcomes, (outcome) => outcome.threadId)).toEqual([O.some("PRRT_open"), O.none()]);
+        for (const outcome of report.outcomes) {
+          expect(outcome.detail).toContain("gh: authentication required");
+          expect(outcome.detail).toContain(REPLY_RERUN_COMMAND);
+        }
+      })
+    ).pipe(provideScopedLayer(replyTestLayer(deniedRepoViewStubs)))
+  );
+
+  it.effect("writes a reply-report.json that decodes back through ReplyReportJson", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = replyContext(root);
+        yield* writeDrafts(context, twoDrafts);
+
+        const report = yield* runYeetReply(context);
+        expect(A.map(report.outcomes, (outcome) => outcome.status)).toEqual(["resolved", "stale"]);
+
+        const fs = yield* FileSystem.FileSystem;
+        const written = yield* fs.readFileString(yield* replyReportPathForContext(context));
+        expect(written).not.toContain('"_id":"Option"');
+        expect(yield* ReplyReportJson.decode(written)).toEqual(report);
+      })
+    ).pipe(provideScopedLayer(replyTestLayer(liveThreadStubs)))
+  );
+});
+
+describe("reply operator surfaces", () => {
+  it("requests the comment databaseId that the comment-id matcher joins on", () => {
+    expect(replyReviewThreadsPageQuery).toContain("databaseId");
+    expect(replyReviewThreadsPageQuery).toContain("reviewThreads(first: 100");
+    expect(replyReviewThreadsPageQuery).toContain("isResolved");
+  });
+
+  it("renders a body-free resolve retry for a thread left open", () => {
+    const command = replyResolveRetryCommand("PRRT_open");
+    expect(command).toContain("resolveReviewThread");
+    expect(command).toContain("threadId=PRRT_open");
+    expect(command).not.toContain("body=");
+  });
+
+  it("pins the artifact file names and the rerun command", () => {
+    expect(REPLY_DRAFTS_FILE_NAME).toBe("reply-drafts.json");
+    expect(REPLY_REPORT_FILE_NAME).toBe("reply-report.json");
+    expect(REPLY_RERUN_COMMAND).toBe("bun run beep yeet reply");
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet-reply-schemas.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-reply-schemas.test.ts
@@ -1,0 +1,146 @@
+import {
+  ReplyDraft,
+  ReplyDraftOutcome,
+  ReplyDrafts,
+  ReplyDraftsJson,
+  ReplyOutcomeStatus,
+  ReplyReport,
+  ReplyReportJson,
+} from "@beep/repo-cli/test/Yeet";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+import * as O from "effect/Option";
+
+const drafts = ReplyDrafts.make({
+  schemaVersion: "yeet-reply-drafts/v1",
+  prNumber: 558,
+  drafts: [
+    ReplyDraft.make({
+      threadId: O.some("PRRT_kwDOKq9lNc5b8Xy1"),
+      body: "Fixed in 0123456: the verdict writer now encodes through the schema codec.",
+    }),
+    ReplyDraft.make({
+      commentId: O.some(2_284_119_001),
+      body: "Not a defect: the sweep reports the skip rather than force-deleting.",
+      resolve: false,
+    }),
+  ],
+});
+
+const report = ReplyReport.make({
+  schemaVersion: "yeet-reply-report/v1",
+  prNumber: 558,
+  createdAt: "2026-08-04T00:00:00.000Z",
+  outcomes: [
+    ReplyDraftOutcome.make({
+      threadId: O.some("PRRT_kwDOKq9lNc5b8Xy1"),
+      status: "resolved",
+      detail: "reply posted and thread resolved",
+    }),
+    ReplyDraftOutcome.make({
+      commentId: O.some(2_284_119_001),
+      status: "posted",
+      detail: "reply posted; draft opted out of resolving",
+    }),
+    ReplyDraftOutcome.make({
+      threadId: O.some("PRRT_kwDOKq9lNc5b8Xy2"),
+      status: "stale",
+      detail: "thread was already resolved upstream",
+    }),
+    ReplyDraftOutcome.make({
+      threadId: O.some("PRRT_kwDOKq9lNc5b8Xy3"),
+      status: "failed",
+      detail: "resolveReviewThread returned RESOURCE_NOT_ACCESSIBLE",
+    }),
+  ],
+});
+
+describe("reply outcome statuses", () => {
+  it("pins the reply outcome domain", () => {
+    expect(ReplyOutcomeStatus.Options).toEqual(["posted", "resolved", "stale", "failed"]);
+  });
+});
+
+describe("ReplyDrafts", () => {
+  it.effect("round-trips through its JSON codec", () =>
+    Effect.gen(function* () {
+      const text = yield* ReplyDraftsJson.encode(drafts);
+      const decoded = yield* ReplyDraftsJson.decode(text);
+      expect(decoded).toEqual(drafts);
+    })
+  );
+
+  it("defaults resolve to true when the draft omits it", () => {
+    expect(drafts.drafts[0]?.resolve).toBe(true);
+    expect(drafts.drafts[1]?.resolve).toBe(false);
+  });
+
+  it.effect("defaults resolve to true when the drafts file omits the key", () =>
+    Effect.gen(function* () {
+      const decoded = yield* ReplyDraftsJson.decode(
+        '{"schemaVersion":"yeet-reply-drafts/v1","prNumber":558,"drafts":[{"threadId":"PRRT_kwDOKq9lNc5b8Xy1","body":"ack"}]}'
+      );
+      expect(decoded.drafts[0]?.resolve).toBe(true);
+      expect(decoded.drafts[0]?.commentId).toEqual(O.none());
+    })
+  );
+
+  it.effect("accepts a draft targeted by numeric REST comment id alone", () =>
+    Effect.gen(function* () {
+      const decoded = yield* ReplyDraftsJson.decode(
+        '{"schemaVersion":"yeet-reply-drafts/v1","prNumber":558,"drafts":[{"commentId":2284119001,"body":"ack"}]}'
+      );
+      expect(decoded.drafts[0]?.threadId).toEqual(O.none());
+      expect(decoded.drafts[0]?.commentId).toEqual(O.some(2_284_119_001));
+    })
+  );
+
+  it.effect("rejects a draft that names neither a thread nor a comment", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        ReplyDraftsJson.decode('{"schemaVersion":"yeet-reply-drafts/v1","prNumber":558,"drafts":[{"body":"ack"}]}')
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+
+  it.effect("rejects a GraphQL comment id pasted into the thread id field", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        ReplyDraftsJson.decode(
+          '{"schemaVersion":"yeet-reply-drafts/v1","prNumber":558,"drafts":[{"threadId":"PRRC_kwDOKq9lNc5b8Xy1","body":"ack"}]}'
+        )
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+
+  it.effect("rejects an empty reply body", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        ReplyDraftsJson.decode(
+          '{"schemaVersion":"yeet-reply-drafts/v1","prNumber":558,"drafts":[{"threadId":"PRRT_kwDOKq9lNc5b8Xy1","body":""}]}'
+        )
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+});
+
+describe("ReplyReport", () => {
+  it.effect("round-trips every outcome status through its JSON codec", () =>
+    Effect.gen(function* () {
+      const text = yield* ReplyReportJson.encode(report);
+      const decoded = yield* ReplyReportJson.decode(text);
+      expect(decoded).toEqual(report);
+    })
+  );
+
+  it.effect("omits absent target keys instead of writing Option runtime objects", () =>
+    Effect.gen(function* () {
+      const text = yield* ReplyReportJson.encode(report);
+      expect(text).not.toContain('"_id":"Option"');
+      expect(text).toContain('{"commentId":2284119001,"status":"posted"');
+    })
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-status-triage.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-status-triage.test.ts
@@ -1,0 +1,263 @@
+import {
+  deriveYeetMergeReady,
+  renderYeetReviewThreadBlock,
+  renderYeetStatusSummary,
+  YeetStatusArtifact,
+  YeetStatusRemote,
+  YeetStatusReviewThread,
+  YeetStatusSnapshot,
+  YeetStatusSnapshotJson,
+  YeetStatusWorktree,
+  yeetReviewThreadExcerpt,
+} from "@beep/repo-cli/test/Yeet";
+import { A } from "@beep/utils";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+
+// Verbatim shape of a Greptile inline review body: a machine marker, a
+// shields.io severity badge, then the sentence a human actually reads.
+const greptileBody = A.join(
+  [
+    "<!-- greptile_comment -->",
+    "![](https://img.shields.io/badge/severity-logic-red)",
+    "",
+    "**logic**: The rerun budget is keyed on the job alone, so a new head SHA never earns a fresh allowance.",
+    "",
+    "<details><summary>Context</summary>",
+    "See `planYeetMonitorReruns`.",
+    "</details>",
+  ],
+  "\n"
+);
+
+const humanBody = "Please  add a regression test\nfor the truncated-capture path.";
+
+const triageThread = YeetStatusReviewThread.make({
+  threadId: "PRRT_kwDOAbC1",
+  author: "greptile-apps[bot]",
+  excerpt: yeetReviewThreadExcerpt(greptileBody),
+  path: O.some("src/commands/Yeet/internal/MonitorLoop.ts"),
+  line: O.some(88),
+  commentDatabaseId: O.some(2412551122),
+});
+
+const humanThread = YeetStatusReviewThread.make({
+  threadId: "PRRT_kwDOAbC2",
+  author: "octocat",
+  excerpt: yeetReviewThreadExcerpt(humanBody),
+  path: O.none(),
+  line: O.none(),
+  commentDatabaseId: O.some(2412551123),
+});
+
+const closeoutArtifact = (issueCount: number, greptileScore: O.Option<string>) =>
+  YeetStatusArtifact.make({
+    detail: "PR #560",
+    issueCount,
+    path: ".beep/yeet/runs/feature/pr-closeout.json",
+    state: "present",
+    greptileScore,
+  });
+
+const openRemote = (fields: {
+  readonly checkCount?: number;
+  readonly failingCheckCount?: number;
+  readonly pendingCheckCount?: number;
+  readonly unresolvedReviewThreadCount?: number;
+  readonly unresolvedThreads?: O.Option<ReadonlyArray<YeetStatusReviewThread>>;
+}) =>
+  YeetStatusRemote.make({
+    available: true,
+    checked: true,
+    detail: "PR #560 OPEN",
+    unresolvedReviewThreadCount: fields.unresolvedReviewThreadCount ?? 0,
+    unresolvedThreads: fields.unresolvedThreads ?? O.some(A.empty<YeetStatusReviewThread>()),
+    ...(fields.checkCount === undefined ? {} : { checkCount: fields.checkCount }),
+    ...(fields.failingCheckCount === undefined ? {} : { failingCheckCount: fields.failingCheckCount }),
+    ...(fields.pendingCheckCount === undefined ? {} : { pendingCheckCount: fields.pendingCheckCount }),
+  });
+
+describe("yeet review-thread excerpts", () => {
+  it("reduces a badge-prefixed bot body to its first readable sentence", () => {
+    const excerpt = yeetReviewThreadExcerpt(greptileBody);
+
+    expect(excerpt).toBe(
+      "logic: The rerun budget is keyed on the job alone, so a new head SHA never earns a fresh allowance."
+    );
+    expect(excerpt).not.toContain("img.shields.io");
+    expect(excerpt).not.toContain("<!--");
+    expect(excerpt).not.toContain("**");
+  });
+
+  it("collapses whitespace in a plain human comment", () => {
+    expect(yeetReviewThreadExcerpt(humanBody)).toBe("Please add a regression test");
+  });
+
+  it("names an empty body rather than rendering a blank line", () => {
+    expect(yeetReviewThreadExcerpt("<!-- greptile_comment -->\n")).toBe("(no comment body)");
+  });
+});
+
+describe("yeet unresolved-thread listing", () => {
+  it("carries author, comment databaseId, location, and excerpt on one line per thread", () => {
+    const block = renderYeetReviewThreadBlock(
+      openRemote({ unresolvedReviewThreadCount: 2, unresolvedThreads: O.some([triageThread, humanThread]) })
+    );
+    const lines = Str.split("\n")(block);
+
+    expect(lines[0]).toBe("review threads: 2 unresolved");
+    expect(lines[1]).toBe(
+      "  - PRRT_kwDOAbC1 comment 2412551122 src/commands/Yeet/internal/MonitorLoop.ts:88 @greptile-apps[bot]: logic: The rerun budget is keyed on the job alone, so a new head SHA never earns a fresh allowance."
+    );
+    // A conversation-level thread has no file location; the reply identifiers
+    // still have to be readable straight off this line.
+    expect(lines[2]).toBe("  - PRRT_kwDOAbC2 comment 2412551123 @octocat: Please add a regression test");
+  });
+
+  it("falls back to the legacy inline id list when a snapshot carries no triage context", () => {
+    const remote = YeetStatusRemote.make({
+      available: true,
+      checked: true,
+      detail: "PR #560 OPEN",
+      unresolvedReviewThreadCount: 1,
+      unresolvedReviewThreads: ["PRRT_kwDOAbC1 (src/example.ts)"],
+    });
+
+    expect(renderYeetReviewThreadBlock(remote)).toBe("review threads: 1 unresolved -> PRRT_kwDOAbC1 (src/example.ts)");
+  });
+
+  it("says so when the pull request was never read", () => {
+    expect(
+      renderYeetReviewThreadBlock(YeetStatusRemote.make({ available: false, checked: false, detail: "pass --remote" }))
+    ).toBe("review threads: not checked");
+  });
+});
+
+describe("yeet merge readiness", () => {
+  it("is unknown, not blocked, when the pull request was not read", () => {
+    expect(
+      deriveYeetMergeReady(
+        closeoutArtifact(0, O.some("5/5")),
+        YeetStatusRemote.make({ available: false, checked: false, detail: "pass --remote" })
+      )
+    ).toStrictEqual(O.none());
+  });
+
+  it("names checks-green first when the pipeline is red and threads are also open", () => {
+    const mergeReady = deriveYeetMergeReady(
+      closeoutArtifact(1, O.some("4/5")),
+      openRemote({ checkCount: 24, failingCheckCount: 1, unresolvedReviewThreadCount: 2 })
+    );
+
+    expect(O.map(mergeReady, (value) => value.ready)).toStrictEqual(O.some(false));
+    expect(O.flatMap(mergeReady, (value) => value.failing)).toStrictEqual(O.some("checks-green"));
+  });
+
+  it("treats a still-pending pipeline as not green", () => {
+    const mergeReady = deriveYeetMergeReady(
+      closeoutArtifact(0, O.none()),
+      openRemote({ checkCount: 24, failingCheckCount: 0, pendingCheckCount: 3 })
+    );
+
+    expect(O.flatMap(mergeReady, (value) => value.failing)).toStrictEqual(O.some("checks-green"));
+  });
+
+  it("names threads-resolved once the pipeline is green", () => {
+    const mergeReady = deriveYeetMergeReady(
+      closeoutArtifact(0, O.some("5/5")),
+      openRemote({ checkCount: 24, failingCheckCount: 0, pendingCheckCount: 0, unresolvedReviewThreadCount: 1 })
+    );
+
+    expect(O.flatMap(mergeReady, (value) => value.failing)).toStrictEqual(O.some("threads-resolved"));
+  });
+
+  it("counts unresolved closeout issues as an open-thread blocker", () => {
+    const mergeReady = deriveYeetMergeReady(
+      closeoutArtifact(2, O.some("5/5")),
+      openRemote({ checkCount: 24, failingCheckCount: 0, pendingCheckCount: 0, unresolvedReviewThreadCount: 0 })
+    );
+
+    expect(O.flatMap(mergeReady, (value) => value.failing)).toStrictEqual(O.some("threads-resolved"));
+  });
+
+  it("is ready with no failing criterion when both hard criteria hold, carrying Greptile as display only", () => {
+    const mergeReady = deriveYeetMergeReady(
+      closeoutArtifact(0, O.some("4/5")),
+      openRemote({ checkCount: 24, failingCheckCount: 0, pendingCheckCount: 0, unresolvedReviewThreadCount: 0 })
+    );
+
+    expect(O.map(mergeReady, (value) => value.ready)).toStrictEqual(O.some(true));
+    expect(O.flatMap(mergeReady, (value) => value.failing)).toStrictEqual(O.none());
+    expect(O.flatMap(mergeReady, (value) => value.criteria.greptileScore)).toStrictEqual(O.some("4/5"));
+  });
+});
+
+describe("yeet status snapshot rendering and encoding", () => {
+  const remote = openRemote({
+    checkCount: 24,
+    failingCheckCount: 0,
+    pendingCheckCount: 0,
+    unresolvedReviewThreadCount: 1,
+    unresolvedThreads: O.some([triageThread]),
+  });
+  const closeout = closeoutArtifact(0, O.some("5/5"));
+  const snapshot = YeetStatusSnapshot.make({
+    base: "origin/main",
+    branch: "feat/merge-loop",
+    closeout,
+    createdAt: "2026-08-04T00:00:00.000Z",
+    head: "HEAD",
+    nextCommand: "bun run beep yeet closeout --summary",
+    remote,
+    runId: "feat_merge-loop",
+    schemaVersion: "yeet-status/v1",
+    statusPath: ".beep/yeet/runs/feat_merge-loop/status.json",
+    verdict: YeetStatusArtifact.make({ detail: "publish success", path: "verdict.json", state: "present" }),
+    worktree: YeetStatusWorktree.make({ clean: true, staged: 0, unstaged: 0, untracked: 0 }),
+    mergeReady: deriveYeetMergeReady(closeout, remote),
+  });
+
+  it("renders the single failing criterion beside the thread triage block", () => {
+    const summary = renderYeetStatusSummary(snapshot);
+
+    expect(summary).toContain("- review threads: 1 unresolved");
+    expect(summary).toContain("  - PRRT_kwDOAbC1 comment 2412551122");
+    expect(summary).toContain("- merge-ready: no, blocked on threads-resolved (greptile 5/5)");
+  });
+
+  it.effect("round-trips through the status JSON codec instead of leaking Option runtime objects", () =>
+    Effect.gen(function* () {
+      const json = yield* YeetStatusSnapshotJson.encode(snapshot);
+      const decoded = yield* YeetStatusSnapshotJson.decode(json);
+
+      // Regression: the writer used a generic JSON encoder over the decoded
+      // snapshot, which rendered Option fields as {"_id":"Option",...} and
+      // produced an artifact that no longer decoded.
+      expect(json).not.toContain('"_id":"Option"');
+      expect(O.flatMap(decoded.mergeReady, (value) => value.failing)).toStrictEqual(O.some("threads-resolved"));
+      expect(
+        O.map(decoded.remote.unresolvedThreads, (threads) => A.map(threads, (thread) => thread.commentDatabaseId))
+      ).toStrictEqual(O.some([O.some(2412551122)]));
+    })
+  );
+
+  it.effect("decodes a status artifact written before merge readiness and thread triage existed", () =>
+    Effect.gen(function* () {
+      const legacy = [
+        '{"base":"origin/main","branch":"feature","closeout":{"detail":"missing","path":"pr-closeout.json",',
+        '"state":"missing"},"createdAt":"2026-06-11T00:00:00.000Z","head":"HEAD","nextCommand":"bun run beep yeet verify",',
+        '"remote":{"available":false,"checked":false,"detail":"pass --remote"},"runId":"feature",',
+        '"schemaVersion":"yeet-status/v1","statusPath":"status.json",',
+        '"verdict":{"detail":"missing","path":"verdict.json","state":"missing"},',
+        '"worktree":{"clean":true,"staged":0,"unstaged":0,"untracked":0}}',
+      ].join("");
+      const decoded = yield* YeetStatusSnapshotJson.decode(legacy);
+
+      expect(decoded.mergeReady).toStrictEqual(O.none());
+      expect(decoded.remote.unresolvedThreads).toStrictEqual(O.none());
+      expect(decoded.remote.headSha).toStrictEqual(O.none());
+    })
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
@@ -1,0 +1,521 @@
+import {
+  buildSweepPlan,
+  executeSweep,
+  MergeOutcome,
+  observeSweepGitState,
+  RepoRunContext,
+  renderSweepReport,
+  SweepGitState,
+  SweepPlan,
+  SweepReport,
+  SweepReportJson,
+  SweepReportStep,
+  SweepStepExecuted,
+  SweepStepId,
+  SweepStepNeedsOperator,
+  SweepStepSkipped,
+  sweepReportPath,
+  sweepStepBlockers,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, pipe, Sink, Stream } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import type { SweepPlanStep } from "@beep/repo-cli/test/Yeet";
+
+const mergedTip = "aaaa1111bbbb2222";
+const createdAt = "2026-08-04T00:00:00.000Z";
+const endedAt = "2026-08-04T00:00:01.000Z";
+
+/**
+ * A squash-merged branch in the ideal shape: the pull request is MERGED and its
+ * head branch is the branch being swept, the local and remote tips both still
+ * equal its recorded head, every probe read completely, no worktree holds the
+ * branch, and the clone is clean and already sitting on `main`.
+ */
+const mergedFacts = {
+  branch: "feat/merge-loop",
+  mainBranch: "main",
+  headBranch: "main",
+  worktreeDirty: false,
+  mainCheckedOutElsewhere: false,
+  branchCheckedOutElsewhere: false,
+  branchMergedIntoBase: false,
+  lockfileMovedOnMainUpdate: true,
+  statusProbeTruncated: false,
+  worktreeProbeTruncated: false,
+  localTip: O.some(mergedTip),
+  remoteTip: O.some(mergedTip),
+  pullRequestState: O.some("MERGED"),
+  pullRequestHeadBranch: O.some("feat/merge-loop"),
+  pullRequestHeadOid: O.some(mergedTip),
+};
+
+const stateWith = (overrides: Partial<typeof mergedFacts>): SweepGitState =>
+  SweepGitState.make({ ...mergedFacts, ...overrides });
+
+const mergedState = stateWith({});
+
+const stepFor = (state: SweepGitState, id: SweepStepId): SweepPlanStep =>
+  O.getOrThrow(A.findFirst(buildSweepPlan(state, createdAt).steps, (step) => step.id === id));
+
+const blockerText = (state: SweepGitState, id: SweepStepId): ReadonlyArray<string> =>
+  A.map(sweepStepBlockers(stepFor(state, id)), (blocker) => blocker.description);
+
+const emptyPlan = SweepPlan.make({
+  schemaVersion: "yeet-sweep-plan/v1",
+  createdAt,
+  branch: "feat/merge-loop",
+  steps: [],
+});
+
+const reportOf = (steps: ReadonlyArray<SweepReportStep>): SweepReport =>
+  SweepReport.make({
+    schemaVersion: "yeet-sweep-report/v1",
+    plan: emptyPlan,
+    steps,
+    startedAt: createdAt,
+    endedAt,
+  });
+
+describe("buildSweepPlan shape", () => {
+  it("plans every step id exactly once, in execution order", () => {
+    expect(A.map(buildSweepPlan(mergedState, createdAt).steps, (step) => step.id)).toEqual([...SweepStepId.Options]);
+  });
+
+  it("stamps the schema version, branch, and creation timestamp", () => {
+    const plan = buildSweepPlan(mergedState, createdAt);
+    expect(plan.schemaVersion).toBe("yeet-sweep-plan/v1");
+    expect(plan.branch).toBe("feat/merge-loop");
+    expect(plan.createdAt).toBe(createdAt);
+  });
+
+  it("leaves every step runnable for a cleanly merged branch", () => {
+    const blocked = A.map(
+      A.filter(buildSweepPlan(mergedState, createdAt).steps, (step) => A.isReadonlyArrayEmpty(sweepStepBlockers(step))),
+      (step) => step.id
+    );
+    expect(blocked).toEqual([...SweepStepId.Options]);
+  });
+});
+
+describe("local branch deletion contract", () => {
+  it("uses -d and records ancestry when the tip is an ancestor of origin/main", () => {
+    const step = stepFor(stateWith({ branchMergedIntoBase: true }), "delete-local-branch");
+    expect(step.action).toBe("git branch -d feat/merge-loop");
+    expect(A.map(step.preconditions, (observed) => observed.description)).toContain(
+      "feat/merge-loop is an ancestor of origin/main"
+    );
+  });
+
+  it("uses -D for a squash merge, whose tip is not an ancestor of origin/main", () => {
+    expect(stepFor(mergedState, "delete-local-branch").action).toBe("git branch -D feat/merge-loop");
+  });
+
+  it("blocks -D when the pull request is not MERGED", () => {
+    expect(blockerText(stateWith({ pullRequestState: O.some("OPEN") }), "delete-local-branch")).toEqual([
+      "pull request for feat/merge-loop is MERGED",
+    ]);
+  });
+
+  it("blocks -D when the local tip has moved past the pull request head", () => {
+    expect(blockerText(stateWith({ localTip: O.some("cccc3333") }), "delete-local-branch")).toEqual([
+      "local tip cccc3333 equals pull request head aaaa1111bbbb2222",
+    ]);
+  });
+
+  it("blocks -D when another worktree holds the branch", () => {
+    expect(blockerText(stateWith({ branchCheckedOutElsewhere: true }), "delete-local-branch")).toEqual([
+      "no worktree holds feat/merge-loop",
+    ]);
+  });
+
+  it("blocks -D when the sweeping worktree itself holds the branch", () => {
+    expect(blockerText(stateWith({ headBranch: "feat/merge-loop" }), "delete-local-branch")).toEqual([
+      "no worktree holds feat/merge-loop",
+    ]);
+  });
+
+  it("blocks deletion when there is no local branch left to delete", () => {
+    expect(blockerText(stateWith({ localTip: O.none() }), "delete-local-branch")).toEqual([
+      "local branch feat/merge-loop exists",
+      "local tip <absent> equals pull request head aaaa1111bbbb2222",
+    ]);
+  });
+
+  it("blocks -D when the pull request never recorded a head oid", () => {
+    expect(blockerText(stateWith({ pullRequestHeadOid: O.none() }), "delete-local-branch")).toEqual([
+      "local tip aaaa1111bbbb2222 equals pull request head <absent>",
+    ]);
+  });
+
+  it("never asks the operator to force-delete a local branch", () => {
+    expect(stepFor(stateWith({ localTip: O.some("cccc3333") }), "delete-local-branch").requiresOperator).toBe(false);
+  });
+});
+
+describe("pull request identity contract", () => {
+  const otherBranchPr = { pullRequestHeadBranch: O.some("feat/other-work") };
+
+  it("blocks -D when the resolved pull request heads a different branch", () => {
+    expect(blockerText(stateWith(otherBranchPr), "delete-local-branch")).toEqual([
+      "pull request head branch feat/other-work is feat/merge-loop",
+    ]);
+  });
+
+  it("blocks the remote deletion when the resolved pull request heads a different branch", () => {
+    const state = stateWith(otherBranchPr);
+    expect(blockerText(state, "delete-remote-branch")).toEqual([
+      "pull request head branch feat/other-work is feat/merge-loop",
+    ]);
+    expect(stepFor(state, "delete-remote-branch").requiresOperator).toBe(false);
+  });
+
+  it("blocks both deletions when no pull request head branch was observed", () => {
+    const state = stateWith({ pullRequestHeadBranch: O.none() });
+    expect(blockerText(state, "delete-local-branch")).toEqual(["pull request head branch <absent> is feat/merge-loop"]);
+    expect(blockerText(state, "delete-remote-branch")).toEqual([
+      "pull request head branch <absent> is feat/merge-loop",
+    ]);
+  });
+
+  it("never turns an identity mismatch into an operator handoff", () => {
+    expect(stepFor(stateWith(otherBranchPr), "delete-local-branch").requiresOperator).toBe(false);
+  });
+});
+
+describe("truncated probe rail", () => {
+  // What `observeSweepGitState` records when the capture bound cut the probe
+  // off: the flag plus the conservative value of every fact it feeds.
+  const truncatedWorktreeProbe = {
+    worktreeProbeTruncated: true,
+    branchCheckedOutElsewhere: true,
+    mainCheckedOutElsewhere: true,
+  };
+  const truncatedStatusProbe = { statusProbeTruncated: true, worktreeDirty: true };
+
+  it("blocks the local deletion and names the truncated command", () => {
+    expect(blockerText(stateWith(truncatedWorktreeProbe), "delete-local-branch")).toEqual([
+      "git worktree list --porcelain output was not truncated",
+    ]);
+  });
+
+  it("blocks moving HEAD back to main on a truncated worktree list", () => {
+    expect(blockerText(stateWith({ ...truncatedWorktreeProbe, headBranch: "feat/merge-loop" }), "end-state")).toEqual([
+      "git worktree list --porcelain output was not truncated",
+    ]);
+  });
+
+  it("blocks the fast-forward fetch on a truncated worktree list", () => {
+    expect(blockerText(stateWith({ ...truncatedWorktreeProbe, headBranch: "feat/merge-loop" }), "ff-main")).toEqual([
+      "git worktree list --porcelain output was not truncated",
+    ]);
+  });
+
+  it("blocks the in-place merge and the install on a truncated status probe", () => {
+    const state = stateWith(truncatedStatusProbe);
+    expect(blockerText(state, "ff-main")).toEqual(["git status --porcelain output was not truncated"]);
+    expect(blockerText(state, "lockfile-install")).toEqual(["git status --porcelain output was not truncated"]);
+  });
+
+  it("leaves the remote deletion untouched by a truncated worktree list", () => {
+    expect(blockerText(stateWith(truncatedWorktreeProbe), "delete-remote-branch")).toEqual([]);
+  });
+});
+
+describe("remote branch deletion contract", () => {
+  it("flags the authorized deletion as an operator handoff with the exact command", () => {
+    const step = stepFor(mergedState, "delete-remote-branch");
+    expect(step.action).toBe("git push origin --delete feat/merge-loop");
+    expect(step.requiresOperator).toBe(true);
+  });
+
+  it("blocks deletion when the remote tip does not match the pull request head", () => {
+    const state = stateWith({ remoteTip: O.some("dddd4444") });
+    expect(blockerText(state, "delete-remote-branch")).toEqual([
+      "remote tip dddd4444 equals pull request head aaaa1111bbbb2222",
+    ]);
+    expect(stepFor(state, "delete-remote-branch").requiresOperator).toBe(false);
+  });
+
+  it("blocks deletion when the remote branch is already gone", () => {
+    expect(blockerText(stateWith({ remoteTip: O.none() }), "delete-remote-branch")).toEqual([
+      "remote branch origin/feat/merge-loop exists",
+      "remote tip <absent> equals pull request head aaaa1111bbbb2222",
+    ]);
+  });
+
+  it("blocks deletion when the pull request is not MERGED", () => {
+    expect(blockerText(stateWith({ pullRequestState: O.some("CLOSED") }), "delete-remote-branch")).toEqual([
+      "pull request for feat/merge-loop is MERGED",
+    ]);
+  });
+});
+
+describe("fast-forward refusal", () => {
+  const onFeatureBranch = { headBranch: "feat/merge-loop" };
+
+  it("fetches the ref directly when no worktree holds main", () => {
+    const step = stepFor(stateWith(onFeatureBranch), "ff-main");
+    expect(step.action).toBe("git fetch origin main:main");
+    expect(sweepStepBlockers(step)).toEqual([]);
+  });
+
+  it("skips with a reason when another worktree holds main", () => {
+    const state = stateWith({ ...onFeatureBranch, mainCheckedOutElsewhere: true });
+    expect(blockerText(state, "ff-main")).toEqual(["main is not checked out in another worktree"]);
+    expect(stepFor(state, "ff-main").action).toBe("git fetch origin main:main");
+  });
+
+  it("never turns a fast-forward refusal into an operator handoff", () => {
+    const state = stateWith({ ...onFeatureBranch, mainCheckedOutElsewhere: true });
+    expect(stepFor(state, "ff-main").requiresOperator).toBe(false);
+  });
+
+  it("merges in place when the sweeping worktree is the one on main", () => {
+    const step = stepFor(mergedState, "ff-main");
+    expect(step.action).toBe("git merge --ff-only refs/remotes/origin/main");
+    expect(sweepStepBlockers(step)).toEqual([]);
+  });
+
+  it("refuses the in-place merge when that worktree is dirty", () => {
+    expect(blockerText(stateWith({ worktreeDirty: true }), "ff-main")).toEqual(["worktree is clean"]);
+  });
+});
+
+describe("dirty worktree rail", () => {
+  const dirty = stateWith({ headBranch: "feat/merge-loop", worktreeDirty: true });
+
+  it("blocks the lockfile install", () => {
+    expect(blockerText(dirty, "lockfile-install")).toEqual(["worktree is clean"]);
+  });
+
+  it("blocks moving HEAD back to main", () => {
+    expect(blockerText(dirty, "end-state")).toEqual(["worktree is clean"]);
+  });
+
+  it("leaves ref-only steps untouched by dirtiness", () => {
+    expect(blockerText(dirty, "fetch-prune")).toEqual([]);
+    expect(blockerText(dirty, "delete-remote-branch")).toEqual([]);
+  });
+
+  it("skips the install when the main update did not move bun.lock", () => {
+    expect(blockerText(stateWith({ lockfileMovedOnMainUpdate: false }), "lockfile-install")).toEqual([
+      "bun.lock moved in the main update",
+    ]);
+  });
+});
+
+describe("end state", () => {
+  it("asks for nothing when the clone is already on main", () => {
+    const step = stepFor(mergedState, "end-state");
+    expect(step.preconditions).toEqual([]);
+    expect(step.action).toBe("git switch main");
+  });
+
+  it("requires a clean worktree and a free main to switch back", () => {
+    const step = stepFor(stateWith({ headBranch: "feat/merge-loop" }), "end-state");
+    expect(A.map(step.preconditions, (observed) => observed.description)).toEqual([
+      "worktree is clean",
+      "main is not checked out in another worktree",
+    ]);
+  });
+});
+
+describe("renderSweepReport", () => {
+  const handoffReport = reportOf([
+    SweepReportStep.make({ id: "fetch-prune", outcome: SweepStepExecuted.make({ detail: O.some("pruned 2") }) }),
+    SweepReportStep.make({
+      id: "ff-main",
+      outcome: SweepStepSkipped.make({ reason: "blocked: main is not checked out in another worktree" }),
+    }),
+    SweepReportStep.make({
+      id: "delete-remote-branch",
+      outcome: SweepStepNeedsOperator.make({
+        reason: "deleting origin/feat/merge-loop was denied by permission: 403",
+        operatorCommand: "git push origin --delete feat/merge-loop",
+      }),
+    }),
+  ]);
+
+  it("summarizes each outcome kind", () => {
+    const rendered = renderSweepReport(handoffReport);
+    expect(rendered).toContain("fetch-prune: executed: pruned 2");
+    expect(rendered).toContain("ff-main: skipped: blocked: main is not checked out in another worktree");
+    expect(rendered).toContain("delete-remote-branch: needs-operator:");
+  });
+
+  it("batches every needs-operator command into one handoff block", () => {
+    const rendered = renderSweepReport(handoffReport);
+    expect(rendered).toContain("operator handoff (1 command(s) only you can run):");
+    expect(rendered).toContain("    git push origin --delete feat/merge-loop");
+  });
+
+  it("omits the handoff block when nothing needs the operator", () => {
+    const rendered = renderSweepReport(reportOf(A.take(handoffReport.steps, 2)));
+    expect(rendered).not.toContain("operator handoff");
+  });
+
+  it("names the swept branch in its header", () => {
+    expect(renderSweepReport(reportOf([]))).toBe("[yeet] sweep feat/merge-loop");
+  });
+});
+
+const encoder = new TextEncoder();
+
+type CommandStub = {
+  readonly exitCode: number;
+  readonly output: string;
+};
+
+const ok = (output: string): CommandStub => ({ exitCode: 0, output });
+
+const nonzero = (exitCode: number): CommandStub => ({ exitCode, output: "" });
+
+const stubHandle = (stub: CommandStub) =>
+  ChildProcessSpawner.makeHandle({
+    all: Stream.make(encoder.encode(stub.output)),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(stub.exitCode)),
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    pid: ChildProcessSpawner.ProcessId(1),
+    stderr: Stream.empty,
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(stub.output)),
+    unref: Effect.succeed(Effect.void),
+  });
+
+/**
+ * A spawner that answers by command-line prefix; anything unlisted succeeds
+ * silently, which is exactly how the mutating steps of a clean sweep behave.
+ */
+const stubSpawnerLayer = (stubs: ReadonlyArray<readonly [string, CommandStub]>) =>
+  Layer.effect(
+    ChildProcessSpawner.ChildProcessSpawner,
+    Effect.succeed(
+      ChildProcessSpawner.make((command) =>
+        ChildProcess.isStandardCommand(command)
+          ? Effect.succeed(
+              stubHandle(
+                pipe(
+                  A.findFirst(stubs, ([prefix]) =>
+                    Str.startsWith(prefix)(A.join([command.command, ...command.args], " "))
+                  ),
+                  O.match({ onNone: () => ok(""), onSome: ([, stub]) => stub })
+                )
+              )
+            )
+          : Effect.die("the sweep never spawns a piped command")
+      )
+    )
+  );
+
+const prViewJson = `{"number":559,"headRefName":"feat/merge-loop","state":"MERGED","headRefOid":"${mergedTip}"}`;
+
+// The probes answer for a clone at /repo whose only worktree is the sweeping
+// one; the temp directory below is where the artifact lands, not what git sees.
+const mergedSweepStubs: ReadonlyArray<readonly [string, CommandStub]> = [
+  ["git rev-parse --abbrev-ref HEAD", ok("main")],
+  ["git rev-parse --show-toplevel", ok("/repo")],
+  ["git rev-parse --verify --quiet refs/heads/feat/merge-loop", ok(mergedTip)],
+  ["git rev-parse --verify --quiet refs/remotes/origin/feat/merge-loop", ok(mergedTip)],
+  ["git status --porcelain", ok("")],
+  ["git worktree list --porcelain", ok(`worktree /repo\nHEAD ${mergedTip}\nbranch refs/heads/main`)],
+  ["git merge-base --is-ancestor", nonzero(1)],
+  ["git diff --name-only", ok("bun.lock")],
+  ["gh pr view feat/merge-loop", ok(prViewJson)],
+];
+
+// Longer than the 512 KiB repo-run capture bound, so the probe comes back
+// flagged truncated. Every block that survives is a detached worktree holding
+// no branch, so "the branch is held" can only come from the truncation itself.
+const truncatedWorktreeOutput = Str.repeat(40_000)("worktree /repo/detached-worktree\nHEAD aaaa1111\ndetached\n\n");
+
+const truncatedWorktreeStubs: ReadonlyArray<readonly [string, CommandStub]> = [
+  ["git worktree list --porcelain", ok(truncatedWorktreeOutput)],
+  ...mergedSweepStubs,
+];
+
+const sweepContext = (root: string): RepoRunContext =>
+  RepoRunContext.make({
+    base: "origin/main",
+    branch: "feat/merge-loop",
+    cwd: root,
+    head: "HEAD",
+    originalArgv: [],
+    packetDir: root,
+    repoRoot: root,
+    turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+  });
+
+const withTempDirectory = Effect.fn("withTempDirectory")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+const sweepTestLayer = (stubs: ReadonlyArray<readonly [string, CommandStub]>) =>
+  Layer.mergeAll(NodeFileSystem.layer, NodePath.layer, stubSpawnerLayer(stubs));
+
+describe("executeSweep", () => {
+  it.effect("writes a sweep-report.json that decodes back through SweepReportJson", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = sweepContext(root);
+        const report = yield* executeSweep(context);
+        expect(A.map(report.steps, (step) => step.id)).toEqual([...SweepStepId.Options]);
+        expect(A.map(report.steps, (step) => step.outcome.status)).toEqual(A.map(report.steps, () => "executed"));
+
+        const fs = yield* FileSystem.FileSystem;
+        const written = yield* fs.readFileString(yield* sweepReportPath(context));
+        expect(yield* SweepReportJson.decode(written)).toEqual(report);
+      })
+    ).pipe(provideScopedLayer(sweepTestLayer(mergedSweepStubs)))
+  );
+
+  it.effect("reads a truncated worktree list as unknown, not as an empty worktree set", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const state = yield* observeSweepGitState(sweepContext(root));
+        expect(state.worktreeProbeTruncated).toBe(true);
+        expect(state.branchCheckedOutElsewhere).toBe(true);
+        expect(state.mainCheckedOutElsewhere).toBe(true);
+        expect(blockerText(state, "delete-local-branch")).toEqual([
+          "git worktree list --porcelain output was not truncated",
+        ]);
+      })
+    ).pipe(provideScopedLayer(sweepTestLayer(truncatedWorktreeStubs)))
+  );
+
+  it.effect("keeps the observed pull request head branch for the identity check", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const state = yield* observeSweepGitState(sweepContext(root));
+        expect(state.pullRequestHeadBranch).toEqual(O.some("feat/merge-loop"));
+        expect(blockerText(state, "delete-local-branch")).toEqual([]);
+      })
+    ).pipe(provideScopedLayer(sweepTestLayer(mergedSweepStubs)))
+  );
+});
+
+describe("MergeOutcome", () => {
+  it("carries the confirmed pull request state alongside the sweep report", () => {
+    const outcome = MergeOutcome.make({
+      pullRequestNumber: 559,
+      state: "MERGED",
+      sweep: reportOf([]),
+    });
+    expect(outcome.pullRequestNumber).toBe(559);
+    expect(outcome.sweep.plan.branch).toBe("feat/merge-loop");
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
@@ -5,6 +5,8 @@ import {
   observeSweepGitState,
   RepoRunContext,
   renderSweepReport,
+  revalidateLocalDeletion,
+  revalidateRemoteDeletion,
   SweepGitState,
   SweepPlan,
   SweepReport,
@@ -47,8 +49,8 @@ const mergedFacts = {
   branchCheckedOutElsewhere: false,
   branchMergedIntoBase: false,
   lockfileMovedOnMainUpdate: true,
-  statusProbeTruncated: false,
-  worktreeProbeTruncated: false,
+  statusProbeUnreliable: false,
+  worktreeProbeUnreliable: false,
   localTip: O.some(mergedTip),
   remoteTip: O.some(mergedTip),
   pullRequestState: O.some("MERGED"),
@@ -193,34 +195,34 @@ describe("truncated probe rail", () => {
   // What `observeSweepGitState` records when the capture bound cut the probe
   // off: the flag plus the conservative value of every fact it feeds.
   const truncatedWorktreeProbe = {
-    worktreeProbeTruncated: true,
+    worktreeProbeUnreliable: true,
     branchCheckedOutElsewhere: true,
     mainCheckedOutElsewhere: true,
   };
-  const truncatedStatusProbe = { statusProbeTruncated: true, worktreeDirty: true };
+  const truncatedStatusProbe = { statusProbeUnreliable: true, worktreeDirty: true };
 
   it("blocks the local deletion and names the truncated command", () => {
     expect(blockerText(stateWith(truncatedWorktreeProbe), "delete-local-branch")).toEqual([
-      "git worktree list --porcelain output was not truncated",
+      "git worktree list --porcelain succeeded without truncation",
     ]);
   });
 
   it("blocks moving HEAD back to main on a truncated worktree list", () => {
     expect(blockerText(stateWith({ ...truncatedWorktreeProbe, headBranch: "feat/merge-loop" }), "end-state")).toEqual([
-      "git worktree list --porcelain output was not truncated",
+      "git worktree list --porcelain succeeded without truncation",
     ]);
   });
 
   it("blocks the fast-forward fetch on a truncated worktree list", () => {
     expect(blockerText(stateWith({ ...truncatedWorktreeProbe, headBranch: "feat/merge-loop" }), "ff-main")).toEqual([
-      "git worktree list --porcelain output was not truncated",
+      "git worktree list --porcelain succeeded without truncation",
     ]);
   });
 
   it("blocks the in-place merge and the install on a truncated status probe", () => {
     const state = stateWith(truncatedStatusProbe);
-    expect(blockerText(state, "ff-main")).toEqual(["git status --porcelain output was not truncated"]);
-    expect(blockerText(state, "lockfile-install")).toEqual(["git status --porcelain output was not truncated"]);
+    expect(blockerText(state, "ff-main")).toEqual(["git status --porcelain succeeded without truncation"]);
+    expect(blockerText(state, "lockfile-install")).toEqual(["git status --porcelain succeeded without truncation"]);
   });
 
   it("leaves the remote deletion untouched by a truncated worktree list", () => {
@@ -430,6 +432,7 @@ const mergedSweepStubs: ReadonlyArray<readonly [string, CommandStub]> = [
   ["git worktree list --porcelain", ok(`worktree /repo\nHEAD ${mergedTip}\nbranch refs/heads/main`)],
   ["git merge-base --is-ancestor", nonzero(1)],
   ["git diff --name-only", ok("bun.lock")],
+  ["git ls-remote origin refs/heads/feat/merge-loop", ok(`${mergedTip}\trefs/heads/feat/merge-loop`)],
   ["gh pr view feat/merge-loop", ok(prViewJson)],
 ];
 
@@ -487,11 +490,11 @@ describe("executeSweep", () => {
     withTempDirectory((root) =>
       Effect.gen(function* () {
         const state = yield* observeSweepGitState(sweepContext(root));
-        expect(state.worktreeProbeTruncated).toBe(true);
+        expect(state.worktreeProbeUnreliable).toBe(true);
         expect(state.branchCheckedOutElsewhere).toBe(true);
         expect(state.mainCheckedOutElsewhere).toBe(true);
         expect(blockerText(state, "delete-local-branch")).toEqual([
-          "git worktree list --porcelain output was not truncated",
+          "git worktree list --porcelain succeeded without truncation",
         ]);
       })
     ).pipe(provideScopedLayer(sweepTestLayer(truncatedWorktreeStubs)))
@@ -505,6 +508,94 @@ describe("executeSweep", () => {
         expect(blockerText(state, "delete-local-branch")).toEqual([]);
       })
     ).pipe(provideScopedLayer(sweepTestLayer(mergedSweepStubs)))
+  );
+
+  it.effect("reads a failed status probe as unknown, not as a clean worktree", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const state = yield* observeSweepGitState(sweepContext(root));
+        expect(state.statusProbeUnreliable).toBe(true);
+        expect(state.worktreeDirty).toBe(true);
+        expect(blockerText(state, "lockfile-install")).toContain("git status --porcelain succeeded without truncation");
+      })
+    ).pipe(provideScopedLayer(sweepTestLayer([["git status --porcelain", nonzero(128)], ...mergedSweepStubs])))
+  );
+
+  it.effect("reads a failed worktree list as held branches, not as a free clone", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const state = yield* observeSweepGitState(sweepContext(root));
+        expect(state.worktreeProbeUnreliable).toBe(true);
+        expect(state.branchCheckedOutElsewhere).toBe(true);
+        expect(state.mainCheckedOutElsewhere).toBe(true);
+        expect(blockerText(state, "delete-local-branch")).toEqual([
+          "git worktree list --porcelain succeeded without truncation",
+        ]);
+      })
+    ).pipe(provideScopedLayer(sweepTestLayer([["git worktree list --porcelain", nonzero(128)], ...mergedSweepStubs])))
+  );
+
+  it.effect("skips remote deletion when the live remote tip moved since planning", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const report = yield* executeSweep(sweepContext(root));
+        const remoteStep = O.getOrThrow(A.findFirst(report.steps, (step) => step.id === "delete-remote-branch"));
+        expect(remoteStep.outcome.status).toBe("skipped");
+        expect(remoteStep.outcome.status === "skipped" ? remoteStep.outcome.reason : "").toContain(
+          "moved since planning"
+        );
+      })
+    ).pipe(
+      provideScopedLayer(
+        sweepTestLayer([
+          ["git ls-remote origin refs/heads/feat/merge-loop", ok("ffff9999eeee8888\trefs/heads/feat/merge-loop")],
+          ...mergedSweepStubs,
+        ])
+      )
+    )
+  );
+});
+
+describe("deletion revalidation", () => {
+  it.effect("refuses a local deletion when the branch tip moved since planning", () =>
+    Effect.gen(function* () {
+      const drifted = stateWith({ localTip: O.some("cccc3333dddd4444") });
+      const refusal = yield* revalidateLocalDeletion("/repo", drifted);
+      expect(O.isSome(refusal)).toBe(true);
+      expect(O.getOrElse(refusal, () => "")).toContain("moved since planning");
+
+      const unchanged = yield* revalidateLocalDeletion("/repo", mergedState);
+      expect(unchanged).toEqual(O.none());
+    }).pipe(provideScopedLayer(sweepTestLayer(mergedSweepStubs)))
+  );
+
+  it.effect("refuses a remote deletion when ls-remote cannot be read", () =>
+    Effect.gen(function* () {
+      const refusal = yield* revalidateRemoteDeletion("/repo", mergedState);
+      expect(O.getOrElse(refusal, () => "")).toContain("could not re-verify");
+    }).pipe(
+      provideScopedLayer(
+        sweepTestLayer([["git ls-remote origin refs/heads/feat/merge-loop", nonzero(128)], ...mergedSweepStubs])
+      )
+    )
+  );
+
+  it.effect("treats an already-deleted remote ref as nothing to delete", () =>
+    Effect.gen(function* () {
+      const refusal = yield* revalidateRemoteDeletion("/repo", mergedState);
+      expect(O.getOrElse(refusal, () => "")).toContain("no longer exists");
+    }).pipe(
+      provideScopedLayer(
+        sweepTestLayer([["git ls-remote origin refs/heads/feat/merge-loop", ok("")], ...mergedSweepStubs])
+      )
+    )
+  );
+
+  it.effect("allows the remote deletion when the live tip still matches the plan", () =>
+    Effect.gen(function* () {
+      const allowed = yield* revalidateRemoteDeletion("/repo", mergedState);
+      expect(allowed).toEqual(O.none());
+    }).pipe(provideScopedLayer(sweepTestLayer(mergedSweepStubs)))
   );
 });
 

--- a/packages/tooling/tool/cli/test/yeet-sweep-schemas.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-sweep-schemas.test.ts
@@ -1,0 +1,153 @@
+import {
+  SweepPlan,
+  SweepPlanJson,
+  SweepPlanStep,
+  SweepPrecondition,
+  SweepReport,
+  SweepReportJson,
+  SweepReportStep,
+  SweepStepExecuted,
+  SweepStepId,
+  SweepStepNeedsOperator,
+  SweepStepSkipped,
+} from "@beep/repo-cli/test/Yeet";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+import * as O from "effect/Option";
+
+const plan = SweepPlan.make({
+  schemaVersion: "yeet-sweep-plan/v1",
+  createdAt: "2026-08-04T00:00:00.000Z",
+  branch: "feat/merge-loop",
+  steps: [
+    SweepPlanStep.make({
+      id: "fetch-prune",
+      action: "git fetch --prune origin",
+      preconditions: [],
+      requiresOperator: false,
+    }),
+    SweepPlanStep.make({
+      id: "ff-main",
+      action: "git fetch origin main:main",
+      preconditions: [
+        SweepPrecondition.make({ description: "main is not checked out in any worktree", satisfied: true }),
+        SweepPrecondition.make({ description: "worktree is clean", satisfied: true }),
+      ],
+      requiresOperator: false,
+    }),
+    SweepPlanStep.make({
+      id: "delete-local-branch",
+      action: "git branch -d feat/merge-loop",
+      preconditions: [SweepPrecondition.make({ description: "no worktree holds feat/merge-loop", satisfied: false })],
+      requiresOperator: true,
+    }),
+  ],
+});
+
+const report = SweepReport.make({
+  schemaVersion: "yeet-sweep-report/v1",
+  plan,
+  steps: [
+    SweepReportStep.make({
+      id: "fetch-prune",
+      outcome: SweepStepExecuted.make({ detail: O.some("pruned 3 remote refs") }),
+      durationMs: O.some(412),
+    }),
+    SweepReportStep.make({
+      id: "ff-main",
+      outcome: SweepStepExecuted.make({}),
+    }),
+    SweepReportStep.make({
+      id: "delete-local-branch",
+      outcome: SweepStepNeedsOperator.make({
+        reason: "feat/merge-loop is checked out in worktree /home/dev/beep-effect3-pra",
+        operatorCommand: "git worktree remove /home/dev/beep-effect3-pra && git branch -d feat/merge-loop",
+      }),
+    }),
+    SweepReportStep.make({
+      id: "lockfile-install",
+      outcome: SweepStepSkipped.make({ reason: "bun.lock did not move across the main update" }),
+    }),
+  ],
+  startedAt: "2026-08-04T00:00:00.000Z",
+  endedAt: "2026-08-04T00:00:05.000Z",
+});
+
+describe("sweep step ids", () => {
+  it("pins the sweep step domain in execution order", () => {
+    expect(SweepStepId.Options).toEqual([
+      "fetch-prune",
+      "ff-main",
+      "delete-local-branch",
+      "delete-remote-branch",
+      "lockfile-install",
+      "end-state",
+    ]);
+  });
+});
+
+describe("SweepPlan", () => {
+  it.effect("round-trips through its JSON codec", () =>
+    Effect.gen(function* () {
+      const text = yield* SweepPlanJson.encode(plan);
+      const decoded = yield* SweepPlanJson.decode(text);
+      expect(decoded).toEqual(plan);
+    })
+  );
+
+  it.effect("encodes observed preconditions as data, not prose", () =>
+    Effect.gen(function* () {
+      const text = yield* SweepPlanJson.encode(plan);
+      expect(text).toContain('{"description":"no worktree holds feat/merge-loop","satisfied":false}');
+    })
+  );
+
+  it.effect("rejects a step id outside the sweep domain", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        SweepPlanJson.decode(
+          '{"schemaVersion":"yeet-sweep-plan/v1","createdAt":"2026-08-04T00:00:00.000Z","branch":"feat/merge-loop","steps":[{"id":"rm-rf-node-modules","action":"nope","preconditions":[],"requiresOperator":false}]}'
+        )
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+});
+
+describe("SweepReport", () => {
+  it.effect("round-trips every step outcome variant through its JSON codec", () =>
+    Effect.gen(function* () {
+      const text = yield* SweepReportJson.encode(report);
+      const decoded = yield* SweepReportJson.decode(text);
+      expect(decoded).toEqual(report);
+    })
+  );
+
+  it.effect("keeps the echoed plan byte-identical to the plan artifact", () =>
+    Effect.gen(function* () {
+      const reportText = yield* SweepReportJson.encode(report);
+      const planText = yield* SweepPlanJson.encode(plan);
+      expect(reportText).toContain(planText);
+    })
+  );
+
+  it.effect("omits absent optional keys instead of writing Option runtime objects", () =>
+    Effect.gen(function* () {
+      const text = yield* SweepReportJson.encode(report);
+      expect(text).not.toContain('"_id":"Option"');
+      expect(text).toContain('{"status":"executed"}');
+    })
+  );
+
+  it.effect("preserves the operator handoff command across the round trip", () =>
+    Effect.gen(function* () {
+      const text = yield* SweepReportJson.encode(report);
+      const decoded = yield* SweepReportJson.decode(text);
+      const handoff = decoded.steps[2];
+      expect(handoff?.outcome.status).toBe("needs-operator");
+      expect(handoff?.outcome.status === "needs-operator" ? handoff.outcome.operatorCommand : undefined).toContain(
+        "git worktree remove"
+      );
+    })
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-verdict-json.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-verdict-json.test.ts
@@ -1,0 +1,124 @@
+import {
+  YeetMergeReady,
+  YeetMergeReadyCriteria,
+  YeetMergeReadyCriterion,
+  YeetVerdict,
+  YeetVerdictJson,
+  YeetVerdictLane,
+} from "@beep/repo-cli/test/Yeet";
+import { UUID } from "@beep/schema/String";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+
+const ATTEMPT_ID_TEXT = "550e8400-e29b-41d4-a716-446655440000";
+const ATTEMPT_ID = S.decodeUnknownSync(UUID)(ATTEMPT_ID_TEXT);
+
+const verdict = YeetVerdict.make({
+  schemaVersion: "yeet-verdict/v2",
+  attemptId: O.some(ATTEMPT_ID),
+  base: "origin/main",
+  branch: "feat/merge-loop",
+  committed: true,
+  createdAt: "2026-08-04T00:00:05.000Z",
+  startedAt: O.some("2026-08-04T00:00:00.000Z"),
+  endedAt: O.some("2026-08-04T00:00:05.000Z"),
+  elapsedMs: O.some(5000),
+  head: "HEAD",
+  lanes: [
+    YeetVerdictLane.make({
+      id: "full:pre-push",
+      label: "full:pre-push",
+      phase: "full",
+      status: "passed",
+      exitCode: 0,
+      durationMs: 4200,
+    }),
+  ],
+  message: "yeet publish proof passed.",
+  mode: "publish",
+  outcome: "success",
+  packetPaths: [],
+  pushed: true,
+  runId: "feat_merge-loop",
+});
+
+// The verdict document written before mergeReady existed: schemaVersion is still
+// v2 and every append-optional key is simply absent.
+const priorVersionVerdictJson = [
+  '{"schemaVersion":"yeet-verdict/v2","base":"origin/main","branch":"feat/merge-loop","committed":true,',
+  '"createdAt":"2026-08-04T00:00:05.000Z","failurePolicy":"fail-fast","head":"HEAD","lanes":[],',
+  '"message":"yeet publish proof passed.","mode":"publish","outcome":"success","packetPaths":[],',
+  '"pushed":true,"runId":"feat_merge-loop"}',
+].join("");
+
+describe("YeetVerdictJson", () => {
+  // Regression: the writer used to render the DECODED verdict through a generic
+  // JSON encoder, which serialized Option fields as their runtime shape
+  // (`{"_id":"Option","_tag":"Some","value":...}`). That artifact no longer
+  // decoded, and `yeet status` reported "verdict artifact could not be decoded"
+  // with nothing pointing back at the writer.
+  it.effect("round-trips a verdict carrying Some(attemptId)", () =>
+    Effect.gen(function* () {
+      const text = yield* YeetVerdictJson.encode(verdict);
+      const decoded = yield* YeetVerdictJson.decode(text);
+      expect(decoded.attemptId).toEqual(O.some(ATTEMPT_ID));
+      expect(decoded).toEqual(verdict);
+    })
+  );
+
+  it.effect("encodes Option fields as plain JSON values, never Option runtime objects", () =>
+    Effect.gen(function* () {
+      const text = yield* YeetVerdictJson.encode(verdict);
+      expect(text).toContain(`"attemptId":"${ATTEMPT_ID_TEXT}"`);
+      expect(text).toContain('"elapsedMs":5000');
+      expect(text).not.toContain('"_id":"Option"');
+      expect(text).not.toContain('"_tag":"Some"');
+    })
+  );
+
+  it.effect("omits absent append-optional keys from the artifact", () =>
+    Effect.gen(function* () {
+      const text = yield* YeetVerdictJson.encode(verdict);
+      expect(text).not.toContain("mergeReady");
+    })
+  );
+
+  it.effect("round-trips a merge-ready verdict naming its blocking criterion", () =>
+    Effect.gen(function* () {
+      const blocked = YeetVerdict.make({
+        ...verdict,
+        mergeReady: O.some(
+          YeetMergeReady.make({
+            ready: false,
+            failing: O.some("threads-resolved"),
+            criteria: YeetMergeReadyCriteria.make({
+              checksGreen: true,
+              threadsResolved: false,
+              greptileScore: O.some("5/5"),
+            }),
+          })
+        ),
+      });
+      const text = yield* YeetVerdictJson.encode(blocked);
+      expect(text).toContain('"failing":"threads-resolved"');
+      expect(text).toContain('"greptileScore":"5/5"');
+      const decoded = yield* YeetVerdictJson.decode(text);
+      expect(decoded).toEqual(blocked);
+    })
+  );
+
+  it.effect("decodes a verdict written before mergeReady existed", () =>
+    Effect.gen(function* () {
+      const decoded = yield* YeetVerdictJson.decode(priorVersionVerdictJson);
+      expect(decoded.mergeReady).toEqual(O.none());
+      expect(decoded.attemptId).toEqual(O.none());
+      expect(decoded.schemaVersion).toBe("yeet-verdict/v2");
+    })
+  );
+
+  it("keeps the Greptile score out of the hard criterion domain", () => {
+    expect(YeetMergeReadyCriterion.Options).toEqual(["checks-green", "threads-resolved"]);
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -85,6 +85,8 @@ import {
   YeetStatusSnapshot,
   YeetStatusWorktree,
   YeetVerdict,
+  yeetRerunDecisionText,
+  yeetRerunJobListingCommand,
   yeetStatusNextCommandForTesting,
 } from "@beep/repo-cli/test/Yeet";
 import { NonNegativeInt } from "@beep/schema";
@@ -1272,7 +1274,10 @@ describe("yeet quality issue index", () => {
       )
     ));
 
-  it("rejects advisory Fallow envelopes older than the Yeet run start", () =>
+  // Ledger #55 / decision 25: advisory Fallow envelopes older than the Yeet run
+  // start are gitignored leftovers, so the phase purges them and skips instead of
+  // failing the publish. Behavioral detail lives in yeet-fallow-self-heal.test.ts.
+  it("purges advisory Fallow envelopes older than the Yeet run start", () =>
     Effect.runPromise(
       withTempDirectory((tmpDir) =>
         Effect.gen(function* () {
@@ -1280,6 +1285,7 @@ describe("yeet quality issue index", () => {
           const path = yield* Path.Path;
           const fromDir = path.join(tmpDir, ".beep", "fallow");
           const emitPath = path.join(tmpDir, ".beep", "yeet", "fallow-quality-issues.json");
+          const envelopePath = path.join(fromDir, "health.advisory.json");
           const healthText = yield* encodeJson(
             fallowOkEnvelope({
               advisory: true,
@@ -1289,16 +1295,19 @@ describe("yeet quality issue index", () => {
             })
           );
           yield* fs.makeDirectory(fromDir, { recursive: true });
-          yield* fs.writeFileString(path.join(fromDir, "health.advisory.json"), `${healthText}\n`);
-          const error = yield* runYeetFallowFeedbackForTesting({
+          yield* fs.writeFileString(envelopePath, `${healthText}\n`);
+          yield* runYeetFallowFeedbackForTesting({
             advisory: true,
             emit: emitPath,
             from: fromDir,
             runStartedAt: "2026-06-16T00:00:00.000Z",
-          }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)), Effect.flip);
+          }).pipe(Effect.provideService(FallowFeedbackAllowedRoot, O.some(tmpDir)));
 
-          expect(error.message).toContain("older than the Yeet run start");
-          expect(error.message).toContain("health");
+          expect(yield* fs.exists(envelopePath)).toBe(false);
+
+          const emittedText = yield* fs.readFileString(emitPath);
+          const index = yield* S.decodeUnknownEffect(S.fromJsonString(QualityIssueIndex))(emittedText);
+          expect(index.issues).toEqual([]);
         })
       )
     ));
@@ -1749,7 +1758,7 @@ describe("yeet status helpers", () => {
           available: true,
           checked: true,
           detail: "PR #42 OPEN",
-          rerunFailedCommand: "gh run rerun 123 --failed",
+          rerunFailedCommand: yeetRerunJobListingCommand(123),
           rerunFailedDecision: "same-SHA red candidate",
           unresolvedReviewThreadCount: 1,
           unresolvedReviewThreads: ["PRRT_1 (src/example.ts)"],
@@ -1758,7 +1767,7 @@ describe("yeet status helpers", () => {
         const decoded = yield* S.decodeUnknownEffect(YeetStatusRemote)(encoded);
 
         expect(decoded.unresolvedReviewThreadCount).toBe(1);
-        expect(decoded.rerunFailedCommand).toBe("gh run rerun 123 --failed");
+        expect(decoded.rerunFailedCommand).toBe(yeetRerunJobListingCommand(123));
       })
     ));
 
@@ -1820,8 +1829,8 @@ describe("yeet status helpers", () => {
       available: true,
       checked: true,
       detail: "PR #42 OPEN",
-      rerunFailedCommand: "gh run rerun 123 --failed",
-      rerunFailedDecision: "same-SHA red detected; suggest rerun-failed before pushing",
+      rerunFailedCommand: yeetRerunJobListingCommand(123),
+      rerunFailedDecision: yeetRerunDecisionText("check"),
       unresolvedReviewThreadCount: 1,
       unresolvedReviewThreads: ["PRRT_1 (src/example.ts)"],
     });
@@ -1832,8 +1841,17 @@ describe("yeet status helpers", () => {
       remote
     );
 
-    expect(command).toContain("gh run rerun 123 --failed");
+    expect(command).toContain(yeetRerunJobListingCommand(123));
     expect(command).not.toContain("merge the PR");
+  });
+
+  it("teaches only the job-scoped rerun form, never --failed", () => {
+    const listing = yeetRerunJobListingCommand(123);
+    expect(listing).toContain("gh run view 123 --json jobs");
+    expect(listing).not.toContain("--failed");
+    const decision = yeetRerunDecisionText("check");
+    expect(decision).toContain("gh run rerun --job <databaseId>");
+    expect(decision).toContain("never");
   });
 });
 


### PR DESCRIPTION
## feat(repo-cli): yeet merge-loop porcelain, until-merged monitor, artifact codecs

Implements speed-loop PR-E: sweep/merge/reply porcelain with the ratified
force-deletion contract, monitor --until-merged with job-scoped flake reruns,
S.encode-backed verdict/status artifacts, fallow advisory self-heal, and the
adversarially verified fix wave (GRILL-DECISIONS 39-48, ledger 61-72).

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_merge-loop-0fd00fee549e/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788581561&installation_model_id=424656&pr_number=569&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F569&signature=069853d053e12ad731517b99f541a1430a2998030bc3a78449fd76d062679a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->