### PR TITLE
fix(repo-cli): aim sweep at a branch and address the refresh handoff

### DIFF
--- a/.changeset/sweep-branch-override.md
+++ b/.changeset/sweep-branch-override.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-cli": patch
+---
+
+Add `yeet sweep --branch` so a second sweep pass can finish a merged branch the clone is no longer standing on, and address the lockfile refresh handoff to the worktree that actually holds `main` instead of telling the operator to re-run in place.

--- a/goals/speed-loop/research/GRILL-DECISIONS.md
+++ b/goals/speed-loop/research/GRILL-DECISIONS.md
@@ -361,7 +361,21 @@ decisions close them:
     worktree is two-pass by design — `delete-local-branch` skips ("held by
     this worktree"), `end-state` moves to main, a re-run completes;
     moving HEAD ahead of the plan's safety facts would violate the rails,
-    and no 7th step id is added for single-pass. (e) Failed commands
+    and no 7th step id is added for single-pass.
+    **AMENDED 2026-08-06 (first real sweep, decision 50(c)): "a re-run
+    completes" was FALSE as shipped.** The premise holds — two-pass is
+    still the right design, and moving HEAD early still violates the
+    rails — but a BARE re-run cannot complete the deletion, because
+    `end-state` has already moved the clone to `main`, so the second
+    pass observes `main` as the current branch and plans against it.
+    The merged branch is never reconsidered. The second pass must NAME
+    its target: `yeet sweep --branch <merged-branch>`. That override
+    ships with this amendment (`overrideSweepBranch`, guarded by the
+    same `guardLiteralArg` refusal as every other argv-bound name), and
+    it is also what makes a blocked `needs-operator` refresh handoff
+    actionable — the worktree holding `main` is rarely the worktree
+    holding the merged branch, so the handoff now names the holder and
+    aims the run back at this branch. (e) Failed commands
     report as `skipped` with the failure text — `SweepStepOutcome` has no
     failure member by design. Review-hardened on #571 (round 5): for the
     REMOTE deletion specifically, the only benign rejection is git's

--- a/goals/speed-loop/research/OPPORTUNITIES.md
+++ b/goals/speed-loop/research/OPPORTUNITIES.md
@@ -1000,7 +1000,14 @@ durability fixes discovery, not trust.
     A verdict older than the branch tip or contradicted by remote state
     renders as "stale (predates last push)" with the re-derivation
     command, never as current truth — operators must not learn to
-    ignore the verdict line.
+    ignore the verdict line. CONFIRMED on PR #592's own publish: the
+    first attempt failed proof after committing; the second attempt
+    passed all 21 lanes, pushed, and created the PR — and `yeet status`
+    STILL printed `verdict: publish failure: yeet publish proof failed
+    after creating the local commit` directly above `remote: PR #592
+    OPEN`. The verdict was the previous run's, rendered as current
+    truth beside remote state that contradicts it. Exactly the disease
+    this item names, on the branch that was fixing a different one.
 84. **Tree parity: local proof and hosted CI run on DIFFERENT TREES,
     and the stale-base guard is structurally blind to the gap.**
     (Reported by beep-effect5, 2026-08-06 — a plan/manifest phase-id
@@ -1035,6 +1042,16 @@ durability fixes discovery, not trust.
     run ON, and together they close "why wasn't this caught locally" on
     both axes. It is also the third class under #74, whose two classes
     both presuppose the guard fired at all. Vehicle: PR-G with #75.
+    CONFIRMED the same day it was written, on this item's own fix PR
+    (#592): PR #587 (Effect beta.103 catalog bump) merged mid-branch.
+    Measured path overlap between `mergeBase..HEAD` and
+    `mergeBase..origin/main` was EMPTY, so `enforceBaseFreshness` would
+    have returned clean — while #587 migrated repo-cli source
+    (Docgen, Laws, Lint, AgentEffectiveness) to beta.103 without
+    touching any of the four files this branch edits. Publishing
+    without merging would have proven a beta.102 tree against a
+    beta.103 CI. The merge happened because an operator reasoned about
+    it, not because any tool signalled it. That gap IS the item.
 85. **Coverage has TWO hosted-only classes, and collapsing them into
     one "structurally cannot" verdict misroutes the fix.** (Live on PR
     #587, the Effect 4.0.0-beta.103 catalog bump: `Coverage Regression`
@@ -1139,6 +1156,65 @@ durability fixes discovery, not trust.
     while its 9–16 happen to be ledger ids. That is a numbering
     collision sitting inside the only join path. Vehicle: PR-G, ahead
     of #86.
+
+88. **A gate run BEFORE the change it gates is a vacuous proof, and
+    reads identically to one run after.** (Lived on PR #592, 2026-08-06.)
+    I ran `bun run beep quality test-tsgo` → exit 0, THEN wrote the new
+    tests, then never re-ran it. `bunx vitest run` reported 61/61 green
+    because vitest does not typecheck. The publish proof then failed on
+    exactly the new lines: `TS2353: 'mainWorktreePath' does not exist
+    in type 'Partial<{...}>'` — the schema field was optional so
+    `.make()` accepted it, but the test helper's `Partial<typeof
+    mergedFacts>` did not. The generalizable law is NOT "remember to
+    run test-tsgo": it is that a gate's transcript entry carries no
+    evidence of WHICH tree it ran against, so a stale pass is
+    indistinguishable from a real one — the same shape as this
+    session's absence-proof receipts and #86's unverifiable premise.
+    Widget: gate results record the worktree hash they ran against, and
+    `yeet status` / the preflight battery render any result from an
+    earlier hash as STALE rather than green — #83's verdict-staleness
+    contract, applied to gate results instead of verdicts. Cheap
+    version available immediately: the battery re-runs a gate whose
+    recorded hash != current instead of reporting its cached verdict.
+    Vehicle: PR-G with #75.
+89. **The flake quarantine recognizes exactly one signature, so every
+    other environment-only failure is hardened by hand.** (Same run.)
+    `@beep/xai#check` failed exit 2 inside the full proof on a branch
+    that does not touch `packages/drivers/xai`; a standalone
+    `bunx turbo run check --filter=@beep/xai --force` passed 9/9,
+    exit 0. The quarantine declined it explicitly — `failure does not
+    match the no-location TS2589 flake signature; keeping failure
+    hard` — which is correct as written and useless in practice: it
+    knows one fingerprint, and this was a different environment-only
+    failure in the same family (53 bun/node processes older than ~11h
+    were live during the proof, all with real parents, so contention is
+    the likely cause and is not reproducible from the diff). Cheap
+    discriminator the quarantine can apply itself, before hardening any
+    package-scoped failure: if the failing package is OUTSIDE
+    `git diff --name-only origin/main...HEAD`, re-run that one package
+    filtered — seconds, against a full re-proof. Escalate to hard only
+    if the isolated re-run also fails. Ties to #35's attribution
+    fingerprints and #47's log fetcher. Vehicle: PR-G.
+
+Hint-misattribution receipt (PR #592, 2026-08-06) — third instance in
+one day, so it is a pattern and not an accident. The monitor phase
+failed on two Vercel deployment checks reporting `Deployment rate
+limited — retry in 24 hours` (an account-level build cap, and neither
+check is among main's 17 required contexts). Yeet's `next:` line said
+`Inspect the OSV finding and rerun bun run beep quality github-checks
+security`. There was no OSV finding. Same class as the verdict-packet
+`repairCommand` misrouting already recorded against the misattribution
+trifecta: the hint selector matches on lane family rather than on the
+failing check's own payload. Until it is fixed, read the failing
+check's message, never the hint.
+
+Exit-code masking, self-inflicted again (same run): I backgrounded the
+publish as `<cmd> > log 2>&1; echo "PUBLISH-EXIT=$?"`. The harness
+reported the invocation's exit as 0 — because the trailing `echo`
+succeeded — while the real publish exited 1. Same family as the
+`cmd | grep | tail` masking already in the ledger, and it defeated the
+same instinct twice in one session: the wrapper's status is not the
+work's status. Read the marker or the artifact, never the invocation.
 
 PLAN.md drift (2026-08-06, hit independently by two lenses and the
 synthesizer): `goals/speed-loop/PLAN.md` is advertised — in agent briefs

--- a/goals/speed-loop/research/OPPORTUNITIES.md
+++ b/goals/speed-loop/research/OPPORTUNITIES.md
@@ -4,6 +4,78 @@ Standing mandate: capture every speed/efficiency opportunity noticed while
 shipping PR-A/PR-B. Status: `unowned` (nobody decided), `queued` (in a locked
 decision), `spiked` (needs measurement first). Reviewed at each grill.
 
+## Ranked — highest impact first (2026-08-06)
+
+The numbered items below are a JOURNAL, appended by provenance, and their
+numbers are STABLE IDS: ~330 references across this file, GRILL-DECISIONS.md,
+AGENTS.md, `ops/manifest.json`, `explorations/fleet-coordination/` (another
+clone's packet), and repo source. NEVER renumber to express priority. This
+section is the only priority axis — re-rank by editing here.
+
+Scope: the 19 items carrying no locked decision and no assigned wave (65 of 85
+are dispositioned). Method: three independent lenses — cycle-time removed,
+unblocking/dependency order, cost-to-ship — merged by cross-lens agreement,
+not by averaging (the axes are not commensurable). Provenance: run
+`wf_b1f680b0-2df`.
+
+1. **#82** publish's machine-parseable last line — one appended line; a piped
+   publish destroys `$?`, false-greened twice. Unanimous.
+2. **#60** generated-path → regenerate-command map — #74, #77, and #84 all
+   consume it. Ship the map standalone first, then its consumers.
+3. **#77** `publish --reconcile`; refuse `--amend` on a diverged branch —
+   manual reconcile run 4× in one session; `--amend` hard-stuck once.
+4. **#74** stale-base guard names class A vs B — fired 4/4; a Class B bypass
+   would have REVERTED new `goals/INDEX.md` entries.
+5. **#76** `verdict.json` lanes as composite sub-lanes — bimodal artifact
+   (3 lanes green vs ~24 failed); one agent nearly false-greened it.
+6. **#72** test-kit barrel import tax — 224s of a 278s run is imports, 6:1
+   import-to-execution. Biggest single win AND the worst thing to run
+   concurrently with a wave: wants a quiet single-owner PR.
+7. **#64** wave gate attribution + test advisory lock — supplies #49's
+   missing gate half; two concurrent vitest runs starved ~15 min.
+8. **#70** append-optional lint: artifact vs input DTO — SCOPE, not
+   follow-up, if PR-F goes next: #34's lint breaks every `buildYeetVerdict`
+   call site without the discriminator.
+9. **#67** adversarial-review harness + `yeet diff` — `git diff
+   origin/main...HEAD` is EMPTY on uncommitted work, so review rounds ran
+   vacuous.
+10. **#73** publish detects an already-MERGED PR before pushing — #569 merged
+    mid-proof and publish landed a proven commit in no PR at all.
+11. **#83** status reconciles verdict against remote reality.
+12. **#63** `A.filterMap` takes Result — 3 hits in one wave; the v3 shape
+    silently empties arrays (a suite ran 31/32 green while broken).
+13. **#71** mutation proof gate — 2 of 7 "fixed" PR-E findings survived a
+    full revert with the suite green (~15s/finding).
+14. **#58** decisions-PR adversarial review as a design gate — costs nothing,
+    rides any PR as a decision-text amendment.
+15. **#66** writer-level artifact coverage + encode lint — reverting the
+    writer fix left 1004 tests green; 3 writers still on `renderJson`.
+16. **#68** binding-contract block colocated with schemas — ~20 min scavenger
+    hunt per implementer; deliverable is one paragraph.
+17. **#65** dedupe/budget keys from retry-stable fields.
+18. **#69** fixture corpus for hosted CI payloads — blocked on #47.
+19. **#80** GitHub native stacked PRs — spike first per decision 49's
+    evidence ladder; should not enter a wave yet.
+
+Operator calls this ranking supports:
+
+- **PR-B is unsupported.** Not one of the 19 routes there (decision 18 parked
+  #36 in it; decision 13 calls PR-B execution-only on disjoint surfaces).
+- **PR-I is the better-supported next wave**, provided it absorbs the
+  agent-facing truth items; #64 is explicitly #49's missing half.
+- **Cheapest real win on the board is a bundle no wave owns:** #82 + #76 +
+  #73 + #83 — one coherent "publish output tells the truth" PR over data yeet
+  already fetches.
+- **#64 and #71 each have a cheap half shippable today** with zero machinery
+  — #64's wave-brief law ("own test files during the loop, one full package
+  run at integration") and #71's checklist line ("if the fix is a write, name
+  the test that reads it back"). Taking the cheap halves decouples them from
+  whichever wave runs next.
+- **#57 is NOT in this pool.** Its own text routes it to the
+  fleet-coordination docket, "not a speed-loop vehicle". It was mis-pooled as
+  undispositioned; all three lenses caught it independently. Do not re-score
+  it next cycle — the self-routing IS its disposition.
+
 ## Unowned — new candidates spotted tonight
 
 1. **Incremental jsdoc inventory.** The ratchet lane regenerates the ENTIRE
@@ -875,9 +947,18 @@ durability fixes discovery, not trust.
     into its originating session — terminals die (2026-08-05 power
     loss), PRs persist. Flags live in operator config templates per
     harness, not code. Identity ladder: `BEEP_AGENT_SESSION` env from a
-    launch wrapper now, PR-I's #45/#52 identity later. Dogfooded:
-    #583's body carries the footer hand-stamped. Vehicle: small yeet
-    rider; graduates into PR-I.
+    launch wrapper now, PR-I's #45/#52 identity later. DESIGN
+    CORRECTION (operator catch on the first dogfooded footer,
+    2026-08-06): the WORK CLONE and the SESSION HOME are distinct — a
+    harness session is keyed to the directory it STARTED in, which may
+    differ from the clone the work landed in (this session: home
+    beep-effect3, work beep-effect3-pra). The footer carries both
+    (`clone=` for git context, `session-home=` for the resume block's
+    cd), and the resume block MUST cd to the session home or the id
+    resolves nowhere. Automation sources the home from the harness
+    transcript path env, never from cwd. Dogfooded: #583/#586 bodies
+    carry the corrected footer. Vehicle: small yeet rider; graduates
+    into PR-I.
 80. **Evaluate GitHub native stacked PRs (public preview).** The docs
     claim the exact fixes for our recorded blockers: required checks run
     for ALL stack layers as if against the default branch (would retire
@@ -920,6 +1001,174 @@ durability fixes discovery, not trust.
     renders as "stale (predates last push)" with the re-derivation
     command, never as current truth — operators must not learn to
     ignore the verdict line.
+84. **Tree parity: local proof and hosted CI run on DIFFERENT TREES,
+    and the stale-base guard is structurally blind to the gap.**
+    (Reported by beep-effect5, 2026-08-06 — a plan/manifest phase-id
+    mismatch and a goals INDEX drift, both green locally, both
+    surfacing only once merged onto a moved main; mechanism verified
+    in source here, and #582 "regenerate the goals index after rebase"
+    is the same class landing as its own remediation commit.) Two
+    facts compose. (a) `.github/workflows/check.yml` is
+    `on: pull_request` using `actions/checkout@v4` with NO `ref:`
+    override, so hosted lanes run on `refs/pull/N/merge` — head merged
+    into the CURRENT base — while `yeet verify` proves the worktree's
+    HEAD. (b) `assessBaseFreshness` derives `overlappingPaths` as a set
+    INTERSECTION of the paths in `mergeBase..HEAD` and
+    `mergeBase..base`, and `enforceBaseFreshness` returns clean the
+    moment that set is empty. (Its `behindCount === 0` short-circuit is
+    sound — nothing to merge means the trees agree.) So the guard fires
+    only on TEXTUAL path overlap. A semantic conflict — this branch
+    edits A, main edits B, and a repo-level invariant couples A to B
+    (goals INDEX vs newly landed packets; packet phase ids vs a plan
+    manifest) — yields an empty intersection, merges without conflict,
+    and passes every local gate. CORRECTION to the reported remedy:
+    `git merge origin/main` / `merge-tree` is NOT sufficient, because
+    both cited failures were CONFLICT-FREE merges — a clean merge
+    proves nothing here. The guard must MATERIALIZE the merged tree and
+    RE-RUN the repo-level invariant gates on it. Widget: `yeet verify
+    --merged` (or a preflight tier) that merges the base into a
+    detached worktree, runs #75's cheap repo-level battery
+    (goals-doctor, goals:index, schema-first inventory) there, and on
+    failure routes through #60's generated-path → regenerate-command
+    map instead of a hand-merge. This is the TREE-parity sibling of
+    #46's LANE-parity — #46 asks which gates run, this asks what they
+    run ON, and together they close "why wasn't this caught locally" on
+    both axes. It is also the third class under #74, whose two classes
+    both presuppose the guard fired at all. Vehicle: PR-G with #75.
+85. **Coverage has TWO hosted-only classes, and collapsing them into
+    one "structurally cannot" verdict misroutes the fix.** (Live on PR
+    #587, the Effect 4.0.0-beta.103 catalog bump: `Coverage Regression`
+    failed at 14m51s; a sibling agent read it as the known
+    structurally-hosted-only gap.) The shared premise is TRUE and
+    verified: `YEET_FEEDBACK_TASKS = ["build", "check", "lint",
+    "test"]` (`Yeet/internal/Planner.ts:52`) — yeet verify/publish
+    never runs a package's `coverage` script. But two different
+    failures hide behind that one fact. CLASS R (runtime): defects that
+    only manifest under the coverage runtime — `coverage` is
+    `bunx vitest run --coverage`, a different runtime from `test`'s
+    `bunx --bun vitest run`, where `Bun.spawn` is inert and stdin never
+    EOFs (PR #570's 40-minute hang). Local proof genuinely cannot reach
+    these. CLASS T (threshold): an ordinary ratchet regression, which
+    #587 is — `check.yml` invokes `bun run beep ci lane coverage
+    --affected --base "origin/${GITHUB_BASE_REF}" --summarize`, an
+    invocation reproducible verbatim on a workstation. Class T is a
+    TASK-LIST gap, not a structural one, and diagnosing it as Class R
+    routes to "accept the hosted-only cost" when the cheap fix exists.
+    Why it cannot simply join #75's battery: measured on this run, the
+    lane is 231 tasks / 0 cached / 13m9s — the single most expensive
+    lane in the repo, against a battery whose ordering law is
+    cost-ascending. Widget: a CHANGED-PACKAGE-SCOPED coverage preflight.
+    Evidence it suffices — every package the ratchet flagged
+    (@beep/documents-server, @beep/duckdb, @beep/nlp,
+    @beep/openai-compat) had exactly ONE changed `src` file in the PR;
+    scoping to changed packages turns 231 tasks into 4. Boundary: local
+    numbers stay machine-sensitive, so this is a PREDICTOR of the drop's
+    direction, never the epsilon oracle — the verdict stays hosted.
+    Second finding from the same log: baseline drift is WARN-ONLY. Six
+    packages (@beep/epistemic-client, @beep/epistemic-ui,
+    @beep/exiftool, @beep/gov-legal-mcp, @beep/obs, @beep/qa-capture)
+    are missing from `standards/coverage.regression-baseline.jsonc`, so
+    they are exempt from the ratchet silently and indefinitely — a new
+    package can never regress what it never registered. That belongs in
+    the new-package governance-gate family as a blocking gate.
+    Vehicle: PR-G with #75.
+    SEQUENCING AMENDMENT (same day, from the parallel session that took
+    #587 to root cause with the operator): the preflight is BLOCKED on
+    fixing the gate itself, and must not ship first. The ratchet
+    compares PERCENTAGES with epsilon 0.001, so deleting covered code
+    from any package below 100% trips it arithmetically —
+    `(C-1)/(T-1) < C/T` whenever `C < T`. #587's drops are that
+    signature exactly: four packages, all migration edits, all tiny
+    fractional falls (-0.02 to -0.05). So the gate PENALIZES removing
+    code, and a changed-package preflight built now would only
+    reproduce a false failure faster — predicting a bogus verdict is
+    not a win. Correct order: (1) land the queued two-signal fix in
+    `Quality/internal/CoverageRegression.ts` — keep the pct baseline,
+    add uncovered (`total - covered`), flag only when pct FELL and
+    uncovered ROSE; (2) make filtered `--write-baseline` merge instead
+    of rebuilding `packages` wholesale (today it silently drops ~130
+    entries, which is a second, larger source of the missing-baseline
+    hole above); (3) only then build the preflight, which by then
+    predicts a verdict worth predicting. Corrects this item's original
+    read of #587 as an ordinary regression — the drops were real
+    arithmetic, but the FAILURE was not.
+86. **The ledger is not queryable, and that now costs more than it saves.**
+    (Convergent finding, 2026-08-06 ranking run `wf_b1f680b0-2df`: three
+    lenses given DIFFERENT briefs — cycle-time, unblocking, cost-to-ship
+    — each reported this blocker unprompted, and each proposed the same
+    remedy. Three independent frames landing on one tool is the
+    strongest signal any fan-out here has produced.) The failure is
+    structural, not cosmetic: 1100+ lines exceed a single read; item
+    numbers are NON-MONOTONIC in file order (verified: `... 54 56 57 58
+    59 60 55 61 ...` — #55 sits physically between #60 and #61); and
+    disposition state lives only in interleaved prose paragraphs, so
+    "is item N still open" requires a full-file scan. Consequence
+    measured this run: not one of the three lenses could verify the
+    handed-in candidate list against the file, so the synthesis
+    knowingly inherited an unverifiable premise — and the premise WAS
+    wrong (#57 was pooled as undispositioned while its own text routes
+    it to the fleet docket). Widget: a machine-readable sidecar keyed
+    by the EXISTING stable ids — id, title, status, vehicle, deciding
+    grill decision, blocked-on — generated from and validated against
+    the prose, never replacing it. Explicitly NOT renumbering: the ids
+    are referenced ~330 times across this file, GRILL-DECISIONS.md,
+    AGENTS.md, `ops/manifest.json`, another clone's
+    `explorations/fleet-coordination/` packet, and repo source. Rider:
+    disposition authority is currently three-way with no stated
+    precedence — numbered grill decisions, the SYNTHESIS-2 map, and
+    self-assigned `Vehicle:` lines in the item text. Everything from
+    #56 up leans on the third and weakest form; #84/#85 self-assign to
+    PR-G with no ratification. The sidecar must name which authority
+    wins. Vehicle: PR-G, and it is a prerequisite for #57's claims
+    manifest and any dependency graph.
+87. **`#NN` is an overloaded sigil across at least five referent kinds.**
+    (Same run; flagged independently by the unblocking lens and the
+    disposition mapper, who measured roughly a third of low-numbered
+    citation hits as false positives.) One bare token means: a ledger
+    item, a grill-decision number, a grill-SESSION number ("as grilled
+    in #3"), an r-report item ("r1 #1"), and a GitHub PR number — often
+    in the same sentence ("#74 ... #571", "#84 ... #587"). Humans
+    disambiguate from context; every machine consumer will not. With
+    ~330 references, a distinct ledger sigil plus a one-time mechanical
+    rewrite is cheap NOW and expensive after #86's sidecar, #57's
+    claims manifest, or a dependency graph is built on top of the
+    ambiguous form. Sequence it BEFORE #86. Concrete cost already paid:
+    ledger items 1–16 are never cited by number in GRILL-DECISIONS.md
+    at all — decision 10 ratifies them by DESCRIPTIVE NAME via
+    SYNTHESIS-2.md, which uses its own 1–8 numbering for o-report items
+    while its 9–16 happen to be ledger ids. That is a numbering
+    collision sitting inside the only join path. Vehicle: PR-G, ahead
+    of #86.
+
+PLAN.md drift (2026-08-06, hit independently by two lenses and the
+synthesizer): `goals/speed-loop/PLAN.md` is advertised — in agent briefs
+and in this packet's own README — as holding the PR-A..PR-I wave
+structure. It is a 9-line cycle-log table whose ledger-delta column stops
+at "8 → 19" with cycle 3 marked "pending", against a ledger now at 87
+items. The wave contents actually live in GRILL-DECISIONS.md #13–20. An
+incoming agent reads PLAN.md as authoritative and gets nothing — the
+mis-pointer cost this run a read cycle on exactly the load-bearing
+question it was launched to answer. Fix is one edit: make PLAN.md either
+current or an explicit pointer to the decisions that carry the waves.
+
+Absence-proof receipts (2026-08-06, self-inflicted twice inside ten
+minutes while verifying the #85 evidence). A negative result needs a
+POSITIVE CONTROL before it counts as proof. (a) `gh pr diff --name-only`
+failed with HTTP 406 (>300 files) and wrote an EMPTY file; the follow-up
+`rg` over it printed no match, which read exactly like "these packages
+were untouched" — the intended conclusion, reached vacuously. (b) The
+repair was worse: `gh api --paginate .../pulls/587/files -q '.[].path'`
+returned 1603 lines, which passed a `wc -l` non-emptiness check, but the
+REST files endpoint's field is `filename` (`path` is the GraphQL name),
+so all 1603 lines were EMPTY and the second absence-proof was vacuous
+too — the sanity check itself was the wrong invariant. Both conclusions
+were false: all four regressed packages DID have changed `src` files.
+Law: when a check's payoff is a no-match, first assert the haystack
+contains a known-present needle (`rg -c '\S'`, a control grep for a path
+you know changed). Kin to [[vacuous-test-pattern]] and the
+jq-capture-annihilation class. Separately: `rg -r` is `--replace`, NOT
+recursive — `rg -rn "pat" path` silently rewrites every match to the
+literal `n` and looks like corrupted source.
 
 Sweep-dogfood receipts (2026-08-06, first executeSweep on its own merged
 branch, exit 0, every rail honored): (a) the lockfile needs-operator

--- a/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
@@ -27,6 +27,11 @@ const baseFlag = Flag.string("base").pipe(
   Flag.withDefault("origin/main")
 );
 
+const branchFlag = Flag.string("branch").pipe(
+  Flag.withDescription("Sweep this branch instead of the checked-out one, so a second pass can finish a merged branch"),
+  Flag.withDefault("")
+);
+
 const headFlag = Flag.string("head").pipe(
   Flag.withDescription("Head ref for affected feedback planning"),
   Flag.withDefault("HEAD")
@@ -243,6 +248,7 @@ const porcelainFlags = {
 
 const sweepFlags = {
   ...porcelainFlags,
+  branch: branchFlag,
   json: jsonFlag,
   plan: planFlag,
 } as const;

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts
@@ -24,13 +24,14 @@
 
 import { Console, Effect } from "effect";
 import * as A from "effect/Array";
+import * as Str from "effect/String";
 import { YeetCommandError } from "../Yeet.errors.ts";
 import { hydrateYeetReadOnlyContext } from "./Handler.ts";
 import { mergePr } from "./Merge.ts";
 import { runYeetMonitorUntilMerged } from "./MonitorLoop.ts";
 import { runYeetReply } from "./Reply.ts";
 import { SweepPlanJson, SweepReportJson } from "./Sweep.schemas.ts";
-import { executeSweep, planSweep, renderSweepReport } from "./Sweep.ts";
+import { executeSweep, overrideSweepBranch, planSweep, renderSweepReport } from "./Sweep.ts";
 import type { FileSystem, Path } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { YeetMonitorTerminalState } from "./MonitorLoop.ts";
@@ -49,9 +50,13 @@ interface YeetPorcelainOptions {
 /**
  * Parsed `yeet sweep` flag values. `plan` is the dry run — observe the clone,
  * build the plan, print it, execute nothing — and `json` selects the artifact
- * codec instead of the operator text, for both the plan and the report.
+ * codec instead of the operator text, for both the plan and the report. An
+ * empty `branch` means "the checked-out branch"; any other value re-aims the
+ * sweep through {@link overrideSweepBranch}, which is how a second pass reaches
+ * a merged branch the clone is no longer standing on.
  */
 interface YeetSweepOptions extends YeetPorcelainOptions {
+  readonly branch: string;
   readonly json: boolean;
   readonly plan: boolean;
 }
@@ -105,7 +110,8 @@ export const runYeetSweep = Effect.fn("Yeet.runSweepCommand")(function* (
   YeetCommandError,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
-  const context = yield* hydrateYeetReadOnlyContext(options);
+  const hydrated = yield* hydrateYeetReadOnlyContext(options);
+  const context = Str.isEmpty(options.branch) ? hydrated : yield* overrideSweepBranch(hydrated, options.branch);
   if (options.plan) {
     const plan = yield* planSweep(context);
     yield* Console.log(options.json ? yield* encodeSweepPlan(plan) : renderSweepPlan(plan));

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
@@ -65,6 +65,7 @@
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
+import { shellQuote } from "@beep/repo-ai-metrics";
 import { guardLiteralArg } from "@beep/repo-utils";
 import { SchemaUtils } from "@beep/schema";
 import { Clock, DateTime, Effect, flow, Path, pipe } from "effect";
@@ -635,7 +636,7 @@ const refuseUnsafeName = (value: string, role: string) =>
  * @param context - The hydrated run context to re-aim.
  * @param branch - The branch name the sweep should plan against.
  * @returns The context with its branch coordinate replaced.
- * @category planning
+ * @category constructors
  * @since 0.0.0
  */
 export const overrideSweepBranch = Effect.fn("Yeet.overrideSweepBranch")(function* (
@@ -980,7 +981,7 @@ const guardedDeletion = (
  * @param localMain - The local `main` tip observed after the refresh step.
  * @param trackingMain - The `origin/main` tip observed after the refresh step.
  * @returns The operator handoff outcome for the lockfile step.
- * @category execution
+ * @category constructors
  * @since 0.0.0
  */
 export const refreshNotCompletedHandoff = (
@@ -997,9 +998,13 @@ export const refreshNotCompletedHandoff = (
         onSome: (holder) => `. ${holder} holds ${state.mainBranch}, so only that worktree can refresh it`,
       }
     )}`,
+    // Both interpolations are POSIX-quoted because this string is COPIED into
+    // a shell: worktree paths routinely contain whitespace, and
+    // `guardLiteralArg` only refuses option-like values — it does not escape
+    // metacharacters, so it is not a substitute for quoting here.
     operatorCommand: O.match(state.mainWorktreePath, {
       onNone: () => "bun run beep yeet sweep",
-      onSome: (holder) => `cd ${holder} && bun run beep yeet sweep --branch ${state.branch}`,
+      onSome: (holder) => `cd ${shellQuote(holder)} && bun run beep yeet sweep --branch ${shellQuote(state.branch)}`,
     }),
   });
 

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
@@ -48,9 +48,17 @@
  *
  * `delete-local-branch` is planned before `end-state`, so a sweep run from the
  * merged branch's own worktree skips the deletion ("no worktree holds
- * `<branch>`" fails) and then leaves the clone on `main`. Re-running the sweep
- * completes the deletion. Moving HEAD first would mean mutating the worktree
- * before the plan's safety facts were acted on, which the rails forbid.
+ * `<branch>`" fails) and then leaves the clone on `main`. Moving HEAD first
+ * would mean mutating the worktree before the plan's safety facts were acted
+ * on, which the rails forbid.
+ *
+ * A bare re-run does NOT complete that deletion. `end-state` has already moved
+ * the clone to `main`, so the second pass observes `main` as the current branch
+ * and plans against it — the merged branch is never reconsidered. The second
+ * pass must name its target: `yeet sweep --branch <merged-branch>`, which
+ * {@link overrideSweepBranch} re-aims. The same override is what makes a
+ * `needs-operator` refresh handoff actionable, since the worktree holding
+ * `main` is rarely the worktree holding the merged branch.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -65,7 +73,7 @@ import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { GhPrView, ghOutput } from "../../../internal/github/index.ts";
-import { runRepoCommandCapture, safeOriginBranchFromBase } from "../../../internal/repo-run/index.ts";
+import { RepoRunContext, runRepoCommandCapture, safeOriginBranchFromBase } from "../../../internal/repo-run/index.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
 import { artifactDirForContext } from "./ArtifactPaths.ts";
 import { optionFromNonEmpty } from "./GitExec.ts";
@@ -85,7 +93,6 @@ import {
 } from "./Sweep.schemas.ts";
 import type { FileSystem } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
-import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
 
 const $I = $RepoCliId.create("commands/Yeet/internal/Sweep");
 
@@ -172,6 +179,7 @@ export class SweepGitState extends S.Class<SweepGitState>($I`SweepGitState`)(
     lockfileMovedOnMainUpdate: S.Boolean,
     statusProbeUnreliable: S.Boolean,
     worktreeProbeUnreliable: S.Boolean,
+    mainWorktreePath: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
     mainTip: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
     localTip: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
     remoteTip: S.NonEmptyString.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
@@ -542,8 +550,18 @@ const parseWorktreeList = (output: string): ReadonlyArray<WorktreeEntry> =>
     A.getSomes
   );
 
+// The path is what a handoff needs: "main is held elsewhere" tells an operator
+// they are blocked, not where to go, and re-running the sweep in the blocked
+// worktree loops forever. `heldByOtherWorktree` stays the boolean the
+// preconditions read, derived from the same lookup so the two cannot disagree.
+const worktreeHolding = (worktrees: ReadonlyArray<WorktreeEntry>, branch: string, selfPath: string): O.Option<string> =>
+  pipe(
+    A.findFirst(worktrees, (entry) => entry.path !== selfPath && O.exists(entry.branch, (held) => held === branch)),
+    O.map((entry) => entry.path)
+  );
+
 const heldByOtherWorktree = (worktrees: ReadonlyArray<WorktreeEntry>, branch: string, selfPath: string): boolean =>
-  A.some(worktrees, (entry) => entry.path !== selfPath && O.exists(entry.branch, (held) => held === branch));
+  O.isSome(worktreeHolding(worktrees, branch, selfPath));
 
 const observeSha = (
   cwd: string,
@@ -583,6 +601,50 @@ const refuseUnsafeName = (value: string, role: string) =>
       })
     )
   );
+
+/**
+ * Aim a sweep at a branch other than the one checked out.
+ *
+ * **Details**
+ *
+ * The sweep plans against `context.branch`, so without an override it can only
+ * ever finish the branch it is standing on. That makes the second pass of a
+ * two-pass sweep unreachable: the first pass leaves the clone on `main`, and
+ * from there the merged branch is no longer the current branch. It is also what
+ * a blocked handoff needs — the worktree holding `main` is usually not the
+ * worktree holding the merged branch, so the operator must be able to run the
+ * sweep in one and target the other.
+ *
+ * **Gotchas**
+ *
+ * The override is pushed through the same `guardLiteralArg` refusal as every
+ * other argv-bound name, so an option-like `--branch` value fails the sweep
+ * instead of becoming a git flag. Only the branch coordinate changes; the base,
+ * head, and packet directory stay as hydrated.
+ *
+ * **Example** (Target a merged branch from another worktree)
+ *
+ * ```ts
+ * import { overrideSweepBranch } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(overrideSweepBranch)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param context - The hydrated run context to re-aim.
+ * @param branch - The branch name the sweep should plan against.
+ * @returns The context with its branch coordinate replaced.
+ * @category planning
+ * @since 0.0.0
+ */
+export const overrideSweepBranch = Effect.fn("Yeet.overrideSweepBranch")(function* (
+  context: RepoRunContext,
+  branch: string
+): Effect.fn.Return<RepoRunContext, YeetCommandError> {
+  const safeBranch = yield* refuseUnsafeName(branch, "branch");
+  return RepoRunContext.make({ ...context, branch: safeBranch });
+});
 
 /**
  * Probe the clone for every fact {@link buildSweepPlan} needs.
@@ -668,6 +730,12 @@ export const observeSweepGitState = Effect.fn("Yeet.observeSweepGitState")(funct
     lockfileMovedOnMainUpdate: lockfile.exitCode === 0 && Str.isNonEmpty(lockfile.output),
     statusProbeUnreliable: probeUnreliable(status),
     worktreeProbeUnreliable: probeUnreliable(worktreeList),
+    // None when the probe was unreliable: an unreadable worktree list forces
+    // `mainCheckedOutElsewhere` true conservatively, but naming a path nobody
+    // observed would send the operator to a worktree that may not hold main.
+    mainWorktreePath: probeUnreliable(worktreeList)
+      ? O.none()
+      : worktreeHolding(worktrees, mainBranch, toplevel.output),
     mainTip,
     localTip,
     remoteTip,
@@ -879,6 +947,62 @@ const guardedDeletion = (
     )
   );
 
+/**
+ * The handoff raised when `main` was never refreshed, naming who can fix it.
+ *
+ * **Details**
+ *
+ * An unrefreshed `main` proves nothing about `bun.lock`, so the dependency
+ * state is unknown rather than unchanged. This is `needs-operator` and not a
+ * skip because it cannot self-heal: whatever blocked the fast-forward — a dirty
+ * tree, or another worktree holding `main` — is still blocking it on the next
+ * run.
+ *
+ * **Gotchas**
+ *
+ * A handoff that names only the command is unactionable when the blocker is
+ * authority rather than state. Re-running the sweep in a worktree that cannot
+ * refresh `main` loops forever. So when the holding worktree is known the
+ * handoff sends the operator THERE and aims the run back at this branch through
+ * `--branch`; when it is not known — an unreliable `worktree list` probe — the
+ * command stays bare and the reason says only what must become true first,
+ * because naming a path nobody observed is worse than naming none.
+ *
+ * **Example** (Build the refresh handoff)
+ *
+ * ```ts
+ * import { refreshNotCompletedHandoff } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(typeof refreshNotCompletedHandoff) // "function"
+ * ```
+ *
+ * @param state - Observed facts for the branch being swept.
+ * @param localMain - The local `main` tip observed after the refresh step.
+ * @param trackingMain - The `origin/main` tip observed after the refresh step.
+ * @returns The operator handoff outcome for the lockfile step.
+ * @category execution
+ * @since 0.0.0
+ */
+export const refreshNotCompletedHandoff = (
+  state: SweepGitState,
+  localMain: O.Option<string>,
+  trackingMain: O.Option<string>
+): SweepStepNeedsOperator =>
+  SweepStepNeedsOperator.make({
+    reason: `${state.mainBranch} was not refreshed to origin/${state.mainBranch} (local ${optionText(localMain)}, origin ${optionText(trackingMain)}); bun.lock state is unknown and dependencies are unreconciled until the refresh succeeds${O.match(
+      state.mainWorktreePath,
+      {
+        onNone: () =>
+          `. Re-running here cannot fix it — clear whatever blocks the ${state.mainBranch} fast-forward first`,
+        onSome: (holder) => `. ${holder} holds ${state.mainBranch}, so only that worktree can refresh it`,
+      }
+    )}`,
+    operatorCommand: O.match(state.mainWorktreePath, {
+      onNone: () => "bun run beep yeet sweep",
+      onSome: (holder) => `cd ${holder} && bun run beep yeet sweep --branch ${state.branch}`,
+    }),
+  });
+
 // The observed lockfile forecast predates the sweep's own fetch/fast-forward,
 // so the executed decision re-diffs the actual update window: the main tip
 // recorded at observation against post-refresh local main. An unreadable
@@ -908,12 +1032,7 @@ const runLockfileInstallStep = (
               // whatever blocked ff-main (dirty tree, held main), so the
               // unreconciled dependency state lands in the batched handoff
               // instead of waiting for someone to read a buried skip.
-              Effect.succeed<SweepStepOutcome>(
-                SweepStepNeedsOperator.make({
-                  reason: `${state.mainBranch} was not refreshed to origin/${state.mainBranch} (local ${optionText(localMain)}, origin ${optionText(trackingMain)}); bun.lock state is unknown and dependencies are unreconciled until the refresh succeeds`,
-                  operatorCommand: "bun run beep yeet sweep",
-                })
-              )
+              Effect.succeed<SweepStepOutcome>(refreshNotCompletedHandoff(state, localMain, trackingMain))
             : captureGit(cwd, [
                 "diff",
                 "--name-only",

--- a/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
@@ -3,7 +3,9 @@ import {
   executeSweep,
   MergeOutcome,
   observeSweepGitState,
+  overrideSweepBranch,
   RepoRunContext,
+  refreshNotCompletedHandoff,
   renderSweepReport,
   revalidateLocalDeletion,
   revalidateRemoteDeletion,
@@ -23,7 +25,7 @@ import { provideScopedLayer } from "@beep/test-utils";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, FileSystem, Layer, pipe, Sink, Stream } from "effect";
+import { Effect, Exit, FileSystem, Layer, pipe, Sink, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as Str from "effect/String";
@@ -52,6 +54,7 @@ const mergedFacts = {
   lockfileMovedOnMainUpdate: true,
   statusProbeUnreliable: false,
   worktreeProbeUnreliable: false,
+  mainWorktreePath: O.none<string>(),
   mainTip: O.some(mainTipBeforeUpdate),
   localTip: O.some(mergedTip),
   remoteTip: O.some(mergedTip),
@@ -706,5 +709,81 @@ describe("MergeOutcome", () => {
     });
     expect(outcome.pullRequestNumber).toBe(559);
     expect(outcome.sweep.plan.branch).toBe("feat/merge-loop");
+  });
+});
+
+// Decision 45(d) shipped claiming "a re-run completes the deletion". It does
+// not: `end-state` leaves the clone on main, so the second pass observes main
+// as the current branch and never reconsiders the merged branch. The override
+// is what makes the documented two-pass design actually reachable.
+describe("sweep branch override", () => {
+  const contextAt = (branch: string) =>
+    RepoRunContext.make({
+      base: "origin/main",
+      branch,
+      cwd: "/repo",
+      head: "HEAD",
+      originalArgv: [],
+      packetDir: "/repo",
+      repoRoot: "/repo",
+      turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+    });
+
+  it.effect("re-aims the sweep at a branch the clone is no longer standing on", () =>
+    Effect.gen(function* () {
+      const reaimed = yield* overrideSweepBranch(contextAt("main"), "feat/merge-loop");
+      expect(reaimed.branch).toBe("feat/merge-loop");
+    })
+  );
+
+  it.effect("changes only the branch coordinate", () =>
+    Effect.gen(function* () {
+      const original = contextAt("main");
+      const reaimed = yield* overrideSweepBranch(original, "feat/merge-loop");
+      expect({ ...reaimed, branch: original.branch }).toEqual({ ...original });
+    })
+  );
+
+  it.effect("refuses an option-like branch name instead of passing it to git", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(overrideSweepBranch(contextAt("main"), "--upload-pack=touch /tmp/pwn"));
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
+});
+
+describe("refresh handoff addressing", () => {
+  const localMain = O.some("cccc3333");
+  const trackingMain = O.some("dddd4444");
+
+  it("sends the operator to the worktree that holds main, aimed back at this branch", () => {
+    const handoff = refreshNotCompletedHandoff(
+      stateWith({ mainCheckedOutElsewhere: true, mainWorktreePath: O.some("/home/dev/beep-effect") }),
+      localMain,
+      trackingMain
+    );
+    expect(handoff.operatorCommand).toBe(
+      "cd /home/dev/beep-effect && bun run beep yeet sweep --branch feat/merge-loop"
+    );
+    expect(handoff.reason).toContain("/home/dev/beep-effect holds main");
+  });
+
+  it("never tells the operator to re-run in place, which is the loop that was shipped", () => {
+    const handoff = refreshNotCompletedHandoff(
+      stateWith({ mainCheckedOutElsewhere: true, mainWorktreePath: O.some("/home/dev/beep-effect") }),
+      localMain,
+      trackingMain
+    );
+    expect(handoff.operatorCommand).not.toBe("bun run beep yeet sweep");
+  });
+
+  it("names no path when the worktree probe could not be read", () => {
+    const handoff = refreshNotCompletedHandoff(
+      stateWith({ mainCheckedOutElsewhere: true, worktreeProbeUnreliable: true }),
+      localMain,
+      trackingMain
+    );
+    expect(handoff.operatorCommand).toBe("bun run beep yeet sweep");
+    expect(handoff.reason).toContain("Re-running here cannot fix it");
   });
 });

--- a/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
@@ -763,9 +763,29 @@ describe("refresh handoff addressing", () => {
       trackingMain
     );
     expect(handoff.operatorCommand).toBe(
-      "cd /home/dev/beep-effect && bun run beep yeet sweep --branch feat/merge-loop"
+      "cd '/home/dev/beep-effect' && bun run beep yeet sweep --branch 'feat/merge-loop'"
     );
     expect(handoff.reason).toContain("/home/dev/beep-effect holds main");
+  });
+
+  // guardLiteralArg refuses option-like values; it does not escape whitespace,
+  // and worktree paths routinely contain spaces.
+  it("quotes a worktree path containing whitespace so the copied command still cds there", () => {
+    const handoff = refreshNotCompletedHandoff(
+      stateWith({ mainCheckedOutElsewhere: true, mainWorktreePath: O.some("/home/dev/beep effect/main") }),
+      localMain,
+      trackingMain
+    );
+    expect(handoff.operatorCommand).toContain("cd '/home/dev/beep effect/main'");
+  });
+
+  it("escapes an embedded single quote instead of ending the quoted string early", () => {
+    const handoff = refreshNotCompletedHandoff(
+      stateWith({ mainCheckedOutElsewhere: true, mainWorktreePath: O.some("/home/dev/o'brien") }),
+      localMain,
+      trackingMain
+    );
+    expect(handoff.operatorCommand).toContain(`cd '/home/dev/o'\\''brien'`);
   });
 
   it("never tells the operator to re-run in place, which is the loop that was shipped", () => {


### PR DESCRIPTION
## fix(repo-cli): aim sweep at a branch and address the refresh handoff

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit:amend: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_sweep-branch-override-58fbe84e3284/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788618992&installation_model_id=424656&pr_number=592&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F592&signature=fd5d9bcd942b207b5f55cc704931d754aa1a9a038dd6c0bf0a21af4ce91980d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->