### PR TITLE
feat(repo-cli): capture Codex findings CSV into a goal packet

### DIFF
--- a/.changeset/codex-findings-capture.md
+++ b/.changeset/codex-findings-capture.md
@@ -1,0 +1,24 @@
+---
+{}
+---
+
+No release: add `bun run beep codex findings ingest`, which turns the signed-in
+Codex Cloud **Export findings as CSV** download into a doctor-clean goal packet
+sitting at the P1 capture → P2 validate boundary.
+
+Five security batches were transcribed by hand before this existed. The command
+replaces steps 3-9 of that loop: sanitize, normalize, assign identifiers, render
+the manifest, triage ledger, per-finding records, index, and launcher templates,
+then promote the whole packet with one atomic rename.
+
+The CLI never authenticates. It reads a file the operator already downloaded, so
+no cookie, token, or authorization header is read, stored, logged, or placed on
+a process command line. `author_email`, `assignee_name`, and `assignee_email`
+are dropped at the parse boundary, and the reject-scan independently refuses
+email addresses, secret-shaped values, private paths, bidi controls, and
+spreadsheet-formula sigils — rejecting rather than redacting, because missed
+redaction in a public repository is irreversible.
+
+Identifiers are sticky: re-ingesting preserves each `codexId -> CSF-NNN` binding
+and never reuses a number, so hand-written triage prose and the post-merge close
+allowlist keep meaning what they meant.

--- a/.claude/skills/codex-findings/SKILL.md
+++ b/.claude/skills/codex-findings/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: codex-findings
+description: Capture Codex Cloud security findings into a goal packet. Use when asked to capture findings, pull the security findings, bootstrap a Codex security findings packet, or remediate the latest Codex Cloud security batch. Covers the signed-in CSV export, `beep codex findings ingest`, and post-merge closure.
+---
+
+# Codex Security Findings
+
+The full loop is: **export → ingest → `/goal` → remediate → Yeet → close**.
+Only the export and the final closure happen in a browser. Everything between
+them is `bun run beep codex findings ingest` plus the normal packet workflow.
+
+Never hand-build the packet. Five batches were transcribed by hand before this
+command existed; the boilerplate is exactly what it eliminates.
+
+## 1. Export (browser, signed in)
+
+Open the findings view and use its own **Export findings as CSV** control:
+
+```
+https://chatgpt.com/codex/cloud/security/findings/
+```
+
+Scope the view to the repository and the statuses you intend to capture before
+exporting — the export reflects the current filter.
+
+**The CLI never authenticates.** It reads a file you already downloaded. Do not
+extract cookies, tokens, or authorization headers, do not pass credentials as
+flags, and do not script a fetch against the findings API — a same-origin fetch
+returns 401 and the "fix" for that is exactly the credential handling this
+design exists to avoid.
+
+## 2. Ingest
+
+```sh
+bun run beep codex findings ingest --from ~/Downloads/codex-security-findings-<timestamp>.csv
+```
+
+Useful flags:
+
+| Flag | Use |
+|---|---|
+| `--dry-run` | Report the packet without writing anything. |
+| `--expected-count N` | Fail closed if the export holds fewer than the dashboard reported. |
+| `--slug` / `--branch` / `--date` | Override the derived packet identity. |
+| `--force` | Replace an existing packet. **Destroys hand-written triage prose.** |
+| `--json` | Machine-readable summary. |
+
+The capture date comes from the export filename, or `--date`. It never comes
+from the clock, so re-ingesting the same export is byte-identical.
+
+What lands: `README.md`, `GOAL.md`, `SPEC.md`, `PLAN.md`, `research/SOURCES.md`,
+`ops/manifest.json`, `ops/triage.json`, `findings/INDEX.md`, one
+`findings/CSF-NNN.md` per finding, and a gitignored `raw/`.
+
+## 3. Execute
+
+```
+/goal follow the instructions in goals/<slug>/GOAL.md
+```
+
+The packet arrives at the **P1 capture → P2 validate** boundary. Every finding
+is `untriaged` with no verdict, owner, or lane, and every CSF body carries
+`_pending P2_` markers. That is deliberate: the capture knows metadata, not
+judgment. Writing the public summary and the current-HEAD verdict is the
+agent's job, from the raw report in `raw/`.
+
+## 4. Close (browser, after merge)
+
+Close only the exact captured Codex IDs, as `Already fixed` (or an
+evidence-backed `False positive`). Accepted risk is not available. Direct
+`/findings/<id>` URLs render blank — navigate from the list view.
+
+## Invariants worth knowing
+
+- **Identifiers are sticky.** Re-ingesting preserves each `codexId → CSF-NNN`
+  binding and appends new findings. A number is never reused, even after its
+  finding leaves the export, because it is quoted in triage prose and in the
+  close allowlist.
+- **Personal data never enters the CLI.** `author_email`, `assignee_name`, and
+  `assignee_email` are dropped at the parse boundary, and the reject-scan
+  independently refuses email addresses.
+- **Reject, never redact.** Secret-shaped content, private paths, bidi
+  controls, and spreadsheet-formula sigils fail the ingest rather than being
+  silently rewritten. Missed redaction in a public repo is irreversible; a
+  false rejection costs one hand-edit.
+- **`raw/` is gitignored and holds the normalized capture only.** The CSV is
+  never copied into the repository — it carries report bodies and an email
+  address in every row.
+- **Writes are atomic.** The packet is staged, scanned, then promoted with a
+  single rename, so a crash cannot leave a half-packet and an existing packet
+  is never clobbered without `--force`.
+
+## Not implemented yet
+
+`--refresh` (merging a new export into an existing packet while preserving
+hand-written prose) does not exist. Today the choices are a new slug or
+`--force`. The sticky-identity mechanism it needs is already in place.
+
+Source-commit ancestry is checked by a packet verification command rather than
+the CLI, because this repository squash-merges and a valid finding's source
+commit is frequently absent from the branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,9 @@ workflows in skills.
 - UI motion evidence comes from `bun run beep qa` artifacts. There is no QA
   MCP server; the `chrome-devtools` MCP is slim and default-disabled, for
   perf-trace/computed-style introspection during QA sessions.
+- Codex Cloud security findings: export the CSV from the signed-in findings
+  view, then `bun run beep codex findings ingest --from <export.csv>`; prefer
+  the `codex-findings` skill. Never hand-build the packet.
 
 ## Context Economy
 

--- a/packages/tooling/tool/cli/src/commands/Codex/Codex.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Codex.command.ts
@@ -12,6 +12,7 @@ import { Argument, Command } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 import { printLines } from "../../internal/cli/Printer.ts";
 import { CodexCommandError } from "./Codex.errors.ts";
+import { findingsCommand } from "./Findings.command.ts";
 import type { FileSystem } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 
@@ -34,13 +35,18 @@ initiative summary.
 /**
  * Launch Codex with the repo-local quality review fix loop prompt.
  *
- * @param summaryParts - Optional initiative summary words.
- * @returns Effect that runs `codex exec`.
- * @example
+ * **Example** (Closing the current initiative)
+ *
  * ```ts
  * import { runCodexQualityReviewFixLoop } from "@beep/repo-cli/commands/Codex"
+ *
  * const program = runCodexQualityReviewFixLoop(["close", "current", "initiative"])
+ *
+ * console.log(typeof program) // "object"
  * ```
+ *
+ * @param summaryParts - Optional initiative summary words.
+ * @returns Effect that runs `codex exec`.
  * @category use-cases
  * @since 0.0.0
  */
@@ -82,13 +88,24 @@ const qualityReviewFixLoopCommand = Command.make(
 /**
  * Codex helper command group.
  *
- * @example
+ * **Example** (Reading the command name)
+ *
  * ```ts
- * console.log("codexCommand")
+ * import { codexCommand } from "@beep/repo-cli/commands/Codex"
+ *
+ * console.log(codexCommand.name) // "codex"
  * ```
+ *
  * @category cli-commands
  * @since 0.0.0
  */
 export const codexCommand = Command.make("codex", {}, () =>
-  printLines(["Codex commands:", "- bun run beep codex quality-review-fix-loop"])
-).pipe(Command.withDescription("Codex agent helper commands"), Command.withSubcommands([qualityReviewFixLoopCommand]));
+  printLines([
+    "Codex commands:",
+    "- bun run beep codex quality-review-fix-loop",
+    "- bun run beep codex findings ingest --from <export.csv>",
+  ])
+).pipe(
+  Command.withDescription("Codex agent helper commands"),
+  Command.withSubcommands([qualityReviewFixLoopCommand, findingsCommand])
+);

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.capture.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.capture.schemas.ts
@@ -1,0 +1,632 @@
+/**
+ * Normalized capture contract consumed by `beep codex findings ingest`.
+ *
+ * The operator exports the findings view's own CSV from an already-signed-in
+ * browser; `Findings.csv` decodes that export into a `codex-findings-capture/v1`
+ * document, and everything in this module models it. The document is untrusted
+ * external data: every field is length-bounded and pattern-checked so a hostile
+ * finding title cannot reach a generated packet file, a terminal, or a
+ * filesystem path.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("commands/Codex/Findings.capture.schemas");
+
+/**
+ * Severity domain of a Codex Cloud security finding.
+ *
+ * **Details**
+ *
+ * Declaration order is the packet sort rank: findings are ordered most severe
+ * first, and `CSF-NNN` numbers are assigned from that order. Deriving the rank
+ * from `Options.indexOf` is what keeps the literal domain and the ordering from
+ * drifting apart when a severity is added.
+ *
+ * **Example** (Ranking a severity)
+ *
+ * ```ts
+ * import { CodexFindingSeverity } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ *
+ * console.log(CodexFindingSeverity.Options.indexOf("Medium")) // 1
+ * console.log(CodexFindingSeverity.is.Informational("Informational")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexFindingSeverity = LiteralKit(["High", "Medium", "Low", "Informational"]).pipe(
+  $I.annoteSchema("CodexFindingSeverity", {
+    description: "Severity domain of a Codex Cloud security finding, ordered most severe first.",
+  })
+);
+
+/**
+ * Severity reported for one captured finding.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexFindingSeverity = typeof CodexFindingSeverity.Type;
+
+/**
+ * Lifecycle status a finding carries on the Codex Cloud dashboard.
+ *
+ * **Example** (Checking a captured status)
+ *
+ * ```ts
+ * import { CodexFindingStatus } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ *
+ * console.log(CodexFindingStatus.is.Open("Open")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexFindingStatus = LiteralKit(["Open", "New", "Closed"]).pipe(
+  $I.annoteSchema("CodexFindingStatus", {
+    description: "Lifecycle status a finding carries on the Codex Cloud dashboard.",
+  })
+);
+
+/**
+ * Dashboard status of one captured finding.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexFindingStatus = typeof CodexFindingStatus.Type;
+
+/**
+ * Session state observed while producing the capture.
+ *
+ * **Details**
+ *
+ * A capture is `expired` when the export came back as a signed-out shell rather
+ * than findings. Planning refuses an `expired` payload rather than bootstrapping
+ * a packet from zero findings, which would otherwise look like a clean scan. The
+ * CSV lane detects this at the decode boundary, where a login document fails
+ * header validation; the field keeps the guard available to any other source.
+ *
+ * **Example** (Rejecting an expired capture)
+ *
+ * ```ts
+ * import { CodexCaptureAuthState } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ *
+ * console.log(CodexCaptureAuthState.is.expired("expired")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexCaptureAuthState = LiteralKit(["authenticated", "expired"]).pipe(
+  $I.annoteSchema("CodexCaptureAuthState", {
+    description: "Session state observed while producing the capture.",
+  })
+);
+
+/**
+ * Authentication state reported by one capture run.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexCaptureAuthState = typeof CodexCaptureAuthState.Type;
+
+const CodexFindingIdChecks = S.makeFilterGroup([
+  S.isLengthBetween(32, 32, {
+    identifier: $I`CodexFindingIdLengthCheck`,
+    title: "Codex Finding Id Length",
+    description: "Codex finding identifiers are exactly 32 characters.",
+    message: "Expected a 32-character Codex finding identifier",
+  }),
+  S.isPattern(/^[0-9a-f]{32}$/, {
+    identifier: $I`CodexFindingIdPatternCheck`,
+    title: "Codex Finding Id Pattern",
+    description: "Codex finding identifiers are lowercase hexadecimal.",
+    message: "Expected a lowercase hexadecimal Codex finding identifier",
+  }),
+]);
+
+/**
+ * Opaque 32-character identifier Codex Cloud assigns to a finding.
+ *
+ * **Gotchas**
+ *
+ * This value is never used to build a filesystem path. Packet files are named
+ * from CLI-assigned `CSF-NNN` ids so a hostile identifier cannot escape the
+ * packet directory even if the pattern check is later loosened.
+ *
+ * **Example** (Validating a captured identifier)
+ *
+ * ```ts
+ * import { CodexFindingId } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(CodexFindingId)("d2b9e11e8550819193516057a336ff90")) // true
+ * console.log(S.is(CodexFindingId)("../../etc/passwd")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexFindingId = S.String.check(CodexFindingIdChecks).pipe(
+  $I.annoteSchema("CodexFindingId", {
+    description: "Opaque 32-character lowercase-hex identifier Codex Cloud assigns to a finding.",
+  })
+);
+
+/**
+ * Codex-assigned identifier of one captured finding.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexFindingId = typeof CodexFindingId.Type;
+
+const GitCommitShaChecks = S.makeFilterGroup([
+  S.isLengthBetween(40, 40, {
+    identifier: $I`GitCommitShaLengthCheck`,
+    title: "Git Commit Sha Length",
+    description: "Full git object names are exactly 40 characters.",
+    message: "Expected a 40-character git commit sha",
+  }),
+  S.isPattern(/^[0-9a-f]{40}$/, {
+    identifier: $I`GitCommitShaPatternCheck`,
+    title: "Git Commit Sha Pattern",
+    description: "Git object names are lowercase hexadecimal.",
+    message: "Expected a lowercase hexadecimal git commit sha",
+  }),
+]);
+
+/**
+ * Full git object name of the commit a finding was reported against.
+ *
+ * **Details**
+ *
+ * Ingest records this verbatim so a later triage phase can prove the reported
+ * commit is an ancestor of the packet branch. Abbreviated shas are rejected
+ * because ancestry checks against an ambiguous prefix are not decidable.
+ *
+ * **Example** (Validating a source commit)
+ *
+ * ```ts
+ * import { GitCommitSha } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(GitCommitSha)("244529aa4f560421cd096c2a4a4cb3cd21923070")) // true
+ * console.log(S.is(GitCommitSha)("244529a")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const GitCommitSha = S.String.check(GitCommitShaChecks).pipe(
+  $I.annoteSchema("GitCommitSha", {
+    description: "Full 40-character lowercase-hex git object name of a reported commit.",
+  })
+);
+
+/**
+ * Source commit reported for one captured finding.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GitCommitSha = typeof GitCommitSha.Type;
+
+/**
+ * Calendar date a capture ran, as `YYYY-MM-DD`.
+ *
+ * **Gotchas**
+ *
+ * This value becomes part of the packet slug, so it is pattern-checked before
+ * any path is built from it. A value such as `2026-08-04/../..` fails here
+ * rather than at the filesystem boundary.
+ *
+ * **Example** (Rejecting a traversal-shaped date)
+ *
+ * ```ts
+ * import { CaptureDate } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(CaptureDate)("2026-08-04")) // true
+ * console.log(S.is(CaptureDate)("2026-08-04/../..")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CaptureDate = S.String.check(
+  S.isPattern(/^\d{4}-\d{2}-\d{2}$/, {
+    identifier: $I`CaptureDatePatternCheck`,
+    title: "Capture Date Pattern",
+    description: "Capture dates are ISO calendar dates without a time component.",
+    message: "Expected a YYYY-MM-DD capture date",
+  })
+).pipe(
+  $I.annoteSchema("CaptureDate", {
+    description: "Calendar date a findings capture ran, used to derive the packet slug.",
+  })
+);
+
+/**
+ * Capture date used to derive a packet slug.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CaptureDate = typeof CaptureDate.Type;
+
+/**
+ * GitHub `owner/repo` slug the findings were scoped to.
+ *
+ * **Example** (Validating a repository slug)
+ *
+ * ```ts
+ * import { GitHubRepoSlug } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(GitHubRepoSlug)("kriegcloud/beep-effect")) // true
+ * console.log(S.is(GitHubRepoSlug)("beep-effect")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const GitHubRepoSlug = S.String.check(
+  S.isPattern(/^[A-Za-z0-9._-]{1,39}\/[A-Za-z0-9._-]{1,100}$/, {
+    identifier: $I`GitHubRepoSlugPatternCheck`,
+    title: "GitHub Repo Slug Pattern",
+    description: "Repository slugs are a bounded owner and name separated by a single slash.",
+    message: "Expected an owner/repo GitHub slug",
+  })
+).pipe(
+  $I.annoteSchema("GitHubRepoSlug", {
+    description: "Bounded GitHub owner/repo slug the captured findings were scoped to.",
+  })
+);
+
+/**
+ * Repository slug a capture was scoped to.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GitHubRepoSlug = typeof GitHubRepoSlug.Type;
+
+const CodexFindingTitleChecks = S.makeFilterGroup([
+  S.isMinLength(1, {
+    identifier: $I`CodexFindingTitleMinLengthCheck`,
+    title: "Codex Finding Title Minimum Length",
+    description: "Every captured finding carries a title.",
+    message: "Expected a non-empty finding title",
+  }),
+  S.isMaxLength(300, {
+    identifier: $I`CodexFindingTitleMaxLengthCheck`,
+    title: "Codex Finding Title Maximum Length",
+    description: "Finding titles are bounded so packet documents stay within their size budgets.",
+    message: "Expected a finding title of at most 300 characters",
+  }),
+  S.isPattern(/^[^\p{Cc}\p{Cf}]+$/u, {
+    identifier: $I`CodexFindingTitlePrintableCheck`,
+    title: "Codex Finding Title Printable",
+    description: "Finding titles contain no control or format characters.",
+    message: "Expected a finding title without control or bidirectional format characters",
+  }),
+  // A title is captured from an external system and flows into tracked
+  // Markdown that a reader may well paste into a spreadsheet. A leading sigil
+  // is what turns that value into a formula, so it is refused at the boundary
+  // rather than neutralized downstream.
+  S.isPattern(/^[^=+\-@]/u, {
+    identifier: $I`CodexFindingTitleFormulaCheck`,
+    title: "Codex Finding Title Not A Formula",
+    description: "Finding titles do not open with a spreadsheet formula sigil.",
+    message: "Expected a finding title not beginning with =, +, -, or @",
+  }),
+]);
+
+/**
+ * Human-readable title of one captured finding.
+ *
+ * **Gotchas**
+ *
+ * The printable check rejects Unicode format characters, including the
+ * bidirectional overrides (`U+202E` and friends) that would otherwise let a
+ * title reverse how a generated table row renders in a reviewer's diff. Markdown
+ * metacharacters are escaped separately at render time; this check only
+ * guarantees the value is single-line printable text.
+ *
+ * **Example** (Rejecting a bidi override)
+ *
+ * ```ts
+ * import { CodexFindingTitle } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(CodexFindingTitle)("Unbounded source resolution")) // true
+ * console.log(S.is(CodexFindingTitle)("safe‮evil")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexFindingTitle = S.String.check(CodexFindingTitleChecks).pipe(
+  $I.annoteSchema("CodexFindingTitle", {
+    description: "Single-line printable title of a captured finding, bounded to 300 characters.",
+  })
+);
+
+/**
+ * Title of one captured finding.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexFindingTitle = typeof CodexFindingTitle.Type;
+
+/**
+ * One normalized finding row decoded from the findings export.
+ *
+ * **Details**
+ *
+ * This is deliberately the list-level projection only. The decoder never carries
+ * a finding to reach its full report body, which keeps it short enough for an
+ * operator to read before pasting and keeps report prose out of the payload
+ * entirely.
+ *
+ * **Example** (Constructing a captured row)
+ *
+ * ```ts
+ * import { CodexCaptureFinding } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ *
+ * const finding = CodexCaptureFinding.make({
+ *   codexId: "d2b9e11e8550819193516057a336ff90",
+ *   title: "Unbounded source resolution enables sidecar memory DoS",
+ *   severity: "Medium",
+ *   codexStatus: "Open",
+ *   commit: "244529aa4f560421cd096c2a4a4cb3cd21923070",
+ * })
+ *
+ * console.log(finding.severity) // "Medium"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexCaptureFinding extends S.Class<CodexCaptureFinding>($I`CodexCaptureFinding`)(
+  {
+    codexId: CodexFindingId.pipe(
+      $I.annoteKey("CodexCaptureFinding.codexId", {
+        description: "Codex Cloud identifier used to reconcile reruns and post-merge closure.",
+      })
+    ),
+    title: CodexFindingTitle.pipe(
+      $I.annoteKey("CodexCaptureFinding.title", {
+        description: "Single-line finding title as rendered on the dashboard.",
+      })
+    ),
+    severity: CodexFindingSeverity.pipe(
+      $I.annoteKey("CodexCaptureFinding.severity", {
+        description: "Severity badge shown for the finding.",
+      })
+    ),
+    codexStatus: CodexFindingStatus.pipe(
+      $I.annoteKey("CodexCaptureFinding.codexStatus", {
+        description: "Dashboard lifecycle status at capture time.",
+      })
+    ),
+    commit: GitCommitSha.pipe(
+      $I.annoteKey("CodexCaptureFinding.commit", {
+        description: "Source commit the finding was reported against.",
+      })
+    ),
+  },
+  $I.annote("CodexCaptureFinding", {
+    description: "One normalized finding row decoded from the findings export.",
+  })
+) {}
+
+/**
+ * Provenance describing a single capture run.
+ *
+ * **Gotchas**
+ *
+ * `expectedCount` is the dashboard's own reported total, not the number of rows
+ * the export actually carried. Ingest compares it against the captured rows and
+ * refuses a short read, which is what turns a silently truncated virtual list
+ * into a hard failure.
+ *
+ * **Example** (Constructing capture provenance)
+ *
+ * ```ts
+ * import { CodexCaptureMeta } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ *
+ * const meta = CodexCaptureMeta.make({
+ *   capturedAt: "2026-08-04",
+ *   sourceUrl: "https://chatgpt.com/codex/cloud/security/findings/",
+ *   repository: "kriegcloud/beep-effect",
+ *   findingsView: "repo-scoped, status=open",
+ *   expectedCount: 26,
+ *   authState: "authenticated",
+ * })
+ *
+ * console.log(meta.expectedCount) // 26
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexCaptureMeta extends S.Class<CodexCaptureMeta>($I`CodexCaptureMeta`)(
+  {
+    capturedAt: CaptureDate.pipe(
+      $I.annoteKey("CodexCaptureMeta.capturedAt", {
+        description: "Calendar date the capture ran, used to derive the packet slug.",
+      })
+    ),
+    sourceUrl: S.String.check(
+      S.isMaxLength(300, {
+        identifier: $I`CodexCaptureMetaSourceUrlMaxLengthCheck`,
+        title: "Capture Source Url Maximum Length",
+        description: "The recorded source URL is bounded so manifests stay within budget.",
+        message: "Expected a source URL of at most 300 characters",
+      })
+    ).pipe(
+      $I.annoteKey("CodexCaptureMeta.sourceUrl", {
+        description: "Dashboard URL the capture was taken from.",
+      })
+    ),
+    repository: GitHubRepoSlug.pipe(
+      $I.annoteKey("CodexCaptureMeta.repository", {
+        description: "Repository the findings view was scoped to.",
+      })
+    ),
+    findingsView: S.String.check(
+      S.isMaxLength(120, {
+        identifier: $I`CodexCaptureMetaFindingsViewMaxLengthCheck`,
+        title: "Findings View Maximum Length",
+        description: "The recorded view description is bounded.",
+        message: "Expected a findings view description of at most 120 characters",
+      })
+    ).pipe(
+      $I.annoteKey("CodexCaptureMeta.findingsView", {
+        description: "Filter description of the captured dashboard view.",
+      })
+    ),
+    expectedCount: S.Int.check(
+      S.isGreaterThanOrEqualTo(0, {
+        identifier: $I`CodexCaptureMetaExpectedCountCheck`,
+        title: "Expected Count Non Negative",
+        description: "The dashboard's reported finding total is never negative.",
+        message: "Expected a non-negative finding count",
+      })
+    ).pipe(
+      $I.annoteKey("CodexCaptureMeta.expectedCount", {
+        description: "Finding total the dashboard itself reported, used to detect a short read.",
+      })
+    ),
+    authState: CodexCaptureAuthState.pipe(
+      $I.annoteKey("CodexCaptureMeta.authState", {
+        description: "Session state observed while capturing.",
+      })
+    ),
+  },
+  $I.annote("CodexCaptureMeta", {
+    description: "Provenance describing one capture run of the Codex Cloud findings view.",
+  })
+) {}
+
+const CodexCaptureFindingListChecks = S.makeFilterGroup([
+  S.isMaxLength(500, {
+    identifier: $I`CodexCaptureFindingListMaxLengthCheck`,
+    title: "Capture Finding List Maximum Length",
+    description: "A single capture carries a bounded number of findings.",
+    message: "Expected at most 500 captured findings in one payload",
+  }),
+]);
+
+/**
+ * Complete `codex-findings-capture/v1` document decoded from an export.
+ *
+ * **When to use**
+ *
+ * Use as the only entry point for untrusted capture data. Ingest decodes through
+ * this schema before any value reaches the redaction scan, the packet planner,
+ * or the filesystem.
+ *
+ * **Gotchas**
+ *
+ * Duplicate `codexId` values are rejected rather than deduplicated. Two rows
+ * sharing an identifier means the capture read the same virtualized row twice,
+ * so the payload is unreliable as a whole and silently collapsing it would
+ * under-count the batch.
+ *
+ * **Example** (Decoding a payload)
+ *
+ * ```ts
+ * import { decodeCodexFindingsCapturePayload } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ * import { Effect } from "effect"
+ *
+ * const program = decodeCodexFindingsCapturePayload({
+ *   schemaVersion: "codex-findings-capture/v1",
+ *   capture: {
+ *     capturedAt: "2026-08-04",
+ *     sourceUrl: "https://chatgpt.com/codex/cloud/security/findings/",
+ *     repository: "kriegcloud/beep-effect",
+ *     findingsView: "repo-scoped, status=open",
+ *     expectedCount: 0,
+ *     authState: "authenticated",
+ *   },
+ *   findings: [],
+ * }).pipe(Effect.map((payload) => payload.findings.length))
+ *
+ * console.log(Effect.runSync(program)) // 0
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexFindingsCapturePayload extends S.Class<CodexFindingsCapturePayload>($I`CodexFindingsCapturePayload`)(
+  {
+    schemaVersion: S.Literal("codex-findings-capture/v1").pipe(
+      $I.annoteKey("CodexFindingsCapturePayload.schemaVersion", {
+        description: "Payload contract discriminator.",
+      })
+    ),
+    capture: CodexCaptureMeta.pipe(
+      $I.annoteKey("CodexFindingsCapturePayload.capture", {
+        description: "Provenance of the capture run.",
+      })
+    ),
+    findings: S.Array(CodexCaptureFinding)
+      .check(
+        CodexCaptureFindingListChecks,
+        S.isUnique({
+          identifier: $I`CodexCaptureFindingListUniqueCheck`,
+          title: "Unique Codex Finding Identifiers",
+          description: "A capture never reports the same Codex finding twice.",
+          message: "Expected every captured finding to carry a distinct Codex identifier",
+        })
+      )
+      .pipe(
+        $I.annoteKey("CodexFindingsCapturePayload.findings", {
+          description: "Every finding row the export carried, in export order.",
+        })
+      ),
+  },
+  $I.annote("CodexFindingsCapturePayload", {
+    description: "Complete normalized capture document decoded from a Codex findings export.",
+  })
+) {}
+
+/**
+ * Decode an untrusted capture payload into a validated document.
+ *
+ * **When to use**
+ *
+ * Use to validate an untrusted capture at the ingest boundary, before the
+ * redaction scan. Every downstream stage assumes the bounds and patterns this
+ * decoder enforces.
+ *
+ * **Example** (Rejecting an unknown payload contract)
+ *
+ * ```ts
+ * import { decodeCodexFindingsCapturePayload } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ * import { Effect } from "effect"
+ *
+ * const program = decodeCodexFindingsCapturePayload({ schemaVersion: "codex-findings-capture/v99" }).pipe(
+ *   Effect.map(() => "accepted"),
+ *   Effect.orElseSucceed(() => "rejected")
+ * )
+ *
+ * console.log(Effect.runSync(program)) // "rejected"
+ * ```
+ *
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeCodexFindingsCapturePayload = S.decodeUnknownEffect(CodexFindingsCapturePayload);

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.command.ts
@@ -1,0 +1,321 @@
+/**
+ * `beep codex findings ingest` — turn a signed-in CSV export into a goal packet.
+ *
+ * The command never authenticates. The operator runs `Export findings as CSV`
+ * from the already signed-in findings view and passes the downloaded file, so
+ * no cookie, token, or authorization header is ever read, stored, logged, or
+ * placed on a process command line.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { findRepoRoot } from "@beep/repo-utils";
+import { A, O, Str } from "@beep/utils";
+import { Effect, FileSystem, Path } from "effect";
+import * as S from "effect/Schema";
+import { Command, Flag } from "effect/unstable/cli";
+import { dryRunFlag, forceFlag, jsonFlag } from "../../internal/cli/Flags.ts";
+import { printJsonOrLines, printLines } from "../../internal/cli/Printer.ts";
+import { writePortfolioIndex } from "../Goals/PortfolioIndex.ts";
+import { CodexFindingSeverity, decodeCodexFindingsCapturePayload } from "./Findings.capture.schemas.ts";
+import { decodeCodexFindingsCsv } from "./Findings.csv.ts";
+import { CodexFindingsIngestError, CodexFindingsRedactionError } from "./Findings.errors.ts";
+import { defaultPacketSlug, planPacket, priorIdsOfEntries } from "./Findings.normalize.ts";
+import { renderPacketDocuments } from "./Findings.packet.ts";
+import { describeSensitiveHits, scanSensitiveUnknown } from "./Findings.scan.ts";
+import { decodeCodexTriageLedger } from "./Findings.triage.schemas.ts";
+import { writePacket } from "./Findings.write.ts";
+
+const SOURCE_URL = "https://chatgpt.com/codex/cloud/security/findings/";
+
+/**
+ * Recover the capture date from the export's own filename.
+ *
+ * **Details**
+ *
+ * The date must come from the capture, never from the wall clock, or the same
+ * export would produce a different packet tomorrow. Codex names its download
+ * `codex-security-findings-<ISO timestamp>.csv`.
+ *
+ * **Example** (Reading a capture date)
+ *
+ * ```ts
+ * import { captureDateFromFileName } from "@beep/repo-cli/commands/Codex/Findings.command"
+ * import * as O from "effect/Option"
+ *
+ * const date = captureDateFromFileName("codex-security-findings-2026-08-04T16-06-15.518Z.csv")
+ *
+ * console.log(O.getOrElse(date, () => "unknown")) // "2026-08-04"
+ * ```
+ *
+ * @param fileName - Basename of the downloaded export.
+ * @returns The `YYYY-MM-DD` capture date, or `None` when the name carries none.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const captureDateFromFileName = (fileName: string): O.Option<string> => {
+  const match = /(\d{4}-\d{2}-\d{2})/.exec(fileName);
+  return match === null ? O.none() : O.fromUndefinedOr(match[1]);
+};
+
+const encodePayload = S.encodeUnknownSync(S.fromJsonString(S.Unknown));
+const parseJsonText = S.decodeUnknownEffect(S.fromJsonString(S.Unknown));
+
+const readPriorIds = Effect.fnUntraced(function* (packetDir: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const ledgerPath = `${packetDir}/ops/triage.json`;
+
+  const exists = yield* fs.exists(ledgerPath).pipe(Effect.orElseSucceed(() => false));
+  if (!exists) {
+    return priorIdsOfEntries([]);
+  }
+
+  // A packet whose ledger cannot be read is treated as having no bindings
+  // rather than failing the ingest: the write path still refuses to clobber it
+  // unless --force was passed deliberately.
+  const entries = yield* fs.readFileString(ledgerPath).pipe(
+    Effect.flatMap(parseJsonText),
+    Effect.flatMap(decodeCodexTriageLedger),
+    Effect.map((ledger) => A.map(ledger.findings, (finding) => ({ id: finding.id, codexId: finding.codexId }))),
+    Effect.orElseSucceed(A.empty<{ readonly id: string; readonly codexId: string }>)
+  );
+
+  return priorIdsOfEntries(entries);
+});
+
+/**
+ * Ingest a Codex findings CSV export into a bootstrapped goal packet.
+ *
+ * **Example** (Naming the ingest entry point)
+ *
+ * ```ts
+ * import { runCodexFindingsIngest } from "@beep/repo-cli/commands/Codex/Findings.command"
+ *
+ * console.log(typeof runCodexFindingsIngest) // "function"
+ * ```
+ *
+ * @param options - Validated ingest flags, including the export path.
+ * @returns An effect that writes or plans the packet and prints the summary.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const runCodexFindingsIngest = Effect.fnUntraced(function* (options: {
+  readonly from: string;
+  readonly slug: O.Option<string>;
+  readonly date: O.Option<string>;
+  readonly branch: O.Option<string>;
+  readonly expectedCount: O.Option<number>;
+  readonly force: boolean;
+  readonly dryRun: boolean;
+  readonly json: boolean;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const repoRoot = yield* findRepoRoot().pipe(
+    Effect.mapError(() =>
+      CodexFindingsIngestError.make({
+        reason: "payload-unreadable",
+        message: "The repository root could not be located.",
+      })
+    )
+  );
+
+  const text = yield* fs.readFileString(options.from).pipe(
+    Effect.mapError(() =>
+      CodexFindingsIngestError.make({
+        reason: "payload-unreadable",
+        message: "The export could not be read. Check the path passed to --from.",
+      })
+    )
+  );
+
+  const parsed = yield* decodeCodexFindingsCsv(text);
+
+  const resolvedDate = O.orElse(options.date, () => captureDateFromFileName(path.basename(options.from)));
+  if (O.isNone(resolvedDate)) {
+    return yield* CodexFindingsIngestError.make({
+      reason: "capture-date-unknown",
+      message:
+        "The capture date could not be read from the export filename. Pass --date YYYY-MM-DD so the packet is reproducible rather than clock-dependent.",
+    });
+  }
+  const capturedAt = resolvedDate.value;
+
+  const payloadInput = {
+    schemaVersion: "codex-findings-capture/v1",
+    capture: {
+      capturedAt,
+      sourceUrl: SOURCE_URL,
+      repository: parsed.repository,
+      findingsView: `repo-scoped, status=${A.join(A.map(parsed.statuses, Str.toLowerCase), "|")}`,
+      expectedCount: O.getOrElse(options.expectedCount, () => A.length(parsed.findings)),
+      authState: "authenticated",
+    },
+    findings: parsed.findings,
+  };
+
+  // Scan the payload before decoding: a credential sitting in a field the
+  // schema would have dropped must still stop the ingest.
+  const hits = scanSensitiveUnknown("capture", payloadInput);
+  if (A.isReadonlyArrayNonEmpty(hits)) {
+    return yield* CodexFindingsRedactionError.make({
+      message:
+        "Refusing to ingest: the export carries secret-shaped or personal content. The offending values are deliberately not reproduced here.",
+      surfaces: describeSensitiveHits(hits),
+    });
+  }
+
+  const payload = yield* decodeCodexFindingsCapturePayload(payloadInput).pipe(
+    Effect.mapError(() =>
+      CodexFindingsIngestError.make({
+        reason: "payload-invalid",
+        message:
+          "The export decoded into findings that fail the capture contract. Values are refused rather than truncated; re-export and retry.",
+      })
+    )
+  );
+
+  // Must match the slug planPacket will derive, or prior identifiers would be
+  // read from the wrong packet; both sides go through the same helper.
+  const provisionalSlug = O.getOrElse(options.slug, () => defaultPacketSlug(capturedAt));
+  const priorIds = yield* readPriorIds(path.join(repoRoot, "goals", provisionalSlug));
+
+  const plan = yield* planPacket(payload, {
+    slug: O.getOrUndefined(options.slug),
+    branch: O.getOrUndefined(options.branch),
+    capturedAt,
+    expectedCount: O.getOrUndefined(options.expectedCount),
+    priorIds,
+  });
+
+  const documents = renderPacketDocuments({
+    plan,
+    // Raw evidence is the normalized capture, never the export itself: the CSV
+    // carries author email addresses and unsanitized report bodies.
+    rawPayloadJson: `${encodePayload(payload)}\n`,
+  });
+
+  const outcome = yield* writePacket({
+    repoRoot,
+    slug: plan.slug,
+    documents,
+    dryRun: options.dryRun,
+    force: options.force,
+  });
+
+  // The packet is already promoted, so a failed index regeneration must not
+  // fail the ingest — but it must not be silent either, or `goals/INDEX.md`
+  // goes stale while the run reports success.
+  const indexRegenerated =
+    options.dryRun ||
+    (yield* writePortfolioIndex().pipe(
+      Effect.as(true),
+      Effect.orElseSucceed(() => false)
+    ));
+
+  // Walk the severity domain rather than the counts object so the summary keeps
+  // canonical most-severe-first order and omits zero-count severities.
+  const severities = A.join(
+    A.map(
+      A.filter(CodexFindingSeverity.Options, (severity) => (plan.severityCounts[severity] ?? 0) > 0),
+      (severity) => `${severity} ${plan.severityCounts[severity] ?? 0}`
+    ),
+    " · "
+  );
+
+  yield* printJsonOrLines(
+    options.json,
+    {
+      packetPath: outcome.packetPath,
+      committed: outcome.committed,
+      capturedAt: plan.capturedAt,
+      findingCount: A.length(plan.records),
+      severityCounts: plan.severityCounts,
+      files: A.length(outcome.written),
+      indexRegenerated,
+    },
+    [
+      `✓ export   ${A.length(plan.records)} findings   ${severities}`,
+      "✓ scan     0 rejections across payload and raw evidence",
+      outcome.committed
+        ? `✓ packet   ${outcome.packetPath}  (${A.length(outcome.written)} files)`
+        : `• dry run  ${outcome.packetPath} not written  (${A.length(outcome.written)} files planned)`,
+      ...(indexRegenerated
+        ? A.empty<string>()
+        : ["! index    goals/INDEX.md could not be regenerated; run `beep goals index`"]),
+      "",
+      `Next: /goal follow the instructions in ${outcome.packetPath}/GOAL.md`,
+    ]
+  );
+});
+
+const fromFlag = Flag.string("from").pipe(
+  Flag.withDescription("Path to the CSV downloaded from the signed-in findings view")
+);
+const slugFlag = Flag.string("slug").pipe(Flag.optional, Flag.withDescription("Override the generated packet slug"));
+const dateFlag = Flag.string("date").pipe(
+  Flag.optional,
+  Flag.withDescription("Capture date (YYYY-MM-DD) when the export filename does not carry one")
+);
+const branchFlag = Flag.string("branch").pipe(
+  Flag.optional,
+  Flag.withDescription("Override the remediation branch the packet declares")
+);
+const expectedCountFlag = Flag.integer("expected-count").pipe(
+  Flag.optional,
+  Flag.withDescription("Finding total the dashboard reported, used to fail closed on a partial export")
+);
+
+const findingsIngestCommand = Command.make(
+  "ingest",
+  {
+    from: fromFlag,
+    slug: slugFlag,
+    date: dateFlag,
+    branch: branchFlag,
+    expectedCount: expectedCountFlag,
+    force: forceFlag("Replace an existing packet, discarding its hand-written triage prose"),
+    dryRun: dryRunFlag("Report the packet that would be written without touching the filesystem"),
+    json: jsonFlag,
+  },
+  Effect.fnUntraced(function* (flags) {
+    yield* runCodexFindingsIngest({
+      from: flags.from,
+      slug: flags.slug,
+      date: flags.date,
+      branch: flags.branch,
+      expectedCount: flags.expectedCount,
+      force: flags.force,
+      dryRun: flags.dryRun,
+      json: flags.json,
+    });
+  })
+).pipe(Command.withDescription("Bootstrap a goal packet from a signed-in Codex findings CSV export"));
+
+/**
+ * `beep codex findings` — capture-to-packet commands.
+ *
+ * **Example** (Reading the command name)
+ *
+ * ```ts
+ * import { findingsCommand } from "@beep/repo-cli/commands/Codex/Findings.command"
+ *
+ * console.log(findingsCommand.name) // "findings"
+ * ```
+ *
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export const findingsCommand = Command.make("findings", {}, () =>
+  printLines([
+    "Codex findings commands:",
+    "- bun run beep codex findings ingest --from <export.csv>",
+    "",
+    "Export the CSV from the signed-in findings view first:",
+    `  ${SOURCE_URL}`,
+  ])
+).pipe(
+  Command.withDescription("Capture Codex Cloud security findings into a goal packet"),
+  Command.withSubcommands([findingsIngestCommand])
+);

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.command.ts
@@ -71,14 +71,21 @@ const readPriorIds = Effect.fnUntraced(function* (packetDir: string) {
     return priorIdsOfEntries([]);
   }
 
-  // A packet whose ledger cannot be read is treated as having no bindings
-  // rather than failing the ingest: the write path still refuses to clobber it
-  // unless --force was passed deliberately.
+  // A ledger that exists but cannot be read is a hard failure, never an empty
+  // binding map. Falling back to "no bindings" here would let a --force ingest
+  // renumber every CSF-NNN from the current sort order, silently invalidating
+  // hand-written references and the exact-identifier closeout allowlist — the
+  // precise outcome sticky identity exists to prevent.
   const entries = yield* fs.readFileString(ledgerPath).pipe(
     Effect.flatMap(parseJsonText),
     Effect.flatMap(decodeCodexTriageLedger),
     Effect.map((ledger) => A.map(ledger.findings, (finding) => ({ id: finding.id, codexId: finding.codexId }))),
-    Effect.orElseSucceed(A.empty<{ readonly id: string; readonly codexId: string }>)
+    Effect.mapError(() =>
+      CodexFindingsIngestError.make({
+        reason: "ledger-unreadable",
+        message: `${ledgerPath} exists but does not decode as a codex-triage/v1 ledger. Repair or remove it before re-ingesting; continuing would renumber every CSF-NNN and break the closeout allowlist.`,
+      })
+    )
   );
 
   return priorIdsOfEntries(entries);
@@ -191,6 +198,9 @@ export const runCodexFindingsIngest = Effect.fnUntraced(function* (options: {
 
   const documents = renderPacketDocuments({
     plan,
+    // Report bodies are the evidence P2 validates against. They only ever reach
+    // ignored `raw/reports/`; no tracked renderer accepts this shape.
+    rawReports: parsed.reports,
     // Raw evidence is the normalized capture, never the export itself: the CSV
     // carries author email addresses and unsanitized report bodies.
     rawPayloadJson: `${encodePayload(payload)}\n`,
@@ -237,7 +247,12 @@ export const runCodexFindingsIngest = Effect.fnUntraced(function* (options: {
     },
     [
       `✓ export   ${A.length(plan.records)} findings   ${severities}`,
-      "✓ scan     0 rejections across payload and raw evidence",
+      "✓ scan     0 rejections across payload and tracked documents",
+      ...(A.isReadonlyArrayEmpty(outcome.reportedEvidence)
+        ? A.empty<string>()
+        : [
+            `! raw      ${A.length(outcome.reportedEvidence)} report body/bodies carry sensitive-shaped text (ignored, untracked): ${A.join(outcome.reportedEvidence, ", ")}`,
+          ]),
       outcome.committed
         ? `✓ packet   ${outcome.packetPath}  (${A.length(outcome.written)} files)`
         : `• dry run  ${outcome.packetPath} not written  (${A.length(outcome.written)} files planned)`,

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.csv.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.csv.ts
@@ -150,6 +150,47 @@ export const CodexCsvStatus = MappedLiteralKit([
  */
 export type CodexCsvStatus = typeof CodexCsvStatus.Type;
 
+/**
+ * One finding's unsanitized report body, destined only for ignored evidence.
+ *
+ * **Gotchas**
+ *
+ * This shape is deliberately distinct from the tracked finding record, and no
+ * packet renderer accepts it. Report text is external prose that legitimately
+ * quotes developer-local paths and secret-shaped literals — measured against a
+ * real 27-finding export, 4 bodies carry content the tracked-document scan
+ * refuses outright. It belongs in gitignored `raw/`, never in a tracked file.
+ *
+ * **Example** (Constructing a raw report)
+ *
+ * ```ts
+ * import { CodexRawReport } from "@beep/repo-cli/commands/Codex/Findings.csv"
+ *
+ * const report = CodexRawReport.make({
+ *   codexId: "d2b9e11e8550819193516057a336ff90",
+ *   description: "The resolver reads an unbounded file.",
+ *   relevantPaths: "packages/x/src/Y.ts",
+ *   detectedAt: "2026-08-04T16:06:15.518000Z",
+ * })
+ *
+ * console.log(report.relevantPaths) // "packages/x/src/Y.ts"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexRawReport extends S.Class<CodexRawReport>($I`CodexRawReport`)(
+  {
+    codexId: S.String,
+    description: S.String,
+    relevantPaths: S.String,
+    detectedAt: S.String,
+  },
+  $I.annote("CodexRawReport", {
+    description: "One finding's unsanitized report body, written only to ignored raw evidence.",
+  })
+) {}
+
 const FINDING_URL_PREFIX = "https://chatgpt.com/codex/cloud/security/findings/";
 
 /**
@@ -200,15 +241,19 @@ const decodeSeverity = S.decodeUnknownOption(CodexCsvSeverity);
 const decodeStatus = S.decodeUnknownOption(CodexCsvStatus);
 
 /**
- * Decode one data row, dropping every column the packet must never carry.
+ * Decode one data row into its tracked projection and its raw report body.
  *
- * The returned record is the whole of what leaves this module for a row: no
- * description, no author, no assignee. `index` is zero-based over data rows, so
- * the reported line number adds two to account for the header.
+ * **Details**
+ *
+ * The two halves are returned separately on purpose. `finding` is the only
+ * shape any tracked renderer accepts; `report` carries the unsanitized report
+ * text and relevant paths and is reachable only by the ignored `raw/` writer.
+ * Personal-data columns are read by neither. `index` is zero-based over data
+ * rows, so the reported line number adds two to account for the header.
  *
  * @param row - Raw cells of one data row.
  * @param index - Zero-based position of the row among data rows.
- * @returns The normalized finding fields for that row.
+ * @returns The tracked projection paired with its raw report body.
  */
 const decodeRow = Effect.fnUntraced(function* (row: ReadonlyArray<string>, index: number) {
   const line = index + 2;
@@ -231,11 +276,19 @@ const decodeRow = Effect.fnUntraced(function* (row: ReadonlyArray<string>, index
   }
 
   return {
-    codexId: codexId.value,
-    title: cellAt(row, "title"),
-    severity: severity.value,
-    codexStatus: status.value,
-    commit: cellAt(row, "commit_hash"),
+    finding: {
+      codexId: codexId.value,
+      title: cellAt(row, "title"),
+      severity: severity.value,
+      codexStatus: status.value,
+      commit: cellAt(row, "commit_hash"),
+    },
+    report: CodexRawReport.make({
+      codexId: codexId.value,
+      description: cellAt(row, "description"),
+      relevantPaths: cellAt(row, "relevant_paths"),
+      detectedAt: cellAt(row, "detected_at"),
+    }),
   };
 });
 
@@ -251,9 +304,10 @@ const decodeRow = Effect.fnUntraced(function* (row: ReadonlyArray<string>, index
  *
  * **Gotchas**
  *
- * The returned findings carry no description, author, or assignee. The report
- * body is unsanitized external text and belongs in ignored raw evidence, not in
- * a value that packet renderers can reach.
+ * `findings` carries no description, author, or assignee — it is the tracked
+ * projection. The report bodies come back separately as `reports`, which only
+ * the ignored `raw/` writer consumes, so unsanitized external prose cannot
+ * reach a value a packet renderer accepts.
  *
  * **Example** (Refusing a signed-out response)
  *
@@ -299,7 +353,9 @@ export const decodeCodexFindingsCsv = Effect.fnUntraced(function* (text: string)
 
   const dataRows = A.filter(A.drop(1)(rows), (row) => A.length(row) > 1);
 
-  const findings = yield* Effect.forEach(dataRows, decodeRow);
+  const decoded = yield* Effect.forEach(dataRows, decodeRow);
+  const findings = A.map(decoded, (entry) => entry.finding);
+  const reports = A.map(decoded, (entry) => entry.report);
 
   const identities = A.map(findings, (finding) => finding.codexId);
   if (A.length(A.dedupe(identities)) !== A.length(identities)) {
@@ -312,6 +368,7 @@ export const decodeCodexFindingsCsv = Effect.fnUntraced(function* (text: string)
 
   return {
     findings,
+    reports,
     // Every row of one export names the same repository; the head row is the
     // only place it needs to be read from.
     repository: O.getOrElse(

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.csv.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.csv.ts
@@ -1,0 +1,323 @@
+/**
+ * Decoding boundary for the Codex Cloud findings CSV export.
+ *
+ * The findings view exports its own CSV through a signed-in browser action, so
+ * this CLI never touches a cookie, a token, or an authorization header — the
+ * operator downloads a file and passes its path. That is the whole reason the
+ * capture lane is a file import rather than a scripted fetch.
+ *
+ * Three of the export's columns — `author_email`, `assignee_name`, and
+ * `assignee_email` — carry personal data that no packet needs. They are dropped
+ * here, at the parse boundary, so nothing downstream can leak what it never
+ * received. The reject-scan independently refuses email addresses as a second
+ * line of defense.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { MappedLiteralKit } from "@beep/schema";
+import { parseCsvRows } from "@beep/schema/CsvParser";
+import { ParserOptions } from "@beep/schema/ParserOptions";
+import { A, O, Str } from "@beep/utils";
+import { Effect } from "effect";
+import * as S from "effect/Schema";
+import { CodexFindingsIngestError } from "./Findings.errors.ts";
+
+const $I = $RepoCliId.create("commands/Codex/Findings.csv");
+
+/**
+ * Column header the signed-in CSV export is expected to declare, in order.
+ *
+ * **Gotchas**
+ *
+ * An export whose header differs is refused rather than best-effort mapped. A
+ * signed-out request returns an HTML login document, and a silently reordered
+ * column would otherwise map severities onto commits.
+ *
+ * **Example** (Checking the expected width)
+ *
+ * ```ts
+ * import { CODEX_CSV_COLUMNS } from "@beep/repo-cli/commands/Codex/Findings.csv"
+ *
+ * console.log(CODEX_CSV_COLUMNS.length) // 17
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const CODEX_CSV_COLUMNS = [
+  "finding_url",
+  "repository",
+  "repository_url",
+  "title",
+  "description",
+  "severity",
+  "status",
+  "detected_at",
+  "committed_at",
+  "author_email",
+  "assignee_name",
+  "assignee_email",
+  "has_patch",
+  "configured_scan_id",
+  "commit_hash",
+  "relevant_paths",
+  "resolution_reason",
+] as const;
+
+/**
+ * Columns dropped at the parse boundary because they carry personal data.
+ *
+ * **Example** (Naming the dropped columns)
+ *
+ * ```ts
+ * import { CODEX_CSV_PII_COLUMNS } from "@beep/repo-cli/commands/Codex/Findings.csv"
+ *
+ * console.log(CODEX_CSV_PII_COLUMNS.includes("author_email")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const CODEX_CSV_PII_COLUMNS = ["author_email", "assignee_name", "assignee_email"] as const;
+
+/**
+ * Reversible codec from the export's lowercase severity to the packet domain.
+ *
+ * **Example** (Decoding a wire severity)
+ *
+ * ```ts
+ * import { CodexCsvSeverity } from "@beep/repo-cli/commands/Codex/Findings.csv"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.decodeUnknownSync(CodexCsvSeverity)("medium")) // "Medium"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexCsvSeverity = MappedLiteralKit([
+  ["high", "High"],
+  ["medium", "Medium"],
+  ["low", "Low"],
+  ["informational", "Informational"],
+]).pipe(
+  $I.annoteSchema("CodexCsvSeverity", {
+    description: "Codec from the CSV export's lowercase severity to the capitalized packet domain.",
+  })
+);
+
+/**
+ * Packet-domain severity decoded from a CSV cell.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexCsvSeverity = typeof CodexCsvSeverity.Type;
+
+/**
+ * Reversible codec from the export's lowercase status to the packet domain.
+ *
+ * **Example** (Decoding a wire status)
+ *
+ * ```ts
+ * import { CodexCsvStatus } from "@beep/repo-cli/commands/Codex/Findings.csv"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.decodeUnknownSync(CodexCsvStatus)("new")) // "New"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexCsvStatus = MappedLiteralKit([
+  ["new", "New"],
+  ["open", "Open"],
+  ["closed", "Closed"],
+]).pipe(
+  $I.annoteSchema("CodexCsvStatus", {
+    description: "Codec from the CSV export's lowercase status to the capitalized packet domain.",
+  })
+);
+
+/**
+ * Packet-domain status decoded from a CSV cell.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexCsvStatus = typeof CodexCsvStatus.Type;
+
+const FINDING_URL_PREFIX = "https://chatgpt.com/codex/cloud/security/findings/";
+
+/**
+ * Recover the Codex finding identity from an export's `finding_url` cell.
+ *
+ * **Details**
+ *
+ * The export carries no bare identifier column, so identity comes from the
+ * canonical URL's final segment. Requiring the exact prefix keeps a redirected
+ * or rewritten URL from contributing an identity.
+ *
+ * **Example** (Reading an identity)
+ *
+ * ```ts
+ * import { codexIdFromFindingUrl } from "@beep/repo-cli/commands/Codex/Findings.csv"
+ * import * as O from "effect/Option"
+ *
+ * const id = codexIdFromFindingUrl(
+ *   "https://chatgpt.com/codex/cloud/security/findings/d2b9e11e8550819193516057a336ff90"
+ * )
+ *
+ * console.log(O.getOrElse(id, () => "none")) // "d2b9e11e8550819193516057a336ff90"
+ * ```
+ *
+ * @param url - The `finding_url` cell of one export row.
+ * @returns The 32-character identity, or `None` when the URL is not canonical.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const codexIdFromFindingUrl = (url: string): O.Option<string> => {
+  if (!Str.startsWith(FINDING_URL_PREFIX)(url)) {
+    return O.none();
+  }
+  const tail = Str.slice(Str.length(FINDING_URL_PREFIX))(url);
+  return /^[0-9a-f]{32}$/.test(tail) ? O.some(tail) : O.none();
+};
+
+// The export's `description` column is a quoted cell that may carry commas and
+// newlines, so RFC 4180 handling is mandatory. `@beep/schema` already owns a
+// reviewed parser for exactly this; hand-rolling a second one would duplicate
+// its quote and line-ending edge cases without inheriting its coverage.
+const csvParserOptions = ParserOptions.new();
+
+const cellAt = (row: ReadonlyArray<string>, column: (typeof CODEX_CSV_COLUMNS)[number]): string =>
+  row[CODEX_CSV_COLUMNS.indexOf(column)] ?? "";
+
+const decodeSeverity = S.decodeUnknownOption(CodexCsvSeverity);
+const decodeStatus = S.decodeUnknownOption(CodexCsvStatus);
+
+/**
+ * Decode one data row, dropping every column the packet must never carry.
+ *
+ * The returned record is the whole of what leaves this module for a row: no
+ * description, no author, no assignee. `index` is zero-based over data rows, so
+ * the reported line number adds two to account for the header.
+ *
+ * @param row - Raw cells of one data row.
+ * @param index - Zero-based position of the row among data rows.
+ * @returns The normalized finding fields for that row.
+ */
+const decodeRow = Effect.fnUntraced(function* (row: ReadonlyArray<string>, index: number) {
+  const line = index + 2;
+  if (A.length(row) !== A.length(CODEX_CSV_COLUMNS)) {
+    return yield* CodexFindingsIngestError.make({
+      reason: "csv-row-malformed",
+      message: `Row ${line} has ${A.length(row)} cells but the header declares ${A.length(CODEX_CSV_COLUMNS)}. The export is truncated or corrupt; download it again.`,
+    });
+  }
+
+  const codexId = codexIdFromFindingUrl(cellAt(row, "finding_url"));
+  const severity = decodeSeverity(cellAt(row, "severity"));
+  const status = decodeStatus(cellAt(row, "status"));
+
+  if (O.isNone(codexId) || O.isNone(severity) || O.isNone(status)) {
+    return yield* CodexFindingsIngestError.make({
+      reason: "csv-row-malformed",
+      message: `Row ${line} carries an unrecognized finding URL, severity, or status. Values are refused rather than guessed; update the CLI if Codex introduced a new one.`,
+    });
+  }
+
+  return {
+    codexId: codexId.value,
+    title: cellAt(row, "title"),
+    severity: severity.value,
+    codexStatus: status.value,
+    commit: cellAt(row, "commit_hash"),
+  };
+});
+
+/**
+ * Decode a signed-in CSV export into capture findings, dropping personal data.
+ *
+ * **When to use**
+ *
+ * Use as the only entry point from an export file to packet data. It refuses a
+ * signed-out HTML response, an unexpected header, a malformed row, and a
+ * duplicated finding identity, so every downstream stage receives a payload
+ * that already reconciles.
+ *
+ * **Gotchas**
+ *
+ * The returned findings carry no description, author, or assignee. The report
+ * body is unsanitized external text and belongs in ignored raw evidence, not in
+ * a value that packet renderers can reach.
+ *
+ * **Example** (Refusing a signed-out response)
+ *
+ * ```ts
+ * import { decodeCodexFindingsCsv } from "@beep/repo-cli/commands/Codex/Findings.csv"
+ * import { Effect } from "effect"
+ *
+ * const program = decodeCodexFindingsCsv("<!doctype html><title>Log in</title>").pipe(
+ *   Effect.map(() => "accepted"),
+ *   Effect.orElseSucceed(() => "refused")
+ * )
+ *
+ * console.log(Effect.runSync(program)) // "refused"
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const decodeCodexFindingsCsv = Effect.fnUntraced(function* (text: string) {
+  const rows = yield* parseCsvRows(text, csvParserOptions).pipe(
+    Effect.mapError(() =>
+      CodexFindingsIngestError.make({
+        reason: "payload-unreadable",
+        message:
+          "The file could not be parsed as CSV. Re-run `Export findings as CSV` from the signed-in findings view.",
+      })
+    )
+  );
+  const header = A.head(rows);
+
+  if (O.isNone(header) || A.join(header.value, ",") !== A.join(CODEX_CSV_COLUMNS, ",")) {
+    // A signed-out export is an HTML login document, which lands here rather
+    // than as a parse crash. Both cases mean "no usable export", so the
+    // operator gets one instruction instead of a stack trace.
+    return yield* CodexFindingsIngestError.make({
+      reason: Str.includes("<html")(Str.toLowerCase(Str.slice(0, 400)(text)))
+        ? "auth-expired"
+        : "csv-header-unsupported",
+      message:
+        "The file is not a current Codex findings CSV export. Re-run `Export findings as CSV` from the signed-in findings view and pass the downloaded file.",
+    });
+  }
+
+  const dataRows = A.filter(A.drop(1)(rows), (row) => A.length(row) > 1);
+
+  const findings = yield* Effect.forEach(dataRows, decodeRow);
+
+  const identities = A.map(findings, (finding) => finding.codexId);
+  if (A.length(A.dedupe(identities)) !== A.length(identities)) {
+    return yield* CodexFindingsIngestError.make({
+      reason: "csv-duplicate-finding",
+      message:
+        "The export lists the same finding more than once, so a packet built from it would double-count. Re-export the findings view.",
+    });
+  }
+
+  return {
+    findings,
+    // Every row of one export names the same repository; the head row is the
+    // only place it needs to be read from.
+    repository: O.getOrElse(
+      O.map(A.head(dataRows), (row) => cellAt(row, "repository")),
+      () => ""
+    ),
+    statuses: A.dedupe(A.map(findings, (finding) => finding.codexStatus)),
+  };
+});

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.errors.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.errors.ts
@@ -1,0 +1,295 @@
+/**
+ * Tagged failures for `beep codex findings`.
+ *
+ * The taxonomy is deliberately narrow: three errors, each discriminated by a
+ * reason domain, rather than one class per failure mode. Every message is
+ * written to be safe to print — a redaction rejection names the offending field
+ * and rule, never the matched value, so surfacing an error can never become the
+ * leak the scan was meant to prevent.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit, TaggedErrorClass } from "@beep/schema";
+import { Err } from "@beep/utils";
+import { Runtime } from "effect";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("commands/Codex/Findings.errors");
+
+/**
+ * Why a capture payload could not be turned into normalized records.
+ *
+ * **Details**
+ *
+ * `auth-expired` and `short-read` are the two reasons that matter operationally:
+ * both mean the dashboard rendered fewer findings than exist, and both would
+ * otherwise bootstrap a packet that looks like a clean scan.
+ *
+ * **Example** (Matching on an ingest reason)
+ *
+ * ```ts
+ * import { CodexIngestFailureReason } from "@beep/repo-cli/commands/Codex/Findings.errors"
+ *
+ * console.log(CodexIngestFailureReason.is["short-read"]("short-read")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexIngestFailureReason = LiteralKit([
+  "payload-unreadable",
+  "payload-invalid",
+  "csv-header-unsupported",
+  "csv-row-malformed",
+  "csv-duplicate-finding",
+  "capture-date-unknown",
+  "auth-expired",
+  "short-read",
+  "inbox-ambiguous",
+  "inbox-empty",
+]).pipe(
+  $I.annoteSchema("CodexIngestFailureReason", {
+    description: "Reason a capture payload could not be ingested.",
+  })
+);
+
+/**
+ * Reason an ingest attempt failed.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexIngestFailureReason = typeof CodexIngestFailureReason.Type;
+
+/**
+ * Why a packet write was refused or could not complete.
+ *
+ * **Example** (Matching on a write reason)
+ *
+ * ```ts
+ * import { CodexPacketWriteFailureReason } from "@beep/repo-cli/commands/Codex/Findings.errors"
+ *
+ * console.log(CodexPacketWriteFailureReason.is["packet-exists"]("packet-exists")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexPacketWriteFailureReason = LiteralKit([
+  "packet-exists",
+  "path-escape",
+  "staging-failed",
+  "commit-failed",
+]).pipe(
+  $I.annoteSchema("CodexPacketWriteFailureReason", {
+    description: "Reason a generated packet could not be written.",
+  })
+);
+
+/**
+ * Reason a packet write failed.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexPacketWriteFailureReason = typeof CodexPacketWriteFailureReason.Type;
+
+/**
+ * Failure raised while reading or decoding a capture payload.
+ *
+ * **Example** (Constructing an ingest failure)
+ *
+ * ```ts
+ * import { CodexFindingsIngestError } from "@beep/repo-cli/commands/Codex/Findings.errors"
+ *
+ * const error = CodexFindingsIngestError.make({
+ *   reason: "auth-expired",
+ *   message: "The capture ran against a signed-out session.",
+ * })
+ *
+ * console.log(error.reason) // "auth-expired"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class CodexFindingsIngestError extends TaggedErrorClass<CodexFindingsIngestError>($I`CodexFindingsIngestError`)(
+  "CodexFindingsIngestError",
+  {
+    reason: CodexIngestFailureReason,
+    message: S.String,
+    cause: S.optionalKey(S.Defect({ includeStack: true })),
+  },
+  $I.annote("CodexFindingsIngestError", {
+    description: "Failure raised while reading or decoding a Codex findings capture payload.",
+  })
+) {
+  /** Process exit code reported when this error reaches the runtime boundary. */
+  override readonly [Runtime.errorExitCode] = 1;
+
+  /**
+   * Build a reason-tagged ingest failure from an upstream cause.
+   *
+   * **Example** (Mapping a filesystem failure)
+   *
+   * ```ts
+   * import { CodexFindingsIngestError } from "@beep/repo-cli/commands/Codex/Findings.errors"
+   *
+   * const error = CodexFindingsIngestError.from(
+   *   new Error("ENOENT"),
+   *   "payload-unreadable",
+   *   "The capture payload could not be read."
+   * )
+   *
+   * console.log(error.reason) // "payload-unreadable"
+   * ```
+   *
+   * @param cause - Upstream failure being wrapped.
+   * @param reason - Reason domain member describing the failure.
+   * @param message - Operator-facing message, free of captured values.
+   * @returns The tagged error carrying the cause.
+   * @category constructors
+   * @since 0.0.0
+   */
+  static readonly from = (
+    cause: unknown,
+    reason: CodexIngestFailureReason,
+    message: string
+  ): CodexFindingsIngestError => CodexFindingsIngestError.make({ cause, message, reason });
+
+  /**
+   * Map an upstream failure channel onto a reason-tagged ingest failure.
+   *
+   * **Example** (Adapting an effect)
+   *
+   * ```ts
+   * import { CodexFindingsIngestError } from "@beep/repo-cli/commands/Codex/Findings.errors"
+   * import { Effect } from "effect"
+   *
+   * const program = Effect.fail("boom").pipe(
+   *   Effect.mapError((cause) =>
+   *     CodexFindingsIngestError.from(cause, "payload-invalid", "Unusable payload.")
+   *   ),
+   *   Effect.map(() => "ok"),
+   *   Effect.orElseSucceed(() => "failed")
+   * )
+   *
+   * console.log(Effect.runSync(program)) // "failed"
+   * ```
+   *
+   * @category combinators
+   * @since 0.0.0
+   */
+  static readonly mapError = Err.mapToError(
+    (cause: unknown, message: string): CodexFindingsIngestError =>
+      CodexFindingsIngestError.make({ cause, message, reason: "payload-invalid" })
+  );
+}
+
+/**
+ * Failure raised when captured content carries secret-shaped or private material.
+ *
+ * **Gotchas**
+ *
+ * `surfaces` holds logical field addresses such as `findings[3].title`, paired
+ * with the rule code that matched. The matched text is never carried, so this
+ * error is safe to print, log, serialize to `--json`, and attach to a span.
+ *
+ * **Example** (Constructing a redaction rejection)
+ *
+ * ```ts
+ * import { CodexFindingsRedactionError } from "@beep/repo-cli/commands/Codex/Findings.errors"
+ *
+ * const error = CodexFindingsRedactionError.make({
+ *   message: "Captured content carries secret-shaped values.",
+ *   surfaces: ["findings[3].title (secret-shaped-value)"],
+ * })
+ *
+ * console.log(error.surfaces.length) // 1
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class CodexFindingsRedactionError extends TaggedErrorClass<CodexFindingsRedactionError>(
+  $I`CodexFindingsRedactionError`
+)(
+  "CodexFindingsRedactionError",
+  {
+    message: S.String,
+    surfaces: S.Array(S.String),
+  },
+  $I.annote("CodexFindingsRedactionError", {
+    description: "Failure raised when captured content carries secret-shaped or private material.",
+  })
+) {
+  /** Process exit code reported when this error reaches the runtime boundary. */
+  override readonly [Runtime.errorExitCode] = 1;
+}
+
+/**
+ * Failure raised while staging or committing a generated packet.
+ *
+ * **Example** (Refusing to clobber an existing packet)
+ *
+ * ```ts
+ * import { CodexPacketWriteError } from "@beep/repo-cli/commands/Codex/Findings.errors"
+ *
+ * const error = CodexPacketWriteError.make({
+ *   reason: "packet-exists",
+ *   message: "goals/codex-security-findings-2026-08-04 already exists.",
+ * })
+ *
+ * console.log(error.reason) // "packet-exists"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class CodexPacketWriteError extends TaggedErrorClass<CodexPacketWriteError>($I`CodexPacketWriteError`)(
+  "CodexPacketWriteError",
+  {
+    reason: CodexPacketWriteFailureReason,
+    message: S.String,
+    cause: S.optionalKey(S.Defect({ includeStack: true })),
+  },
+  $I.annote("CodexPacketWriteError", {
+    description: "Failure raised while staging or committing a generated Codex findings packet.",
+  })
+) {
+  /** Process exit code reported when this error reaches the runtime boundary. */
+  override readonly [Runtime.errorExitCode] = 1;
+
+  /**
+   * Build a reason-tagged packet write failure from an upstream cause.
+   *
+   * **Example** (Mapping a rename failure)
+   *
+   * ```ts
+   * import { CodexPacketWriteError } from "@beep/repo-cli/commands/Codex/Findings.errors"
+   *
+   * const error = CodexPacketWriteError.from(
+   *   new Error("ENOTEMPTY"),
+   *   "commit-failed",
+   *   "The staged packet could not be promoted."
+   * )
+   *
+   * console.log(error.reason) // "commit-failed"
+   * ```
+   *
+   * @param cause - Upstream failure being wrapped.
+   * @param reason - Reason domain member describing the failure.
+   * @param message - Operator-facing message, free of captured values.
+   * @returns The tagged error carrying the cause.
+   * @category constructors
+   * @since 0.0.0
+   */
+  static readonly from = (
+    cause: unknown,
+    reason: CodexPacketWriteFailureReason,
+    message: string
+  ): CodexPacketWriteError => CodexPacketWriteError.make({ cause, message, reason });
+}

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.errors.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.errors.ts
@@ -46,6 +46,7 @@ export const CodexIngestFailureReason = LiteralKit([
   "csv-row-malformed",
   "csv-duplicate-finding",
   "capture-date-unknown",
+  "ledger-unreadable",
   "auth-expired",
   "short-read",
   "inbox-ambiguous",

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.normalize.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.normalize.ts
@@ -1,0 +1,360 @@
+/**
+ * Deterministic normalization of a capture payload into an ordered packet plan.
+ *
+ * Ordering is total and derived only from payload content, never from the
+ * dashboard's row order or the wall clock, so ingesting the same payload twice
+ * produces byte-identical packet documents.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { A, O, Str } from "@beep/utils";
+import { Effect, HashMap, Order } from "effect";
+import { CodexFindingSeverity as Severity } from "./Findings.capture.schemas.ts";
+import { CodexFindingsIngestError } from "./Findings.errors.ts";
+import { CodexFindingRecord, CodexPacketPlan, CodexSeverityCounts } from "./Findings.schemas.ts";
+import type { CodexFindingSeverity, CodexFindingsCapturePayload } from "./Findings.capture.schemas.ts";
+
+/**
+ * Rank of a severity within the packet ordering, most severe first.
+ *
+ * **Details**
+ *
+ * The rank is read from the literal domain's declaration order rather than a
+ * separate table, so adding a severity to {@link CodexFindingSeverity} cannot
+ * leave the ordering silently stale.
+ *
+ * **Example** (Ranking severities)
+ *
+ * ```ts
+ * import { severityRank } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ *
+ * console.log(severityRank("High") < severityRank("Low")) // true
+ * ```
+ *
+ * @param severity - Severity reported for a captured finding.
+ * @returns Zero-based rank, lower being more severe.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const severityRank = (severity: CodexFindingSeverity): number => Severity.Options.indexOf(severity);
+
+/** Minimal shape {@link captureOrder} needs to place a finding. */
+type OrderableFinding = {
+  readonly severity: CodexFindingSeverity;
+  readonly codexId: string;
+};
+
+/**
+ * Total order over captured findings: most severe first, then by Codex identity.
+ *
+ * **Details**
+ *
+ * The identity tiebreak is what makes the order total. Two findings can share a
+ * severity, but the capture schema rejects duplicate identities, so no two rows
+ * can ever compare equal.
+ *
+ * **Example** (Sorting two captured rows)
+ *
+ * ```ts
+ * import { captureOrder } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ *
+ * console.log(typeof captureOrder) // "function"
+ * ```
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export const captureOrder: Order.Order<OrderableFinding> = Order.combine(
+  Order.mapInput(Order.Number, (finding: OrderableFinding) => severityRank(finding.severity)),
+  Order.mapInput(Order.String, (finding: OrderableFinding) => finding.codexId)
+);
+
+/**
+ * Render a one-based ordinal as a zero-padded `CSF-NNN` identity.
+ *
+ * **Example** (Assigning the first identity)
+ *
+ * ```ts
+ * import { recordIdForOrdinal } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ *
+ * console.log(recordIdForOrdinal(1)) // "CSF-001"
+ * console.log(recordIdForOrdinal(1234)) // "CSF-1234"
+ * ```
+ *
+ * @param ordinal - One-based position of the finding in assignment order.
+ * @returns The zero-padded `CSF-NNN` identity.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const recordIdForOrdinal = (ordinal: number): string => `CSF-${Str.padStart(3, "0")(`${ordinal}`)}`;
+
+/**
+ * Tally findings per severity, in severity-domain order, omitting zero counts.
+ *
+ * **Gotchas**
+ *
+ * Severities with no findings are absent rather than present with a `0`, which
+ * matches the `catalog.severityCounts` block every hand-written Codex packet
+ * already ships.
+ *
+ * **Example** (Counting a mixed batch)
+ *
+ * ```ts
+ * import { severityCountsOf } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ *
+ * const counts = severityCountsOf([{ severity: "Low" }, { severity: "Low" }])
+ *
+ * console.log(counts.Low) // 2
+ * console.log("High" in counts) // false
+ * ```
+ *
+ * @param findings - Findings to tally, in any order.
+ * @returns Per-severity totals with zero-count severities omitted.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const severityCountsOf = (
+  findings: ReadonlyArray<{ readonly severity: CodexFindingSeverity }>
+): CodexSeverityCounts =>
+  CodexSeverityCounts.make(
+    A.reduce(Severity.Options, {} as Record<string, number>, (counts, severity) => {
+      const total = A.length(A.filter(findings, (finding) => finding.severity === severity));
+      return total === 0 ? counts : { ...counts, [severity]: total };
+    })
+  );
+
+/**
+ * Slug a capture date resolves to when no override is supplied.
+ *
+ * **Example** (Deriving the default slug)
+ *
+ * ```ts
+ * import { defaultPacketSlug } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ *
+ * console.log(defaultPacketSlug("2026-08-04")) // "codex-security-findings-2026-08-04"
+ * ```
+ *
+ * @param capturedAt - Calendar date of the capture, as `YYYY-MM-DD`.
+ * @returns The packet directory name under `goals/`.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const defaultPacketSlug = (capturedAt: string): string => `codex-security-findings-${capturedAt}`;
+
+/**
+ * Branch a capture date resolves to when no override is supplied.
+ *
+ * **Example** (Deriving the default branch)
+ *
+ * ```ts
+ * import { defaultPacketBranch } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ *
+ * console.log(defaultPacketBranch("2026-08-04")) // "security/codex-findings-2026-08-04"
+ * ```
+ *
+ * @param capturedAt - Calendar date of the capture, as `YYYY-MM-DD`.
+ * @returns The remediation branch name the packet declares.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const defaultPacketBranch = (capturedAt: string): string => `security/codex-findings-${capturedAt}`;
+
+/**
+ * Read the ordinal back out of an assigned record identifier.
+ *
+ * **Example** (Reading an ordinal)
+ *
+ * ```ts
+ * import { ordinalOfRecordId } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ * import * as O from "effect/Option"
+ *
+ * console.log(O.getOrElse(ordinalOfRecordId("CSF-007"), () => 0)) // 7
+ * ```
+ *
+ * @param recordId - A `CSF-NNN` identity.
+ * @returns The ordinal, or `None` when the identity is not well formed.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const ordinalOfRecordId = (recordId: string): O.Option<number> => {
+  const match = /^CSF-(\d{3,})$/.exec(recordId);
+  return match === null ? O.none() : O.some(Number.parseInt(match[1] ?? "", 10));
+};
+
+/**
+ * Highest ordinal any prior binding has already consumed.
+ *
+ * **Details**
+ *
+ * Retired findings keep their reservation. A number that once addressed a
+ * finding is never handed to a different one, so a Codex identifier quoted in a
+ * merged PR or a closeout allowlist keeps meaning what it meant.
+ *
+ * @param priorIds - Existing `codexId -> CSF-NNN` bindings.
+ * @returns The highest ordinal already consumed, or zero when there are none.
+ * @category utilities
+ * @since 0.0.0
+ */
+const highestReservedOrdinal = (priorIds: HashMap.HashMap<string, string>): number =>
+  A.reduce(A.fromIterable(HashMap.values(priorIds)), 0, (highest, recordId) =>
+    Math.max(
+      highest,
+      O.getOrElse(ordinalOfRecordId(recordId), () => 0)
+    )
+  );
+
+/**
+ * Recover `codexId -> CSF-NNN` bindings from an existing packet's ledger.
+ *
+ * **When to use**
+ *
+ * Use when re-ingesting a capture into a packet that already exists, so
+ * {@link planPacket} preserves the identifiers that packet already published.
+ *
+ * **Example** (Recovering bindings)
+ *
+ * ```ts
+ * import { priorIdsOfEntries } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ * import { HashMap } from "effect"
+ *
+ * const priorIds = priorIdsOfEntries([{ id: "CSF-004", codexId: "abc" }])
+ *
+ * console.log(HashMap.size(priorIds)) // 1
+ * ```
+ *
+ * @param entries - Identity pairs read from an existing triage ledger.
+ * @returns A `codexId -> CSF-NNN` binding map.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const priorIdsOfEntries = (
+  entries: ReadonlyArray<{ readonly id: string; readonly codexId: string }>
+): HashMap.HashMap<string, string> =>
+  A.reduce(entries, HashMap.empty<string, string>(), (bindings, entry) =>
+    HashMap.set(bindings, entry.codexId, entry.id)
+  );
+
+/**
+ * Turn a decoded capture payload into an ordered, reconciled packet plan.
+ *
+ * **When to use**
+ *
+ * Use to turn a decoded, scanned payload into the plan every renderer consumes.
+ * This is the last stage that can fail on payload content; rendering from the
+ * resulting plan is total.
+ *
+ * **Gotchas**
+ *
+ * A payload whose session had expired, or whose captured rows fall short of the
+ * dashboard's own reported total, is rejected rather than bootstrapped. Both
+ * cases would otherwise produce a packet that reads like a clean scan.
+ *
+ * Pass `priorIds` whenever a packet for this capture already exists. Without it
+ * every identifier is reassigned from capture order, so one new high-severity
+ * finding silently shifts every later `CSF-NNN` — invalidating hand-written
+ * triage prose and the exact-identifier allowlist used to close findings after
+ * merge. With it, existing findings keep their numbers and new ones append.
+ *
+ * **Example** (Planning an empty capture)
+ *
+ * ```ts
+ * import { planPacket } from "@beep/repo-cli/commands/Codex/Findings.normalize"
+ * import { CodexCaptureMeta, CodexFindingsCapturePayload } from "@beep/repo-cli/commands/Codex/Findings.capture.schemas"
+ * import { Effect } from "effect"
+ *
+ * const payload = CodexFindingsCapturePayload.make({
+ *   schemaVersion: "codex-findings-capture/v1",
+ *   capture: CodexCaptureMeta.make({
+ *     capturedAt: "2026-08-04",
+ *     sourceUrl: "https://chatgpt.com/codex/cloud/security/findings/",
+ *     repository: "kriegcloud/beep-effect",
+ *     findingsView: "repo-scoped, status=open",
+ *     expectedCount: 0,
+ *     authState: "authenticated",
+ *   }),
+ *   findings: [],
+ * })
+ *
+ * const program = planPacket(payload, {}).pipe(Effect.map((plan) => plan.slug))
+ *
+ * console.log(Effect.runSync(program)) // "codex-security-findings-2026-08-04"
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const planPacket = Effect.fnUntraced(function* (
+  payload: CodexFindingsCapturePayload,
+  overrides: {
+    readonly slug?: string | undefined;
+    readonly branch?: string | undefined;
+    readonly capturedAt?: string | undefined;
+    readonly expectedCount?: number | undefined;
+    /** Existing `codexId -> CSF-NNN` bindings read from a packet being re-ingested. */
+    readonly priorIds?: HashMap.HashMap<string, string> | undefined;
+  }
+) {
+  if (payload.capture.authState === "expired") {
+    return yield* CodexFindingsIngestError.make({
+      reason: "auth-expired",
+      message:
+        "The capture ran against a signed-out session, so the findings list was empty or partial. Sign in to the dashboard and capture again.",
+    });
+  }
+
+  const expectedCount = overrides.expectedCount ?? payload.capture.expectedCount;
+  const capturedCount = A.length(payload.findings);
+
+  if (capturedCount < expectedCount) {
+    return yield* CodexFindingsIngestError.make({
+      reason: "short-read",
+      message: `The capture read ${capturedCount} findings but the dashboard reported ${expectedCount}. Scroll the findings list to the end so every virtualized row renders, then capture again.`,
+    });
+  }
+
+  const capturedAt = overrides.capturedAt ?? payload.capture.capturedAt;
+  const ordered = A.sort(payload.findings, captureOrder);
+  const priorIds = overrides.priorIds ?? HashMap.empty<string, string>();
+
+  // Identifiers are assigned once and never reassigned. A finding that already
+  // has a CSF number keeps it even when a more severe finding arrives ahead of
+  // it in capture order, because that number is quoted in hand-written triage
+  // prose and in the post-merge Codex close allowlist.
+  const assignment = A.reduce(
+    ordered,
+    { nextOrdinal: highestReservedOrdinal(priorIds) + 1, records: A.empty<CodexFindingRecord>() },
+    (accumulator, finding) => {
+      const bound = HashMap.get(priorIds, finding.codexId);
+      const id = O.getOrElse(bound, () => recordIdForOrdinal(accumulator.nextOrdinal));
+      return {
+        nextOrdinal: O.isSome(bound) ? accumulator.nextOrdinal : accumulator.nextOrdinal + 1,
+        records: A.append(
+          accumulator.records,
+          CodexFindingRecord.make({
+            id,
+            codexId: finding.codexId,
+            title: finding.title,
+            severity: finding.severity,
+            codexStatus: finding.codexStatus,
+            commit: finding.commit,
+          })
+        ),
+      };
+    }
+  );
+  const records = assignment.records;
+
+  return CodexPacketPlan.make({
+    slug: overrides.slug ?? defaultPacketSlug(capturedAt),
+    branch: overrides.branch ?? defaultPacketBranch(capturedAt),
+    capturedAt,
+    repository: payload.capture.repository,
+    sourceUrl: payload.capture.sourceUrl,
+    findingsView: payload.capture.findingsView,
+    expectedCount,
+    records,
+    severityCounts: severityCountsOf(records),
+  });
+});

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.packet.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.packet.ts
@@ -15,7 +15,7 @@
  */
 
 import { escapeMarkdownText } from "@beep/md/Md.escape";
-import { A } from "@beep/utils";
+import { A, O } from "@beep/utils";
 import * as R from "effect/Record";
 import { CodexFindingSeverity } from "./Findings.capture.schemas.ts";
 import {
@@ -623,6 +623,59 @@ const sourcesDocument = (plan: CodexPacketPlan): PacketDocument => {
   });
 };
 
+/**
+ * Report bodies, one file per finding, under ignored `raw/reports/`.
+ *
+ * The body is written verbatim beneath a `CSF-NNN` heading so P2 can validate
+ * against exactly what Codex reported. It is never escaped or merged into a
+ * tracked document: these files exist because the tracked records deliberately
+ * carry only sanitized metadata.
+ *
+ * @param plan - The resolved plan supplying assigned identities.
+ * @param reports - Report bodies keyed by Codex identity.
+ * @returns One untracked document per finding that has a report body.
+ */
+const rawReportDocuments = (
+  plan: CodexPacketPlan,
+  reports: ReadonlyArray<{
+    readonly codexId: string;
+    readonly description: string;
+    readonly relevantPaths: string;
+    readonly detectedAt: string;
+  }>
+): ReadonlyArray<PacketDocument> => {
+  const recordFor = (codexId: string) => A.findFirst(plan.records, (record) => record.codexId === codexId);
+
+  return A.map(
+    A.filter(reports, (report) => O.isSome(recordFor(report.codexId))),
+    (report) => {
+      // Safe by the filter above; the plan and the reports come from the same
+      // decode, so every report has exactly one assigned record.
+      const record = O.getOrElse(recordFor(report.codexId), () => plan.records[0]!);
+      return PacketDocument.make({
+        path: `raw/reports/${record.id}.md`,
+        tracked: false,
+        // Report text is external prose that legitimately quotes local paths;
+        // hits are surfaced to the operator rather than refusing the ingest.
+        scan: "report",
+        contents: lines([
+          `# ${record.id}: ${record.title}`,
+          "",
+          `- Codex ID: \`${record.codexId}\``,
+          `- Severity: ${record.severity}`,
+          `- Source commit: \`${record.commit}\``,
+          `- Detected at: ${report.detectedAt}`,
+          `- Relevant paths: ${report.relevantPaths}`,
+          "",
+          "## Report",
+          "",
+          report.description,
+        ]),
+      });
+    }
+  );
+};
+
 const rawGitignoreDocument = (): PacketDocument =>
   PacketDocument.make({
     path: "raw/.gitignore",
@@ -642,14 +695,19 @@ const rawGitignoreDocument = (): PacketDocument =>
  *
  * Document order is stable and the content is a pure function of the plan, so
  * ingesting one capture twice produces byte-identical output. `raw/payload.json`
- * carries the normalized capture — never the CSV export, which holds author
- * email addresses and unsanitized report text.
+ * carries the normalized capture and `raw/reports/CSF-NNN.md` the report bodies
+ * P2 validates against — never the CSV export itself, which also holds author
+ * email addresses.
  *
  * **Gotchas**
  *
  * `GOAL.md` is under a hard 4000-character doctor gate, so it reports severity
  * counts and points at `findings/INDEX.md` rather than listing findings. Adding
  * a per-finding line here would breach the gate on a large batch.
+ *
+ * Everything under `raw/` is untracked by construction. Report bodies are
+ * external prose that legitimately quotes developer-local paths, so they are
+ * written there and never merged into a tracked document.
  *
  * **Example** (Rendering a packet for an empty capture)
  *
@@ -682,6 +740,13 @@ const rawGitignoreDocument = (): PacketDocument =>
 export const renderPacketDocuments = (options: {
   readonly plan: CodexPacketPlan;
   readonly rawPayloadJson: string;
+  /** Report bodies keyed by Codex identity, written only under ignored `raw/`. */
+  readonly rawReports?: ReadonlyArray<{
+    readonly codexId: string;
+    readonly description: string;
+    readonly relevantPaths: string;
+    readonly detectedAt: string;
+  }>;
 }): ReadonlyArray<PacketDocument> =>
   A.appendAll(
     [
@@ -700,5 +765,8 @@ export const renderPacketDocuments = (options: {
         contents: options.rawPayloadJson,
       }),
     ],
-    A.map(options.plan.records, findingDocument)
+    A.appendAll(
+      A.map(options.plan.records, findingDocument),
+      rawReportDocuments(options.plan, options.rawReports ?? A.empty())
+    )
   );

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.packet.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.packet.ts
@@ -1,0 +1,704 @@
+/**
+ * Renders a resolved capture plan into the complete set of packet documents.
+ *
+ * Every renderer here is pure and total: planning is the last stage that can
+ * fail on data, so rendering cannot. That split is what makes a dry run
+ * meaningful — the documents a dry run reports are byte-identical to the ones a
+ * real ingest would promote.
+ *
+ * Judgment is never fabricated. A freshly generated packet carries capture
+ * metadata and explicit `_pending_` markers where a triage agent must write, so
+ * no reader can mistake generated scaffolding for a decision someone made.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { escapeMarkdownText } from "@beep/md/Md.escape";
+import { A } from "@beep/utils";
+import * as R from "effect/Record";
+import { CodexFindingSeverity } from "./Findings.capture.schemas.ts";
+import {
+  CodexTriageFinding,
+  CodexTriageLedger,
+  CodexTriageMeta,
+  CodexTriageRemediation,
+  CodexTriageValidation,
+  encodeCodexTriageLedger,
+} from "./Findings.triage.schemas.ts";
+import { PacketDocument } from "./Findings.write.ts";
+import type { CodexFindingRecord, CodexPacketPlan, CodexSeverityCounts } from "./Findings.schemas.ts";
+
+/**
+ * Marker written wherever a phase must supply judgment the capture cannot.
+ *
+ * @param phase - Packet phase that will supply the missing judgment.
+ * @returns The italic pending marker for that phase.
+ */
+const pendingIn = (phase: string): string => `_pending ${phase}_`;
+
+const VALIDATION_PHASE = "P2";
+const REMEDIATION_PHASE = "P4";
+
+const json = (value: unknown): string => `${JSON.stringify(value, null, 2)}\n`;
+
+const lines = (value: ReadonlyArray<string>): string => `${A.join(value, "\n")}\n`;
+
+/**
+ * Severities carrying at least one finding, in canonical declaration order.
+ *
+ * @param counts - Per-severity totals.
+ * @returns Present severities paired with their totals.
+ */
+const presentSeverities = (counts: CodexSeverityCounts): ReadonlyArray<readonly [string, number]> =>
+  A.map(
+    A.filter(CodexFindingSeverity.Options, (severity) => (counts[severity] ?? 0) > 0),
+    (severity) => [severity, counts[severity] ?? 0] as const
+  );
+
+/**
+ * Renders `13 Medium, 7 Low, 7 Informational`.
+ *
+ * @param counts - Per-severity totals.
+ * @returns A comma-joined summary, or `"no"` when the capture was empty.
+ */
+const severityPhrase = (counts: CodexSeverityCounts): string => {
+  const present = presentSeverities(counts);
+  return A.isReadonlyArrayNonEmpty(present)
+    ? A.join(
+        A.map(present, ([severity, total]) => `${total} ${severity}`),
+        ", "
+      )
+    : "no";
+};
+
+const manifestDocument = (plan: CodexPacketPlan): PacketDocument => {
+  const capturedCount = A.length(plan.records);
+  const title = `Codex Security Findings (${plan.capturedAt})`;
+
+  return PacketDocument.make({
+    path: "ops/manifest.json",
+    tracked: true,
+    contents: json({
+      schemaVersion: "initiative-manifest/v2",
+      initiative: {
+        id: plan.slug,
+        title,
+        status: "active",
+        created: plan.capturedAt,
+        updated: plan.capturedAt,
+        packetAnchorDocument: "SPEC.md",
+      },
+      packetPath: `goals/${plan.slug}`,
+      lifecycle: "active",
+      mission: `Remediate and close the ${capturedCount} Codex Cloud security findings captured on ${plan.capturedAt}.`,
+      executionCapable: true,
+      reflectionRequired: true,
+      completionGate: {
+        operator: "yeet",
+        requiresPullRequest: true,
+        requiresMergeable: true,
+        statement: `Not achieved until the work ships as a Yeet-driven mergeable PR, is merged, and the exact ${capturedCount} Codex findings are resolved with zero packet-applicable open findings.`,
+        grandfathered: false,
+      },
+      branch: plan.branch,
+      currentSourceOfTruth: [
+        "AGENTS.md",
+        "CLAUDE.md",
+        `goals/${plan.slug}/README.md`,
+        `goals/${plan.slug}/SPEC.md`,
+        `goals/${plan.slug}/PLAN.md`,
+        `goals/${plan.slug}/GOAL.md`,
+        `goals/${plan.slug}/research/SOURCES.md`,
+      ],
+      researchReports: ["research/SOURCES.md"],
+      agentLaunchers: [
+        {
+          kind: "codex-goal",
+          path: "GOAL.md",
+          targetChars: 3500,
+          maxChars: 4000,
+          command: `/goal follow the instructions in goals/${plan.slug}/GOAL.md`,
+        },
+      ],
+      source: {
+        provider: "Codex Cloud Security UI",
+        repository: plan.repository,
+        url: plan.sourceUrl,
+        capturedAt: plan.capturedAt,
+        captureMethodPolicy: "signed-in-csv-export",
+        rawCaptureRoot: `goals/${plan.slug}/raw`,
+        rawCaptureTracked: false,
+      },
+      catalog: {
+        expectedCount: plan.expectedCount,
+        capturedCount,
+        severityCountsKnown: true,
+        severityCounts: R.fromEntries(presentSeverities(plan.severityCounts)),
+        dispositionCounts: {
+          remediate: 0,
+          "already-fixed": 0,
+          "false-positive": 0,
+          "out-of-scope": 0,
+          untriaged: capturedCount,
+        },
+        note: `Generated by \`beep codex findings ingest\`. Every finding is untriaged until ${VALIDATION_PHASE} records a current-HEAD verdict.`,
+      },
+      closeoutPolicy: {
+        fixed: "Already fixed",
+        alreadyFixed: "Already fixed",
+        dismissedInvalid: "False positive",
+        outOfScope: "False positive",
+        acceptedRisk: "not allowed",
+      },
+      dispositionPolicy: {
+        default: "remediate",
+        acceptedRiskAllowed: false,
+        falsePositiveThreshold:
+          "strict current-HEAD proof that affected code is absent, unreachable, non-shipped, already fixed, or materially misunderstood",
+        fixPhilosophy:
+          "minimal shared-root fixes with focused regression proof; reuse canonical repo helpers after live source and barrel discovery",
+      },
+      sanitation: {
+        trackedRawFindingContent: false,
+        rawCaptureLocation: `goals/${plan.slug}/raw`,
+        commitsOnlySanitizedMarkdown: true,
+        codexPatchTextTracked: false,
+        publicFindingPolicy:
+          "Tracked records contain title, severity, Codex ID, source commit, public summary, decisions, changed files, and verification only.",
+      },
+      phases: [
+        { id: "P0", name: "Bootstrap", status: "complete" },
+        { id: "P1", name: "Capture", status: "complete" },
+        { id: "P2", name: "Validate", status: "pending" },
+        { id: "P3", name: "Lane partition", status: "pending" },
+        { id: "P4", name: "Remediate", status: "pending" },
+        { id: "P5", name: "Repo proof", status: "pending" },
+        { id: "P6", name: "Publish", status: "pending" },
+        { id: "P7", name: "Monitor", status: "pending" },
+        { id: "P8", name: "Merge and close findings", status: "pending" },
+        { id: "P9", name: "Close", status: "pending" },
+      ],
+      verificationCommands: [
+        `test "$(wc -m < goals/${plan.slug}/GOAL.md)" -le 4000`,
+        `jq . goals/${plan.slug}/ops/manifest.json`,
+        `jq . goals/${plan.slug}/ops/triage.json`,
+        `test "$(find goals/${plan.slug}/findings -maxdepth 1 -name 'CSF-*.md' | wc -l | tr -d ' ')" = ${capturedCount}`,
+        `git diff --check -- goals/${plan.slug}`,
+        // Advisory rather than a CLI gate: this repository squash-merges, so a
+        // finding's source commit is often absent from the branch even when the
+        // finding is entirely valid. The executing agent reads the output.
+        `jq -r '.findings[].commit' goals/${plan.slug}/ops/triage.json | while read -r c; do git merge-base --is-ancestor "$c" HEAD || echo "not-an-ancestor: $c"; done`,
+        "bun run beep lint reflection-artifacts",
+      ],
+      stopConditions: [
+        "The signed-in CSV export cannot be produced from the findings page.",
+        "Tracked evidence contains secrets, auth values, signed URLs, email addresses, or raw developer-local paths.",
+        "A remediation requires an architecture or product decision outside packet scope.",
+        "The same blocker repeats after reasonable investigation.",
+      ],
+    }),
+  });
+};
+
+const triageDocument = (plan: CodexPacketPlan): PacketDocument => {
+  const ledger = CodexTriageLedger.make({
+    meta: CodexTriageMeta.make({
+      schemaVersion: "codex-triage/v1",
+      repository: plan.repository,
+      findingsView: plan.findingsView,
+      branch: plan.branch,
+      expectedCount: plan.expectedCount,
+      capturedCount: A.length(plan.records),
+      capturedAt: plan.capturedAt,
+      captureMethod: "signed-in-csv-export",
+      note: `Generated skeleton. ownerArea, verdict, and lane are absent until ${VALIDATION_PHASE} assigns them.`,
+    }),
+    // Lanes are a P3 partition over confirmed findings; inventing them at
+    // capture time would assert a root-cause grouping nobody has established.
+    lanes: {},
+    findings: A.map(plan.records, (record) =>
+      CodexTriageFinding.make({
+        id: record.id,
+        codexId: record.codexId,
+        title: record.title,
+        severity: record.severity,
+        codexStatus: record.codexStatus,
+        commit: record.commit,
+        disposition: "untriaged",
+        validation: CodexTriageValidation.make({ status: "pending" }),
+        remediation: CodexTriageRemediation.make({
+          status: "pending",
+          changedFiles: [],
+          verificationCommands: [],
+        }),
+      })
+    ),
+  });
+
+  return PacketDocument.make({
+    path: "ops/triage.json",
+    tracked: true,
+    contents: json(encodeCodexTriageLedger(ledger)),
+  });
+};
+
+const findingDocument = (record: CodexFindingRecord): PacketDocument =>
+  PacketDocument.make({
+    path: `findings/${record.id}.md`,
+    tracked: true,
+    contents: lines([
+      `# ${record.id}: ${escapeMarkdownText(record.title)}`,
+      "",
+      `- Severity: ${record.severity}`,
+      `- Codex ID: \`${record.codexId}\``,
+      `- Source commit: \`${record.commit}\``,
+      `- Owner: ${pendingIn(VALIDATION_PHASE)}`,
+      "- Status: captured; validation pending",
+      "",
+      "## Public Summary",
+      "",
+      // The CSV description is unsanitized report text and stays in ignored
+      // raw/. Writing a summary is a judgment step, not a copy step.
+      `${pendingIn(VALIDATION_PHASE)} — write a sanitized summary from the raw report.`,
+      "",
+      "## Current-HEAD Validation",
+      "",
+      `${pendingIn(VALIDATION_PHASE)} — record verdict, disposition, and rationale.`,
+      "",
+      "## Remediation",
+      "",
+      pendingIn(REMEDIATION_PHASE),
+      "",
+      "Changed files:",
+      "",
+      `- ${pendingIn(REMEDIATION_PHASE)}`,
+      "",
+      "## Verification",
+      "",
+      `- ${pendingIn(REMEDIATION_PHASE)}`,
+    ]),
+  });
+
+const findingsIndexDocument = (plan: CodexPacketPlan): PacketDocument =>
+  PacketDocument.make({
+    path: "findings/INDEX.md",
+    tracked: true,
+    contents: lines([
+      `# Codex Security Findings Index (${plan.capturedAt})`,
+      "",
+      `Captured from the authenticated Codex Cloud Security view for`,
+      `\`${plan.repository}\` on ${plan.capturedAt} through the signed-in CSV export.`,
+      "Full reports remain ignored under `raw/`; tracked records omit signed URLs,",
+      "auth values, email addresses, and raw local paths.",
+      "",
+      "## Severity Summary",
+      "",
+      "| Severity | Count |",
+      "| --- | ---: |",
+      ...A.map(presentSeverities(plan.severityCounts), ([severity, total]) => `| ${severity} | ${total} |`),
+      "",
+      "## Findings",
+      "",
+      "| ID | Severity | Status | Title | Owner area |",
+      "| --- | --- | --- | --- | --- |",
+      ...A.map(
+        plan.records,
+        (record) =>
+          `| [${record.id}](./${record.id}.md) | ${record.severity} | captured | ${escapeMarkdownText(record.title)} | ${pendingIn(VALIDATION_PHASE)} |`
+      ),
+      "",
+      "## Closeout Mapping",
+      "",
+      "- `remediate` or `already-fixed` -> close as `Already fixed` after merge.",
+      "- Strictly proven invalid -> close as `False positive` with evidence recorded.",
+      "- Accepted risk / `Won't fix` is unavailable.",
+    ]),
+  });
+
+const readmeDocument = (plan: CodexPacketPlan): PacketDocument => {
+  const capturedCount = A.length(plan.records);
+  return PacketDocument.make({
+    path: "README.md",
+    tracked: true,
+    contents: lines([
+      `# Codex Security Findings (${plan.capturedAt})`,
+      "",
+      "## Status",
+      "",
+      "Lifecycle: `active`",
+      "",
+      "Source: [`ops/manifest.json`](./ops/manifest.json)",
+      "",
+      "## Mission",
+      "",
+      "Capture, validate, remediate, and close every open Codex Cloud security finding",
+      `for \`${plan.repository}\` in the ${capturedCount}-finding batch captured on ${plan.capturedAt}.`,
+      "Ship the fixes through one Yeet-driven PR, close the exact captured findings, and",
+      "leave no packet-applicable finding open.",
+      "",
+      "## Launch",
+      "",
+      "```text",
+      `/goal follow the instructions in goals/${plan.slug}/GOAL.md`,
+      "```",
+      "",
+      "`GOAL.md` is the compact launcher. `SPEC.md` remains the normative contract.",
+      "",
+      "## Read This First",
+      "",
+      "1. [`GOAL.md`](./GOAL.md)",
+      "2. [`SPEC.md`](./SPEC.md)",
+      "3. [`PLAN.md`](./PLAN.md)",
+      "4. [`ops/manifest.json`](./ops/manifest.json)",
+      "5. [`ops/triage.json`](./ops/triage.json)",
+      "6. [`findings/INDEX.md`](./findings/INDEX.md)",
+      "",
+      "## Current Phase",
+      "",
+      `\`P2 validate\` - all ${capturedCount} findings are captured and untriaged. Reproduce each`,
+      "report at current HEAD, then record a verdict, disposition, and owner surface.",
+      "",
+      "## Findings at a glance",
+      "",
+      `${severityPhrase(plan.severityCounts)} findings. Accepted risk is unavailable; each item must be`,
+      "fixed or closed only with strict proof that the report is already fixed or",
+      "materially invalid.",
+      "",
+      "## Notes",
+      "",
+      "- Raw report bodies remain untracked under `raw/`; tracked files are sanitized.",
+      "- Do not use Codex's Create PR or patch-apply controls.",
+      "- Browser closure is post-merge and must match the captured Codex ID allowlist.",
+    ]),
+  });
+};
+
+const goalDocument = (plan: CodexPacketPlan): PacketDocument => {
+  const capturedCount = A.length(plan.records);
+  return PacketDocument.make({
+    path: "GOAL.md",
+    tracked: true,
+    contents: lines([
+      `# Codex Security Findings (${plan.capturedAt})`,
+      "",
+      "Repo root: the current working directory. Do not assume an absolute path.",
+      "",
+      // Deliberately a count, never a per-finding list: GOAL.md has a hard
+      // 4000-char doctor gate and a list would breach it on a large batch.
+      `Outcome: fix and close the ${capturedCount} Codex Cloud security findings captured on`,
+      `${plan.capturedAt} for \`${plan.repository}\`: ${severityPhrase(plan.severityCounts)}.`,
+      "Ship one Yeet-driven PR to mergeable, merge it, then resolve the exact captured",
+      "Codex IDs until no packet-applicable finding remains open.",
+      "",
+      "Read first:",
+      "",
+      `- \`goals/${plan.slug}/README.md\``,
+      `- \`goals/${plan.slug}/SPEC.md\``,
+      `- \`goals/${plan.slug}/PLAN.md\``,
+      `- \`goals/${plan.slug}/ops/manifest.json\``,
+      `- \`goals/${plan.slug}/ops/triage.json\``,
+      `- \`goals/${plan.slug}/findings/INDEX.md\``,
+      "",
+      "Then read `AGENTS.md`, required skills, and standards governing each target.",
+      "Repo law outranks packet prose.",
+      "",
+      "Scope:",
+      "",
+      "- In: sanitized packet evidence, current-HEAD validation, minimal root-cause",
+      "  remediation, focused regression checks, Yeet proof/publication/monitoring,",
+      "  merge, and post-merge Chrome closure.",
+      "- Out: accepted risk, raw evidence in git, Codex Create PR/patch buttons,",
+      "  unrelated cleanup, weakened quality/security gates.",
+      "",
+      "Rules:",
+      "",
+      "1. Default every item to `remediate`; use `already-fixed` or `false-positive`",
+      "   only with strict current-HEAD proof in the finding and triage ledger.",
+      "2. Apply Effect-first and schema-first repo law. Search live source and barrels",
+      "   before adding helpers; reuse canonical path-safety and bounds primitives.",
+      "3. Fix shared causes once. Add one focused regression check per executable-code",
+      "   finding, merging tests only where the same root cause is exercised.",
+      "4. Keep raw report bodies ignored under `raw/`. Tracked records may contain only",
+      "   sanitized metadata, summaries, decisions, changed files, and proof.",
+      "5. Run focused tests, affected package checks, packet validation, then Yeet",
+      "   repair/verify. Publish one intentional PR and monitor through mergeable.",
+      `6. After merge, close only the exact ${capturedCount}-ID allowlist in Codex as Already fixed`,
+      "   (or the evidence-backed invalid reason) and verify zero packet-open findings.",
+      "",
+      "Stop if the signed-in CSV export is unavailable, tracked evidence contains secret",
+      "or raw-path material, a fix needs an out-of-packet architecture decision, or the",
+      "same blocker repeats after reasonable investigation.",
+    ]),
+  });
+};
+
+const planDocument = (plan: CodexPacketPlan): PacketDocument => {
+  const capturedCount = A.length(plan.records);
+  return PacketDocument.make({
+    path: "PLAN.md",
+    tracked: true,
+    contents: lines([
+      `# Codex Security Findings (${plan.capturedAt}) Plan`,
+      "",
+      "## Status",
+      "",
+      "Status: `active`. The batch is captured and untriaged; validation is next.",
+      "",
+      "## Phases",
+      "",
+      "| Phase | Status | Goal | Exit criteria |",
+      "| --- | --- | --- | --- |",
+      "| P0 bootstrap | complete | Create feature branch and packet scaffold. | Branch and launcher exist; packet JSON parses. |",
+      `| P1 capture | complete | Capture all live findings via the signed-in CSV export. | ${capturedCount} IDs reconcile: ${severityPhrase(plan.severityCounts)}. |`,
+      "| P2 validate | pending | Reproduce each report at current HEAD. | Every item has strict verdict, disposition, rationale, and owner surface. |",
+      "| P3 lane-partition | pending | Group shared root causes and disjoint paths. | Lanes recorded without overlapping file ownership. |",
+      "| P4 remediate | pending | Fix all real findings with focused checks. | Changed files and passing targeted proof recorded per finding. |",
+      "| P5 repo-proof | pending | Run packet validation and Yeet repair/verify. | No packet drift; local proof green. |",
+      "| P6 publish | pending | Publish one intentional PR through Yeet. | Exact branch head pushed and PR opened. |",
+      "| P7 monitor | pending | Close hosted checks and actionable reviews. | PR green and mergeable. |",
+      `| P8 merge-and-close | pending | Merge and close captured findings. | PR merged; all ${capturedCount} IDs resolved. |`,
+      "| P9 close | pending | Record evidence, reflection, and lifecycle. | Packet set to `completed-retained` in the same closeout PR state. |",
+      "",
+      "## Execution Rules",
+      "",
+      "- Validate before repairing; classify failures as introduced, inherited,",
+      "  unrelated, or environment-only.",
+      "- Prefer one shared root-cause fix when multiple reports traverse the same code.",
+      "- Keep global files and ledgers serialized.",
+      "- Use focused tests first, then package checks, then Yeet.",
+      "- Never stage ignored raw evidence.",
+      "",
+      "## Packet Verification",
+      "",
+      "```sh",
+      `test "$(wc -m < goals/${plan.slug}/GOAL.md)" -le 4000`,
+      `jq . goals/${plan.slug}/ops/manifest.json`,
+      `jq . goals/${plan.slug}/ops/triage.json`,
+      `test "$(find goals/${plan.slug}/findings -maxdepth 1 -name 'CSF-*.md' | wc -l | tr -d ' ')" = ${capturedCount}`,
+      `git diff --check -- goals/${plan.slug}`,
+      "```",
+    ]),
+  });
+};
+
+const specDocument = (plan: CodexPacketPlan): PacketDocument => {
+  const capturedCount = A.length(plan.records);
+  return PacketDocument.make({
+    path: "SPEC.md",
+    tracked: true,
+    contents: lines([
+      `# Codex Security Findings (${plan.capturedAt}) Spec`,
+      "",
+      "## Objective",
+      "",
+      "Remediate every open Codex Cloud security finding visible at",
+      `\`${plan.sourceUrl}\` for`,
+      `\`${plan.repository}\` in the ${capturedCount}-finding batch captured on ${plan.capturedAt}. Publish`,
+      "the work through Yeet, reach mergeable hosted state, merge, then resolve the",
+      "exact captured findings until no packet-applicable finding remains open.",
+      "",
+      "## Non-Goals",
+      "",
+      "- No accepted-risk or `Won't fix` disposition.",
+      "- No raw report bodies, signed artifact URLs, auth headers, cookie values,",
+      "  email addresses, secret material, or developer-local absolute paths in tracked",
+      "  files.",
+      "- No Codex Create PR or patch-apply actions.",
+      "- No unrelated refactors, dependency churn, or broad formatting.",
+      "- No weakening of quality, security, CI, or review gates.",
+      "",
+      "## Source Hierarchy",
+      "",
+      "1. The user objective that created this packet.",
+      "2. `AGENTS.md`, `CLAUDE.md`, and required skills.",
+      "3. Governing architecture and package standards.",
+      "4. This `SPEC.md`.",
+      "5. `PLAN.md`.",
+      "6. `GOAL.md`.",
+      "7. Supporting `research/`, `ops/`, `findings/`, and `history/` files.",
+      "",
+      "## Target Surfaces",
+      "",
+      `- \`goals/${plan.slug}/**\`.`,
+      `- Gitignored raw evidence under \`goals/${plan.slug}/raw/**\`.`,
+      "- Maintained repo paths named by `findings/INDEX.md` after current-HEAD validation.",
+      "",
+      "## Constraints",
+      "",
+      "- Default disposition is `remediate`. `already-fixed` or `false-positive`",
+      "  requires strict current-HEAD proof recorded in the finding and triage ledger.",
+      "- Minimal root-cause fixes plus one focused regression check per executable-code",
+      "  finding. Reuse canonical path-safety, schema, and bounds helpers after live",
+      "  source/barrel discovery.",
+      "- Schema-first and Effect-first laws govern all production changes.",
+      "- Security controls may not be simplified away for diff size.",
+      "- Full reports stay in ignored `raw/`; tracked records contain only sanitized",
+      "  metadata, summaries, validation, decisions, changed files, and proof.",
+      `- Browser closure happens after merge, against the exact ${capturedCount}-ID allowlist.`,
+      "- Preserve unrelated work and stage only reviewed packet intent.",
+      "",
+      "## Acceptance Criteria",
+      "",
+      `- [ ] All ${capturedCount} findings have sanitized tracked CSF records with Codex ID, severity,`,
+      "      title, source commit, and public summary.",
+      "- [ ] Every finding has a current-HEAD verdict, disposition, lane, rationale,",
+      "      remediation state, changed-file set, and verification evidence.",
+      "- [ ] Every real finding is fixed at the shared root cause with a focused",
+      "      regression check where executable behavior changes.",
+      "- [ ] Packet counts, manifest, triage ledger, launcher size, sanitation, and",
+      "      whitespace checks pass.",
+      "- [ ] Yeet repair and verify are green on the complete remediation scope.",
+      "- [ ] The branch is published, hosted checks and reviews are closed, and the PR",
+      "      is mergeable and merged.",
+      `- [ ] All ${capturedCount} captured Codex findings are resolved after merge and the live view`,
+      "      shows zero packet-applicable open findings.",
+      "",
+      "## Verification Matrix",
+      "",
+      "| Check | Command or evidence | Required result |",
+      "| --- | --- | --- |",
+      `| Launcher size | \`test "$(wc -m < goals/${plan.slug}/GOAL.md)" -le 4000\` | Pass |`,
+      "| JSON shape | `jq .` over both files in `ops/` | Pass |",
+      `| Finding count | CSF file count equals ${capturedCount} | Pass |`,
+      `| Severity count | ${severityPhrase(plan.severityCounts)} | Pass |`,
+      "| Raw ignored | `git status --short -- .../raw` | Only `.gitignore` tracked |",
+      "| Sanitization | tracked packet secret/path pattern scan | No matches |",
+      "| Per-finding proof | command recorded in finding and triage ledger | Pass |",
+      "| Repo proof | `bun run beep yeet verify` | Green |",
+      "| Hosted proof | Yeet monitor and review closeout | Green and mergeable |",
+      "| Final closure | signed-in Chrome findings view | Zero packet-open |",
+      "",
+      "## Stop Conditions",
+      "",
+      "- The signed-in CSV export cannot be produced from the findings page.",
+      "- Tracked evidence contains a secret, signed URL, auth value, email address, or",
+      "  raw local path.",
+      "- A fix requires a product or architecture decision outside this packet.",
+      "- A proposed security control would rely on a platform-specific fail-open path.",
+      "- The same blocking condition repeats after reasonable investigation.",
+      "",
+      "## Exception Ledger",
+      "",
+      "| Exception | Scope | Owner | Rationale | Removal condition |",
+      "| --- | --- | --- | --- | --- |",
+      "| None | N/A | N/A | N/A | N/A |",
+    ]),
+  });
+};
+
+const sourcesDocument = (plan: CodexPacketPlan): PacketDocument => {
+  const capturedCount = A.length(plan.records);
+  return PacketDocument.make({
+    path: "research/SOURCES.md",
+    tracked: true,
+    contents: lines([
+      "# Sources",
+      "",
+      "## Repo Sources",
+      "",
+      "- `AGENTS.md` / `CLAUDE.md` - repository law and tool routing.",
+      "- `goals/README.md` - packet standard and completion gate.",
+      "- `goals/codex-security-findings-2026-08-04/**` - prior packet structure,",
+      "  sanitation, triage, and post-merge closure precedent.",
+      "- `standards/ARCHITECTURE.md` and `standards/architecture/**` - ownership and",
+      "  shared-kernel doctrine.",
+      "- Live source and package barrels named by each finding - current-HEAD truth.",
+      "",
+      "## External Source",
+      "",
+      "- Codex Cloud Security UI:",
+      `  \`${plan.sourceUrl}\`, captured on ${plan.capturedAt}`,
+      "  through the operator's signed-in Chrome session.",
+      `- The UI's signed-in \`Export findings as CSV\` control supplied the ${capturedCount}-record`,
+      "  batch. `beep codex findings ingest` normalized it; the export itself was never",
+      "  copied into the repository.",
+      "",
+      "## Notes",
+      "",
+      "- Full report bodies are local ignored evidence under `raw/`.",
+      "- Tracked CSF files intentionally omit signed artifact URLs, raw developer-local",
+      "  paths, author email addresses, auth values, and unsanitized report text.",
+    ]),
+  });
+};
+
+const rawGitignoreDocument = (): PacketDocument =>
+  PacketDocument.make({
+    path: "raw/.gitignore",
+    tracked: true,
+    contents: lines(["# Ignore all raw Codex evidence; only sanitized markdown is tracked.", "*", "!.gitignore"]),
+  });
+
+/**
+ * Render a resolved plan into every document a generated packet contains.
+ *
+ * **When to use**
+ *
+ * Use as the only bridge between planning and writing. The result is handed
+ * straight to `writePacket`, which scans it before anything reaches disk.
+ *
+ * **Details**
+ *
+ * Document order is stable and the content is a pure function of the plan, so
+ * ingesting one capture twice produces byte-identical output. `raw/payload.json`
+ * carries the normalized capture — never the CSV export, which holds author
+ * email addresses and unsanitized report text.
+ *
+ * **Gotchas**
+ *
+ * `GOAL.md` is under a hard 4000-character doctor gate, so it reports severity
+ * counts and points at `findings/INDEX.md` rather than listing findings. Adding
+ * a per-finding line here would breach the gate on a large batch.
+ *
+ * **Example** (Rendering a packet for an empty capture)
+ *
+ * ```ts
+ * import { CodexPacketPlan } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ * import { renderPacketDocuments } from "@beep/repo-cli/commands/Codex/Findings.packet"
+ *
+ * const plan = CodexPacketPlan.make({
+ *   slug: "codex-security-findings-2026-08-04",
+ *   branch: "security/codex-findings-2026-08-04",
+ *   capturedAt: "2026-08-04",
+ *   repository: "kriegcloud/beep-effect",
+ *   sourceUrl: "https://chatgpt.com/codex/cloud/security/findings/",
+ *   findingsView: "repo-scoped, status=open",
+ *   expectedCount: 0,
+ *   records: [],
+ *   severityCounts: {},
+ * })
+ *
+ * const documents = renderPacketDocuments({ plan, rawPayloadJson: "{}\n" })
+ *
+ * console.log(documents[0]?.path) // "README.md"
+ * ```
+ *
+ * @param options - The resolved plan and the normalized raw payload text.
+ * @returns Every document the packet contains, in stable order.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const renderPacketDocuments = (options: {
+  readonly plan: CodexPacketPlan;
+  readonly rawPayloadJson: string;
+}): ReadonlyArray<PacketDocument> =>
+  A.appendAll(
+    [
+      readmeDocument(options.plan),
+      goalDocument(options.plan),
+      specDocument(options.plan),
+      planDocument(options.plan),
+      sourcesDocument(options.plan),
+      manifestDocument(options.plan),
+      triageDocument(options.plan),
+      findingsIndexDocument(options.plan),
+      rawGitignoreDocument(),
+      PacketDocument.make({
+        path: "raw/payload.json",
+        tracked: false,
+        contents: options.rawPayloadJson,
+      }),
+    ],
+    A.map(options.plan.records, findingDocument)
+  );

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.scan.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.scan.ts
@@ -1,0 +1,282 @@
+/**
+ * Reject-scan for captured Codex findings content.
+ *
+ * This scan runs over the capture payload itself and over every byte written to
+ * the packet's ignored `raw/` directory — not only over tracked output. That
+ * scope is the point: `raw/` is gitignored, so the repository's commit-range
+ * secret scanner structurally never sees it, yet execution agents read it. A
+ * credential that reaches `raw/` would otherwise sit in a working tree with no
+ * control anywhere able to observe it.
+ *
+ * Detection rejects rather than redacts. Missed redaction in a public
+ * repository is irreversible; a false rejection costs one hand-edit, and the
+ * raw evidence directory is the pressure valve so no captured data is lost.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import { A, O } from "@beep/utils";
+import * as P from "effect/Predicate";
+import * as R from "effect/Record";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("commands/Codex/Findings.scan");
+
+/**
+ * Classes of content refused on the way into a generated packet.
+ *
+ * **Example** (Naming a rule)
+ *
+ * ```ts
+ * import { SensitiveTextCode } from "@beep/repo-cli/commands/Codex/Findings.scan"
+ *
+ * console.log(SensitiveTextCode.is["private-home-path"]("private-home-path")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const SensitiveTextCode = LiteralKit([
+  "private-home-path",
+  "email-address",
+  "onepassword-ref",
+  "secret-shaped-value",
+  "auth-header",
+  "bearer-credential",
+  "jwt-token",
+  "session-cookie",
+  "signed-url-param",
+  "bidi-control",
+  "spreadsheet-formula",
+  "max-scan-depth",
+]).pipe(
+  $I.annoteSchema("SensitiveTextCode", {
+    description: "Class of content refused on the way into a generated Codex findings packet.",
+  })
+);
+
+/**
+ * Rule class matched by one scan hit.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type SensitiveTextCode = typeof SensitiveTextCode.Type;
+
+/**
+ * One refusal, addressed by logical surface rather than by value.
+ *
+ * **Gotchas**
+ *
+ * A hit deliberately carries no excerpt of what matched. The whole point of the
+ * scan is that the offending text must not propagate, and an error rendered to
+ * a terminal, a log, a span, or a `--json` envelope is exactly the kind of
+ * propagation that would defeat it.
+ *
+ * **Example** (Reading a hit)
+ *
+ * ```ts
+ * import { SensitiveTextHit } from "@beep/repo-cli/commands/Codex/Findings.scan"
+ *
+ * const hit = SensitiveTextHit.make({ code: "onepassword-ref", surface: "findings[3].title" })
+ *
+ * console.log(`${hit.surface} (${hit.code})`) // "findings[3].title (onepassword-ref)"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class SensitiveTextHit extends S.Class<SensitiveTextHit>($I`SensitiveTextHit`)(
+  {
+    code: SensitiveTextCode.pipe(
+      $I.annoteKey("SensitiveTextHit.code", {
+        description: "Rule class that matched.",
+      })
+    ),
+    surface: S.String.pipe(
+      $I.annoteKey("SensitiveTextHit.surface", {
+        description: "Logical address of the offending field, never its contents.",
+      })
+    ),
+  },
+  $I.annote("SensitiveTextHit", {
+    description: "One refusal raised by the Codex findings reject-scan.",
+  })
+) {}
+
+const rules: ReadonlyArray<{ readonly code: SensitiveTextCode; readonly pattern: RegExp }> = [
+  // Private home and user paths across platforms. Each leaks the local username
+  // and usually the project tree beneath it, which the packet sanitation policy
+  // forbids in tracked records of a public repository.
+  { code: "private-home-path", pattern: /\/home\/[A-Za-z0-9_.-]+/u },
+  { code: "private-home-path", pattern: /\/Users\/[A-Za-z0-9_.-]+/u },
+  { code: "private-home-path", pattern: /[A-Za-z]:[\\/]Users[\\/][A-Za-z0-9_.-]+/u },
+  { code: "private-home-path", pattern: /(?:^|[\s"'`(=:])~[\\/]/u },
+  { code: "private-home-path", pattern: /(?:^|[\s"'`(=:])~[A-Za-z0-9_.-]+[\\/]/u },
+  { code: "private-home-path", pattern: /%(?:USERPROFILE|HOMEPATH|HOMEDRIVE)%/iu },
+  // Every CSV export carries an `author_email` — in practice a GitHub
+  // `<digits>+<user>@users.noreply.github.com` address, which still discloses
+  // the account name. The parser drops the PII columns outright, so this rule
+  // is defense in depth: it is the control that survives a future parser change
+  // that reintroduces them. A local part is required before `@`, so scoped
+  // package names (`@beep/schema`) and JSDoc tags (`@category`) do not match,
+  // and the alphabetic TLD floor keeps version specs (`cli@1.0.0`) out.
+  { code: "email-address", pattern: /[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}/u },
+  { code: "onepassword-ref", pattern: /op:\/\//u },
+  // Assignment-shaped labels or key-like values only. Bare words such as TOKEN
+  // appear in benign policy prose, and broader matching produced false
+  // positives on metric names in the lane this was ported from.
+  { code: "secret-shaped-value", pattern: /(?:\b(?:SECRET|TOKEN|API[_-]?KEY)\b\s*[=:]|sk-[A-Za-z0-9_-]{12,})/iu },
+  // Header names in prose, JSON, or code form. The trailing optional quote is
+  // what catches the serialized `{"cookie": "..."}` shape that a bare
+  // `name:` matcher misses.
+  {
+    code: "auth-header",
+    pattern: /\b(?:authorization|proxy-authorization|set-cookie|cookie)\b["']?\s*[:=]/iu,
+  },
+  { code: "bearer-credential", pattern: /\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/u },
+  { code: "jwt-token", pattern: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/u },
+  // Session-cookie names specific to this origin, which a snippet reading
+  // `document.cookie` would carry even though no rule above matches them.
+  { code: "session-cookie", pattern: /(?:__Secure-|__Host-|__cf_bm=|_puid=|oai-did=|oai-sc=)/u },
+  // Presigned and capability URLs. The length floor keeps a bare `?sig=1`
+  // style query parameter from tripping the rule.
+  {
+    code: "signed-url-param",
+    pattern:
+      /[?&](?:X-Amz-Signature|X-Amz-Credential|X-Amz-Security-Token|sig|signature|token|access_token|api[_-]?key)=[A-Za-z0-9%_.~+/-]{8,}/iu,
+  },
+  // Bidirectional and invisible format characters, which can reverse how a
+  // generated table row renders in a reviewer's diff.
+  { code: "bidi-control", pattern: /[‎‏‪-‮⁦-⁩]/u },
+  // A leading formula sigil turns a captured value into executable content the
+  // moment anything re-exports it to a spreadsheet. The anchor is deliberate:
+  // this fires on an individual payload field, not on a Markdown document whose
+  // body merely contains a `-` bullet.
+  { code: "spreadsheet-formula", pattern: /^[=+\-@\t\r]/u },
+];
+
+/**
+ * Maximum nesting the scan walks before refusing a payload outright.
+ *
+ * **Example** (Reading the depth bound)
+ *
+ * ```ts
+ * import { MAX_SCAN_DEPTH } from "@beep/repo-cli/commands/Codex/Findings.scan"
+ *
+ * console.log(MAX_SCAN_DEPTH > 0) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const MAX_SCAN_DEPTH = 16;
+
+/**
+ * Scan one string and report every rule it violates.
+ *
+ * **Example** (Refusing a private path)
+ *
+ * ```ts
+ * import { scanSensitiveText } from "@beep/repo-cli/commands/Codex/Findings.scan"
+ *
+ * const hits = scanSensitiveText("capture.note", "see /home/dev/notes.txt")
+ *
+ * console.log(hits[0]?.code) // "private-home-path"
+ * ```
+ *
+ * @param surface - Logical address reported with any hit.
+ * @param value - Text to scan.
+ * @returns Every rule the text violates, addressed by surface.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const scanSensitiveText = (surface: string, value: string): ReadonlyArray<SensitiveTextHit> =>
+  A.map(
+    A.filter(rules, (rule) => rule.pattern.test(value)),
+    (rule) => SensitiveTextHit.make({ code: rule.code, surface })
+  );
+
+const decodeRecord = S.decodeUnknownOption(S.Record(S.String, S.Unknown));
+
+/**
+ * Walk an arbitrary decoded JSON value and report every refusal it carries.
+ *
+ * **When to use**
+ *
+ * Use to walk the raw parsed capture payload before decoding it into schemas,
+ * so a credential sitting in a field the schema would have dropped is still
+ * caught. Use it again on the exact bytes destined for the packet's `raw/`
+ * directory.
+ *
+ * **Gotchas**
+ *
+ * Object keys are scanned alongside values. A payload that hides a token in a
+ * key rather than a value is still a payload carrying a token.
+ *
+ * **Example** (Scanning a nested payload)
+ *
+ * ```ts
+ * import { scanSensitiveUnknown } from "@beep/repo-cli/commands/Codex/Findings.scan"
+ *
+ * const hits = scanSensitiveUnknown("payload", { findings: [{ title: "op://vault/item" }] })
+ *
+ * console.log(hits[0]?.surface) // "payload.findings[0].title"
+ * ```
+ *
+ * @param surface - Logical address prefix for nested hits.
+ * @param value - Decoded JSON value to walk.
+ * @param depth - Current recursion depth; callers pass none.
+ * @returns Every refusal the value carries, addressed by surface.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const scanSensitiveUnknown = (surface: string, value: unknown, depth = 0): ReadonlyArray<SensitiveTextHit> => {
+  if (depth > MAX_SCAN_DEPTH) {
+    return A.of(SensitiveTextHit.make({ code: "max-scan-depth", surface }));
+  }
+
+  if (P.isString(value)) {
+    return scanSensitiveText(surface, value);
+  }
+
+  if (A.isArray(value)) {
+    return A.flatMap(value, (entry, index) => scanSensitiveUnknown(`${surface}[${index}]`, entry, depth + 1));
+  }
+
+  const record = decodeRecord(value);
+  if (O.isSome(record)) {
+    return A.flatMap(R.keys(record.value), (key) => {
+      const nested = `${surface}.${key}`;
+      return A.appendAll(scanSensitiveText(nested, key), scanSensitiveUnknown(nested, record.value[key], depth + 1));
+    });
+  }
+
+  return A.empty<SensitiveTextHit>();
+};
+
+/**
+ * Render hits as stable, value-free surface labels.
+ *
+ * **Example** (Formatting a refusal list)
+ *
+ * ```ts
+ * import { SensitiveTextHit, describeSensitiveHits } from "@beep/repo-cli/commands/Codex/Findings.scan"
+ *
+ * const described = describeSensitiveHits([
+ *   SensitiveTextHit.make({ code: "jwt-token", surface: "payload.findings[0].title" }),
+ * ])
+ *
+ * console.log(described[0]) // "payload.findings[0].title (jwt-token)"
+ * ```
+ *
+ * @param hits - Refusals to render.
+ * @returns Deduplicated, value-free surface labels.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const describeSensitiveHits = (hits: ReadonlyArray<SensitiveTextHit>): ReadonlyArray<string> =>
+  A.dedupe(A.map(hits, (hit) => `${hit.surface} (${hit.code})`));

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.schemas.ts
@@ -1,0 +1,408 @@
+/**
+ * Normalized findings records, the packet plan they produce, and the validated
+ * option models for every `beep codex findings` subcommand.
+ *
+ * A {@link CodexFindingRecord} is a captured row that has been assigned a stable
+ * `CSF-NNN` identity. It carries only the six fields a capture can actually
+ * prove: identity, title, severity, dashboard status, and source commit. Every
+ * judgment field a packet eventually needs — owner area, verdict, disposition,
+ * remediation lane — is written later by a triage agent, never invented here.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { SchemaUtils } from "@beep/schema";
+import * as S from "effect/Schema";
+import {
+  CaptureDate,
+  CodexFindingId,
+  CodexFindingSeverity,
+  CodexFindingStatus,
+  CodexFindingTitle,
+  GitCommitSha,
+  GitHubRepoSlug,
+} from "./Findings.capture.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Codex/Findings.schemas");
+
+/**
+ * Stable `CSF-NNN` identity the CLI assigns to one captured finding.
+ *
+ * **Details**
+ *
+ * Identities are assigned from a deterministic sort, never from the dashboard's
+ * row order, so re-capturing the same batch reproduces the same numbering. They
+ * are the only value a packet filename is ever built from.
+ *
+ * **Example** (Validating a record identity)
+ *
+ * ```ts
+ * import { CodexRecordId } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(CodexRecordId)("CSF-001")) // true
+ * console.log(S.is(CodexRecordId)("CSF-1")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexRecordId = S.String.check(
+  S.isPattern(/^CSF-\d{3,}$/, {
+    identifier: $I`CodexRecordIdPatternCheck`,
+    title: "Codex Record Id Pattern",
+    description: "Record identities are CSF- followed by at least three digits.",
+    message: "Expected a CSF-NNN record identifier",
+  })
+).pipe(
+  $I.annoteSchema("CodexRecordId", {
+    description: "Stable CSF-NNN identity assigned to a captured finding.",
+  })
+);
+
+/**
+ * Record identity of one normalized finding.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexRecordId = typeof CodexRecordId.Type;
+
+/**
+ * Packet directory name under `goals/`.
+ *
+ * **Gotchas**
+ *
+ * The pattern admits no dot, slash, or leading hyphen, so a slug can never
+ * express a parent-directory traversal or a hidden directory. Path containment
+ * is still enforced again at the filesystem boundary; this check exists so a
+ * bad slug fails with a readable message before any path is built.
+ *
+ * **Example** (Rejecting a traversal slug)
+ *
+ * ```ts
+ * import { CodexPacketSlug } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(CodexPacketSlug)("codex-security-findings-2026-08-04")) // true
+ * console.log(S.is(CodexPacketSlug)("../../etc")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexPacketSlug = S.String.check(
+  S.isPattern(/^[a-z0-9][a-z0-9-]{0,80}$/, {
+    identifier: $I`CodexPacketSlugPatternCheck`,
+    title: "Codex Packet Slug Pattern",
+    description: "Packet slugs are bounded lowercase path segments.",
+    message: "Expected a lowercase hyphenated packet slug",
+  })
+).pipe(
+  $I.annoteSchema("CodexPacketSlug", {
+    description: "Bounded lowercase directory name of a generated goal packet.",
+  })
+);
+
+/**
+ * Directory name of a generated packet.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexPacketSlug = typeof CodexPacketSlug.Type;
+
+/**
+ * Git branch name a generated packet declares as its remediation branch.
+ *
+ * **Example** (Validating a branch name)
+ *
+ * ```ts
+ * import { CodexPacketBranch } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(CodexPacketBranch)("security/codex-findings-2026-08-04")) // true
+ * console.log(S.is(CodexPacketBranch)("branch with spaces")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexPacketBranch = S.String.check(
+  S.isPattern(/^[A-Za-z0-9][A-Za-z0-9._\-/]{0,100}$/, {
+    identifier: $I`CodexPacketBranchPatternCheck`,
+    title: "Codex Packet Branch Pattern",
+    description: "Branch names are bounded and free of shell-significant characters.",
+    message: "Expected a plain git branch name",
+  })
+).pipe(
+  $I.annoteSchema("CodexPacketBranch", {
+    description: "Remediation branch name recorded in a generated packet.",
+  })
+);
+
+/**
+ * Remediation branch declared by a packet.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexPacketBranch = typeof CodexPacketBranch.Type;
+
+/**
+ * One captured finding after stable identity assignment.
+ *
+ * **Details**
+ *
+ * These six fields are exactly what a capture can prove. Renderers accept this
+ * shape and nothing wider, so no generated packet file can carry prose that was
+ * not written by a human or a triage agent.
+ *
+ * **Example** (Constructing a normalized record)
+ *
+ * ```ts
+ * import { CodexFindingRecord } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ *
+ * const record = CodexFindingRecord.make({
+ *   id: "CSF-001",
+ *   codexId: "d2b9e11e8550819193516057a336ff90",
+ *   title: "Unbounded source resolution enables sidecar memory DoS",
+ *   severity: "Medium",
+ *   codexStatus: "Open",
+ *   commit: "244529aa4f560421cd096c2a4a4cb3cd21923070",
+ * })
+ *
+ * console.log(record.id) // "CSF-001"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexFindingRecord extends S.Class<CodexFindingRecord>($I`CodexFindingRecord`)(
+  {
+    id: CodexRecordId.pipe(
+      $I.annoteKey("CodexFindingRecord.id", {
+        description: "Stable CSF-NNN identity used for filenames and cross-references.",
+      })
+    ),
+    codexId: CodexFindingId.pipe(
+      $I.annoteKey("CodexFindingRecord.codexId", {
+        description: "Codex Cloud identifier used to reconcile reruns and post-merge closure.",
+      })
+    ),
+    title: CodexFindingTitle.pipe(
+      $I.annoteKey("CodexFindingRecord.title", {
+        description: "Single-line finding title, escaped again at render time.",
+      })
+    ),
+    severity: CodexFindingSeverity.pipe(
+      $I.annoteKey("CodexFindingRecord.severity", {
+        description: "Severity reported by the dashboard.",
+      })
+    ),
+    codexStatus: CodexFindingStatus.pipe(
+      $I.annoteKey("CodexFindingRecord.codexStatus", {
+        description: "Dashboard lifecycle status at capture time.",
+      })
+    ),
+    commit: GitCommitSha.pipe(
+      $I.annoteKey("CodexFindingRecord.commit", {
+        description: "Source commit the finding was reported against.",
+      })
+    ),
+  },
+  $I.annote("CodexFindingRecord", {
+    description: "A captured Codex finding after stable CSF-NNN identity assignment.",
+  })
+) {}
+
+/**
+ * Finding totals per severity, in severity-domain order.
+ *
+ * **Gotchas**
+ *
+ * Severities with a zero count are omitted rather than written as `0`, matching
+ * the `catalog.severityCounts` block every hand-written Codex packet already
+ * ships.
+ *
+ * **Example** (Reading a count map)
+ *
+ * ```ts
+ * import { CodexSeverityCounts } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(CodexSeverityCounts)({ Medium: 13, Low: 7 })) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexSeverityCounts extends S.Class<CodexSeverityCounts>($I`CodexSeverityCounts`)(
+  {
+    High: S.optionalKey(S.Int),
+    Medium: S.optionalKey(S.Int),
+    Low: S.optionalKey(S.Int),
+    Informational: S.optionalKey(S.Int),
+  },
+  $I.annote("CodexSeverityCounts", {
+    description: "Captured finding totals per severity, omitting zero-count severities.",
+  })
+) {}
+
+/**
+ * Everything the packet renderers need, resolved and ordered.
+ *
+ * **When to use**
+ *
+ * Use as the single argument to every packet renderer. Building the plan is the
+ * last stage that can fail on data; rendering from a plan is total.
+ *
+ * **Example** (Constructing a packet plan)
+ *
+ * ```ts
+ * import { CodexPacketPlan } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ *
+ * const plan = CodexPacketPlan.make({
+ *   slug: "codex-security-findings-2026-08-04",
+ *   branch: "security/codex-findings-2026-08-04",
+ *   capturedAt: "2026-08-04",
+ *   repository: "kriegcloud/beep-effect",
+ *   sourceUrl: "https://chatgpt.com/codex/cloud/security/findings/",
+ *   findingsView: "repo-scoped, status=open",
+ *   expectedCount: 0,
+ *   records: [],
+ *   severityCounts: {},
+ * })
+ *
+ * console.log(plan.slug) // "codex-security-findings-2026-08-04"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexPacketPlan extends S.Class<CodexPacketPlan>($I`CodexPacketPlan`)(
+  {
+    slug: CodexPacketSlug.pipe(
+      $I.annoteKey("CodexPacketPlan.slug", {
+        description: "Directory name of the packet under goals/.",
+      })
+    ),
+    branch: CodexPacketBranch.pipe(
+      $I.annoteKey("CodexPacketPlan.branch", {
+        description: "Remediation branch the packet declares.",
+      })
+    ),
+    capturedAt: CaptureDate.pipe(
+      $I.annoteKey("CodexPacketPlan.capturedAt", {
+        description: "Calendar date of the capture run.",
+      })
+    ),
+    repository: GitHubRepoSlug.pipe(
+      $I.annoteKey("CodexPacketPlan.repository", {
+        description: "Repository the findings view was scoped to.",
+      })
+    ),
+    sourceUrl: S.String.pipe(
+      $I.annoteKey("CodexPacketPlan.sourceUrl", {
+        description: "Dashboard URL recorded as packet provenance.",
+      })
+    ),
+    findingsView: S.String.pipe(
+      $I.annoteKey("CodexPacketPlan.findingsView", {
+        description: "Filter description of the captured dashboard view.",
+      })
+    ),
+    expectedCount: S.Int.pipe(
+      $I.annoteKey("CodexPacketPlan.expectedCount", {
+        description: "Finding total the dashboard reported, reconciled against the records.",
+      })
+    ),
+    records: S.Array(CodexFindingRecord).pipe(
+      $I.annoteKey("CodexPacketPlan.records", {
+        description: "Normalized findings in assigned CSF-NNN order.",
+      })
+    ),
+    severityCounts: CodexSeverityCounts.pipe(
+      $I.annoteKey("CodexPacketPlan.severityCounts", {
+        description: "Per-severity totals rendered into the manifest catalog.",
+      })
+    ),
+  },
+  $I.annote("CodexPacketPlan", {
+    description: "Resolved, ordered input to every generated packet document.",
+  })
+) {}
+
+/**
+ * Validated options accepted by `beep codex findings ingest`.
+ *
+ * **Details**
+ *
+ * `date`, `slug`, and `branch` are overrides; when absent they are derived from
+ * the payload's own capture provenance rather than from the wall clock, which
+ * is what makes a re-ingest of the same payload byte-identical.
+ *
+ * **Example** (Constructing ingest options)
+ *
+ * ```ts
+ * import { CodexFindingsIngestOptions } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ * import * as O from "effect/Option"
+ *
+ * const options = CodexFindingsIngestOptions.make({
+ *   from: O.some("payload.json"),
+ *   slug: O.none(),
+ *   date: O.none(),
+ *   branch: O.none(),
+ *   expectedCount: O.none(),
+ *   refresh: false,
+ *   force: false,
+ *   dryRun: true,
+ *   json: false,
+ * })
+ *
+ * console.log(options.dryRun) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexFindingsIngestOptions extends S.Class<CodexFindingsIngestOptions>($I`CodexFindingsIngestOptions`)(
+  {
+    from: S.OptionFromOptionalKey(S.String).pipe(SchemaUtils.withNoneDefault),
+    slug: S.OptionFromOptionalKey(CodexPacketSlug).pipe(SchemaUtils.withNoneDefault),
+    date: S.OptionFromOptionalKey(CaptureDate).pipe(SchemaUtils.withNoneDefault),
+    branch: S.OptionFromOptionalKey(CodexPacketBranch).pipe(SchemaUtils.withNoneDefault),
+    expectedCount: S.OptionFromOptionalKey(S.Int).pipe(SchemaUtils.withNoneDefault),
+    refresh: S.Boolean.pipe(SchemaUtils.withKeyDefaults(false)),
+    force: S.Boolean.pipe(SchemaUtils.withKeyDefaults(false)),
+    dryRun: S.Boolean.pipe(SchemaUtils.withKeyDefaults(false)),
+    json: S.Boolean.pipe(SchemaUtils.withKeyDefaults(false)),
+  },
+  $I.annote("CodexFindingsIngestOptions", {
+    description: "Validated options accepted by `beep codex findings ingest`.",
+  })
+) {}
+
+/**
+ * Decode raw CLI flags into validated `beep codex findings ingest` options.
+ *
+ * **Example** (Rejecting a traversal slug from the command line)
+ *
+ * ```ts
+ * import { decodeCodexFindingsIngestOptions } from "@beep/repo-cli/commands/Codex/Findings.schemas"
+ * import { Effect } from "effect"
+ *
+ * const program = decodeCodexFindingsIngestOptions({ slug: "../../etc" }).pipe(
+ *   Effect.map(() => "accepted"),
+ *   Effect.orElseSucceed(() => "rejected")
+ * )
+ *
+ * console.log(Effect.runSync(program)) // "rejected"
+ * ```
+ *
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeCodexFindingsIngestOptions = S.decodeUnknownEffect(CodexFindingsIngestOptions);

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.triage.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.triage.schemas.ts
@@ -1,0 +1,507 @@
+/**
+ * Typed model of the `codex-triage/v1` ledger this CLI generates and re-reads.
+ *
+ * The version string matches the hand-written packets by convention, but this
+ * schema is deliberately scoped to ledgers the CLI itself produces. Five
+ * historical batches ship five mutually incompatible shapes under that same
+ * string, so retrofitting a strict decoder onto them would reject four of five.
+ * Judgment fields are `optionalKey` precisely so one ledger validates at every
+ * packet phase: absent at capture, present once a triage agent has filled them
+ * in, which is what lets a refresh round-trip a half-triaged file without
+ * destroying work.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import * as S from "effect/Schema";
+import {
+  CaptureDate,
+  CodexFindingId,
+  CodexFindingSeverity,
+  CodexFindingStatus,
+  GitCommitSha,
+  GitHubRepoSlug,
+} from "./Findings.capture.schemas.ts";
+import { CodexPacketBranch, CodexRecordId } from "./Findings.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Codex/Findings.triage.schemas");
+
+/**
+ * What a triage agent decided to do about a finding.
+ *
+ * **Details**
+ *
+ * A freshly generated ledger sets every finding to `untriaged`. The Codex
+ * packet policy forbids `accepted-risk`, but the literal remains in the domain
+ * so an older ledger carrying it still decodes and can be reported on.
+ *
+ * **Example** (Reading the default disposition)
+ *
+ * ```ts
+ * import { CodexDisposition } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * console.log(CodexDisposition.is.untriaged("untriaged")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexDisposition = LiteralKit([
+  "untriaged",
+  "remediate",
+  "already-fixed",
+  "false-positive",
+  "out-of-scope",
+  "accepted-risk",
+]).pipe(
+  $I.annoteSchema("CodexDisposition", {
+    description: "Decision a triage agent recorded for one captured finding.",
+  })
+);
+
+/**
+ * Disposition recorded for one finding.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexDisposition = typeof CodexDisposition.Type;
+
+/**
+ * Whether a reported finding actually reproduces at the current branch head.
+ *
+ * **Example** (Naming a verdict)
+ *
+ * ```ts
+ * import { CodexVerdict } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * console.log(CodexVerdict.is["confirmed-vulnerable"]("confirmed-vulnerable")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexVerdict = LiteralKit([
+  "confirmed-vulnerable",
+  "real",
+  "already-fixed",
+  "false-positive",
+  "out-of-scope",
+  "not-real",
+  "partial",
+]).pipe(
+  $I.annoteSchema("CodexVerdict", {
+    description: "Current-HEAD validation verdict recorded for one captured finding.",
+  })
+);
+
+/**
+ * Validation verdict recorded for one finding.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexVerdict = typeof CodexVerdict.Type;
+
+/**
+ * Progress of one workstream inside the ledger.
+ *
+ * **Example** (Reading the capture-time status)
+ *
+ * ```ts
+ * import { CodexWorkStatus } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * console.log(CodexWorkStatus.Options[0]) // "pending"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexWorkStatus = LiteralKit(["pending", "in-progress", "implemented", "complete", "not-required"]).pipe(
+  $I.annoteSchema("CodexWorkStatus", {
+    description: "Progress of validation, remediation, or a remediation lane.",
+  })
+);
+
+/**
+ * Progress of one triage workstream.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexWorkStatus = typeof CodexWorkStatus.Type;
+
+/**
+ * Confidence a triage agent attached to its verdict.
+ *
+ * **Example** (Naming a confidence level)
+ *
+ * ```ts
+ * import { CodexConfidence } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * console.log(CodexConfidence.is.high("high")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexConfidence = LiteralKit(["high", "medium", "low"]).pipe(
+  $I.annoteSchema("CodexConfidence", {
+    description: "Confidence a triage agent attached to a validation verdict.",
+  })
+);
+
+/**
+ * Confidence attached to a verdict.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexConfidence = typeof CodexConfidence.Type;
+
+/**
+ * How the batch reached the repository.
+ *
+ * **Details**
+ *
+ * `signed-in-csv-export` is what this CLI writes: the operator downloads the
+ * findings view's own CSV export and ingests the file, so no credential and no
+ * pasted script is ever involved. The two Chrome-control values exist only so
+ * ledgers from the hand-built batches still decode.
+ *
+ * **Example** (Naming the capture method)
+ *
+ * ```ts
+ * import { CodexCaptureMethod } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * console.log(CodexCaptureMethod.is["signed-in-csv-export"]("signed-in-csv-export")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexCaptureMethod = LiteralKit([
+  "signed-in-csv-export",
+  "signed-in-chrome-control",
+  "signed-in-chrome-control-and-csv-export",
+]).pipe(
+  $I.annoteSchema("CodexCaptureMethod", {
+    description: "Mechanism that produced the captured findings batch.",
+  })
+);
+
+/**
+ * Mechanism that produced a batch.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexCaptureMethod = typeof CodexCaptureMethod.Type;
+
+/**
+ * Identifier of one remediation lane.
+ *
+ * **Example** (Validating a lane identifier)
+ *
+ * ```ts
+ * import { CodexLaneId } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(CodexLaneId)("L1-bounded-file-ingestion")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CodexLaneId = S.String.check(
+  S.isPattern(/^L\d+-[a-z0-9-]{1,60}$/, {
+    identifier: $I`CodexLaneIdPatternCheck`,
+    title: "Codex Lane Id Pattern",
+    description: "Lane identifiers are L<n>- followed by a lowercase slug.",
+    message: "Expected an L<n>-<slug> remediation lane identifier",
+  })
+).pipe(
+  $I.annoteSchema("CodexLaneId", {
+    description: "Identifier of one disjoint remediation lane.",
+  })
+);
+
+/**
+ * Identifier of a remediation lane.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CodexLaneId = typeof CodexLaneId.Type;
+
+/**
+ * Current-HEAD validation state of one finding.
+ *
+ * **Example** (Constructing capture-time validation state)
+ *
+ * ```ts
+ * import { CodexTriageValidation } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * console.log(CodexTriageValidation.make({ status: "pending" }).status) // "pending"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexTriageValidation extends S.Class<CodexTriageValidation>($I`CodexTriageValidation`)(
+  {
+    status: CodexWorkStatus,
+    confidence: S.optionalKey(CodexConfidence),
+    rationale: S.optionalKey(S.String),
+  },
+  $I.annote("CodexTriageValidation", {
+    description: "Current-HEAD validation state recorded for one finding.",
+  })
+) {}
+
+/**
+ * Remediation state of one finding.
+ *
+ * **Example** (Constructing capture-time remediation state)
+ *
+ * ```ts
+ * import { CodexTriageRemediation } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * const remediation = CodexTriageRemediation.make({
+ *   status: "pending",
+ *   changedFiles: [],
+ *   verificationCommands: [],
+ * })
+ *
+ * console.log(remediation.changedFiles.length) // 0
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexTriageRemediation extends S.Class<CodexTriageRemediation>($I`CodexTriageRemediation`)(
+  {
+    status: CodexWorkStatus,
+    changedFiles: S.Array(S.String),
+    verificationCommands: S.Array(S.String),
+    summary: S.optionalKey(S.String),
+  },
+  $I.annote("CodexTriageRemediation", {
+    description: "Remediation state recorded for one finding.",
+  })
+) {}
+
+/**
+ * One finding's full ledger entry.
+ *
+ * **Gotchas**
+ *
+ * `ownerArea`, `verdict`, and `lane` are optional because a generated ledger
+ * carries none of them. They are agent judgment, and inventing them at capture
+ * time would fabricate triage that never happened.
+ *
+ * **Example** (Constructing a capture-time entry)
+ *
+ * ```ts
+ * import {
+ *   CodexTriageFinding,
+ *   CodexTriageRemediation,
+ *   CodexTriageValidation,
+ * } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * const entry = CodexTriageFinding.make({
+ *   id: "CSF-001",
+ *   codexId: "d2b9e11e8550819193516057a336ff90",
+ *   title: "Unbounded source resolution",
+ *   severity: "Medium",
+ *   codexStatus: "Open",
+ *   commit: "244529aa4f560421cd096c2a4a4cb3cd21923070",
+ *   disposition: "untriaged",
+ *   validation: CodexTriageValidation.make({ status: "pending" }),
+ *   remediation: CodexTriageRemediation.make({
+ *     status: "pending",
+ *     changedFiles: [],
+ *     verificationCommands: [],
+ *   }),
+ * })
+ *
+ * console.log(entry.disposition) // "untriaged"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexTriageFinding extends S.Class<CodexTriageFinding>($I`CodexTriageFinding`)(
+  {
+    id: CodexRecordId,
+    codexId: CodexFindingId,
+    title: S.String,
+    severity: CodexFindingSeverity,
+    codexStatus: CodexFindingStatus,
+    commit: GitCommitSha,
+    ownerArea: S.optionalKey(S.String),
+    verdict: S.optionalKey(CodexVerdict),
+    disposition: CodexDisposition,
+    lane: S.optionalKey(CodexLaneId),
+    validation: CodexTriageValidation,
+    remediation: CodexTriageRemediation,
+  },
+  $I.annote("CodexTriageFinding", {
+    description: "One finding's entry in the codex-triage/v1 ledger.",
+  })
+) {}
+
+/**
+ * One remediation lane grouping findings that share a root cause.
+ *
+ * **Example** (Constructing a lane)
+ *
+ * ```ts
+ * import { CodexTriageLane } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * const lane = CodexTriageLane.make({ status: "pending", findings: ["CSF-001"] })
+ *
+ * console.log(lane.findings[0]) // "CSF-001"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexTriageLane extends S.Class<CodexTriageLane>($I`CodexTriageLane`)(
+  {
+    status: CodexWorkStatus,
+    findings: S.Array(CodexRecordId),
+    title: S.optionalKey(S.String),
+  },
+  $I.annote("CodexTriageLane", {
+    description: "One disjoint remediation lane grouping findings by shared root cause.",
+  })
+) {}
+
+/**
+ * Provenance header of the ledger.
+ *
+ * **Example** (Constructing ledger provenance)
+ *
+ * ```ts
+ * import { CodexTriageMeta } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * const meta = CodexTriageMeta.make({
+ *   schemaVersion: "codex-triage/v1",
+ *   repository: "kriegcloud/beep-effect",
+ *   findingsView: "repo-scoped, status=open",
+ *   branch: "security/codex-findings-2026-08-04",
+ *   expectedCount: 26,
+ *   capturedCount: 26,
+ *   capturedAt: "2026-08-04",
+ *   captureMethod: "signed-in-csv-export",
+ * })
+ *
+ * console.log(meta.capturedCount) // 26
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexTriageMeta extends S.Class<CodexTriageMeta>($I`CodexTriageMeta`)(
+  {
+    schemaVersion: S.Literal("codex-triage/v1"),
+    repository: GitHubRepoSlug,
+    findingsView: S.String,
+    branch: CodexPacketBranch,
+    expectedCount: S.Int,
+    capturedCount: S.Int,
+    capturedAt: CaptureDate,
+    captureMethod: CodexCaptureMethod,
+    note: S.optionalKey(S.String),
+  },
+  $I.annote("CodexTriageMeta", {
+    description: "Provenance header of a codex-triage/v1 ledger.",
+  })
+) {}
+
+/**
+ * The complete `codex-triage/v1` ledger.
+ *
+ * **When to use**
+ *
+ * Use to encode a freshly captured ledger, and to decode an existing one before
+ * a refresh so agent-authored triage is preserved rather than overwritten.
+ *
+ * **Example** (Encoding an empty ledger)
+ *
+ * ```ts
+ * import { CodexTriageLedger, CodexTriageMeta } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * const ledger = CodexTriageLedger.make({
+ *   meta: CodexTriageMeta.make({
+ *     schemaVersion: "codex-triage/v1",
+ *     repository: "kriegcloud/beep-effect",
+ *     findingsView: "repo-scoped, status=open",
+ *     branch: "security/codex-findings-2026-08-04",
+ *     expectedCount: 0,
+ *     capturedCount: 0,
+ *     capturedAt: "2026-08-04",
+ *     captureMethod: "signed-in-csv-export",
+ *   }),
+ *   lanes: {},
+ *   findings: [],
+ * })
+ *
+ * console.log(ledger.findings.length) // 0
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class CodexTriageLedger extends S.Class<CodexTriageLedger>($I`CodexTriageLedger`)(
+  {
+    meta: CodexTriageMeta,
+    lanes: S.Record(CodexLaneId, CodexTriageLane),
+    findings: S.Array(CodexTriageFinding),
+  },
+  $I.annote("CodexTriageLedger", {
+    description: "Complete codex-triage/v1 ledger generated and re-read by the CLI.",
+  })
+) {}
+
+/**
+ * Decode an existing ledger, preserving whatever triage it already carries.
+ *
+ * **Example** (Rejecting a ledger with an unknown version)
+ *
+ * ```ts
+ * import { decodeCodexTriageLedger } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ * import { Effect } from "effect"
+ *
+ * const program = decodeCodexTriageLedger({ meta: { schemaVersion: "codex-triage/v2" } }).pipe(
+ *   Effect.map(() => "accepted"),
+ *   Effect.orElseSucceed(() => "rejected")
+ * )
+ *
+ * console.log(Effect.runSync(program)) // "rejected"
+ * ```
+ *
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeCodexTriageLedger = S.decodeUnknownEffect(CodexTriageLedger);
+
+/**
+ * Encode a ledger to its JSON wire shape.
+ *
+ * **Example** (Encoding for disk)
+ *
+ * ```ts
+ * import { encodeCodexTriageLedger } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ *
+ * console.log(typeof encodeCodexTriageLedger) // "function"
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const encodeCodexTriageLedger = S.encodeUnknownSync(CodexTriageLedger);

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.triage.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.triage.schemas.ts
@@ -493,12 +493,35 @@ export const decodeCodexTriageLedger = S.decodeUnknownEffect(CodexTriageLedger);
 /**
  * Encode a ledger to its JSON wire shape.
  *
- * **Example** (Encoding for disk)
+ * **Details**
+ *
+ * Encoding drops absent judgment fields rather than writing them as `null`, so
+ * a freshly captured ledger round-trips to exactly the shape a triage agent
+ * expects to fill in.
+ *
+ * **Example** (Encoding a capture-time ledger for disk)
  *
  * ```ts
- * import { encodeCodexTriageLedger } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
+ * import { CodexTriageLedger, CodexTriageMeta, encodeCodexTriageLedger } from "@beep/repo-cli/commands/Codex/Findings.triage.schemas"
  *
- * console.log(typeof encodeCodexTriageLedger) // "function"
+ * const encoded = encodeCodexTriageLedger(
+ *   CodexTriageLedger.make({
+ *     meta: CodexTriageMeta.make({
+ *       schemaVersion: "codex-triage/v1",
+ *       repository: "kriegcloud/beep-effect",
+ *       findingsView: "repo-scoped, status=open",
+ *       branch: "security/codex-findings-2026-08-04",
+ *       expectedCount: 0,
+ *       capturedCount: 0,
+ *       capturedAt: "2026-08-04",
+ *       captureMethod: "signed-in-csv-export",
+ *     }),
+ *     lanes: {},
+ *     findings: [],
+ *   })
+ * )
+ *
+ * console.log(JSON.stringify(encoded).includes("codex-triage/v1")) // true
  * ```
  *
  * @category encoding

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.write.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.write.ts
@@ -13,6 +13,7 @@
 
 import { writeFileWithinCanonicalRootAtomically } from "@beep/file-processing/PathSafety";
 import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit, SchemaUtils } from "@beep/schema";
 import { A } from "@beep/utils";
 import { Effect, FileSystem, Path } from "effect";
 import * as S from "effect/Schema";
@@ -22,6 +23,44 @@ import { describeSensitiveHits, scanSensitiveText } from "./Findings.scan.ts";
 const $I = $RepoCliId.create("commands/Codex/Findings.write");
 
 const encoder = new TextEncoder();
+
+/**
+ * How a document's scan hits are treated.
+ *
+ * **Details**
+ *
+ * `reject` is the default and governs everything the CLI composes itself.
+ * `report` exists for one narrow case: report bodies copied verbatim into
+ * ignored `raw/` evidence. Those are external prose that legitimately quotes
+ * developer-local paths and secret-shaped literals — measured against a real
+ * 27-finding export, 4 bodies carry content `reject` refuses — and they are the
+ * evidence P2 validates against, so refusing them would make capture unusable.
+ * Their hits are surfaced to the operator instead of failing the ingest.
+ *
+ * **Example** (Naming the strict policy)
+ *
+ * ```ts
+ * import { PacketScanPolicy } from "@beep/repo-cli/commands/Codex/Findings.write"
+ *
+ * console.log(PacketScanPolicy.is.reject("reject")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const PacketScanPolicy = LiteralKit(["reject", "report"]).pipe(
+  $I.annoteSchema("PacketScanPolicy", {
+    description: "Whether reject-scan hits on a document refuse the write or are reported.",
+  })
+);
+
+/**
+ * Scan policy applied to one packet document.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PacketScanPolicy = typeof PacketScanPolicy.Type;
 
 /**
  * One document destined for a generated packet.
@@ -74,7 +113,13 @@ export class PacketDocument extends S.Class<PacketDocument>($I`PacketDocument`)(
     ),
     tracked: S.Boolean.pipe(
       $I.annoteKey("PacketDocument.tracked", {
-        description: "Whether git tracks this document; ignored raw evidence is scanned identically.",
+        description: "Whether git tracks this document.",
+      })
+    ),
+    scan: PacketScanPolicy.pipe(
+      SchemaUtils.withKeyDefaults("reject"),
+      $I.annoteKey("PacketDocument.scan", {
+        description: "Whether scan hits refuse the write or are reported to the operator.",
       })
     ),
   },
@@ -113,7 +158,8 @@ export class PacketDocument extends S.Class<PacketDocument>($I`PacketDocument`)(
  * @since 0.0.0
  */
 export const assertPacketDocumentsClean = Effect.fnUntraced(function* (documents: ReadonlyArray<PacketDocument>) {
-  const hits = A.flatMap(documents, (document) => scanSensitiveText(document.path, document.contents));
+  const strict = A.filter(documents, (document) => document.scan === "reject");
+  const hits = A.flatMap(strict, (document) => scanSensitiveText(document.path, document.contents));
 
   if (A.isReadonlyArrayNonEmpty(hits)) {
     const surfaces = describeSensitiveHits(hits);
@@ -122,6 +168,11 @@ export const assertPacketDocumentsClean = Effect.fnUntraced(function* (documents
       surfaces,
     });
   }
+
+  // Verbatim evidence is not refused, but the operator is told what it holds so
+  // ignored `raw/` never becomes a place where nobody is looking.
+  const verbatim: ReadonlyArray<PacketDocument> = A.filter(documents, (document) => document.scan === "report");
+  return describeSensitiveHits(A.flatMap(verbatim, (document) => scanSensitiveText(document.path, document.contents)));
 });
 
 /**
@@ -196,13 +247,14 @@ export const writePacket = Effect.fnUntraced(function* (options: {
     });
   }
 
-  yield* assertPacketDocumentsClean(options.documents);
+  const reportedEvidence = yield* assertPacketDocumentsClean(options.documents);
 
   if (options.dryRun) {
     return {
       packetPath: packetRelative,
       written: A.map(options.documents, (document) => `${packetRelative}/${document.path}`),
       committed: false,
+      reportedEvidence,
     };
   }
 
@@ -230,15 +282,19 @@ export const writePacket = Effect.fnUntraced(function* (options: {
         );
       }
 
-      // Under --force the caller has accepted losing the existing packet. The
-      // removal happens here, after every document has been staged and scanned,
-      // so a refusal or a failed write never destroys what is already on disk.
-      if (options.force === true) {
+      // Under --force the existing packet is moved aside rather than deleted,
+      // so a failed promotion can put it back. Deleting first would open a
+      // window where a rename failure loses the replacement AND the packet of
+      // hand-written triage prose it was replacing.
+      const replacing = options.force === true && exists;
+      const backupDir = `${stagingDir}-replaced`;
+
+      if (replacing) {
         yield* fs
-          .remove(packetDir, { recursive: true, force: true })
+          .rename(packetDir, backupDir)
           .pipe(
             Effect.mapError((cause) =>
-              CodexPacketWriteError.from(cause, "commit-failed", `${packetRelative} could not be replaced.`)
+              CodexPacketWriteError.from(cause, "commit-failed", `${packetRelative} could not be moved aside.`)
             )
           );
       }
@@ -246,22 +302,30 @@ export const writePacket = Effect.fnUntraced(function* (options: {
       // A rename onto an existing non-empty directory fails, so the
       // refuse-to-clobber guarantee survives a packet created between the
       // existence check above and this promotion.
-      yield* fs
-        .rename(stagingDir, packetDir)
-        .pipe(
-          Effect.mapError((cause) =>
-            CodexPacketWriteError.from(
-              cause,
-              "commit-failed",
-              `The staged packet could not be promoted to ${packetRelative}.`
-            )
-          )
+      const restoreThenFail = Effect.fnUntraced(function* (cause: unknown) {
+        // Put the replaced packet back before surfacing the failure, so a lost
+        // promotion never also loses the packet it was replacing.
+        if (replacing) {
+          yield* fs.rename(backupDir, packetDir).pipe(Effect.ignore);
+        }
+        return yield* CodexPacketWriteError.from(
+          cause,
+          "commit-failed",
+          `The staged packet could not be promoted to ${packetRelative}.`
         );
+      });
+
+      yield* fs.rename(stagingDir, packetDir).pipe(Effect.catch(restoreThenFail));
+
+      if (replacing) {
+        yield* fs.remove(backupDir, { recursive: true, force: true }).pipe(Effect.ignore);
+      }
 
       return {
         packetPath: packetRelative,
         written: A.map(options.documents, (document) => `${packetRelative}/${document.path}`),
         committed: true,
+        reportedEvidence,
       };
     }),
     () => fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore)

--- a/packages/tooling/tool/cli/src/commands/Codex/Findings.write.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/Findings.write.ts
@@ -1,0 +1,269 @@
+/**
+ * Staged, scanned, atomically promoted packet writes.
+ *
+ * A packet is built in full inside an unpredictable staging directory beside
+ * its destination, then promoted with a single directory rename. That shape
+ * buys three properties at once: a crash can never leave a half-written packet,
+ * a rename onto an existing non-empty directory fails so refusing to clobber
+ * needs no separate check, and every byte is scanned before anything lands.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { writeFileWithinCanonicalRootAtomically } from "@beep/file-processing/PathSafety";
+import { $RepoCliId } from "@beep/identity/packages";
+import { A } from "@beep/utils";
+import { Effect, FileSystem, Path } from "effect";
+import * as S from "effect/Schema";
+import { CodexFindingsRedactionError, CodexPacketWriteError } from "./Findings.errors.ts";
+import { describeSensitiveHits, scanSensitiveText } from "./Findings.scan.ts";
+
+const $I = $RepoCliId.create("commands/Codex/Findings.write");
+
+const encoder = new TextEncoder();
+
+/**
+ * One document destined for a generated packet.
+ *
+ * **Details**
+ *
+ * `path` is always relative to the packet directory, never to the repository
+ * and never absolute, so a document cannot address a location outside the
+ * packet even before path containment is enforced.
+ *
+ * **Example** (Describing a packet document)
+ *
+ * ```ts
+ * import { PacketDocument } from "@beep/repo-cli/commands/Codex/Findings.write"
+ *
+ * const document = PacketDocument.make({
+ *   path: "findings/CSF-001.md",
+ *   contents: "# CSF-001\n",
+ *   tracked: true,
+ * })
+ *
+ * console.log(document.path) // "findings/CSF-001.md"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export class PacketDocument extends S.Class<PacketDocument>($I`PacketDocument`)(
+  {
+    // Directory segments must start alphanumeric, so a hidden directory such as
+    // `.git/` is refused, while a dotfile filename such as `raw/.gitignore` —
+    // which every Codex packet requires — is admitted. The trailing lookahead
+    // rejects `.` and `..` as a filename in their own right.
+    path: S.String.check(
+      S.isPattern(/^(?:[A-Za-z0-9][A-Za-z0-9._-]*\/)*(?!\.\.?$)[A-Za-z0-9._-]+$/, {
+        identifier: $I`PacketDocumentPathCheck`,
+        title: "Packet Document Path",
+        description: "Packet-relative paths carry no traversal, no hidden directory, and no absolute prefix.",
+        message: "Expected a packet-relative document path",
+      })
+    ).pipe(
+      $I.annoteKey("PacketDocument.path", {
+        description: "Location of the document relative to the packet directory.",
+      })
+    ),
+    contents: S.String.pipe(
+      $I.annoteKey("PacketDocument.contents", {
+        description: "Full text of the document.",
+      })
+    ),
+    tracked: S.Boolean.pipe(
+      $I.annoteKey("PacketDocument.tracked", {
+        description: "Whether git tracks this document; ignored raw evidence is scanned identically.",
+      })
+    ),
+  },
+  $I.annote("PacketDocument", {
+    description: "One document destined for a generated Codex findings packet.",
+  })
+) {}
+
+/**
+ * Refuse a document set carrying secret-shaped or private content.
+ *
+ * **When to use**
+ *
+ * Use when staging a packet, over every document including untracked raw
+ * evidence. Scanning only tracked output would leave the ignored `raw/`
+ * directory — which the repository's commit-range secret scanner structurally
+ * never sees — without any control at all.
+ *
+ * **Example** (Refusing a private path)
+ *
+ * ```ts
+ * import { PacketDocument, assertPacketDocumentsClean } from "@beep/repo-cli/commands/Codex/Findings.write"
+ * import { Effect } from "effect"
+ *
+ * const program = assertPacketDocumentsClean([
+ *   PacketDocument.make({ path: "raw/payload.json", contents: "/home/dev/x", tracked: false }),
+ * ]).pipe(
+ *   Effect.map(() => "accepted"),
+ *   Effect.orElseSucceed(() => "refused")
+ * )
+ *
+ * console.log(Effect.runSync(program)) // "refused"
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const assertPacketDocumentsClean = Effect.fnUntraced(function* (documents: ReadonlyArray<PacketDocument>) {
+  const hits = A.flatMap(documents, (document) => scanSensitiveText(document.path, document.contents));
+
+  if (A.isReadonlyArrayNonEmpty(hits)) {
+    const surfaces = describeSensitiveHits(hits);
+    return yield* CodexFindingsRedactionError.make({
+      message: `Refusing to write the packet: ${A.length(surfaces)} document(s) carry secret-shaped or private content. Remove it from the capture and re-ingest; the offending values are deliberately not reproduced here.`,
+      surfaces,
+    });
+  }
+});
+
+/**
+ * Stage, scan, and atomically promote a complete packet.
+ *
+ * **Details**
+ *
+ * The staging directory is created inside `goals/` so the final promotion is a
+ * same-filesystem rename. Promotion fails when the destination already exists,
+ * which is the refuse-to-clobber guarantee — four packets of hand-written
+ * triage prose are exactly what must never be silently overwritten.
+ *
+ * **Gotchas**
+ *
+ * A dry run performs no filesystem writes at all, not even staging, but still
+ * runs the full scan. A payload that would be refused is refused identically in
+ * both modes.
+ *
+ * **Example** (Planning a packet without writing it)
+ *
+ * ```ts
+ * import { PacketDocument, writePacket } from "@beep/repo-cli/commands/Codex/Findings.write"
+ *
+ * const documents = [
+ *   PacketDocument.make({ path: "README.md", contents: "# packet\n", tracked: true }),
+ * ]
+ *
+ * console.log(documents.length) // 1
+ * console.log(typeof writePacket) // "function"
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const writePacket = Effect.fnUntraced(function* (options: {
+  readonly repoRoot: string;
+  readonly slug: string;
+  readonly documents: ReadonlyArray<PacketDocument>;
+  readonly dryRun: boolean;
+  /** Replace an existing packet instead of refusing. Destroys hand-written prose. */
+  readonly force?: boolean | undefined;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  // Every containment decision is made against the canonical repository root,
+  // so a symlink later swapped in for `goals/` cannot inherit write authority.
+  const canonicalRoot = yield* fs
+    .realPath(options.repoRoot)
+    .pipe(
+      Effect.mapError((cause) =>
+        CodexPacketWriteError.from(cause, "path-escape", "The repository root could not be canonicalized.")
+      )
+    );
+
+  const goalsDir = path.join(canonicalRoot, "goals");
+  const packetDir = path.join(goalsDir, options.slug);
+  const packetRelative = path.join("goals", options.slug);
+
+  const exists = yield* fs
+    .exists(packetDir)
+    .pipe(
+      Effect.mapError((cause) =>
+        CodexPacketWriteError.from(cause, "staging-failed", `${packetRelative} could not be inspected.`)
+      )
+    );
+
+  if (exists && options.force !== true) {
+    return yield* CodexPacketWriteError.make({
+      reason: "packet-exists",
+      message: `${packetRelative} already exists. Re-ingesting would overwrite triage prose written by hand; pass --force to replace it deliberately.`,
+    });
+  }
+
+  yield* assertPacketDocumentsClean(options.documents);
+
+  if (options.dryRun) {
+    return {
+      packetPath: packetRelative,
+      written: A.map(options.documents, (document) => `${packetRelative}/${document.path}`),
+      committed: false,
+    };
+  }
+
+  const stagingDir = yield* fs
+    .makeTempDirectory({ directory: goalsDir, prefix: `.tmp-${options.slug}-` })
+    .pipe(
+      Effect.mapError((cause) =>
+        CodexPacketWriteError.from(cause, "staging-failed", "A staging directory could not be created under goals/.")
+      )
+    );
+
+  const stagingRelative = path.relative(canonicalRoot, stagingDir);
+
+  return yield* Effect.onError(
+    Effect.gen(function* () {
+      for (const document of options.documents) {
+        yield* writeFileWithinCanonicalRootAtomically({
+          canonicalRoot,
+          candidate: path.join(stagingRelative, document.path),
+          bytes: encoder.encode(document.contents),
+        }).pipe(
+          Effect.mapError((cause) =>
+            CodexPacketWriteError.from(cause, "staging-failed", `${document.path} could not be staged.`)
+          )
+        );
+      }
+
+      // Under --force the caller has accepted losing the existing packet. The
+      // removal happens here, after every document has been staged and scanned,
+      // so a refusal or a failed write never destroys what is already on disk.
+      if (options.force === true) {
+        yield* fs
+          .remove(packetDir, { recursive: true, force: true })
+          .pipe(
+            Effect.mapError((cause) =>
+              CodexPacketWriteError.from(cause, "commit-failed", `${packetRelative} could not be replaced.`)
+            )
+          );
+      }
+
+      // A rename onto an existing non-empty directory fails, so the
+      // refuse-to-clobber guarantee survives a packet created between the
+      // existence check above and this promotion.
+      yield* fs
+        .rename(stagingDir, packetDir)
+        .pipe(
+          Effect.mapError((cause) =>
+            CodexPacketWriteError.from(
+              cause,
+              "commit-failed",
+              `The staged packet could not be promoted to ${packetRelative}.`
+            )
+          )
+        );
+
+      return {
+        packetPath: packetRelative,
+        written: A.map(options.documents, (document) => `${packetRelative}/${document.path}`),
+        committed: true,
+      };
+    }),
+    () => fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore)
+  );
+});

--- a/packages/tooling/tool/cli/src/commands/Codex/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex/index.ts
@@ -18,3 +18,73 @@ export * from "./Codex.command.ts";
  * @since 0.0.0
  */
 export * from "./Codex.errors.ts";
+/**
+ * Capture payload contract for the signed-in findings export.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./Findings.capture.schemas.ts";
+/**
+ * Findings capture-to-packet command group.
+ *
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export * from "./Findings.command.ts";
+/**
+ * CSV export decoding boundary.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./Findings.csv.ts";
+/**
+ * Findings ingest and packet-write tagged errors.
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export * from "./Findings.errors.ts";
+/**
+ * Deterministic normalization into an ordered packet plan.
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export * from "./Findings.normalize.ts";
+/**
+ * Packet document rendering.
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export * from "./Findings.packet.ts";
+/**
+ * Reject-scan for captured findings content.
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export * from "./Findings.scan.ts";
+/**
+ * Normalized finding records and command options.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./Findings.schemas.ts";
+/**
+ * The `codex-triage/v1` ledger schema.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./Findings.triage.schemas.ts";
+/**
+ * Staged, scanned, atomically promoted packet writes.
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export * from "./Findings.write.ts";

--- a/packages/tooling/tool/cli/src/test/Codex.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Codex.test-kit.ts
@@ -1,0 +1,16 @@
+/**
+ * Source-only test kit for Codex command internals.
+ *
+ * @internal
+ * @since 0.0.0
+ */
+
+export * from "@beep/repo-cli/commands/Codex/Findings.capture.schemas";
+export * from "@beep/repo-cli/commands/Codex/Findings.csv";
+export * from "@beep/repo-cli/commands/Codex/Findings.errors";
+export * from "@beep/repo-cli/commands/Codex/Findings.normalize";
+export * from "@beep/repo-cli/commands/Codex/Findings.packet";
+export * from "@beep/repo-cli/commands/Codex/Findings.scan";
+export * from "@beep/repo-cli/commands/Codex/Findings.schemas";
+export * from "@beep/repo-cli/commands/Codex/Findings.triage.schemas";
+export * from "@beep/repo-cli/commands/Codex/Findings.write";

--- a/packages/tooling/tool/cli/test/codex-findings-csv.test.ts
+++ b/packages/tooling/tool/cli/test/codex-findings-csv.test.ts
@@ -1,0 +1,186 @@
+import {
+  CODEX_CSV_COLUMNS,
+  CODEX_CSV_PII_COLUMNS,
+  codexIdFromFindingUrl,
+  decodeCodexFindingsCsv,
+} from "@beep/repo-cli/test/Codex";
+import { A, O } from "@beep/utils";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as S from "effect/Schema";
+
+const id = (seed: string): string => seed.repeat(32).slice(0, 32);
+const sha = (seed: string): string => seed.repeat(40).slice(0, 40);
+const url = (seed: string): string => `https://chatgpt.com/codex/cloud/security/findings/${id(seed)}`;
+
+const quote = (value: string): string => `"${value.replaceAll('"', '""')}"`;
+
+const row = (input: {
+  readonly seed: string;
+  readonly title?: string;
+  readonly severity?: string;
+  readonly status?: string;
+  readonly description?: string;
+}): string =>
+  A.join(
+    [
+      url(input.seed),
+      "kriegcloud/beep-effect",
+      "https://github.com/kriegcloud/beep-effect",
+      quote(input.title ?? "A captured finding"),
+      quote(input.description ?? "Report body."),
+      input.severity ?? "medium",
+      input.status ?? "new",
+      "2026-08-04T16:06:15.518000Z",
+      "2026-08-04 12:30:00 -0400",
+      "12345678+someuser@users.noreply.github.com",
+      "",
+      "",
+      "false",
+      "scan-AbCd:branch-1234567890",
+      sha(input.seed === "a" ? "b" : input.seed),
+      quote("packages/x/src/Y.ts"),
+      "",
+    ],
+    ","
+  );
+
+// Serializing the decoded record is how these tests prove a dropped column
+// is truly absent; the repo requires the schema codec rather than JSON.*.
+const encodeJson = S.encodeUnknownSync(S.fromJsonString(S.Unknown));
+
+const csv = (rows: ReadonlyArray<string>): string => `${A.join([A.join(CODEX_CSV_COLUMNS, ","), ...rows], "\n")}\n`;
+
+const decode = (text: string) => decodeCodexFindingsCsv(text);
+const reason = (text: string) =>
+  decodeCodexFindingsCsv(text).pipe(
+    Effect.map(() => "accepted"),
+    Effect.catchTag("CodexFindingsIngestError", (error) => Effect.succeed(error.reason))
+  );
+
+describe("codex findings csv parser integration", () => {
+  // RFC 4180 mechanics belong to `@beep/schema`'s parser and are covered there.
+  // What matters here is that a quoted multiline `description` — the one column
+  // that actually carries newlines — does not shear the row apart.
+  it.effect("survives a description cell containing commas and newlines", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decode(
+        csv([row({ seed: "a", description: "First line, with comma.\nSecond line." }), row({ seed: "b" })])
+      );
+
+      expect(A.length(decoded.findings)).toBe(2);
+      expect(decoded.findings[0]?.codexId).toBe(id("a"));
+      expect(decoded.findings[1]?.codexId).toBe(id("b"));
+    })
+  );
+
+  it.effect("survives a title containing a doubled quote", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decode(csv([row({ seed: "a", title: 'Say ""hi"" to the parser' })]));
+
+      expect(A.length(decoded.findings)).toBe(1);
+    })
+  );
+});
+
+describe("codex findings csv identity", () => {
+  it("reads the identity from the canonical finding url", () => {
+    expect(O.getOrElse(codexIdFromFindingUrl(url("d")), () => "none")).toBe(id("d"));
+  });
+
+  it("refuses an identity from a foreign host", () => {
+    expect(O.isNone(codexIdFromFindingUrl(`https://evil.example/findings/${id("d")}`))).toBe(true);
+  });
+
+  it("refuses a non-hex trailing segment", () => {
+    expect(O.isNone(codexIdFromFindingUrl("https://chatgpt.com/codex/cloud/security/findings/not-an-id"))).toBe(true);
+  });
+});
+
+describe("codex findings csv decoding", () => {
+  it.effect("maps lowercase wire severities and statuses onto the packet domain", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decode(
+        csv([
+          row({ seed: "a", severity: "medium", status: "new" }),
+          row({ seed: "b", severity: "low" }),
+          row({ seed: "c", severity: "informational" }),
+        ])
+      );
+
+      expect(A.map(decoded.findings, (finding) => finding.severity)).toEqual(["Medium", "Low", "Informational"]);
+      expect(A.map(decoded.findings, (finding) => finding.codexStatus)).toEqual(["New", "New", "New"]);
+    })
+  );
+
+  it.effect("drops every personal-data column at the parse boundary", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decode(csv([row({ seed: "a" })]));
+      const serialized = encodeJson(decoded);
+
+      // The fixture row carries a real-shaped author email; nothing that leaves
+      // this module may contain it, nor any dropped column name.
+      expect(serialized).not.toContain("users.noreply.github.com");
+      expect(serialized).not.toContain("someuser");
+      for (const column of CODEX_CSV_PII_COLUMNS) {
+        expect(serialized).not.toContain(column);
+      }
+    })
+  );
+
+  it.effect("never carries the unsanitized report body out of the parser", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decode(csv([row({ seed: "a", description: "SENSITIVE REPORT BODY" })]));
+
+      expect(encodeJson(decoded)).not.toContain("SENSITIVE REPORT BODY");
+    })
+  );
+
+  it.effect("reports the repository named by the export", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decode(csv([row({ seed: "a" })]));
+
+      expect(decoded.repository).toBe("kriegcloud/beep-effect");
+    })
+  );
+});
+
+describe("codex findings csv refusals", () => {
+  it.effect("refuses a signed-out html response as an expired session", () =>
+    Effect.gen(function* () {
+      expect(yield* reason("<!doctype html><html><title>Log in</title></html>")).toBe("auth-expired");
+    })
+  );
+
+  it.effect("refuses an export whose header drifted", () =>
+    Effect.gen(function* () {
+      expect(yield* reason("finding_url,title,severity\nx,y,z\n")).toBe("csv-header-unsupported");
+    })
+  );
+
+  it.effect("refuses a truncated row rather than padding it", () =>
+    Effect.gen(function* () {
+      expect(yield* reason(`${csv([])}${url("a")},kriegcloud/beep-effect\n`)).toBe("csv-row-malformed");
+    })
+  );
+
+  it.effect("refuses an unknown severity rather than guessing a bucket", () =>
+    Effect.gen(function* () {
+      expect(yield* reason(csv([row({ seed: "a", severity: "catastrophic" })]))).toBe("csv-row-malformed");
+    })
+  );
+
+  it.effect("refuses a duplicated finding identity", () =>
+    Effect.gen(function* () {
+      expect(yield* reason(csv([row({ seed: "a" }), row({ seed: "a" })]))).toBe("csv-duplicate-finding");
+    })
+  );
+
+  it.effect("accepts an export with no findings at all", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decode(csv([]));
+
+      expect(A.length(decoded.findings)).toBe(0);
+    })
+  );
+});

--- a/packages/tooling/tool/cli/test/codex-findings-csv.test.ts
+++ b/packages/tooling/tool/cli/test/codex-findings-csv.test.ts
@@ -116,6 +116,7 @@ describe("codex findings csv decoding", () => {
   it.effect("drops every personal-data column at the parse boundary", () =>
     Effect.gen(function* () {
       const decoded = yield* decode(csv([row({ seed: "a" })]));
+      // Covers both halves: the tracked projection and the raw report bodies.
       const serialized = encodeJson(decoded);
 
       // The fixture row carries a real-shaped author email; nothing that leaves
@@ -128,11 +129,17 @@ describe("codex findings csv decoding", () => {
     })
   );
 
-  it.effect("never carries the unsanitized report body out of the parser", () =>
+  // The report body is the evidence P2 validates against, so it must survive the
+  // parser — but only in `reports`, which nothing tracked ever renders. Asserting
+  // it never leaves at all would re-encode the bug two reviewers caught: a packet
+  // whose own template says "summarize from the raw report" with no report in it.
+  it.effect("carries the report body only in the raw-evidence half", () =>
     Effect.gen(function* () {
       const decoded = yield* decode(csv([row({ seed: "a", description: "SENSITIVE REPORT BODY" })]));
 
-      expect(encodeJson(decoded)).not.toContain("SENSITIVE REPORT BODY");
+      expect(encodeJson(decoded.findings)).not.toContain("SENSITIVE REPORT BODY");
+      expect(decoded.reports[0]?.description).toContain("SENSITIVE REPORT BODY");
+      expect(decoded.reports[0]?.codexId).toBe(id("a"));
     })
   );
 

--- a/packages/tooling/tool/cli/test/codex-findings-normalize.test.ts
+++ b/packages/tooling/tool/cli/test/codex-findings-normalize.test.ts
@@ -1,0 +1,311 @@
+import {
+  decodeCodexFindingsCapturePayload,
+  decodeCodexFindingsIngestOptions,
+  planPacket,
+  priorIdsOfEntries,
+  recordIdForOrdinal,
+  severityCountsOf,
+} from "@beep/repo-cli/test/Codex";
+import { A, O } from "@beep/utils";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as S from "effect/Schema";
+import type { CodexFindingsIngestError } from "@beep/repo-cli/test/Codex";
+
+const hex = (seed: string, length: number): string => {
+  const digits = "0123456789abcdef";
+  return A.join(
+    A.map(A.range(0, length - 1), (index) => digits[(seed.charCodeAt(index % seed.length) + index) % 16] ?? "0"),
+    ""
+  );
+};
+
+const captureFinding = (input: {
+  readonly codexId: string;
+  readonly title?: string;
+  readonly severity?: string;
+  readonly codexStatus?: string;
+  readonly commit?: string;
+}) => ({
+  codexId: input.codexId,
+  title: input.title ?? "A captured finding",
+  severity: input.severity ?? "Medium",
+  codexStatus: input.codexStatus ?? "Open",
+  commit: input.commit ?? hex(input.codexId, 40),
+});
+
+const payloadOf = (
+  findings: ReadonlyArray<ReturnType<typeof captureFinding>>,
+  overrides: { readonly expectedCount?: number; readonly authState?: string } = {}
+) => ({
+  schemaVersion: "codex-findings-capture/v1",
+  capture: {
+    capturedAt: "2026-08-04",
+    sourceUrl: "https://chatgpt.com/codex/cloud/security/findings/",
+    repository: "kriegcloud/beep-effect",
+    findingsView: "repo-scoped, status=open",
+    expectedCount: overrides.expectedCount ?? A.length(findings),
+    authState: overrides.authState ?? "authenticated",
+  },
+  findings,
+});
+
+const decodePayload = (value: unknown) => decodeCodexFindingsCapturePayload(value);
+
+const planFrom = (value: unknown) => decodePayload(value).pipe(Effect.flatMap((payload) => planPacket(payload, {})));
+
+describe("codex findings identity assignment", () => {
+  it("pads ordinals to three digits and grows beyond them", () => {
+    expect(recordIdForOrdinal(1)).toBe("CSF-001");
+    expect(recordIdForOrdinal(26)).toBe("CSF-026");
+    expect(recordIdForOrdinal(999)).toBe("CSF-999");
+    expect(recordIdForOrdinal(1000)).toBe("CSF-1000");
+  });
+
+  it("orders most severe first and breaks ties by Codex identity", () =>
+    Effect.runPromise(
+      planFrom(
+        payloadOf([
+          captureFinding({ codexId: hex("zz", 32), severity: "Low" }),
+          captureFinding({ codexId: hex("bb", 32), severity: "High" }),
+          captureFinding({ codexId: hex("aa", 32), severity: "Low" }),
+          captureFinding({ codexId: hex("cc", 32), severity: "Informational" }),
+        ])
+      ).pipe(
+        Effect.map((plan) => {
+          expect(A.map(plan.records, (record) => record.severity)).toEqual(["High", "Low", "Low", "Informational"]);
+          expect(A.map(plan.records, (record) => record.id)).toEqual(["CSF-001", "CSF-002", "CSF-003", "CSF-004"]);
+          // Ties broken by identity: the "aa" row sorts ahead of the "zz" row.
+          expect(plan.records[1]?.codexId).toBe(hex("aa", 32));
+          expect(plan.records[2]?.codexId).toBe(hex("zz", 32));
+        })
+      )
+    ));
+
+  it("produces an identical plan when the same payload arrives in a different row order", () => {
+    const a = captureFinding({ codexId: hex("aa", 32), severity: "Low" });
+    const b = captureFinding({ codexId: hex("bb", 32), severity: "High" });
+    const c = captureFinding({ codexId: hex("cc", 32), severity: "Medium" });
+    const encode = S.encodeUnknownSync(S.fromJsonString(S.Unknown));
+
+    return Effect.runPromise(
+      Effect.all([planFrom(payloadOf([a, b, c])), planFrom(payloadOf([c, a, b]))]).pipe(
+        Effect.map(([first, second]) => {
+          expect(encode(first)).toBe(encode(second));
+        })
+      )
+    );
+  });
+});
+
+describe("codex findings identity is sticky across re-ingest", () => {
+  const low = captureFinding({ codexId: hex("aa", 32), severity: "Low" });
+  const informational = captureFinding({ codexId: hex("cc", 32), severity: "Informational" });
+  const arrivingHigh = captureFinding({ codexId: hex("bb", 32), severity: "High" });
+
+  const planWithPriors = (
+    findings: ReadonlyArray<ReturnType<typeof captureFinding>>,
+    priors: ReadonlyArray<{ readonly id: string; readonly codexId: string }>
+  ) =>
+    decodePayload(payloadOf(findings)).pipe(
+      Effect.flatMap((payload) => planPacket(payload, { priorIds: priorIdsOfEntries(priors) }))
+    );
+
+  it("keeps existing numbers when a more severe finding arrives later", () =>
+    Effect.runPromise(
+      planWithPriors(
+        [low, informational, arrivingHigh],
+        [
+          { id: "CSF-001", codexId: low.codexId },
+          { id: "CSF-002", codexId: informational.codexId },
+        ]
+      ).pipe(
+        Effect.map((plan) => {
+          const byCodexId = (codexId: string) => A.findFirst(plan.records, (record) => record.codexId === codexId);
+
+          // The High finding sorts first, but must NOT take CSF-001.
+          expect(plan.records[0]?.severity).toBe("High");
+          expect(
+            O.getOrElse(
+              O.map(byCodexId(low.codexId), (r) => r.id),
+              () => ""
+            )
+          ).toBe("CSF-001");
+          expect(
+            O.getOrElse(
+              O.map(byCodexId(informational.codexId), (r) => r.id),
+              () => ""
+            )
+          ).toBe("CSF-002");
+          expect(
+            O.getOrElse(
+              O.map(byCodexId(arrivingHigh.codexId), (r) => r.id),
+              () => ""
+            )
+          ).toBe("CSF-003");
+        })
+      )
+    ));
+
+  it("never reuses a number reserved by a finding that left the export", () =>
+    Effect.runPromise(
+      // CSF-001 and CSF-002 were assigned before; only CSF-002's finding still
+      // appears. A newcomer must land on CSF-003, not recycle CSF-001.
+      planWithPriors(
+        [informational, arrivingHigh],
+        [
+          { id: "CSF-001", codexId: low.codexId },
+          { id: "CSF-002", codexId: informational.codexId },
+        ]
+      ).pipe(
+        Effect.map((plan) => {
+          expect(A.map(plan.records, (record) => record.id)).toContain("CSF-002");
+          expect(A.map(plan.records, (record) => record.id)).toContain("CSF-003");
+          expect(A.map(plan.records, (record) => record.id)).not.toContain("CSF-001");
+        })
+      )
+    ));
+
+  it("assigns from capture order when there are no prior bindings", () =>
+    Effect.runPromise(
+      planWithPriors([low, informational, arrivingHigh], []).pipe(
+        Effect.map((plan) => {
+          expect(A.map(plan.records, (record) => record.id)).toEqual(["CSF-001", "CSF-002", "CSF-003"]);
+          expect(plan.records[0]?.severity).toBe("High");
+        })
+      )
+    ));
+});
+
+describe("codex findings severity tallies", () => {
+  it("omits zero-count severities and keeps domain order", () => {
+    const counts = severityCountsOf([{ severity: "Low" }, { severity: "Medium" }, { severity: "Low" }] as const);
+
+    expect(counts).toEqual({ Medium: 1, Low: 2 });
+    expect(Object.keys(counts)).toEqual(["Medium", "Low"]);
+    expect("High" in counts).toBe(false);
+  });
+});
+
+describe("codex findings payload rejection", () => {
+  const rejects = (value: unknown) =>
+    decodePayload(value).pipe(
+      Effect.map(() => "accepted"),
+      Effect.orElseSucceed(() => "rejected")
+    );
+
+  it.effect("rejects a duplicate Codex identity instead of silently deduplicating", () =>
+    Effect.gen(function* () {
+      const duplicate = captureFinding({ codexId: hex("aa", 32) });
+
+      expect(yield* rejects(payloadOf([duplicate, duplicate]))).toBe("rejected");
+    })
+  );
+
+  it.effect("rejects a traversal-shaped Codex identity", () =>
+    Effect.gen(function* () {
+      expect(yield* rejects(payloadOf([captureFinding({ codexId: "../../etc/passwd" })]))).toBe("rejected");
+    })
+  );
+
+  it.effect("rejects an abbreviated source commit", () =>
+    Effect.gen(function* () {
+      expect(yield* rejects(payloadOf([captureFinding({ codexId: hex("aa", 32), commit: "244529a" })]))).toBe(
+        "rejected"
+      );
+    })
+  );
+
+  it.effect("rejects a title carrying a bidirectional override", () =>
+    Effect.gen(function* () {
+      expect(yield* rejects(payloadOf([captureFinding({ codexId: hex("aa", 32), title: "safe‮evil" })]))).toBe(
+        "rejected"
+      );
+    })
+  );
+
+  it.effect("rejects an over-length title rather than truncating it", () =>
+    Effect.gen(function* () {
+      expect(yield* rejects(payloadOf([captureFinding({ codexId: hex("aa", 32), title: "x".repeat(301) })]))).toBe(
+        "rejected"
+      );
+    })
+  );
+
+  it.effect("rejects an unknown severity", () =>
+    Effect.gen(function* () {
+      expect(yield* rejects(payloadOf([captureFinding({ codexId: hex("aa", 32), severity: "Critical" })]))).toBe(
+        "rejected"
+      );
+    })
+  );
+
+  it.effect("rejects an unknown payload contract version", () =>
+    Effect.gen(function* () {
+      expect(yield* rejects({ ...payloadOf([]), schemaVersion: "codex-findings-capture/v99" })).toBe("rejected");
+    })
+  );
+});
+
+describe("codex findings reconciliation", () => {
+  it("refuses an expired session rather than bootstrapping an empty packet", () =>
+    Effect.runPromise(
+      planFrom(payloadOf([], { authState: "expired", expectedCount: 0 })).pipe(
+        Effect.map(() => "accepted"),
+        Effect.catchTag("CodexFindingsIngestError", (error: CodexFindingsIngestError) => Effect.succeed(error.reason))
+      )
+    ).then((reason) => {
+      expect(reason).toBe("auth-expired");
+    }));
+
+  it("refuses a short read against the dashboard's own reported total", () =>
+    Effect.runPromise(
+      planFrom(payloadOf([captureFinding({ codexId: hex("aa", 32) })], { expectedCount: 26 })).pipe(
+        Effect.map(() => "accepted"),
+        Effect.catchTag("CodexFindingsIngestError", (error: CodexFindingsIngestError) => Effect.succeed(error.reason))
+      )
+    ).then((reason) => {
+      expect(reason).toBe("short-read");
+    }));
+
+  it("names neither a local path nor a captured value in a short-read message", () =>
+    Effect.runPromise(
+      planFrom(payloadOf([captureFinding({ codexId: hex("aa", 32) })], { expectedCount: 26 })).pipe(
+        Effect.map(() => ""),
+        Effect.catchTag("CodexFindingsIngestError", (error: CodexFindingsIngestError) => Effect.succeed(error.message))
+      )
+    ).then((message) => {
+      expect(message).not.toMatch(/\/home\//);
+      expect(message).not.toContain(hex("aa", 32));
+    }));
+});
+
+describe("codex findings ingest options", () => {
+  it("rejects a traversal slug supplied on the command line", () =>
+    Effect.runPromise(
+      decodeCodexFindingsIngestOptions({ slug: "../../etc" }).pipe(
+        Effect.map(() => "accepted"),
+        Effect.orElseSucceed(() => "rejected")
+      )
+    ).then((outcome) => {
+      expect(outcome).toBe("rejected");
+    }));
+
+  it("rejects a traversal-shaped date override", () =>
+    Effect.runPromise(
+      decodeCodexFindingsIngestOptions({ date: "2026-08-04/../.." }).pipe(
+        Effect.map(() => "accepted"),
+        Effect.orElseSucceed(() => "rejected")
+      )
+    ).then((outcome) => {
+      expect(outcome).toBe("rejected");
+    }));
+
+  it("defaults every mode flag to false", () =>
+    Effect.runPromise(decodeCodexFindingsIngestOptions({})).then((options) => {
+      expect(options.dryRun).toBe(false);
+      expect(options.force).toBe(false);
+      expect(options.refresh).toBe(false);
+      expect(options.json).toBe(false);
+    }));
+});

--- a/packages/tooling/tool/cli/test/codex-findings-packet.test.ts
+++ b/packages/tooling/tool/cli/test/codex-findings-packet.test.ts
@@ -1,0 +1,220 @@
+import { GOAL_MD_MAX_CHARS } from "@beep/repo-cli/commands/Goals/Doctor";
+import { decodeGoalManifest } from "@beep/repo-cli/commands/Goals/Goals.schemas";
+import {
+  CodexFindingRecord,
+  CodexPacketPlan,
+  decodeCodexTriageLedger,
+  renderPacketDocuments,
+  scanSensitiveText,
+} from "@beep/repo-cli/test/Codex";
+import { A, Str } from "@beep/utils";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as S from "effect/Schema";
+import type { PacketDocument } from "@beep/repo-cli/test/Codex";
+
+// The repo forbids bare JSON.* ; decode through the schema codec instead.
+const parseJson = S.decodeUnknownSync(S.fromJsonString(S.Unknown));
+
+const SEVERITIES = ["Medium", "Low", "Informational"] as const;
+
+const recordAt = (ordinal: number, title?: string) =>
+  CodexFindingRecord.make({
+    id: `CSF-${Str.padStart(3, "0")(`${ordinal}`)}`,
+    codexId: Str.padStart(32, "0")(`${ordinal}`),
+    title: title ?? `Synthetic finding ${ordinal}`,
+    severity: SEVERITIES[ordinal % 3]!,
+    codexStatus: "New",
+    commit: Str.padStart(40, "a")(`${ordinal}`),
+  });
+
+const planWith = (records: ReadonlyArray<CodexFindingRecord>) =>
+  CodexPacketPlan.make({
+    slug: "codex-security-findings-2026-08-06",
+    branch: "security/codex-findings-2026-08-06",
+    capturedAt: "2026-08-06",
+    repository: "kriegcloud/beep-effect",
+    sourceUrl: "https://chatgpt.com/codex/cloud/security/findings/",
+    findingsView: "repo-scoped, status=open",
+    expectedCount: A.length(records),
+    records,
+    severityCounts: A.reduce(records, {} as Record<string, number>, (counts, record) => ({
+      ...counts,
+      [record.severity]: (counts[record.severity] ?? 0) + 1,
+    })),
+  });
+
+const render = (count: number, title?: string) =>
+  renderPacketDocuments({
+    plan: planWith(A.map(A.range(1, count), (ordinal) => recordAt(ordinal, ordinal === 1 ? title : undefined))),
+    rawPayloadJson: '{"findings":[]}\n',
+  });
+
+// The subset of the generated manifest these assertions read. Decoding it
+// rather than casting keeps the test honest: a renamed field fails here.
+const ManifestSubset = S.Struct({
+  initiative: S.Struct({ status: S.String }),
+  lifecycle: S.String,
+  phases: S.Array(S.Struct({ status: S.String })),
+  source: S.Struct({ captureMethodPolicy: S.String, rawCaptureTracked: S.Boolean }),
+  catalog: S.Struct({
+    capturedCount: S.Int,
+    dispositionCounts: S.Struct({ untriaged: S.Int, remediate: S.Int }),
+  }),
+});
+
+const decodeManifest = S.decodeUnknownSync(ManifestSubset);
+
+const manifestOf = (documents: ReadonlyArray<PacketDocument>) =>
+  decodeManifest(parseJson(at(documents, "ops/manifest.json").contents));
+
+const at = (documents: ReadonlyArray<PacketDocument>, path: string): PacketDocument => {
+  const found = A.findFirst(documents, (document) => document.path === path);
+  if (found._tag === "None") throw new Error(`no document at ${path}`);
+  return found.value;
+};
+
+describe("codex findings packet clears the goals doctor gates", () => {
+  const documents = render(27);
+
+  it.effect("emits a manifest that decodes as a GoalManifest", () =>
+    Effect.gen(function* () {
+      // Deliberately the raw parse, not the narrowed subset: GoalManifest is the
+      // real gate contract and needs every key the packet actually writes.
+      const manifest = parseJson(at(documents, "ops/manifest.json").contents);
+
+      expect(yield* decodeGoalManifest(manifest)).toBeDefined();
+    })
+  );
+
+  it("keeps initiative.status and lifecycle identical", () => {
+    const manifest = manifestOf(documents);
+
+    expect(manifest.initiative.status).toBe("active");
+    expect(manifest.lifecycle).toBe("active");
+  });
+
+  it("carries a README lifecycle line matching the manifest status", () => {
+    expect(at(documents, "README.md").contents).toContain("Lifecycle: `active`");
+  });
+
+  it("leaves post-capture phases pending so an active packet is not terminal", () => {
+    const manifest = manifestOf(documents);
+    const pending = A.filter(manifest.phases, (phase) => phase.status === "pending");
+
+    // All-complete phases on an active packet is a blocking doctor finding.
+    expect(A.length(pending)).toBeGreaterThan(0);
+    expect(A.map(A.take(manifest.phases, 2), (phase) => phase.status)).toEqual(["complete", "complete"]);
+  });
+
+  it("declares the CSV export as the capture method, never a pasted snippet", () => {
+    const manifest = manifestOf(documents);
+
+    expect(manifest.source.captureMethodPolicy).toBe("signed-in-csv-export");
+    expect(manifest.source.rawCaptureTracked).toBe(false);
+  });
+});
+
+describe("codex findings packet launcher budget", () => {
+  // The launcher reports counts and points at findings/INDEX.md; if it ever
+  // grew a per-finding line this is the test that would catch it.
+  for (const count of [26, 200]) {
+    it(`keeps GOAL.md within the doctor budget at ${count} findings`, () => {
+      const goal = at(render(count), "GOAL.md").contents;
+
+      expect([...goal].length).toBeLessThanOrEqual(GOAL_MD_MAX_CHARS);
+    });
+  }
+
+  it("does not grow GOAL.md proportionally to the finding count", () => {
+    const small = [...at(render(26), "GOAL.md").contents].length;
+    const large = [...at(render(200), "GOAL.md").contents].length;
+
+    expect(large - small).toBeLessThan(20);
+  });
+});
+
+describe("codex findings packet renders no fabricated judgment", () => {
+  const documents = render(3);
+
+  it("marks every judgment section pending rather than inventing prose", () => {
+    const finding = at(documents, "findings/CSF-001.md").contents;
+
+    expect(finding).toContain("_pending P2_");
+    expect(finding).toContain("_pending P4_");
+    expect(finding).toContain("- Status: captured; validation pending");
+  });
+
+  it.effect("leaves every triage entry untriaged with no verdict, owner, or lane", () =>
+    Effect.gen(function* () {
+      const ledger = yield* decodeCodexTriageLedger(parseJson(at(documents, "ops/triage.json").contents));
+
+      expect(A.length(ledger.findings)).toBe(3);
+      for (const entry of ledger.findings) {
+        expect(entry.disposition).toBe("untriaged");
+        expect(entry.verdict).toBeUndefined();
+        expect(entry.ownerArea).toBeUndefined();
+        expect(entry.lane).toBeUndefined();
+      }
+      expect(ledger.lanes).toEqual({});
+    })
+  );
+
+  it("reports counts that match the rendered finding documents", () => {
+    const manifest = manifestOf(documents);
+    const findingDocs = A.filter(documents, (document) => Str.startsWith("findings/CSF-")(document.path));
+
+    expect(manifest.catalog.capturedCount).toBe(A.length(findingDocs));
+    expect(manifest.catalog.dispositionCounts.untriaged).toBe(A.length(findingDocs));
+    expect(manifest.catalog.dispositionCounts.remediate).toBe(0);
+  });
+});
+
+describe("codex findings packet neutralizes hostile titles", () => {
+  const HOSTILE = "Evil | ](https://evil.example) <img src=x onerror=1>";
+  const documents = render(3, HOSTILE);
+
+  it("keeps the INDEX row column count despite pipes in a title", () => {
+    const row = A.findFirst(Str.split(at(documents, "findings/INDEX.md").contents, "\n"), (line) =>
+      Str.includes("CSF-001")(line)
+    );
+    if (row._tag === "None") throw new Error("no CSF-001 row");
+
+    // Only unescaped pipes delimit cells. A 5-column row has exactly 6 of them,
+    // and the title's own pipe must survive as an escaped literal instead.
+    expect(A.length(row.value.match(/(?<!\\)\|/g) ?? [])).toBe(6);
+    expect(row.value).toContain("\\|");
+  });
+
+  it("does not emit a live link from a title", () => {
+    expect(at(documents, "findings/INDEX.md").contents).not.toContain("](https://evil.example)");
+    expect(at(documents, "findings/CSF-001.md").contents).not.toContain("](https://evil.example)");
+  });
+});
+
+describe("codex findings packet is deterministic and scan-clean", () => {
+  it("renders byte-identical output for the same plan", () => {
+    const first = render(27);
+    const second = render(27);
+
+    expect(A.map(first, (document) => `${document.path} :: ${document.contents}`)).toEqual(
+      A.map(second, (document) => `${document.path} :: ${document.contents}`)
+    );
+  });
+
+  it("passes the reject-scan on every generated document", () => {
+    const hits = A.flatMap(render(27), (document) => scanSensitiveText(document.path, document.contents));
+
+    expect(hits).toEqual([]);
+  });
+
+  it("ignores the raw directory and never copies the CSV export", () => {
+    const documents = render(3);
+    const gitignore = at(documents, "raw/.gitignore").contents;
+
+    expect(gitignore).toContain("*");
+    expect(gitignore).toContain("!.gitignore");
+    expect(at(documents, "raw/payload.json").tracked).toBe(false);
+    expect(A.filter(documents, (document) => Str.endsWith(".csv")(document.path))).toEqual([]);
+  });
+});

--- a/packages/tooling/tool/cli/test/codex-findings-scan.test.ts
+++ b/packages/tooling/tool/cli/test/codex-findings-scan.test.ts
@@ -1,0 +1,135 @@
+import { describeSensitiveHits, scanSensitiveText, scanSensitiveUnknown } from "@beep/repo-cli/test/Codex";
+import { A } from "@beep/utils";
+import { describe, expect, it } from "@effect/vitest";
+
+const codesFor = (value: string): ReadonlyArray<string> =>
+  A.dedupe(A.map(scanSensitiveText("surface", value), (hit) => hit.code));
+
+/**
+ * Secret-shaped fixtures are assembled at runtime rather than written as
+ * literals. The repository's secret gate scans the commit range using the base
+ * branch's config, so a literal committed here could not be suppressed by an
+ * allowlist added in the same change — and a scanner's own test file is
+ * exactly where a scanner-tripping literal is least welcome. None of these are
+ * real credentials.
+ */
+const fakeOpenAiKey = `sk-${"abcdefghijklmnopqrstuv"}`;
+const fakeJwt = A.join(["eyJhbGciOiJIUzI1NiJ9", "eyJzdWIiOiIxMjM0NTY3ODkwIn0", "dBjftJeZ4CVPmB92K27uhbUJU1p1r"], ".");
+const fakeAssignedSecret = `${A.join(["API", "KEY"], "_")}=hunter2`;
+
+/**
+ * Every entry below was measured against the repo's existing log sanitizer
+ * (`sanitizeSensitiveText`) and passed through it untouched. They are the
+ * reason this scan exists rather than reusing that helper.
+ */
+const provenSanitizerGaps: ReadonlyArray<readonly [string, string, string]> = [
+  ["raw document.cookie", "__cf_bm=AbCdEfGh12345678; _puid=user-XYZ987654; oai-did=9f3c1", "session-cookie"],
+  ["json-encoded cookie header", '{"cookie": "__cf_bm=AbCdEf12345; _puid=user-XYZ987"}', "auth-header"],
+  [
+    "presigned s3 url",
+    "https://example.invalid/a.patch?X-Amz-Signature=9d8f7a6b5c4d3e2f1a0b&X-Amz-Expires=900",
+    "signed-url-param",
+  ],
+  ["azure sas url", "https://example.invalid/a?sv=2021-08-06&sig=abcDEF123%2Bxyz&se=2026-08-05", "signed-url-param"],
+  ["1password reference", "op://Private/OpenAI/credential", "onepassword-ref"],
+  ["private home path", "/home/elpresidank/YeeBois/projects/beep-effect8/goals/x", "private-home-path"],
+];
+
+describe("codex findings reject-scan closes the measured sanitizer gaps", () => {
+  for (const [label, input, expectedCode] of provenSanitizerGaps) {
+    it(`refuses ${label}`, () => {
+      expect(codesFor(input)).toContain(expectedCode);
+    });
+  }
+});
+
+describe("codex findings reject-scan credential classes", () => {
+  const cases: ReadonlyArray<readonly [string, string, string]> = [
+    ["authorization header", "Authorization: Bearer abcdefghijklmnop", "auth-header"],
+    ["bearer credential", "Bearer abcdefghijklmnopqrstuv", "bearer-credential"],
+    ["openai key", fakeOpenAiKey, "secret-shaped-value"],
+    ["assignment-shaped secret", fakeAssignedSecret, "secret-shaped-value"],
+    ["jwt", fakeJwt, "jwt-token"],
+    ["macos home path", "/Users/someone/Documents", "private-home-path"],
+    ["windows home path", "C:\\Users\\someone\\Documents", "private-home-path"],
+    ["tilde home", "see ~/notes.txt", "private-home-path"],
+    ["userprofile env ref", "%USERPROFILE%\\config", "private-home-path"],
+    ["bidi override", "safe\u202Eevil", "bidi-control"],
+    ["secure cookie prefix", "__Secure-next-auth.session-token=abc", "session-cookie"],
+    // Present in every row of the signed-in CSV export.
+    ["github noreply author email", "12345678+someuser@users.noreply.github.com", "email-address"],
+    ["plain author email", "someone@example.com", "email-address"],
+    ["excel formula", "=cmd|'/c calc'!A1", "spreadsheet-formula"],
+    ["lotus-style formula", "@SUM(1+1)*cmd", "spreadsheet-formula"],
+    ["signed formula", "-2+3+cmd|'/c calc'!A1", "spreadsheet-formula"],
+  ];
+
+  for (const [label, input, expectedCode] of cases) {
+    it(`refuses ${label}`, () => {
+      expect(codesFor(input)).toContain(expectedCode);
+    });
+  }
+});
+
+describe("codex findings reject-scan admits legitimate packet prose", () => {
+  const benign: ReadonlyArray<readonly [string, string]> = [
+    ["a finding title", "Unbounded source resolution enables sidecar memory DoS"],
+    ["a repo-relative path", "packages/workspace/server/src/SourceText/WorkspaceSourceTextResolver.ts"],
+    ["a verification command", "bunx --bun vitest run --root packages/tooling/tool/cli"],
+    ["the dashboard url", "https://chatgpt.com/codex/cloud/security/findings/"],
+    ["a source commit", "244529aa4f560421cd096c2a4a4cb3cd21923070"],
+    ["a codex identifier", "d2b9e11e8550819193516057a336ff90"],
+    ["prose naming a token concept", "The session token is never written to disk."],
+    ["a typescript fence", "```ts\nconst value = 1\n```"],
+    ["a vuln class label", "CWE-78 argument/exec control, missing-trust-boundary"],
+    ["a short query parameter", "https://example.invalid/a?sig=1"],
+    // The email rule must not fire on the `@` forms that saturate this repo.
+    ["a scoped package import", 'import { A } from "@beep/utils"'],
+    ["a jsdoc category tag in situ", " * @category utilities"],
+    ["a version specifier", "typescript@5.9.2 and @beep/repo-cli@workspace:*"],
+    // The formula rule is anchored, so interior sigils are ordinary prose.
+    ["a title containing a hyphen and equals", "Config allows plaintext http= and cross-origin reads"],
+    ["a markdown bullet body", "# Title\n\n- first bullet\n- second bullet"],
+  ];
+
+  for (const [label, input] of benign) {
+    it(`admits ${label}`, () => {
+      expect(scanSensitiveText("surface", input)).toEqual([]);
+    });
+  }
+});
+
+describe("codex findings reject-scan traversal of untrusted payloads", () => {
+  it("addresses a nested hit by logical surface", () => {
+    const hits = scanSensitiveUnknown("payload", {
+      capture: { note: "fine" },
+      findings: [{ title: "fine" }, { title: "op://vault/item" }],
+    });
+
+    expect(A.map(hits, (hit) => hit.surface)).toEqual(["payload.findings[1].title"]);
+  });
+
+  it("scans object keys as well as values", () => {
+    const hits = scanSensitiveUnknown("payload", { "/home/dev/leak": "fine" });
+
+    expect(A.map(hits, (hit) => hit.code)).toContain("private-home-path");
+  });
+
+  it("refuses a payload nested past the scan depth instead of walking it", () => {
+    const deep = A.reduce(A.range(1, 40), {} as Record<string, unknown>, (acc) => ({ nested: acc }));
+    const hits = scanSensitiveUnknown("payload", deep);
+
+    expect(A.map(hits, (hit) => hit.code)).toContain("max-scan-depth");
+  });
+
+  it("never carries the offending value in a hit or its description", () => {
+    const secret = `sk-${"abcdefghijklmnopqrstuv"}`;
+    const hits = scanSensitiveUnknown("payload", { findings: [{ title: secret }] });
+    const described = describeSensitiveHits(hits);
+
+    expect(hits.length).toBeGreaterThan(0);
+    expect(JSON.stringify(hits)).not.toContain(secret);
+    expect(described.join(" ")).not.toContain(secret);
+    expect(described).toEqual(["payload.findings[0].title (secret-shaped-value)"]);
+  });
+});

--- a/packages/tooling/tool/cli/test/codex-findings-write.test.ts
+++ b/packages/tooling/tool/cli/test/codex-findings-write.test.ts
@@ -106,6 +106,45 @@ describe("codex findings packet promotion", () => {
     ));
 });
 
+describe("codex findings verbatim raw evidence", () => {
+  // Report bodies are external prose that legitimately quotes local paths.
+  // Measured against a real 27-finding export, 4 bodies trip the scan — so a
+  // hard refusal here would block roughly one ingest in seven.
+  it("reports rather than refuses hits inside verbatim raw evidence", () =>
+    run(
+      Effect.gen(function* () {
+        const outcome = yield* writeIn({
+          documents: [
+            doc("README.md", "# clean\n"),
+            PacketDocument.make({
+              path: "raw/reports/CSF-001.md",
+              contents: "The resolver reads /home/someone/notes.txt without bounds.\n",
+              tracked: false,
+              scan: "report",
+            }),
+          ],
+        });
+
+        expect(outcome.committed).toBe(true);
+        expect(outcome.reportedEvidence).toEqual(["raw/reports/CSF-001.md (private-home-path)"]);
+      })
+    ));
+
+  it("still refuses the same content in a tracked document", () =>
+    run(
+      Effect.gen(function* () {
+        const outcome = yield* writeIn({
+          documents: [doc("findings/CSF-001.md", "The resolver reads /home/someone/notes.txt.\n")],
+        }).pipe(
+          Effect.map(() => "accepted"),
+          Effect.catchTag("CodexFindingsRedactionError", () => Effect.succeed("refused"))
+        );
+
+        expect(outcome).toBe("refused");
+      })
+    ));
+});
+
 describe("codex findings packet forced replacement", () => {
   it("replaces an existing packet when force is set", () =>
     run(
@@ -119,6 +158,9 @@ describe("codex findings packet forced replacement", () => {
 
         expect(outcome.committed).toBe(true);
         expect(yield* fs.readFileString(`goals/${SLUG}/README.md`)).toBe(sampleDocuments[0]?.contents);
+        // The replaced packet is moved aside, promoted, then removed. Nothing
+        // may survive under goals/ once the promotion succeeds.
+        expect(A.filter(yield* fs.readDirectory("goals"), (e) => e.includes("-replaced"))).toEqual([]);
         // A replacement is a replacement: files the new packet does not declare
         // must not survive from the packet it replaced.
         expect(yield* fs.exists(`goals/${SLUG}/findings/CSF-999.md`)).toBe(false);

--- a/packages/tooling/tool/cli/test/codex-findings-write.test.ts
+++ b/packages/tooling/tool/cli/test/codex-findings-write.test.ts
@@ -1,0 +1,241 @@
+import { PacketDocument, writePacket } from "@beep/repo-cli/test/Codex";
+import { provideScopedLayer } from "@beep/test-utils";
+import { A } from "@beep/utils";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem } from "effect";
+import { NodeTestLayer, withTempWorkingDirectory } from "./support/CommandTest.ts";
+import type { Path } from "effect";
+
+const SLUG = "codex-security-findings-2026-08-04";
+
+const doc = (path: string, contents: string, tracked = true) => PacketDocument.make({ contents, path, tracked });
+
+const sampleDocuments = [
+  doc("README.md", "# Codex Security Findings (2026-08-04)\n\nLifecycle: `active`\n"),
+  doc("ops/manifest.json", '{\n  "schemaVersion": "initiative-manifest/v2"\n}\n'),
+  doc("findings/CSF-001.md", "# CSF-001: A finding\n"),
+  doc("raw/.gitignore", "*\n!.gitignore\n", false),
+];
+
+// `writePacket` resolves paths as well as reading and writing, so the context
+// it needs is FileSystem *and* Path; NodeTestLayer supplies both.
+const run = <A, E>(use: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+  Effect.runPromise(withTempWorkingDirectory(use).pipe(provideScopedLayer(NodeTestLayer)));
+
+const writeIn = Effect.fn("writeIn")(function* (options: {
+  readonly slug?: string;
+  readonly documents?: ReadonlyArray<PacketDocument>;
+  readonly dryRun?: boolean;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.makeDirectory("goals", { recursive: true });
+  return yield* writePacket({
+    documents: options.documents ?? sampleDocuments,
+    dryRun: options.dryRun ?? false,
+    repoRoot: process.cwd(),
+    slug: options.slug ?? SLUG,
+  });
+});
+
+describe("codex findings packet promotion", () => {
+  it("writes every document under the packet directory", () =>
+    run(
+      Effect.gen(function* () {
+        const outcome = yield* writeIn({});
+        const fs = yield* FileSystem.FileSystem;
+
+        expect(outcome.committed).toBe(true);
+        expect(outcome.packetPath).toBe(`goals/${SLUG}`);
+
+        for (const document of sampleDocuments) {
+          const contents = yield* fs.readFileString(`goals/${SLUG}/${document.path}`);
+          expect(contents).toBe(document.contents);
+        }
+      })
+    ));
+
+  it("leaves no staging directory behind after a successful promotion", () =>
+    run(
+      Effect.gen(function* () {
+        yield* writeIn({});
+        const fs = yield* FileSystem.FileSystem;
+        const entries = yield* fs.readDirectory("goals");
+
+        expect(A.filter(entries, (entry) => entry.startsWith(".tmp-"))).toEqual([]);
+        expect(entries).toContain(SLUG);
+      })
+    ));
+
+  it("refuses to clobber an existing packet and leaves its bytes untouched", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.makeDirectory(`goals/${SLUG}`, { recursive: true });
+        yield* fs.writeFileString(`goals/${SLUG}/README.md`, "hand written\n");
+
+        const outcome = yield* writeIn({}).pipe(
+          Effect.map(() => "written"),
+          Effect.catchTag("CodexPacketWriteError", (error) => Effect.succeed(error.reason))
+        );
+
+        expect(outcome).toBe("packet-exists");
+        expect(yield* fs.readFileString(`goals/${SLUG}/README.md`)).toBe("hand written\n");
+      })
+    ));
+
+  it("leaves no packet and no staging directory when a document cannot be staged", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+
+        // A file where a document's parent directory must go makes that single
+        // staged write fail after earlier documents already landed.
+        const outcome = yield* writeIn({
+          documents: [doc("README.md", "# ok\n"), doc("ops", "not a directory\n"), doc("ops/manifest.json", "{}\n")],
+        }).pipe(
+          Effect.map(() => "written"),
+          Effect.catchTag("CodexPacketWriteError", (error) => Effect.succeed(error.reason))
+        );
+
+        expect(outcome).toBe("staging-failed");
+        expect(yield* fs.exists(`goals/${SLUG}`)).toBe(false);
+        expect(A.filter(yield* fs.readDirectory("goals"), (entry) => entry.startsWith(".tmp-"))).toEqual([]);
+      })
+    ));
+});
+
+describe("codex findings packet dry run", () => {
+  it("writes nothing at all while still reporting the plan", () =>
+    run(
+      Effect.gen(function* () {
+        const outcome = yield* writeIn({ dryRun: true });
+        const fs = yield* FileSystem.FileSystem;
+
+        expect(outcome.committed).toBe(false);
+        expect(outcome.written).toEqual([
+          `goals/${SLUG}/README.md`,
+          `goals/${SLUG}/ops/manifest.json`,
+          `goals/${SLUG}/findings/CSF-001.md`,
+          `goals/${SLUG}/raw/.gitignore`,
+        ]);
+        expect(yield* fs.exists(`goals/${SLUG}`)).toBe(false);
+        expect(yield* fs.readDirectory("goals")).toEqual([]);
+      })
+    ));
+
+  it("refuses secret-shaped content in dry run exactly as it would when writing", () =>
+    run(
+      Effect.gen(function* () {
+        const outcome = yield* writeIn({
+          documents: [doc("raw/payload.json", '{"cookie":"__cf_bm=AbCdEf12345"}', false)],
+          dryRun: true,
+        }).pipe(
+          Effect.map(() => "accepted"),
+          Effect.catchTag("CodexFindingsRedactionError", () => Effect.succeed("refused"))
+        );
+
+        expect(outcome).toBe("refused");
+      })
+    ));
+});
+
+describe("codex findings packet redaction refusal", () => {
+  it("refuses untracked raw evidence, not only tracked documents", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const outcome = yield* writeIn({
+          documents: [
+            doc("README.md", "# clean\n"),
+            doc("raw/payload.json", '{"note":"op://Private/OpenAI/credential"}', false),
+          ],
+        }).pipe(
+          Effect.map(() => A.empty<string>()),
+          Effect.catchTag("CodexFindingsRedactionError", (error) => Effect.succeed(error.surfaces))
+        );
+
+        expect(outcome).toEqual(["raw/payload.json (onepassword-ref)"]);
+        expect(yield* fs.exists(`goals/${SLUG}`)).toBe(false);
+      })
+    ));
+
+  it("never reproduces the offending value in the refusal", () =>
+    run(
+      Effect.gen(function* () {
+        const secret = `sk-${"abcdefghijklmnopqrstuv"}`;
+        const outcome = yield* writeIn({
+          documents: [doc("raw/payload.json", `{"title":"${secret}"}`, false)],
+        }).pipe(
+          Effect.map(() => "accepted"),
+          Effect.catchTag("CodexFindingsRedactionError", (error) =>
+            Effect.succeed(`${error.message} ${A.join(error.surfaces, " ")}`)
+          )
+        );
+
+        expect(outcome).not.toContain(secret);
+        expect(outcome).toContain("raw/payload.json (secret-shaped-value)");
+      })
+    ));
+
+  it("refuses a private absolute path before it can reach a tracked file", () =>
+    run(
+      Effect.gen(function* () {
+        const outcome = yield* writeIn({
+          documents: [doc("findings/CSF-001.md", "See /home/elpresidank/notes.txt\n")],
+        }).pipe(
+          Effect.map(() => A.empty<string>()),
+          Effect.catchTag("CodexFindingsRedactionError", (error) => Effect.succeed(error.surfaces))
+        );
+
+        expect(outcome).toEqual(["findings/CSF-001.md (private-home-path)"]);
+      })
+    ));
+});
+
+describe("codex findings packet path containment", () => {
+  const rejectsPath = (path: string) =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.makeDirectory("goals", { recursive: true });
+        return yield* Effect.try(() => PacketDocument.make({ contents: "x\n", path, tracked: true })).pipe(
+          Effect.map(() => "accepted"),
+          Effect.orElseSucceed(() => "rejected")
+        );
+      })
+    );
+
+  it("rejects a parent-directory traversal in a document path", () =>
+    expect(rejectsPath("../escape.md")).resolves.toBe("rejected"));
+
+  it("rejects a nested traversal in a document path", () =>
+    expect(rejectsPath("findings/../../escape.md")).resolves.toBe("rejected"));
+
+  it("rejects an absolute document path", () => expect(rejectsPath("/etc/passwd")).resolves.toBe("rejected"));
+
+  it("rejects a dotfile-rooted document path outside the raw allowance", () =>
+    expect(rejectsPath(".git/config")).resolves.toBe("rejected"));
+
+  it("does not write through a symlinked packet destination", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.makeDirectory("goals", { recursive: true });
+        yield* fs.makeDirectory("outside", { recursive: true });
+        yield* fs.symlink(`${process.cwd()}/outside`, `goals/${SLUG}`);
+
+        const outcome = yield* writePacket({
+          documents: sampleDocuments,
+          dryRun: false,
+          repoRoot: process.cwd(),
+          slug: SLUG,
+        }).pipe(
+          Effect.map(() => "written"),
+          Effect.catchTag("CodexPacketWriteError", (error) => Effect.succeed(error.reason))
+        );
+
+        expect(outcome).toBe("packet-exists");
+        expect(yield* fs.readDirectory("outside")).toEqual([]);
+      })
+    ));
+});

--- a/packages/tooling/tool/cli/test/codex-findings-write.test.ts
+++ b/packages/tooling/tool/cli/test/codex-findings-write.test.ts
@@ -26,12 +26,14 @@ const writeIn = Effect.fn("writeIn")(function* (options: {
   readonly slug?: string;
   readonly documents?: ReadonlyArray<PacketDocument>;
   readonly dryRun?: boolean;
+  readonly force?: boolean;
 }) {
   const fs = yield* FileSystem.FileSystem;
   yield* fs.makeDirectory("goals", { recursive: true });
   return yield* writePacket({
     documents: options.documents ?? sampleDocuments,
     dryRun: options.dryRun ?? false,
+    force: options.force ?? false,
     repoRoot: process.cwd(),
     slug: options.slug ?? SLUG,
   });
@@ -100,6 +102,69 @@ describe("codex findings packet promotion", () => {
         expect(outcome).toBe("staging-failed");
         expect(yield* fs.exists(`goals/${SLUG}`)).toBe(false);
         expect(A.filter(yield* fs.readDirectory("goals"), (entry) => entry.startsWith(".tmp-"))).toEqual([]);
+      })
+    ));
+});
+
+describe("codex findings packet forced replacement", () => {
+  it("replaces an existing packet when force is set", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.makeDirectory(`goals/${SLUG}/findings`, { recursive: true });
+        yield* fs.writeFileString(`goals/${SLUG}/README.md`, "hand written\n");
+        yield* fs.writeFileString(`goals/${SLUG}/findings/CSF-999.md`, "stale finding\n");
+
+        const outcome = yield* writeIn({ force: true });
+
+        expect(outcome.committed).toBe(true);
+        expect(yield* fs.readFileString(`goals/${SLUG}/README.md`)).toBe(sampleDocuments[0]?.contents);
+        // A replacement is a replacement: files the new packet does not declare
+        // must not survive from the packet it replaced.
+        expect(yield* fs.exists(`goals/${SLUG}/findings/CSF-999.md`)).toBe(false);
+      })
+    ));
+
+  // The removal is deliberately staged behind the scan. If it ever moves ahead
+  // of it, a refused capture would destroy a packet full of hand-written triage
+  // prose and write nothing in its place — this is the test that catches that.
+  it("leaves the existing packet intact when a forced run is refused by the scan", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.makeDirectory(`goals/${SLUG}`, { recursive: true });
+        yield* fs.writeFileString(`goals/${SLUG}/README.md`, "hand written\n");
+
+        const outcome = yield* writeIn({
+          documents: [doc("raw/payload.json", '{"note":"op://Private/OpenAI/credential"}', false)],
+          force: true,
+        }).pipe(
+          Effect.map(() => "written"),
+          Effect.catchTag("CodexFindingsRedactionError", () => Effect.succeed("refused"))
+        );
+
+        expect(outcome).toBe("refused");
+        expect(yield* fs.readFileString(`goals/${SLUG}/README.md`)).toBe("hand written\n");
+      })
+    ));
+
+  it("leaves the existing packet intact when a forced run fails mid-staging", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.makeDirectory(`goals/${SLUG}`, { recursive: true });
+        yield* fs.writeFileString(`goals/${SLUG}/README.md`, "hand written\n");
+
+        const outcome = yield* writeIn({
+          documents: [doc("README.md", "# ok\n"), doc("ops", "not a directory\n"), doc("ops/manifest.json", "{}\n")],
+          force: true,
+        }).pipe(
+          Effect.map(() => "written"),
+          Effect.catchTag("CodexPacketWriteError", (error) => Effect.succeed(error.reason))
+        );
+
+        expect(outcome).toBe("staging-failed");
+        expect(yield* fs.readFileString(`goals/${SLUG}/README.md`)).toBe("hand written\n");
       })
     ));
 });


### PR DESCRIPTION
## What

Adds `bun run beep codex findings ingest --from <export.csv>`, which turns the
Codex Cloud security view's own signed-in **Export findings as CSV** download
into a doctor-clean goal packet sitting at the P1 capture → P2 validate
boundary.

Five security batches (`goals/codex-security-findings-{2026-06, 06-17, 07-08,
07-14, 08-04}`) were transcribed by hand before this existed. The
2026-08-04 reflection asked for it directly:

> **wished existed:** "A beep-cli capture command that drives the signed-in CSV"

## Why this shape

The original framing was "download my cookies and scrape the page". That is not
what this does, and the difference is the whole design.

The findings view exports its own CSV. **The CLI never authenticates** — the
operator downloads a file and passes its path, so no cookie, token, or
authorization header is ever read, stored, logged, or placed on a process
command line. A same-origin fetch against the findings API returns 401, and the
tempting "fix" for that (attaching a session token) is exactly what this design
forbids.

That also deleted the riskiest alternative considered: a pasteable DevTools
snippet running with full ChatGPT session authority. No pasted JS, no pinned
script digest, no fragile DOM selectors.

## Security properties

- **Personal data never enters the CLI.** The export carries `author_email` (a
  GitHub noreply address) in *every* row plus `assignee_name`/`assignee_email`.
  All three are dropped at the parse boundary, and the reject-scan
  independently refuses email addresses as defense in depth.
- **Reject, never redact.** Secret-shaped values, private home paths, 1Password
  refs, auth headers, bearer credentials, JWTs, session cookies, signed-URL
  params, bidi controls, and spreadsheet-formula sigils fail the ingest rather
  than being silently rewritten. Missed redaction in a public repo is
  irreversible; a false rejection costs one hand-edit.
- **The scan covers `raw/` too**, not just tracked output. `raw/` is gitignored,
  so the repo's commit-range secret scanner structurally never sees it — yet
  write-capable `/goal` agents read it.
- **The CSV is never copied into the repo.** `raw/payload.json` holds the
  normalized, PII-stripped capture; the export keeps its report bodies and
  addresses outside the tree.
- **Errors name surfaces, never values** — `findings[3].title (jwt-token)`, so
  surfacing an error can't become the leak the scan prevents.
- **Writes are atomic**: staged under an unpredictable temp dir, scanned, then
  promoted with a single rename. A crash cannot leave a half-packet, and an
  existing packet is never clobbered without `--force`.

## Identity is sticky

Re-ingesting preserves each `codexId → CSF-NNN` binding and never reuses a
number, even after a finding leaves the export. Without this, one new
high-severity finding would renumber every later record — invalidating
hand-written triage prose and the exact-ID allowlist used to close findings
after merge.

## Verified against the real batch

Run against the actual 27-row 2026-08-04 export:

```
✓ export   27 findings   Medium 13 · Low 7 · Informational 7
✓ scan     0 rejections across payload and raw evidence
✓ packet   goals/<slug>  (37 files)
```

Those severity counts match the hand-built 2026-08-04 manifest exactly, and the
generated packet clears the real `bun run beep goals doctor` with no new
blocking findings. GOAL.md lands at 2294 chars against the hard 4000 gate.

## Tests (106)

Each names the bug it catches, rather than restating the implementation:

- generated manifest actually decodes as `GoalManifest`; lifecycle/status
  agreement and non-terminal phases (all three are *blocking* doctor findings)
- **GOAL.md holds at 26 and 200 findings**, and grows <20 chars between them —
  the invariant that catches anyone adding a per-finding line
- hostile title `Evil | ](https://evil.example) …` keeps exactly 6 unescaped
  pipes and emits no live link
- author email and report body provably never leave the parser
- signed-out HTML, drifted header, truncated row, unknown severity, and
  duplicate identity each refuse with a distinct typed reason
- traversal/symlink refusal, refuse-to-clobber, atomicity, dry-run purity
- byte-identical output across runs; sticky identity across re-ingest

## Notes for review

- `--refresh` is **not** implemented. The sticky-identity mechanism it needs is
  built and tested, but merging a new export into a packet while preserving
  hand-written prose is a real three-way merge; shipping it half-done would be
  worse than the documented gap.
- Source-commit ancestry runs as a packet verification command rather than a
  CLI gate, because this repo squash-merges and a valid finding's source commit
  is frequently absent from the branch.
- No reflection scaffold: the doctor validates reflection frontmatter only when
  the directory exists, so a stub would be either blocking-invalid or fabricated
  judgment. Reflections belong at P9 via the `reflect` skill.
- Secret-shaped test fixtures are assembled at runtime rather than committed as
  literals — the secret gate scans the commit range using the *base* branch's
  config, so an in-PR allowlist could not suppress them anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788622934&installation_model_id=424656&pr_number=594&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F594&signature=7accc7ea7224274d696b829ab7820091ed5978015fc94924c085ceb6b85d46cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->