### PR TITLE
docs(jsdoc): give override records the kind field the binding rule requires

### DIFF
--- a/goals/jsdoc-carrier-migration/SPEC.md
+++ b/goals/jsdoc-carrier-migration/SPEC.md
@@ -120,9 +120,16 @@ The only non-code inputs. Frozen and versioned once P3 opens.
   "leadEnd":    1 }                    // paragraphs 2..n -> Details, for the 872
 
 // overrides.jsonl — full replacement block text for quarantined blocks
-{ "anchor": "packages/x/src/Y.ts#thing#0", "sourceHash": "sha256:9c02…",
-  "block": "/** ... */" }
+{ "anchor":     "packages/x/src/Y.ts#thing#0",
+  "sourceHash": "sha256:9c02…",       // same verification fields as titles.jsonl
+  "kind":       "value",
+  "block":      "/** ... */" }
 ```
+
+Both files carry `anchor`, `sourceHash`, and `kind`. The binding rule below applies to **every**
+frozen record regardless of which file it came from — an override is a hand-authored replacement
+block, so applying one to the wrong declaration is exactly as damaging as a mis-bound title, and
+the `kind` check is what stops a value-level replacement landing on a type-level companion.
 
 #### Anchor format
 


### PR DESCRIPTION
## docs(jsdoc): give override records the kind field the binding rule requires

Greptile 4/5 on #581 caught a schema inconsistency introduced by the previous
commit. The fail-closed binding rule requires kind agreement for every frozen
record, and titles.jsonl gained the field, but the overrides.jsonl example did
not. An implementer following the spec would have had to either reject every
override, having no kind to compare, or silently skip one of the three identity
checks - the exact fail-open the rule exists to prevent. decisions-locked.md
also states that frozen records carry kind, which contradicted the displayed
override schema.

Adds kind to the override example and states explicitly that both files carry
anchor, sourceHash and kind, and that the binding rule applies to every frozen
record regardless of source file. An override is a hand-authored replacement
block, so binding one to the wrong declaration is as damaging as a mis-bound
title; the kind check is what stops a value-level replacement landing on a
type-level companion.

This finding lived only in the Greptile summary, not in a review thread, so a
zero-unresolved-threads reading did not surface it.

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/docs_jsdoc-override-kind-field-a8504a412d02/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788611372&installation_model_id=424656&pr_number=585&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F585&signature=44ea7afeb08d8692b4b130c567ecff94d0c1cdfdc3724809dfa3de09c3639721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->