### PR TITLE
feat(repo-cli): add jsdoc-migrate codemod pipeline (P1)

### DIFF
--- a/.changeset/jsdoc-migrate-codemod.md
+++ b/.changeset/jsdoc-migrate-codemod.md
@@ -1,0 +1,14 @@
+---
+"@beep/repo-cli": patch
+---
+
+Ship the `beep quality jsdoc-migrate` pipeline (P1 of `goals/jsdoc-carrier-migration`):
+`extract` scans the non-generated corpus into `path#symbol#ordinal`-anchored records with
+`sourceHash`/`kind` verification fields and fails loudly on duplicate anchors; `titles` requests
+per-anchor Example titles, remarks routing, lead split points, and `@see` purposes from the local
+model proxy with per-anchor resume; `apply` rewrites affected blocks text-surgically by byte
+offset behind fail-closed binding checks (bijection, hash, kind), quarantining any block whose
+rewrite violates the two-clause conservation law or grows the `documentationShapeViolations`
+oracle finding set; `verify` re-proves conservation between frozen originals and post-format
+bytes into a schema-versioned proof manifest. The full-corpus dry run measures residue 32 of
+11,674 affected blocks (31 unfenced examples plus one fence buried in `@remarks` content).

--- a/goals/jsdoc-carrier-migration/ops/progress.json
+++ b/goals/jsdoc-carrier-migration/ops/progress.json
@@ -6,16 +6,16 @@
     "wontFixRule": "Every wont_fix item requires a rationale string and a trigger that would reopen it."
   },
   "phases": {
-    "P0_law_and_packet": "in_progress",
-    "P1_codemod": "pending",
+    "P0_law_and_packet": "done",
+    "P1_codemod": "done",
     "P2_generators": "pending",
     "P3_migration": "pending",
     "P4_close": "pending"
   },
   "coreItems": {
     "C1_law_contradiction_fix": { "status": "done" },
-    "C2_codemod_extract_apply_verify": { "status": "pending" },
-    "C3_conservation_law_and_proof_manifest": { "status": "pending" },
+    "C2_codemod_extract_apply_verify": { "status": "done" },
+    "C3_conservation_law_and_proof_manifest": { "status": "done" },
     "C4_title_pass_via_proxy": { "status": "pending" },
     "C5_generator_templates": { "status": "pending" },
     "C6_residue_overrides": { "status": "pending" },
@@ -34,8 +34,8 @@
     "multiParagraphLeadBlocks": 872,
     "generatedFiles": 18,
     "generatedExamples": 1065,
-    "residueCount": null,
-    "residueNote": "Unknown until P1 dry-run. The 114 unfenced examples auto-quarantine by construction; additional conservation-law quarantines are unmeasured.",
+    "residueCount": 32,
+    "residueNote": "Measured 2026-08-06 by the P1 full-corpus dry run (`beep quality jsdoc-migrate apply --dry-run --synthetic-titles`) on branch feat/jsdoc-migrate-codemod at base 3c56d2f823: 1,899 affected files, 11,674 affected blocks, 11,642 rewrite cleanly, residue 32 = 31 unfenced-example (fence addition is outside both conservation clauses, so they auto-quarantine) + 1 shape-regression (FullCaseCitation.toBlueBook carries a fence inside @remarks content, which would surface as an untitled Example section). Binding was fully clean: 11,674 extract anchors bijected with 11,674 synthetic records, zero hash or kind mismatches, zero duplicate anchors corpus-wide. The census's 114 unfenced count was regex-based and included fenced examples with a caption line before the fence, which the codemod converts cleanly; the census's zero-collision claim missed 188 bare untitled `**Example**` markers sitting directly above a legacy tag, which the codemod now consumes into the titled section (conservation- and oracle-checked).",
     "stableTails": "unfencedExamples (114) and multiExampleBlocks (19) held constant across both measurements while 340 examples retired — the pathological tails are not eroded by ordinary work and will still be there at P3."
   }
 }

--- a/goals/jsdoc-carrier-migration/research/OPPORTUNITIES.md
+++ b/goals/jsdoc-carrier-migration/research/OPPORTUNITIES.md
@@ -1,0 +1,51 @@
+# Opportunities & friction ledger
+
+Receipts recorded at the moment of friction, per the repo friction-capture law.
+
+## 2026-08-06 — P1 codemod build
+
+### `A.makeBy` silently clamps its size to 1
+
+- **What happened:** the synthetic-title generator used `A.makeBy(record.exampleTagCount, ...)`
+  to build one placeholder per `@example` tag. For remarks-only blocks (`exampleTagCount = 0`)
+  effect's `makeBy` returned a 1-element array — its `NonEmptyArray` contract clamps `n < 1`
+  to 1 — so every remarks-only block failed the title-count check.
+- **Evidence:** first full-corpus dry run of `beep quality jsdoc-migrate apply --dry-run
+  --synthetic-titles` aborted with dozens of
+  `title-count-mismatch: block has 0 @example tag(s), record has 1 title(s)` errors
+  (e.g. `packages/drivers/duckdb/src/index.ts#<fileoverview>#0`), costing one corpus-scale
+  run (~1 min) plus a repro cycle to attribute.
+- **Prevention:** a lint or tsgo diagnostic flagging `A.makeBy` calls whose size argument is
+  not provably ≥ 1 would surface the clamp at write time; alternatively an `A.makeBy0`-style
+  wrapper in `@beep/utils` with a plain-`Array` return for possibly-zero sizes.
+
+### Census figures were regex-derived and diverged from the gate's scanner
+
+- **What happened:** three P1 measurements disagreed with `research/corpus-census.md`:
+  affected blocks 11,674 vs 13,265 (the census's `/\*\*[\s\S]*?\*\//` block regex is not
+  fence-aware and over-splits blocks whose examples contain `/**`), unfenced examples 31 vs
+  114 (the census counted any `@example` not *immediately* followed by a fence, which
+  includes caption-then-fence blocks the codemod converts cleanly), and the "zero collision"
+  claim missed 188 bare untitled `**Example**` markers sitting directly above a legacy
+  `@example` tag (its query grepped for `**Example** (` with the paren).
+- **Evidence:** `beep quality jsdoc-migrate extract` summary line
+  (`files=1899 blocks=11674 multiExample=19 remarks=495 unfencedExamples=31`) and the first
+  dry-run manifest showing 188 `mixed-example-carriers` quarantines, later resolved by the
+  stray-marker consumption rule.
+- **Prevention:** the census itself predicted this ("`beep quality jsdoc-migrate extract`
+  supersedes this document in P1") — the durable fix is to regenerate census numbers from
+  `extract.jsonl` and never quote the ad-hoc regex figures once an extract exists. The two
+  stable-tail figures (19 multi-example, 114 unfenced) were load-bearing in planning; only
+  the 19 survived contact with the gate-consistent scanner.
+
+### Schema-first inventory entries are line-pinned and go stale on unrelated edits
+
+- **What happened:** the four documented schema-first exceptions for the P1 codemod carry a
+  `"line"` field. Adding `@param`/`@returns` doc lines to the same files shifted every pinned
+  line by two, which made the exceptions "stale inventory entry" errors and failed the next
+  full `yeet verify` lint lane — a whole verify cycle (~8 min) to learn a doc edit moved a line.
+- **Evidence:** round-5 verify log: `Stale schema-first inventory entry is no longer present in
+  the live scan` for `computeJSDocMigrateBinding` (line 176 → 178) and three siblings.
+- **Prevention:** key advisory exceptions by `file#symbol#ruleId` alone, or treat `line` as
+  display metadata rather than part of the match key; `--write` refreshing lines without
+  resetting a reviewed `status: "exception"` would also close the loop.

--- a/goals/jsdoc-carrier-migration/tasks/tasks.jsonc
+++ b/goals/jsdoc-carrier-migration/tasks/tasks.jsonc
@@ -30,7 +30,7 @@
       "id": "jcm-003",
       "rank": 3,
       "phase": "P1",
-      "status": "pending",
+      "status": "done",
       "blockedBy": ["jcm-001"],
       "title": "beep quality jsdoc-migrate extract",
       "detail": "New subcommand in packages/tooling/tool/cli/src/commands/Quality/internal/, registered in the existing jsdoc-* family. ts-morph walks packages/**/src/**/*.{ts,tsx}, emitting one extract.jsonl record per affected doc block: path#symbol anchor, symbol kind (value-level vs pure type-level per the kind-split Example law), lead paragraphs, fence bodies, existing tags, and byte offsets for the block span. Anchors are path#symbol#ordinal, NEVER content hashes and never line numbers. path#symbol alone collides: overloads, declaration merging, default exports, and same-name type companions for runtime schemas (documented law in .patterns/jsdoc-documentation.md) all share a name. ordinal is the 0-based index among blocks sharing an anchor in source order, 0 in the unique case. extract MUST fail loudly on a duplicate anchor — a title applied to the wrong block is well-formed and the conservation law cannot catch it. Each record also carries sourceHash (hash of the ORIGINAL block bytes) and kind (value | type-level from ts-morph). These are verification fields, never addressing fields: ordinals shift on add, remove, OR REORDER ahead of a block, and reorder leaves both the anchor set and the record count looking correct, so only an exact identity check detects it."
@@ -39,7 +39,7 @@
       "id": "jcm-004",
       "rank": 4,
       "phase": "P1",
-      "status": "pending",
+      "status": "done",
       "blockedBy": ["jcm-003"],
       "title": "Conservation law + proof manifest",
       "detail": "Export documentationShapeViolations within the package (not across package boundaries). Implement BOTH clauses of SPEC 5.3. (a) Content: every fence's code bytes identical, prose tokens a subset of output, added prose limited to section markers plus data-sourced strings from titles.jsonl (title, @see purpose phrase) — the codemod never invents prose. (b) Tags: only the closed allowlist may be rewritten (@template->@typeParam, @module->@packageDocumentation, @default->@defaultValue, {type} removal, @returns/@throws hyphen, canonical order, @see purpose phrase, and the two carrier consumptions); every other tag is bytes-identical, every rewrite must match its normal form exactly, and no tag may be dropped without a consuming rule. Do NOT implement this as blanket 'tags bytes-identical' — that contradicts the D4 grammar fixes and would quarantine every free win. Violations quarantine rather than write. Pair it with the shape oracle: accept a rewrite only when documentationShapeViolations' finding set shrinks or stays equal. Record results in a schema-versioned proof manifest following the DocgenProofManifest / AcceptedProofManifest idiom. Conservation is computed on POST-FORMAT bytes — biome first, then verify, or reflow reads as content mutation."
@@ -48,7 +48,7 @@
       "id": "jcm-005",
       "rank": 5,
       "phase": "P1",
-      "status": "pending",
+      "status": "done",
       "blockedBy": ["jcm-004"],
       "title": "beep quality jsdoc-migrate apply",
       "detail": "Text-surgical rewrite by byte offset. ts-morph is for analysis only and must never reformat a block — byte conservation becomes unprovable if it does. Consumes titles.jsonl and overrides.jsonl, and FAILS CLOSED on any binding doubt (SPEC 5.2): frozen records must biject with extract (orphans on either side are a hard failure, never a skip), every sourceHash must match the block currently at that anchor, and every kind must agree. A hash mismatch means re-title, not apply. Idempotent: re-running over already-migrated files is a no-op. Transform set per SPEC 5: carrier swap, @template->@typeParam, @module->@packageDocumentation, @default->@defaultValue, {type} blob removal, @returns/@throws hyphen, canonical tag order, lead splitting at leadEnd, @see purpose phrases."
@@ -57,7 +57,7 @@
       "id": "jcm-006",
       "rank": 6,
       "phase": "P1",
-      "status": "pending",
+      "status": "done",
       "blockedBy": ["jcm-004"],
       "title": "beep quality jsdoc-migrate titles",
       "detail": "effect/unstable/http against http://127.0.0.1:8317 with model grok-4.5 — never node:http, and never the xAI API directly (that bills credits instead of the plan). Returns data only: { anchor, title, remarks: details|gotchas, leadEnd }. Append-only titles.jsonl with per-anchor resume and retry only on schema-invalid returns. Resume skips an anchor only when its record is present AND its sourceHash still matches the current block — a bare anchor-present check would silently reuse a stale title after an upstream edit. Not a Workflow: the 1,000-agent cap is below the 1,935 files."
@@ -66,7 +66,7 @@
       "id": "jcm-007",
       "rank": 7,
       "phase": "P1",
-      "status": "pending",
+      "status": "done",
       "blockedBy": ["jcm-005"],
       "title": "Fixture corpus + full-corpus dry run",
       "detail": "Fixtures covering every recognised block shape, including the pathological ones: unfenced example (expect quarantine — a fence is a third addition), multi-example block (19 exist, max 5, the only place title uniqueness binds), @remarks + @example together (464 blocks), multi-paragraph lead (872 blocks), block already carrying **Example** sections (expect no-op), and ANCHOR COLLISIONS — a runtime schema plus its same-name type companion in one file, an overload set, and a merged declaration, each expecting distinct ordinals and a loud failure if extract would emit a duplicate anchor. Also ANCHOR DRIFT against a frozen record set: same-named declarations REORDERED (anchors and counts both unchanged, expect sourceHash mismatch and fail-closed), one added ahead (expect bijection failure), one removed (expect orphan record failure), and a block edited in place (expect re-title, not apply). Also cover each allowlisted tag rewrite and at least one off-normal-form rewrite (expect quarantine). Then dry-run the full corpus and record the true residue count into ops/progress.json measurements.residueCount. P3's zero claim is not committable until this number exists."

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -9,17 +9,19 @@ import { $RepoCliId } from "@beep/identity/packages";
 import { findRepoRoot, jsonStringifyPretty } from "@beep/repo-utils";
 import { A, Str, thunkFalse } from "@beep/utils";
 import * as OptionUtils from "@beep/utils/Option";
-import { Console, DateTime, Effect, FileSystem, flow, Order, Path, pipe } from "effect";
+import { Console, DateTime, Effect, FileSystem, flow, Layer, Order, Path, pipe } from "effect";
 import { dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as R from "effect/Record";
 import * as S from "effect/Schema";
 import { Argument, Command, Flag } from "effect/unstable/cli";
+import { FetchHttpClient } from "effect/unstable/http";
 import { XMLParser } from "fast-xml-parser";
 import { parse } from "jsonc-parser";
 import { configStringEqualsSync } from "../../internal/cli/EnvConfig.ts";
 import { printLines } from "../../internal/cli/Printer.ts";
+import { unknownRecordKeys, unknownRecordProperty } from "../../internal/cli/UnknownProbe.ts";
 import { formatCommandLine, QualityTaskStep, runCaptured, runToExit } from "../../internal/process/index.ts";
 import { GITHUB_CHECK_MODE_VALUES } from "../../internal/repo-run/index.ts";
 import { runChangesetGraphCheck } from "./ChangesetGraph.ts";
@@ -42,6 +44,14 @@ import {
   JSDocDocumentationInventoryOptions,
   writeJSDocDocumentationInventory,
 } from "./internal/JSDocDocumentationInventory.ts";
+import {
+  RunJSDocMigrateApplyOptions,
+  RunJSDocMigrateVerifyOptions,
+  runJSDocMigrateApply,
+  runJSDocMigrateVerify,
+} from "./internal/JSDocMigrateApply.ts";
+import { RunJSDocMigrateExtractOptions, runJSDocMigrateExtract } from "./internal/JSDocMigrateExtract.ts";
+import { RunJSDocMigrateTitlesOptions, runJSDocMigrateTitles } from "./internal/JSDocMigrateTitles.ts";
 import { defaultJSDocInventoryPath, defaultJSDocTotalsBaselinePath, runJSDocRatchet } from "./internal/JSDocRatchet.ts";
 import { defaultKnipBaselinePath, runKnipRatchet } from "./internal/KnipRatchet.ts";
 import { runPackageVerifyCli } from "./internal/PackageVerify.ts";
@@ -1304,25 +1314,6 @@ export const collectEffectTsgoDiagnosticLines: (results: ReadonlyArray<TsgoDiagn
     )
   );
 
-const unknownRecordProperty: {
-  (value: unknown, key: string): O.Option<unknown>;
-  (key: string): (value: unknown) => O.Option<unknown>;
-} = dual(2, (value: unknown, key: string): O.Option<unknown> => {
-  if (A.isArray(value)) {
-    return O.none();
-  }
-
-  return pipe(
-    decodeUnknownRecordOption(value),
-    O.flatMap((record) => O.fromUndefinedOr(record[key]))
-  );
-});
-
-const unknownRecordKeys = (value: unknown): ReadonlyArray<string> =>
-  A.isArray(value)
-    ? A.empty<string>()
-    : pipe(decodeUnknownRecordOption(value), O.map(flow(R.keys, A.sort(Order.String))), O.getOrElse(A.empty<string>));
-
 const extractEffectTsgoDiagnosticsTableFragment = (readme: string): O.Option<string> => {
   const tableStart = readme.indexOf(effectTsgoDiagnosticsTableStartMarker);
   const tableEnd = readme.indexOf(effectTsgoDiagnosticsTableEndMarker);
@@ -2093,6 +2084,112 @@ const jsdocRatchetCommand = Command.make(
     )
 ).pipe(Command.withDescription("Run JSDoc inventory totals as a fail-on-growth regression-baseline gate"));
 
+const jsdocMigrateExtractCommand = Command.make(
+  "extract",
+  {
+    output: Flag.string("output").pipe(
+      Flag.withDescription("extract.jsonl output path; defaults to the goal packet data directory"),
+      Flag.optional
+    ),
+  },
+  ({ output }) =>
+    runQualityProgram(
+      runJSDocMigrateExtract(RunJSDocMigrateExtractOptions.make({ ...OptionUtils.getSomesStruct({ output }) }))
+    )
+).pipe(Command.withDescription("Scan the corpus and emit one extract.jsonl record per legacy doc block"));
+
+const jsdocMigrateTitlesCommand = Command.make(
+  "titles",
+  {
+    extract: Flag.string("extract").pipe(Flag.withDescription("extract.jsonl input path"), Flag.optional),
+    titles: Flag.string("titles").pipe(Flag.withDescription("titles.jsonl append path"), Flag.optional),
+    proxyUrl: Flag.string("proxy-url").pipe(
+      Flag.withDescription("Local CLIProxyAPI base URL; never the xAI API"),
+      Flag.optional
+    ),
+    model: Flag.string("model").pipe(Flag.withDescription("Proxy model id"), Flag.optional),
+    limitFiles: Flag.integer("limit-files").pipe(
+      Flag.withDescription("Process at most this many pending files this run"),
+      Flag.optional
+    ),
+  },
+  ({ extract, limitFiles, model, proxyUrl, titles }) =>
+    runQualityProgram(
+      Effect.scoped(
+        Layer.build(FetchHttpClient.layer).pipe(
+          Effect.flatMap((context) =>
+            Effect.provideContext(
+              runJSDocMigrateTitles(
+                RunJSDocMigrateTitlesOptions.make({
+                  ...OptionUtils.getSomesStruct({ extract, titles, proxyUrl, model, limitFiles }),
+                })
+              ),
+              context
+            )
+          )
+        )
+      )
+    )
+).pipe(Command.withDescription("Append per-anchor title records from the local model proxy (data only)"));
+
+const jsdocMigrateApplyCommand = Command.make(
+  "apply",
+  {
+    titles: Flag.string("titles").pipe(Flag.withDescription("titles.jsonl input path"), Flag.optional),
+    overrides: Flag.string("overrides").pipe(Flag.withDescription("overrides.jsonl input path"), Flag.optional),
+    manifest: Flag.string("manifest").pipe(Flag.withDescription("Proof manifest output path"), Flag.optional),
+    dryRun: Flag.boolean("dry-run").pipe(Flag.withDescription("Report outcomes without writing any file")),
+    syntheticTitles: Flag.boolean("synthetic-titles").pipe(
+      Flag.withDescription("Generate in-memory placeholder titles for the residue measurement")
+    ),
+  },
+  ({ dryRun, manifest, overrides, syntheticTitles, titles }) =>
+    runQualityProgram(
+      runJSDocMigrateApply(
+        RunJSDocMigrateApplyOptions.make({
+          dryRun,
+          syntheticTitles,
+          ...OptionUtils.getSomesStruct({ titles, overrides, manifest }),
+        })
+      )
+    )
+).pipe(Command.withDescription("Rewrite affected blocks text-surgically; fail closed on binding doubt"));
+
+const jsdocMigrateVerifyCommand = Command.make(
+  "verify",
+  {
+    extract: Flag.string("extract").pipe(Flag.withDescription("Frozen extract.jsonl input path"), Flag.optional),
+    titles: Flag.string("titles").pipe(Flag.withDescription("titles.jsonl input path"), Flag.optional),
+    overrides: Flag.string("overrides").pipe(Flag.withDescription("overrides.jsonl input path"), Flag.optional),
+    manifest: Flag.string("manifest").pipe(Flag.withDescription("Proof manifest output path"), Flag.optional),
+  },
+  ({ extract, manifest, overrides, titles }) =>
+    runQualityProgram(
+      runJSDocMigrateVerify(
+        RunJSDocMigrateVerifyOptions.make({ ...OptionUtils.getSomesStruct({ extract, titles, overrides, manifest }) })
+      )
+    )
+).pipe(Command.withDescription("Prove conservation between frozen originals and the current tree"));
+
+const jsdocMigrateCommand = Command.make("jsdoc-migrate", {}, () =>
+  printLines([
+    "JSDoc carrier-migration commands:",
+    "- bun run beep quality jsdoc-migrate extract",
+    "- bun run beep quality jsdoc-migrate titles --limit-files 5",
+    "- bun run beep quality jsdoc-migrate apply --dry-run --synthetic-titles",
+    "- bun run beep quality jsdoc-migrate apply",
+    "- bun run beep quality jsdoc-migrate verify",
+  ])
+).pipe(
+  Command.withDescription("JSDoc legacy-carrier migration pipeline (extract, titles, apply, verify)"),
+  Command.withSubcommands([
+    jsdocMigrateExtractCommand,
+    jsdocMigrateTitlesCommand,
+    jsdocMigrateApplyCommand,
+    jsdocMigrateVerifyCommand,
+  ])
+);
+
 const knipCommand = Command.make(
   "knip",
   {
@@ -2262,6 +2359,8 @@ export const qualityCommand = Command.make("quality", {}, () =>
     "- bun run beep quality jsdoc-quality",
     "- bun run beep quality jsdoc-ratchet",
     "- bun run beep quality jsdoc-ratchet --write-baseline",
+    "- bun run beep quality jsdoc-migrate extract",
+    "- bun run beep quality jsdoc-migrate apply --dry-run --synthetic-titles",
     "- bun run beep quality knip",
     "- bun run beep quality knip --write-baseline",
     "- bun run beep quality turbo-config-proof --base origin/main --head HEAD",
@@ -2283,6 +2382,7 @@ export const qualityCommand = Command.make("quality", {}, () =>
     jsdocInventoryCommand,
     jsdocQualityCommand,
     jsdocRatchetCommand,
+    jsdocMigrateCommand,
     knipCommand,
     turboConfigProofCommand,
     qualityProfileCommand,

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts
@@ -8,6 +8,7 @@ import * as R from "effect/Record";
 import * as S from "effect/Schema";
 import { Node, SyntaxKind } from "ts-morph";
 import { formatJsonc } from "../../../internal/artifacts/index.ts";
+import { globPatternToRegExp as sharedGlobPatternToRegExp } from "../../../internal/GlobPattern.ts";
 import { runGitLines } from "../../../internal/repo-run/index.ts";
 import { createInMemoryTsMorphProject, leadingJsDocText, topFileoverview } from "../../../internal/tsmorph/index.ts";
 import {
@@ -88,13 +89,40 @@ const newDocumentationRuleCodes = JSDocDocumentationRuleCode.pickOptions([
   "forbidden-remarks",
 ]);
 
-type DocumentationIssue = {
-  readonly rule: JSDocDocumentationRuleCode;
-  readonly detail?: string;
-  readonly lineOffset?: number;
-  readonly text?: string;
-  readonly example?: number;
-};
+/**
+ * One JSDoc documentation finding produced by an inventory rule.
+ *
+ * **Example** (Construct a finding)
+ *
+ * ```ts
+ * import { DocumentationIssue } from "@beep/repo-cli/test/Quality"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(DocumentationIssue)({ rule: "forbidden-remarks" })) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const DocumentationIssue = S.Struct({
+  rule: JSDocDocumentationRuleCode,
+  detail: S.String.pipe(S.UndefinedOr, S.optionalKey),
+  lineOffset: S.Int.pipe(S.UndefinedOr, S.optionalKey),
+  text: S.String.pipe(S.UndefinedOr, S.optionalKey),
+  example: S.Int.pipe(S.UndefinedOr, S.optionalKey),
+}).pipe(
+  $I.annoteSchema("DocumentationIssue", {
+    description: "One JSDoc documentation finding produced by an inventory rule.",
+  })
+);
+
+/**
+ * One JSDoc documentation finding produced by an inventory rule.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type DocumentationIssue = typeof DocumentationIssue.Type;
 
 type InventoryEntry = JsonRecord & {
   readonly remediationStatus: "open" | "resolved";
@@ -260,40 +288,8 @@ const resolveJSDocInventoryOptions = Effect.fn("JSDocDocumentationInventory.reso
 const markdownAnchor = (value: string): string =>
   Str.replace(/^-+|-+$/g, "")(Str.replace(/[^a-z0-9]+/g, "-")(Str.replace(/`/g, "")(Str.toLowerCase(value))));
 
-const globPatternToRegExp = (pattern: string): RegExp => {
-  const normalized = normalizeSlashes(Str.replace(/^\.\//, "")(pattern));
-  let source = "^";
-  let index = 0;
-
-  while (index < normalized.length) {
-    const char = normalized[index];
-    const next = normalized[index + 1];
-    const afterNext = normalized[index + 2];
-
-    if (char === "*" && next === "*" && afterNext === "/") {
-      source += "(?:.*/)?";
-      index += 3;
-      continue;
-    }
-
-    if (char === "*" && next === "*") {
-      source += ".*";
-      index += 2;
-      continue;
-    }
-
-    if (char === "*") {
-      source += "[^/]*";
-      index += 1;
-      continue;
-    }
-
-    source += escapeRegExp(char ?? "");
-    index += 1;
-  }
-
-  return new RegExp(`${source}$`);
-};
+const globPatternToRegExp = (pattern: string): RegExp =>
+  sharedGlobPatternToRegExp(normalizeSlashes(Str.replace(/^\.\//, "")(pattern)));
 
 const packageSourceMatchesExclude = (
   packagePath: string,
@@ -435,8 +431,32 @@ const missingRequiredExportTags = (
   return missingRequiredTags(effectiveTags, requiredTags);
 };
 
+/**
+ * Score one JSDoc comment against the documentation section-shape rules.
+ *
+ * **Details**
+ *
+ * This is the exact scorer the JSDoc ratchet totals are built from, exported
+ * within the package so the carrier-migration codemod can use it as a
+ * per-block oracle: a rewrite is acceptable only when the finding set shrinks
+ * or holds. It never becomes a cross-package public surface.
+ *
+ * **Example** (Score a legacy comment)
+ *
+ * ```ts
+ * import { documentationShapeViolations } from "@beep/repo-cli/test/Quality"
+ *
+ * const findings = documentationShapeViolations("/** Lead.\n *\n * @remarks Detail. *" + "/")
+ * console.log(findings.some((finding) => finding.rule === "forbidden-remarks")) // true
+ * ```
+ *
+ * @param commentText - Raw JSDoc comment text to score.
+ * @returns Shape findings for the comment, empty when compliant.
+ * @category use-cases
+ * @since 0.0.0
+ */
 // fallow-ignore-next-line complexity -- this flat pass preserves the documented section-order state machine in one auditable rule boundary
-const documentationShapeViolations = (commentText: string): ReadonlyArray<DocumentationIssue> => {
+export const documentationShapeViolations = (commentText: string): ReadonlyArray<DocumentationIssue> => {
   const findings: Array<DocumentationIssue> = [];
   const { bodyLines, sections } = parseSections(commentText);
   const hasNewStyleSections = A.isReadonlyArrayNonEmpty(sections);

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrate.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrate.schemas.ts
@@ -1,0 +1,472 @@
+/**
+ * Data-file schemas for the JSDoc legacy-carrier migration pipeline.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("commands/Quality/internal/JSDocMigrate.schemas");
+
+/**
+ * Classification of the declaration a migrated doc block binds to.
+ *
+ * **Details**
+ *
+ * The kind is a verification field: a frozen title or override record may only
+ * be applied when its stored kind agrees with what ts-morph reports for the
+ * block currently at the anchor, so a value-level record never lands on a
+ * type-level companion. `module` marks fileoverview blocks and `detached`
+ * marks comments ts-morph binds to no declaration.
+ *
+ * **Example** (Check a block kind)
+ *
+ * ```ts
+ * import { JSDocMigrateBlockKind } from "@beep/repo-cli/test/Quality"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(JSDocMigrateBlockKind)("value")) // true
+ * console.log(S.is(JSDocMigrateBlockKind)("function")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const JSDocMigrateBlockKind = LiteralKit(["value", "type-level", "module", "detached"]).pipe(
+  $I.annoteSchema("JSDocMigrateBlockKind", {
+    description: "Declaration kind a migrated JSDoc block binds to, used for fail-closed record verification.",
+  })
+);
+
+/**
+ * Declaration kind a migrated JSDoc block binds to.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type JSDocMigrateBlockKind = typeof JSDocMigrateBlockKind.Type;
+
+/**
+ * Routing target for consumed `@remarks` content.
+ *
+ * **Example** (Validate a routing value)
+ *
+ * ```ts
+ * import { JSDocMigrateRemarksRouting } from "@beep/repo-cli/test/Quality"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(JSDocMigrateRemarksRouting)("details")) // true
+ * console.log(S.is(JSDocMigrateRemarksRouting)("summary")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const JSDocMigrateRemarksRouting = LiteralKit(["details", "gotchas"]).pipe(
+  $I.annoteSchema("JSDocMigrateRemarksRouting", {
+    description: "Body section that receives a consumed @remarks tag's content.",
+  })
+);
+
+/**
+ * Body section that receives a consumed `@remarks` tag's content.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type JSDocMigrateRemarksRouting = typeof JSDocMigrateRemarksRouting.Type;
+
+/**
+ * One affected doc block emitted by `beep quality jsdoc-migrate extract`.
+ *
+ * **Details**
+ *
+ * The anchor is `path#symbol#ordinal` and is used for addressing only; the
+ * `sourceHash` (sha256 of the original block bytes) and `kind` are
+ * verification fields that make freezing the downstream data files safe.
+ * `blockText` carries the original block verbatim so the title pass and the
+ * conservation law never need to re-read a moving working tree.
+ *
+ * **Example** (Construct an extract record)
+ *
+ * ```ts
+ * import { JSDocMigrateExtractRecord } from "@beep/repo-cli/test/Quality"
+ *
+ * const record = JSDocMigrateExtractRecord.make({
+ *   anchor: "packages/x/src/Y.ts#decode#0",
+ *   filePath: "packages/x/src/Y.ts",
+ *   symbol: "decode",
+ *   ordinal: 0,
+ *   kind: "value",
+ *   sourceHash: "sha256:0000",
+ *   start: 0,
+ *   end: 40,
+ *   blockText: "/** Doc. *" + "/",
+ *   leadParagraphCount: 1,
+ *   exampleTagCount: 1,
+ *   unfencedExampleCount: 0,
+ *   remarksTagCount: 0,
+ *   undescribedSeeCount: 0
+ * })
+ * console.log(record.anchor) // "packages/x/src/Y.ts#decode#0"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class JSDocMigrateExtractRecord extends S.Class<JSDocMigrateExtractRecord>($I`JSDocMigrateExtractRecord`)(
+  {
+    anchor: S.String,
+    filePath: S.String,
+    symbol: S.String,
+    ordinal: S.Int,
+    kind: JSDocMigrateBlockKind,
+    sourceHash: S.String,
+    start: S.Int,
+    end: S.Int,
+    blockText: S.String,
+    leadParagraphCount: S.Int,
+    exampleTagCount: S.Int,
+    unfencedExampleCount: S.Int,
+    remarksTagCount: S.Int,
+    undescribedSeeCount: S.Int,
+  },
+  $I.annote("JSDocMigrateExtractRecord", {
+    description: "One affected JSDoc block: anchor, verification fields, and the original block bytes.",
+  })
+) {}
+
+/**
+ * One frozen title-pass record consumed by `jsdoc-migrate apply`.
+ *
+ * **Details**
+ *
+ * `titles` carries one Example title per `@example` tag in block order; it is
+ * empty for blocks whose only legacy carrier is `@remarks`. `leadEnd` is the
+ * number of lead paragraphs to keep; paragraphs after it move into
+ * `**Details**`. `seePurposes` supplies one purpose phrase per undescribed
+ * `@see`, in source order. The codemod adds no prose beyond these fields.
+ *
+ * **Example** (Construct a title record)
+ *
+ * ```ts
+ * import { JSDocMigrateTitleRecord } from "@beep/repo-cli/test/Quality"
+ *
+ * const record = JSDocMigrateTitleRecord.make({
+ *   anchor: "packages/x/src/Y.ts#decode#0",
+ *   sourceHash: "sha256:0000",
+ *   kind: "value",
+ *   titles: ["Decode a user name"],
+ *   remarks: "details"
+ * })
+ * console.log(record.titles[0]) // "Decode a user name"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class JSDocMigrateTitleRecord extends S.Class<JSDocMigrateTitleRecord>($I`JSDocMigrateTitleRecord`)(
+  {
+    anchor: S.String,
+    sourceHash: S.String,
+    kind: JSDocMigrateBlockKind,
+    titles: S.Array(S.String),
+    remarks: S.optionalKey(JSDocMigrateRemarksRouting),
+    leadEnd: S.optionalKey(S.Int),
+    seePurposes: S.Array(S.String).pipe(S.optionalKey),
+  },
+  $I.annote("JSDocMigrateTitleRecord", {
+    description: "Frozen per-anchor title-pass output: Example titles, remarks routing, lead split, see purposes.",
+  })
+) {}
+
+/**
+ * One frozen full-block replacement for a quarantined block.
+ *
+ * **Details**
+ *
+ * Overrides carry the same `anchor`/`sourceHash`/`kind` verification fields as
+ * title records: a hand-authored replacement applied to the wrong declaration
+ * is exactly as damaging as a mis-bound title, so apply fails closed on any
+ * mismatch.
+ *
+ * **Example** (Construct an override record)
+ *
+ * ```ts
+ * import { JSDocMigrateOverrideRecord } from "@beep/repo-cli/test/Quality"
+ *
+ * const record = JSDocMigrateOverrideRecord.make({
+ *   anchor: "packages/x/src/Y.ts#thing#0",
+ *   sourceHash: "sha256:9c02",
+ *   kind: "value",
+ *   block: "/** Rewritten. *" + "/"
+ * })
+ * console.log(record.kind) // "value"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class JSDocMigrateOverrideRecord extends S.Class<JSDocMigrateOverrideRecord>($I`JSDocMigrateOverrideRecord`)(
+  {
+    anchor: S.String,
+    sourceHash: S.String,
+    kind: JSDocMigrateBlockKind,
+    block: S.String,
+  },
+  $I.annote("JSDocMigrateOverrideRecord", {
+    description: "Frozen full replacement block text for a quarantined JSDoc block.",
+  })
+) {}
+
+/**
+ * One block the codemod refused to rewrite, with its violation reasons.
+ *
+ * **Example** (Construct a quarantine record)
+ *
+ * ```ts
+ * import { JSDocMigrateQuarantineRecord } from "@beep/repo-cli/test/Quality"
+ *
+ * const record = JSDocMigrateQuarantineRecord.make({
+ *   anchor: "packages/x/src/Y.ts#thing#0",
+ *   filePath: "packages/x/src/Y.ts",
+ *   reasons: ["unfenced-example"]
+ * })
+ * console.log(record.reasons[0]) // "unfenced-example"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class JSDocMigrateQuarantineRecord extends S.Class<JSDocMigrateQuarantineRecord>(
+  $I`JSDocMigrateQuarantineRecord`
+)(
+  {
+    anchor: S.String,
+    filePath: S.String,
+    reasons: S.Array(S.String),
+  },
+  $I.annote("JSDocMigrateQuarantineRecord", {
+    description: "One JSDoc block the codemod quarantined instead of writing, with violation reasons.",
+  })
+) {}
+
+/**
+ * Fail-closed binding verification result between frozen records and a live extract.
+ *
+ * **Details**
+ *
+ * All four arrays must be empty before apply writes anything: orphans on
+ * either side catch additions and removals, hash mismatches catch reorders and
+ * in-place edits where counts still match, and kind mismatches stop a
+ * value-level record landing on a type-level companion.
+ *
+ * **Example** (Inspect a clean binding report)
+ *
+ * ```ts
+ * import { JSDocMigrateBindingReport } from "@beep/repo-cli/test/Quality"
+ *
+ * const report = JSDocMigrateBindingReport.make({
+ *   extractCount: 1,
+ *   recordCount: 1,
+ *   orphanRecordAnchors: [],
+ *   unmatchedExtractAnchors: [],
+ *   sourceHashMismatchAnchors: [],
+ *   kindMismatchAnchors: []
+ * })
+ * console.log(report.extractCount) // 1
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class JSDocMigrateBindingReport extends S.Class<JSDocMigrateBindingReport>($I`JSDocMigrateBindingReport`)(
+  {
+    extractCount: S.Int,
+    recordCount: S.Int,
+    orphanRecordAnchors: S.Array(S.String),
+    unmatchedExtractAnchors: S.Array(S.String),
+    sourceHashMismatchAnchors: S.Array(S.String),
+    kindMismatchAnchors: S.Array(S.String),
+  },
+  $I.annote("JSDocMigrateBindingReport", {
+    description: "Bijection, sourceHash, and kind agreement results between frozen records and a live extract.",
+  })
+) {}
+
+/**
+ * Pipeline mode recorded in the proof manifest.
+ *
+ * **Example** (Validate a mode)
+ *
+ * ```ts
+ * import { JSDocMigrateMode } from "@beep/repo-cli/test/Quality"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(JSDocMigrateMode)("dry-run")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const JSDocMigrateMode = LiteralKit(["dry-run", "apply", "verify"]).pipe(
+  $I.annoteSchema("JSDocMigrateMode", {
+    description: "Which jsdoc-migrate pipeline stage produced a proof manifest.",
+  })
+);
+
+/**
+ * Which jsdoc-migrate pipeline stage produced a proof manifest.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type JSDocMigrateMode = typeof JSDocMigrateMode.Type;
+
+/**
+ * Schema-versioned conservation proof manifest for a jsdoc-migrate run.
+ *
+ * **Details**
+ *
+ * Follows the `DocgenProofManifest` / `AcceptedProofManifest` idiom: a
+ * committed, decodable artifact that records exhaustive per-block results
+ * rather than a sample. `quarantines` lists every block the codemod refused
+ * to rewrite; the run is only clean when each quarantine is explained by an
+ * override record.
+ *
+ * **Example** (Construct an empty manifest)
+ *
+ * ```ts
+ * import { JSDocMigrateBindingReport, JSDocMigrateProofManifest } from "@beep/repo-cli/test/Quality"
+ *
+ * const manifest = JSDocMigrateProofManifest.make({
+ *   schema_version: 1,
+ *   generated_at: "2026-08-06T00:00:00.000Z",
+ *   mode: "dry-run",
+ *   files: 0,
+ *   blocksAffected: 0,
+ *   rewritten: 0,
+ *   overridden: 0,
+ *   quarantined: 0,
+ *   conservationViolations: 0,
+ *   shapeRegressions: 0,
+ *   residueLegacyBlocks: 0,
+ *   binding: JSDocMigrateBindingReport.make({
+ *     extractCount: 0,
+ *     recordCount: 0,
+ *     orphanRecordAnchors: [],
+ *     unmatchedExtractAnchors: [],
+ *     sourceHashMismatchAnchors: [],
+ *     kindMismatchAnchors: []
+ *   }),
+ *   quarantines: []
+ * })
+ * console.log(manifest.mode) // "dry-run"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class JSDocMigrateProofManifest extends S.Class<JSDocMigrateProofManifest>($I`JSDocMigrateProofManifest`)(
+  {
+    schema_version: S.Literal(1),
+    generated_at: S.String,
+    mode: JSDocMigrateMode,
+    files: S.Int,
+    blocksAffected: S.Int,
+    rewritten: S.Int,
+    overridden: S.Int,
+    quarantined: S.Int,
+    conservationViolations: S.Int,
+    shapeRegressions: S.Int,
+    residueLegacyBlocks: S.Int,
+    binding: JSDocMigrateBindingReport,
+    quarantines: S.Array(JSDocMigrateQuarantineRecord),
+  },
+  $I.annote("JSDocMigrateProofManifest", {
+    description: "Schema-versioned exhaustive conservation and binding proof for a jsdoc-migrate run.",
+  })
+) {}
+
+/**
+ * Default repo-relative directory holding jsdoc-migrate data files.
+ *
+ * **Example** (Inspect the default data directory)
+ *
+ * ```ts
+ * import { defaultJSDocMigrateDataDir } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(defaultJSDocMigrateDataDir.startsWith("goals/")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const defaultJSDocMigrateDataDir = "goals/jsdoc-carrier-migration/data";
+
+/**
+ * Default repo-relative path of the extract output.
+ *
+ * **Example** (Inspect the default extract path)
+ *
+ * ```ts
+ * import { defaultJSDocMigrateExtractPath } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(defaultJSDocMigrateExtractPath.endsWith("extract.jsonl")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const defaultJSDocMigrateExtractPath = `${defaultJSDocMigrateDataDir}/extract.jsonl`;
+
+/**
+ * Default repo-relative path of the frozen title-pass output.
+ *
+ * **Example** (Inspect the default titles path)
+ *
+ * ```ts
+ * import { defaultJSDocMigrateTitlesPath } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(defaultJSDocMigrateTitlesPath.endsWith("titles.jsonl")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const defaultJSDocMigrateTitlesPath = `${defaultJSDocMigrateDataDir}/titles.jsonl`;
+
+/**
+ * Default repo-relative path of the frozen override records.
+ *
+ * **Example** (Inspect the default overrides path)
+ *
+ * ```ts
+ * import { defaultJSDocMigrateOverridesPath } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(defaultJSDocMigrateOverridesPath.endsWith("overrides.jsonl")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const defaultJSDocMigrateOverridesPath = `${defaultJSDocMigrateDataDir}/overrides.jsonl`;
+
+/**
+ * Default repo-relative path of the emitted proof manifest.
+ *
+ * **Example** (Inspect the default manifest path)
+ *
+ * ```ts
+ * import { defaultJSDocMigrateManifestPath } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(defaultJSDocMigrateManifestPath.endsWith(".jsonc")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const defaultJSDocMigrateManifestPath = `${defaultJSDocMigrateDataDir}/jsdoc-migrate.proof-manifest.jsonc`;

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts
@@ -7,7 +7,7 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { findRepoRoot } from "@beep/repo-utils";
-import { A, Str } from "@beep/utils";
+import { A, Str, thunkFalse } from "@beep/utils";
 import { Console, DateTime, Effect, FileSystem, MutableHashMap, MutableHashSet, Order, Path } from "effect";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -199,6 +199,54 @@ export const computeJSDocMigrateBinding = (input: {
   });
 };
 
+/**
+ * Split orphan record anchors into already-migrated blocks and true orphans.
+ *
+ * **Details**
+ *
+ * A record becomes an orphan when its anchor is absent from the affected
+ * extract. When the anchor still resolves to a block in the current tree and
+ * that block no longer carries a legacy tag, the block was already migrated —
+ * a normal state while iterating apply over residue — so the record is
+ * tolerated. Anchors that resolve nowhere remain hard failures.
+ *
+ * **Example** (Tolerate a migrated block)
+ *
+ * ```ts
+ * import { MutableHashMap } from "effect"
+ * import { partitionMigratedOrphans } from "@beep/repo-cli/test/Quality"
+ *
+ * const blocks = MutableHashMap.make([
+ *   "packages/x/src/a.ts#done#0",
+ *   { affected: false }
+ * ])
+ * const result = partitionMigratedOrphans(["packages/x/src/a.ts#done#0"], blocks)
+ * console.log(result.missing) // []
+ * ```
+ *
+ * @param orphanAnchors - Record anchors the bijection found no extract row for.
+ * @param currentBlocksByAnchor - Every scanned block in the current tree keyed by anchor.
+ * @returns Anchors of already-migrated blocks and anchors that resolve nowhere.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const partitionMigratedOrphans = (
+  orphanAnchors: ReadonlyArray<string>,
+  currentBlocksByAnchor: MutableHashMap.MutableHashMap<string, { readonly affected: boolean }>
+): { readonly migrated: ReadonlyArray<string>; readonly missing: ReadonlyArray<string> } => {
+  const migrated: Array<string> = [];
+  const missing: Array<string> = [];
+  for (const anchor of orphanAnchors) {
+    const block = MutableHashMap.get(currentBlocksByAnchor, anchor);
+    if (O.isSome(block) && !block.value.affected) {
+      A.appendInPlace(migrated, anchor);
+    } else {
+      A.appendInPlace(missing, anchor);
+    }
+  }
+  return { migrated, missing };
+};
+
 const bindingIsClean = (report: JSDocMigrateBindingReport): boolean =>
   A.isReadonlyArrayEmpty(report.orphanRecordAnchors) &&
   A.isReadonlyArrayEmpty(report.unmatchedExtractAnchors) &&
@@ -212,9 +260,9 @@ const bindingIsClean = (report: JSDocMigrateBindingReport): boolean =>
  *
  * Placeholder titles keep the rewrite machinery honest without inventing
  * shippable prose: titles are unique within the block, remarks route to
- * Details, and no lead split or see purposes are synthesized. Dry runs must
- * never be applied for real — the binding checks reject synthetic data in a
- * non-dry apply because it is generated in memory, not frozen.
+ * Details, and no lead split or see purposes are synthesized. Placeholders
+ * can never reach a file: apply refuses `--synthetic-titles` without
+ * `--dry-run` before any rewrite happens.
  *
  * **Example** (Synthesize a record for a two-example block)
  *
@@ -393,6 +441,49 @@ export class RunJSDocMigrateApplyOptions extends S.Class<RunJSDocMigrateApplyOpt
   })
 ) {}
 
+const anchorFilePath = (anchor: string): string => Str.split("#")(anchor)[0] ?? anchor;
+
+const scanAnchorsForOrphans = Effect.fn("JSDocMigrateApply.scanAnchorsForOrphans")(function* (
+  repoRoot: string,
+  affectedFiles: ReadonlyArray<AffectedFile>,
+  orphanAnchors: ReadonlyArray<string>
+): Effect.fn.Return<
+  MutableHashMap.MutableHashMap<string, JSDocMigrateScannedBlock>,
+  QualityScriptCommandError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const blocksByAnchor = MutableHashMap.empty<string, JSDocMigrateScannedBlock>();
+  const scannedFiles = MutableHashSet.empty<string>();
+  for (const file of affectedFiles) {
+    MutableHashSet.add(scannedFiles, file.filePath);
+    for (const block of file.blocks) {
+      MutableHashMap.set(blocksByAnchor, block.anchor, block);
+    }
+  }
+  const orphanFiles = A.dedupe(
+    A.filter(A.map(orphanAnchors, anchorFilePath), (filePath) => !MutableHashSet.has(scannedFiles, filePath))
+  );
+  yield* Effect.forEach(
+    orphanFiles,
+    Effect.fnUntraced(function* (filePath: string) {
+      const exists = yield* fs.exists(path.join(repoRoot, filePath)).pipe(Effect.orElseSucceed(thunkFalse));
+      if (!exists) {
+        return;
+      }
+      const sourceText = yield* fs
+        .readFileString(path.join(repoRoot, filePath))
+        .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to read ${filePath}.`)));
+      for (const block of scanJSDocMigrateBlocks(filePath, sourceText)) {
+        MutableHashMap.set(blocksByAnchor, block.anchor, block);
+      }
+    }),
+    { concurrency: 8 }
+  );
+  return blocksByAnchor;
+});
+
 type BlockOutcome =
   | { readonly _tag: "Rewritten"; readonly replacement: string }
   | { readonly _tag: "Overridden"; readonly replacement: string }
@@ -471,6 +562,9 @@ export const runJSDocMigrateApply = Effect.fn("JSDocMigrateApply.run")(function*
   QualityScriptCommandError,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
+  if (options.syntheticTitles && !options.dryRun) {
+    return yield* migrateError("--synthetic-titles is a measurement mode; combine it with --dry-run.");
+  }
   const repoRoot = yield* findRepoRoot().pipe(QualityScriptCommandError.mapError("Failed to locate repository root."));
   const path = yield* Path.Path;
   const files = yield* listJSDocMigrateCorpusFiles(repoRoot);
@@ -485,8 +579,19 @@ export const runJSDocMigrateApply = Effect.fn("JSDocMigrateApply.run")(function*
     options.syntheticTitles ? O.some(A.map(liveExtract, syntheticJSDocMigrateTitleRecord)) : O.none()
   );
 
-  const binding = computeJSDocMigrateBinding({ extract: liveExtract, titles, overrides });
+  const rawBinding = computeJSDocMigrateBinding({ extract: liveExtract, titles, overrides });
+  const currentBlocksByAnchor = yield* scanAnchorsForOrphans(repoRoot, affectedFiles, rawBinding.orphanRecordAnchors);
+  const orphanSplit = partitionMigratedOrphans(rawBinding.orphanRecordAnchors, currentBlocksByAnchor);
+  const binding = JSDocMigrateBindingReport.make({
+    ...rawBinding,
+    orphanRecordAnchors: orphanSplit.missing,
+  });
   yield* failOnDirtyBinding(binding);
+  if (A.isReadonlyArrayNonEmpty(orphanSplit.migrated)) {
+    yield* Console.log(
+      `[jsdoc-migrate] tolerating ${orphanSplit.migrated.length} record(s) whose blocks are already migrated`
+    );
+  }
 
   const quarantines: Array<JSDocMigrateQuarantineRecord> = [];
   const mismatches: Array<string> = [];
@@ -533,6 +638,7 @@ export const runJSDocMigrateApply = Effect.fn("JSDocMigrateApply.run")(function*
   }
 
   const changedFiles = A.map(pendingWrites, (write) => write.filePath);
+  let biomeFailure: QualityScriptCommandError | undefined;
   if (!options.dryRun && pendingWrites.length > 0) {
     const fs = yield* FileSystem.FileSystem;
     yield* Effect.forEach(
@@ -543,7 +649,12 @@ export const runJSDocMigrateApply = Effect.fn("JSDocMigrateApply.run")(function*
           .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to write ${write.filePath}.`))),
       { concurrency: 8 }
     );
-    yield* formatBiome(repoRoot, changedFiles);
+    // The manifest below must still be written when formatting fails, so a
+    // retry sees the applied state instead of an unexplained partial write.
+    const formatted = yield* formatBiome(repoRoot, changedFiles).pipe(Effect.result);
+    if (formatted._tag === "Failure") {
+      biomeFailure = formatted.failure;
+    }
   }
 
   const generatedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
@@ -564,6 +675,9 @@ export const runJSDocMigrateApply = Effect.fn("JSDocMigrateApply.run")(function*
     quarantines,
   });
   yield* writeManifest(repoRoot, options.manifest ?? defaultJSDocMigrateManifestPath, manifest);
+  if (biomeFailure !== undefined) {
+    return yield* biomeFailure;
+  }
   yield* Console.log(
     `[jsdoc-migrate] ${mode} ok: files=${affectedFiles.length} blocks=${liveExtract.length} rewritten=${rewritten} ` +
       `overridden=${overridden} residue=${quarantines.length}`

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts
@@ -1,0 +1,770 @@
+/**
+ * Apply and verify stages of the JSDoc legacy-carrier migration.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { findRepoRoot } from "@beep/repo-utils";
+import { A, Str } from "@beep/utils";
+import { Console, DateTime, Effect, FileSystem, MutableHashMap, MutableHashSet, Order, Path } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { formatJsonc, writeArtifact } from "../../../internal/artifacts/index.ts";
+import { runCaptured } from "../../../internal/process/index.ts";
+import { QualityScriptCommandError } from "../Quality.errors.ts";
+import {
+  defaultJSDocMigrateExtractPath,
+  defaultJSDocMigrateManifestPath,
+  defaultJSDocMigrateOverridesPath,
+  defaultJSDocMigrateTitlesPath,
+  JSDocMigrateBindingReport,
+  JSDocMigrateProofManifest,
+  JSDocMigrateQuarantineRecord,
+  JSDocMigrateTitleRecord,
+} from "./JSDocMigrate.schemas.ts";
+import {
+  indexJSDocMigrateByAnchor,
+  jsdocMigrateOverrideCodec,
+  jsdocMigrateRunContext,
+  jsdocMigrateTitleCodec,
+  readJSDocMigrateExtractRequired,
+  readJSDocMigrateJsonl,
+} from "./JSDocMigrateData.ts";
+import {
+  jsdocMigrateExtractRecordsForFile,
+  listJSDocMigrateCorpusFiles,
+  readJSDocMigrateSourceText,
+  scanJSDocMigrateBlocks,
+} from "./JSDocMigrateExtract.ts";
+import {
+  jsdocMigrateConservationFindings,
+  jsdocMigrateShapeRegressions,
+  rewriteJSDocMigrateBlock,
+} from "./JSDocMigrateRewrite.ts";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type {
+  JSDocMigrateExtractRecord,
+  JSDocMigrateMode,
+  JSDocMigrateOverrideRecord,
+} from "./JSDocMigrate.schemas.ts";
+import type { JSDocMigrateScannedBlock } from "./JSDocMigrateExtract.ts";
+
+const $I = $RepoCliId.create("commands/Quality/internal/JSDocMigrateApply");
+
+type FrozenRecordSets = {
+  readonly titles: ReadonlyArray<JSDocMigrateTitleRecord>;
+  readonly overrides: ReadonlyArray<JSDocMigrateOverrideRecord>;
+  readonly titleByAnchor: MutableHashMap.MutableHashMap<string, JSDocMigrateTitleRecord>;
+  readonly overrideByAnchor: MutableHashMap.MutableHashMap<string, JSDocMigrateOverrideRecord>;
+};
+
+const loadFrozenRecordSets = Effect.fn("JSDocMigrateApply.loadFrozenRecordSets")(function* (
+  repoRoot: string,
+  options: { readonly titles?: string | undefined; readonly overrides?: string | undefined },
+  syntheticTitles: O.Option<ReadonlyArray<JSDocMigrateTitleRecord>>
+): Effect.fn.Return<FrozenRecordSets, QualityScriptCommandError, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const titles = O.isSome(syntheticTitles)
+    ? syntheticTitles.value
+    : yield* readJSDocMigrateJsonl(
+        path.resolve(repoRoot, options.titles ?? defaultJSDocMigrateTitlesPath),
+        jsdocMigrateTitleCodec.decode,
+        "titles.jsonl"
+      );
+  const overrides = yield* readJSDocMigrateJsonl(
+    path.resolve(repoRoot, options.overrides ?? defaultJSDocMigrateOverridesPath),
+    jsdocMigrateOverrideCodec.decode,
+    "overrides.jsonl"
+  );
+  return {
+    titles,
+    overrides,
+    titleByAnchor: indexJSDocMigrateByAnchor(titles),
+    overrideByAnchor: indexJSDocMigrateByAnchor(overrides),
+  };
+});
+
+const migrateError = (message: string): QualityScriptCommandError =>
+  QualityScriptCommandError.make({
+    message,
+    command: "bun run beep quality jsdoc-migrate",
+    exitCode: 1,
+  });
+
+type FrozenVerificationFields = { readonly sourceHash: string; readonly kind: string };
+
+const frozenVerificationIndex = (
+  titles: ReadonlyArray<JSDocMigrateTitleRecord>,
+  overrides: ReadonlyArray<JSDocMigrateOverrideRecord>
+): MutableHashMap.MutableHashMap<string, FrozenVerificationFields> => {
+  const records = MutableHashMap.empty<string, FrozenVerificationFields>();
+  for (const record of titles) {
+    MutableHashMap.set(records, record.anchor, { sourceHash: record.sourceHash, kind: record.kind });
+  }
+  for (const record of overrides) {
+    MutableHashMap.set(records, record.anchor, { sourceHash: record.sourceHash, kind: record.kind });
+  }
+  return records;
+};
+
+const compareExtractToFrozen = (
+  extract: ReadonlyArray<JSDocMigrateExtractRecord>,
+  records: MutableHashMap.MutableHashMap<string, FrozenVerificationFields>
+): {
+  readonly extractAnchors: MutableHashSet.MutableHashSet<string>;
+  readonly unmatchedExtractAnchors: Array<string>;
+  readonly sourceHashMismatchAnchors: Array<string>;
+  readonly kindMismatchAnchors: Array<string>;
+} => {
+  const extractAnchors = MutableHashSet.empty<string>();
+  const unmatchedExtractAnchors: Array<string> = [];
+  const sourceHashMismatchAnchors: Array<string> = [];
+  const kindMismatchAnchors: Array<string> = [];
+  for (const record of extract) {
+    MutableHashSet.add(extractAnchors, record.anchor);
+    const frozen = MutableHashMap.get(records, record.anchor);
+    if (O.isNone(frozen)) {
+      A.appendInPlace(unmatchedExtractAnchors, record.anchor);
+      continue;
+    }
+    if (frozen.value.sourceHash !== record.sourceHash) {
+      A.appendInPlace(sourceHashMismatchAnchors, record.anchor);
+    }
+    if (frozen.value.kind !== record.kind) {
+      A.appendInPlace(kindMismatchAnchors, record.anchor);
+    }
+  }
+  return { extractAnchors, unmatchedExtractAnchors, sourceHashMismatchAnchors, kindMismatchAnchors };
+};
+
+/**
+ * Compute the fail-closed binding report between frozen records and an extract.
+ *
+ * **Details**
+ *
+ * Implements SPEC §5.2: every extract anchor must have exactly one frozen
+ * record and vice versa (bijection), every record's `sourceHash` must equal
+ * the hash of the block at its anchor (identity — this is what catches
+ * reorders), and every record's `kind` must agree. Later records win when a
+ * jsonl file carries duplicate anchors, matching append-only retry semantics.
+ *
+ * **Example** (Detect an orphan record)
+ *
+ * ```ts
+ * import { computeJSDocMigrateBinding, JSDocMigrateTitleRecord } from "@beep/repo-cli/test/Quality"
+ *
+ * const report = computeJSDocMigrateBinding({
+ *   extract: [],
+ *   titles: [
+ *     JSDocMigrateTitleRecord.make({
+ *       anchor: "packages/x/src/Y.ts#gone#0",
+ *       sourceHash: "sha256:0000",
+ *       kind: "value",
+ *       titles: ["Title"]
+ *     })
+ *   ],
+ *   overrides: []
+ * })
+ * console.log(report.orphanRecordAnchors) // ["packages/x/src/Y.ts#gone#0"]
+ * ```
+ *
+ * @param input - Live extract records with the frozen title and override sets.
+ * @returns Binding report carrying all four fail-closed mismatch lists.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const computeJSDocMigrateBinding = (input: {
+  readonly extract: ReadonlyArray<JSDocMigrateExtractRecord>;
+  readonly titles: ReadonlyArray<JSDocMigrateTitleRecord>;
+  readonly overrides: ReadonlyArray<JSDocMigrateOverrideRecord>;
+}): JSDocMigrateBindingReport => {
+  const records = frozenVerificationIndex(input.titles, input.overrides);
+  const { extractAnchors, kindMismatchAnchors, sourceHashMismatchAnchors, unmatchedExtractAnchors } =
+    compareExtractToFrozen(input.extract, records);
+  const orphanRecordAnchors: Array<string> = [];
+  for (const [anchor] of records) {
+    if (!MutableHashSet.has(extractAnchors, anchor)) {
+      A.appendInPlace(orphanRecordAnchors, anchor);
+    }
+  }
+  return JSDocMigrateBindingReport.make({
+    extractCount: input.extract.length,
+    recordCount: MutableHashMap.size(records),
+    orphanRecordAnchors: A.sort(orphanRecordAnchors, Order.String),
+    unmatchedExtractAnchors: A.sort(unmatchedExtractAnchors, Order.String),
+    sourceHashMismatchAnchors: A.sort(sourceHashMismatchAnchors, Order.String),
+    kindMismatchAnchors: A.sort(kindMismatchAnchors, Order.String),
+  });
+};
+
+const bindingIsClean = (report: JSDocMigrateBindingReport): boolean =>
+  A.isReadonlyArrayEmpty(report.orphanRecordAnchors) &&
+  A.isReadonlyArrayEmpty(report.unmatchedExtractAnchors) &&
+  A.isReadonlyArrayEmpty(report.sourceHashMismatchAnchors) &&
+  A.isReadonlyArrayEmpty(report.kindMismatchAnchors);
+
+/**
+ * Build the placeholder title record used by the dry-run residue measurement.
+ *
+ * **Details**
+ *
+ * Placeholder titles keep the rewrite machinery honest without inventing
+ * shippable prose: titles are unique within the block, remarks route to
+ * Details, and no lead split or see purposes are synthesized. Dry runs must
+ * never be applied for real — the binding checks reject synthetic data in a
+ * non-dry apply because it is generated in memory, not frozen.
+ *
+ * **Example** (Synthesize a record for a two-example block)
+ *
+ * ```ts
+ * import { JSDocMigrateExtractRecord, syntheticJSDocMigrateTitleRecord } from "@beep/repo-cli/test/Quality"
+ *
+ * const extract = JSDocMigrateExtractRecord.make({
+ *   anchor: "packages/x/src/Y.ts#f#0",
+ *   filePath: "packages/x/src/Y.ts",
+ *   symbol: "f",
+ *   ordinal: 0,
+ *   kind: "value",
+ *   sourceHash: "sha256:0000",
+ *   start: 0,
+ *   end: 10,
+ *   blockText: "/** Doc. *" + "/",
+ *   leadParagraphCount: 1,
+ *   exampleTagCount: 2,
+ *   unfencedExampleCount: 0,
+ *   remarksTagCount: 0,
+ *   undescribedSeeCount: 0
+ * })
+ * const record = syntheticJSDocMigrateTitleRecord(extract)
+ * console.log(record.titles) // ["Placeholder title", "Placeholder title 2"]
+ * ```
+ *
+ * @param record - Extract record to synthesize a placeholder for.
+ * @returns Placeholder title record bound to the extract record.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const syntheticJSDocMigrateTitleRecord = (record: JSDocMigrateExtractRecord): JSDocMigrateTitleRecord => {
+  // A.makeBy clamps its size to at least 1, so remarks-only blocks must map to
+  // an empty title list explicitly.
+  const titles =
+    record.exampleTagCount === 0
+      ? []
+      : A.makeBy(record.exampleTagCount, (index) =>
+          index === 0 ? "Placeholder title" : `Placeholder title ${index + 1}`
+        );
+  return record.remarksTagCount > 0
+    ? JSDocMigrateTitleRecord.make({
+        anchor: record.anchor,
+        sourceHash: record.sourceHash,
+        kind: record.kind,
+        titles,
+        remarks: "details",
+      })
+    : JSDocMigrateTitleRecord.make({
+        anchor: record.anchor,
+        sourceHash: record.sourceHash,
+        kind: record.kind,
+        titles,
+      });
+};
+
+const applyReplacements = (
+  sourceText: string,
+  replacements: ReadonlyArray<{ readonly start: number; readonly end: number; readonly text: string }>
+): string => {
+  let result = sourceText;
+  const descending = A.sortWith(replacements, (replacement) => -replacement.start, Order.Number);
+  for (const replacement of descending) {
+    result = `${Str.slice(0, replacement.start)(result)}${replacement.text}${Str.slice(replacement.end)(result)}`;
+  }
+  return result;
+};
+
+type AffectedFile = {
+  readonly filePath: string;
+  readonly sourceText: string;
+  readonly blocks: ReadonlyArray<JSDocMigrateScannedBlock>;
+};
+
+const readAffectedFiles = Effect.fn("JSDocMigrateApply.readAffectedFiles")(function* (
+  repoRoot: string,
+  files: ReadonlyArray<string>
+): Effect.fn.Return<ReadonlyArray<AffectedFile>, QualityScriptCommandError, FileSystem.FileSystem | Path.Path> {
+  const perFile = yield* Effect.forEach(
+    files,
+    (filePath) =>
+      readJSDocMigrateSourceText(repoRoot, filePath).pipe(
+        Effect.map(
+          O.flatMap((sourceText) => {
+            const blocks = scanJSDocMigrateBlocks(filePath, sourceText);
+            return A.some(blocks, (block) => block.affected)
+              ? O.some<AffectedFile>({ filePath, sourceText, blocks })
+              : O.none<AffectedFile>();
+          })
+        )
+      ),
+    { concurrency: 8 }
+  );
+  return A.getSomes(perFile);
+});
+
+const formatBiome = Effect.fn("JSDocMigrateApply.formatBiome")(function* (
+  repoRoot: string,
+  files: ReadonlyArray<string>
+): Effect.fn.Return<void, QualityScriptCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  for (const chunk of A.chunksOf(files, 50)) {
+    const step = yield* runCaptured({
+      command: "bun",
+      args: ["x", "biome", "format", "--write", ...chunk],
+      cwd: repoRoot,
+    }).pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, "Failed to run biome format.")));
+    if (step.exitCode !== 0) {
+      return yield* migrateError(`biome format exited ${step.exitCode}: ${Str.slice(0, 2000)(step.output)}`);
+    }
+  }
+});
+
+const writeManifest = Effect.fn("JSDocMigrateApply.writeManifest")(function* (
+  repoRoot: string,
+  manifestPath: string,
+  manifest: JSDocMigrateProofManifest
+): Effect.fn.Return<void, QualityScriptCommandError, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const jsonc = yield* formatJsonc(manifest).pipe(
+    QualityScriptCommandError.mapError("Failed to format jsdoc-migrate proof manifest.")
+  );
+  yield* writeArtifact({
+    path: path.resolve(repoRoot, manifestPath),
+    body: `// jsdoc-migrate conservation proof manifest. Generated by bun run beep quality jsdoc-migrate.\n${jsonc}\n`,
+    onError: (cause) => QualityScriptCommandError.new(cause, `Failed to write ${manifestPath}.`),
+  });
+});
+
+const renderAnchors = (label: string, anchors: ReadonlyArray<string>): ReadonlyArray<string> =>
+  A.isReadonlyArrayEmpty(anchors)
+    ? []
+    : [`  ${label} (${anchors.length}):`, ...A.map(A.take(anchors, 10), (anchor) => `    - ${anchor}`)];
+
+const failOnDirtyBinding = Effect.fn("JSDocMigrateApply.failOnDirtyBinding")(function* (
+  binding: JSDocMigrateBindingReport
+): Effect.fn.Return<void, QualityScriptCommandError> {
+  if (bindingIsClean(binding)) {
+    return;
+  }
+  const lines = [
+    "[jsdoc-migrate] binding verification failed; refusing to continue:",
+    ...renderAnchors("orphan records", binding.orphanRecordAnchors),
+    ...renderAnchors("extract anchors without records", binding.unmatchedExtractAnchors),
+    ...renderAnchors("sourceHash mismatches (re-title these)", binding.sourceHashMismatchAnchors),
+    ...renderAnchors("kind mismatches", binding.kindMismatchAnchors),
+  ];
+  yield* Console.error(A.join(lines, "\n"));
+  return yield* migrateError("jsdoc-migrate binding verification failed.");
+});
+
+/**
+ * Options accepted by {@link runJSDocMigrateApply}.
+ *
+ * **Example** (Configure a dry run)
+ *
+ * ```ts
+ * import { RunJSDocMigrateApplyOptions } from "@beep/repo-cli/test/Quality"
+ *
+ * const options = RunJSDocMigrateApplyOptions.make({ dryRun: true, syntheticTitles: true })
+ * console.log(options.dryRun) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class RunJSDocMigrateApplyOptions extends S.Class<RunJSDocMigrateApplyOptions>($I`RunJSDocMigrateApplyOptions`)(
+  {
+    titles: S.optionalKey(S.String),
+    overrides: S.optionalKey(S.String),
+    manifest: S.optionalKey(S.String),
+    dryRun: S.Boolean,
+    syntheticTitles: S.Boolean,
+  },
+  $I.annote("RunJSDocMigrateApplyOptions", {
+    description: "Options for the jsdoc-migrate apply stage: data-file paths, dry-run, and synthetic titles.",
+  })
+) {}
+
+type BlockOutcome =
+  | { readonly _tag: "Rewritten"; readonly replacement: string }
+  | { readonly _tag: "Overridden"; readonly replacement: string }
+  | { readonly _tag: "Quarantined"; readonly quarantine: JSDocMigrateQuarantineRecord }
+  | { readonly _tag: "DataMismatch"; readonly reasons: ReadonlyArray<string> };
+
+const blockOutcome = (
+  block: JSDocMigrateScannedBlock,
+  title: O.Option<JSDocMigrateTitleRecord>,
+  override: O.Option<JSDocMigrateOverrideRecord>
+): BlockOutcome => {
+  if (O.isSome(override)) {
+    return { _tag: "Overridden", replacement: override.value.block };
+  }
+  if (O.isNone(title)) {
+    return { _tag: "DataMismatch", reasons: [`missing-title-record: ${block.anchor}`] };
+  }
+  const result = rewriteJSDocMigrateBlock({
+    blockText: block.text,
+    indent: block.indent,
+    data: {
+      titles: title.value.titles,
+      remarks: title.value.remarks,
+      leadEnd: title.value.leadEnd,
+      seePurposes: title.value.seePurposes,
+    },
+  });
+  if (result._tag === "Rewritten") {
+    return { _tag: "Rewritten", replacement: result.text };
+  }
+  if (result._tag === "DataMismatch") {
+    return { _tag: "DataMismatch", reasons: A.map(result.reasons, (reason) => `${block.anchor}: ${reason}`) };
+  }
+  return {
+    _tag: "Quarantined",
+    quarantine: JSDocMigrateQuarantineRecord.make({
+      anchor: block.anchor,
+      filePath: block.filePath,
+      reasons: result.reasons,
+    }),
+  };
+};
+
+/**
+ * Run the apply stage: rewrite every affected block that binds cleanly.
+ *
+ * **Details**
+ *
+ * Re-extracts the live corpus, verifies the frozen records against it (fail
+ * closed on any orphan, hash mismatch, or kind disagreement), rewrites blocks
+ * text-surgically by byte offset from the bottom of each file up, quarantines
+ * conservation violations instead of writing them, and formats the touched
+ * files with biome so verify always sees post-format bytes. With `dryRun` no
+ * file is written and the reported quarantine count is the migration's
+ * residue measurement; with `syntheticTitles` placeholder records are
+ * generated in memory for exactly that measurement.
+ *
+ * **Example** (Build a dry-run Effect)
+ *
+ * ```ts
+ * import { runJSDocMigrateApply, RunJSDocMigrateApplyOptions } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const program = runJSDocMigrateApply(RunJSDocMigrateApplyOptions.make({ dryRun: true, syntheticTitles: true }))
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+// fallow-ignore-next-line complexity -- the apply pipeline is the SPEC §5 order of operations (bind, rewrite, quarantine, write, format) kept as one auditable sequence
+export const runJSDocMigrateApply = Effect.fn("JSDocMigrateApply.run")(function* (
+  options: RunJSDocMigrateApplyOptions
+): Effect.fn.Return<
+  void,
+  QualityScriptCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const repoRoot = yield* findRepoRoot().pipe(QualityScriptCommandError.mapError("Failed to locate repository root."));
+  const path = yield* Path.Path;
+  const files = yield* listJSDocMigrateCorpusFiles(repoRoot);
+  const affectedFiles = yield* readAffectedFiles(repoRoot, files);
+  const liveExtract = A.flatMap(affectedFiles, (file) =>
+    jsdocMigrateExtractRecordsForFile(file.filePath, file.sourceText)
+  );
+
+  const { overrideByAnchor, overrides, titleByAnchor, titles } = yield* loadFrozenRecordSets(
+    repoRoot,
+    options,
+    options.syntheticTitles ? O.some(A.map(liveExtract, syntheticJSDocMigrateTitleRecord)) : O.none()
+  );
+
+  const binding = computeJSDocMigrateBinding({ extract: liveExtract, titles, overrides });
+  yield* failOnDirtyBinding(binding);
+
+  const quarantines: Array<JSDocMigrateQuarantineRecord> = [];
+  const mismatches: Array<string> = [];
+  const pendingWrites: Array<{ readonly filePath: string; readonly nextText: string }> = [];
+  let rewritten = 0;
+  let overridden = 0;
+
+  for (const file of affectedFiles) {
+    const replacements: Array<{ readonly start: number; readonly end: number; readonly text: string }> = [];
+    for (const block of A.filter(file.blocks, (candidate) => candidate.affected)) {
+      const outcome = blockOutcome(
+        block,
+        MutableHashMap.get(titleByAnchor, block.anchor),
+        MutableHashMap.get(overrideByAnchor, block.anchor)
+      );
+      if (outcome._tag === "Rewritten" || outcome._tag === "Overridden") {
+        A.appendInPlace(replacements, { start: block.start, end: block.end, text: outcome.replacement });
+        if (outcome._tag === "Rewritten") {
+          rewritten += 1;
+        } else {
+          overridden += 1;
+        }
+        continue;
+      }
+      if (outcome._tag === "Quarantined") {
+        A.appendInPlace(quarantines, outcome.quarantine);
+        continue;
+      }
+      A.appendAllInPlace(mismatches, outcome.reasons);
+    }
+    if (replacements.length > 0) {
+      A.appendInPlace(pendingWrites, {
+        filePath: file.filePath,
+        nextText: applyReplacements(file.sourceText, replacements),
+      });
+    }
+  }
+
+  if (mismatches.length > 0) {
+    yield* Console.error(
+      A.join([`[jsdoc-migrate] frozen-data mismatches (${mismatches.length}):`, ...A.take(mismatches, 20)], "\n")
+    );
+    return yield* migrateError("jsdoc-migrate apply found frozen-data mismatches.");
+  }
+
+  const changedFiles = A.map(pendingWrites, (write) => write.filePath);
+  if (!options.dryRun && pendingWrites.length > 0) {
+    const fs = yield* FileSystem.FileSystem;
+    yield* Effect.forEach(
+      pendingWrites,
+      (write) =>
+        fs
+          .writeFileString(path.join(repoRoot, write.filePath), write.nextText)
+          .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to write ${write.filePath}.`))),
+      { concurrency: 8 }
+    );
+    yield* formatBiome(repoRoot, changedFiles);
+  }
+
+  const generatedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  const mode: JSDocMigrateMode = options.dryRun ? "dry-run" : "apply";
+  const manifest = JSDocMigrateProofManifest.make({
+    schema_version: 1,
+    generated_at: generatedAt,
+    mode,
+    files: affectedFiles.length,
+    blocksAffected: liveExtract.length,
+    rewritten,
+    overridden,
+    quarantined: quarantines.length,
+    conservationViolations: 0,
+    shapeRegressions: 0,
+    residueLegacyBlocks: quarantines.length,
+    binding,
+    quarantines,
+  });
+  yield* writeManifest(repoRoot, options.manifest ?? defaultJSDocMigrateManifestPath, manifest);
+  yield* Console.log(
+    `[jsdoc-migrate] ${mode} ok: files=${affectedFiles.length} blocks=${liveExtract.length} rewritten=${rewritten} ` +
+      `overridden=${overridden} residue=${quarantines.length}`
+  );
+});
+
+/**
+ * Options accepted by {@link runJSDocMigrateVerify}.
+ *
+ * **Example** (Configure a verify run)
+ *
+ * ```ts
+ * import { RunJSDocMigrateVerifyOptions } from "@beep/repo-cli/test/Quality"
+ *
+ * const options = RunJSDocMigrateVerifyOptions.make({})
+ * console.log(options.extract === undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class RunJSDocMigrateVerifyOptions extends S.Class<RunJSDocMigrateVerifyOptions>(
+  $I`RunJSDocMigrateVerifyOptions`
+)(
+  {
+    extract: S.optionalKey(S.String),
+    titles: S.optionalKey(S.String),
+    overrides: S.optionalKey(S.String),
+    manifest: S.optionalKey(S.String),
+  },
+  $I.annote("RunJSDocMigrateVerifyOptions", {
+    description: "Options for the jsdoc-migrate verify stage: frozen data-file paths and the manifest output.",
+  })
+) {}
+
+/**
+ * Run the verify stage: prove conservation between frozen originals and the tree.
+ *
+ * **Details**
+ *
+ * Reads the frozen `extract.jsonl` (the original block bytes), re-scans the
+ * current tree, and for every record either matches the exact expected
+ * rewrite, re-proves conservation on the post-format bytes, confirms an
+ * override was applied verbatim, or reports the block as residue when it
+ * still carries its legacy form. Any conservation violation or binding
+ * failure exits non-zero; the proof manifest records the exhaustive result.
+ *
+ * **Example** (Build a verify Effect)
+ *
+ * ```ts
+ * import { runJSDocMigrateVerify, RunJSDocMigrateVerifyOptions } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const program = runJSDocMigrateVerify(RunJSDocMigrateVerifyOptions.make({}))
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+// fallow-ignore-next-line complexity -- the verify decision tree mirrors the SPEC §7 verification matrix case-by-case; splitting it would hide which row each branch proves
+export const runJSDocMigrateVerify = Effect.fn("JSDocMigrateApply.runVerify")(function* (
+  options: RunJSDocMigrateVerifyOptions
+): Effect.fn.Return<
+  void,
+  QualityScriptCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const { fs, path, repoRoot } = yield* jsdocMigrateRunContext();
+
+  const extractPath = path.resolve(repoRoot, options.extract ?? defaultJSDocMigrateExtractPath);
+  const frozen = yield* readJSDocMigrateExtractRequired(extractPath);
+  const { overrideByAnchor, titleByAnchor, titles, overrides } = yield* loadFrozenRecordSets(
+    repoRoot,
+    options,
+    O.none()
+  );
+  const binding = computeJSDocMigrateBinding({ extract: frozen, titles, overrides });
+
+  const frozenFiles = A.dedupe(A.map(frozen, (record) => record.filePath));
+  const currentBlocks = MutableHashMap.empty<string, JSDocMigrateScannedBlock>();
+  const loadCurrentBlocks = Effect.fnUntraced(function* (filePath: string) {
+    const sourceText = yield* fs
+      .readFileString(path.join(repoRoot, filePath))
+      .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to read ${filePath}.`)));
+    for (const block of scanJSDocMigrateBlocks(filePath, sourceText)) {
+      MutableHashMap.set(currentBlocks, block.anchor, block);
+    }
+  });
+  yield* Effect.forEach(frozenFiles, loadCurrentBlocks, { concurrency: 8 });
+
+  const violations: Array<string> = [];
+  const quarantines: Array<JSDocMigrateQuarantineRecord> = [];
+  let conserved = 0;
+  let overridden = 0;
+  let residue = 0;
+  let shapeRegressionCount = 0;
+  let conservationViolationCount = 0;
+
+  for (const record of frozen) {
+    const current = MutableHashMap.get(currentBlocks, record.anchor);
+    if (O.isNone(current)) {
+      A.appendInPlace(violations, `anchor-missing: ${record.anchor}`);
+      continue;
+    }
+    const override = MutableHashMap.get(overrideByAnchor, record.anchor);
+    if (O.isSome(override)) {
+      if (current.value.text === override.value.block) {
+        overridden += 1;
+      } else if (current.value.text === record.blockText) {
+        residue += 1;
+      } else {
+        A.appendInPlace(violations, `override-not-applied: ${record.anchor}`);
+      }
+      continue;
+    }
+    if (current.value.text === record.blockText) {
+      residue += 1;
+      continue;
+    }
+    const title = MutableHashMap.get(titleByAnchor, record.anchor);
+    if (O.isNone(title)) {
+      A.appendInPlace(violations, `changed-without-record: ${record.anchor}`);
+      continue;
+    }
+    const expected = rewriteJSDocMigrateBlock({
+      blockText: record.blockText,
+      indent: current.value.indent,
+      data: {
+        titles: title.value.titles,
+        remarks: title.value.remarks,
+        leadEnd: title.value.leadEnd,
+        seePurposes: title.value.seePurposes,
+      },
+    });
+    if (expected._tag === "Quarantined") {
+      A.appendInPlace(
+        quarantines,
+        JSDocMigrateQuarantineRecord.make({
+          anchor: record.anchor,
+          filePath: record.filePath,
+          reasons: expected.reasons,
+        })
+      );
+      A.appendInPlace(violations, `quarantined-block-changed: ${record.anchor}`);
+      continue;
+    }
+    if (expected._tag === "DataMismatch") {
+      A.appendInPlace(violations, `data-mismatch: ${record.anchor}`);
+      continue;
+    }
+    if (current.value.text === expected.text) {
+      conserved += 1;
+      continue;
+    }
+    const conservation = jsdocMigrateConservationFindings({
+      original: record.blockText,
+      candidate: current.value.text,
+      allowedAddedTokens: expected.allowedAddedTokens,
+      allowedRemovedTokens: expected.allowedRemovedTokens,
+    });
+    const shape = jsdocMigrateShapeRegressions(record.blockText, current.value.text);
+    if (A.isReadonlyArrayEmpty(conservation) && A.isReadonlyArrayEmpty(shape)) {
+      conserved += 1;
+      continue;
+    }
+    conservationViolationCount += conservation.length > 0 ? 1 : 0;
+    shapeRegressionCount += shape.length > 0 ? 1 : 0;
+    for (const reason of [...conservation, ...shape]) {
+      A.appendInPlace(violations, `${record.anchor}: ${reason}`);
+    }
+  }
+
+  const generatedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  const manifest = JSDocMigrateProofManifest.make({
+    schema_version: 1,
+    generated_at: generatedAt,
+    mode: "verify",
+    files: frozenFiles.length,
+    blocksAffected: frozen.length,
+    rewritten: conserved,
+    overridden,
+    quarantined: quarantines.length,
+    conservationViolations: conservationViolationCount,
+    shapeRegressions: shapeRegressionCount,
+    residueLegacyBlocks: residue,
+    binding,
+    quarantines,
+  });
+  yield* writeManifest(repoRoot, options.manifest ?? defaultJSDocMigrateManifestPath, manifest);
+
+  if (!bindingIsClean(binding)) {
+    yield* failOnDirtyBinding(binding);
+  }
+  if (A.isReadonlyArrayNonEmpty(violations)) {
+    yield* Console.error(
+      A.join([`[jsdoc-migrate] verify violations (${violations.length}):`, ...A.take(violations, 25)], "\n")
+    );
+    return yield* migrateError("jsdoc-migrate verify found conservation violations.");
+  }
+  yield* Console.log(
+    `[jsdoc-migrate] verify ok: blocks=${frozen.length} conserved=${conserved} overridden=${overridden} residue=${residue}`
+  );
+});

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateData.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateData.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared data-file codecs and jsonl IO for the JSDoc carrier migration.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { findRepoRoot } from "@beep/repo-utils";
+import { A, Str, thunkFalse } from "@beep/utils";
+import { Effect, FileSystem, MutableHashMap, Path } from "effect";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
+import { QualityScriptCommandError } from "../Quality.errors.ts";
+import {
+  JSDocMigrateExtractRecord,
+  JSDocMigrateOverrideRecord,
+  JSDocMigrateTitleRecord,
+} from "./JSDocMigrate.schemas.ts";
+import type * as S from "effect/Schema";
+
+/**
+ * JSON-line codec for {@link JSDocMigrateExtractRecord} rows.
+ *
+ * **Example** (Round-trip an extract row)
+ *
+ * ```ts
+ * import { jsdocMigrateExtractCodec } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(jsdocMigrateExtractCodec.decode("{}"))) // true
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const jsdocMigrateExtractCodec = JsonStringCodec(JSDocMigrateExtractRecord);
+
+/**
+ * JSON-line codec for {@link JSDocMigrateTitleRecord} rows.
+ *
+ * **Example** (Round-trip a title row)
+ *
+ * ```ts
+ * import { jsdocMigrateTitleCodec } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(jsdocMigrateTitleCodec.decode("{}"))) // true
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const jsdocMigrateTitleCodec = JsonStringCodec(JSDocMigrateTitleRecord);
+
+/**
+ * JSON-line codec for {@link JSDocMigrateOverrideRecord} rows.
+ *
+ * **Example** (Round-trip an override row)
+ *
+ * ```ts
+ * import { jsdocMigrateOverrideCodec } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(jsdocMigrateOverrideCodec.decode("{}"))) // true
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const jsdocMigrateOverrideCodec = JsonStringCodec(JSDocMigrateOverrideRecord);
+
+/**
+ * Resolve the repo root and platform services every migration stage starts from.
+ *
+ * **Example** (Build the run-context Effect)
+ *
+ * ```ts
+ * import { jsdocMigrateRunContext } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(jsdocMigrateRunContext())) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const jsdocMigrateRunContext = Effect.fn("JSDocMigrateData.runContext")(function* (): Effect.fn.Return<
+  {
+    readonly repoRoot: string;
+    readonly path: Path.Path;
+    readonly fs: FileSystem.FileSystem;
+  },
+  QualityScriptCommandError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const repoRoot = yield* findRepoRoot().pipe(QualityScriptCommandError.mapError("Failed to locate repository root."));
+  const path = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
+  return { repoRoot, path, fs };
+});
+
+/**
+ * Read one migration jsonl data file, treating a missing file as empty.
+ *
+ * **Example** (Build a jsonl reader Effect)
+ *
+ * ```ts
+ * import { jsdocMigrateTitleCodec, readJSDocMigrateJsonl } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const program = readJSDocMigrateJsonl("/tmp/none.jsonl", jsdocMigrateTitleCodec.decode, "titles.jsonl")
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const readJSDocMigrateJsonl = Effect.fn("JSDocMigrateData.readJsonl")(function* <T>(
+  absolutePath: string,
+  decodeLine: (line: string) => Effect.Effect<T, S.SchemaError>,
+  label: string
+): Effect.fn.Return<ReadonlyArray<T>, QualityScriptCommandError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const exists = yield* fs.exists(absolutePath).pipe(Effect.orElseSucceed(thunkFalse));
+  if (!exists) {
+    return [];
+  }
+  const content = yield* fs
+    .readFileString(absolutePath)
+    .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to read ${label}.`)));
+  const jsonLines = A.filter(A.map(Str.split(/\r?\n/)(content), Str.trim), Str.isNonEmpty);
+  return yield* Effect.forEach(jsonLines, (line, index) =>
+    decodeLine(line).pipe(
+      Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to decode ${label} line ${index + 1}.`))
+    )
+  );
+});
+
+/**
+ * Read the frozen extract, failing when it is missing or empty.
+ *
+ * **Example** (Build the required-extract Effect)
+ *
+ * ```ts
+ * import { readJSDocMigrateExtractRequired } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(readJSDocMigrateExtractRequired("/tmp/none.jsonl"))) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const readJSDocMigrateExtractRequired = Effect.fn("JSDocMigrateData.readExtractRequired")(function* (
+  absolutePath: string
+): Effect.fn.Return<ReadonlyArray<JSDocMigrateExtractRecord>, QualityScriptCommandError, FileSystem.FileSystem> {
+  const records = yield* readJSDocMigrateJsonl(absolutePath, jsdocMigrateExtractCodec.decode, "extract.jsonl");
+  if (A.isReadonlyArrayEmpty(records)) {
+    return yield* QualityScriptCommandError.make({
+      message: `A non-empty extract is required at ${absolutePath}; run jsdoc-migrate extract first.`,
+      command: "bun run beep quality jsdoc-migrate",
+      exitCode: 1,
+    });
+  }
+  return records;
+});
+
+/**
+ * Index anchored records by anchor; later rows win on duplicates.
+ *
+ * **Details**
+ *
+ * Later-wins matches the append-only retry semantics of `titles.jsonl`: a
+ * re-titled anchor appends a fresh row rather than editing history.
+ *
+ * **Example** (Index two records)
+ *
+ * ```ts
+ * import { indexJSDocMigrateByAnchor } from "@beep/repo-cli/test/Quality"
+ * import { MutableHashMap } from "effect"
+ *
+ * const index = indexJSDocMigrateByAnchor([{ anchor: "a#x#0" }, { anchor: "b#y#0" }])
+ * console.log(MutableHashMap.size(index)) // 2
+ * ```
+ *
+ * @param records - Anchored records to index.
+ * @returns Mutable map from anchor to the last record carrying it.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const indexJSDocMigrateByAnchor = <T extends { readonly anchor: string }>(
+  records: ReadonlyArray<T>
+): MutableHashMap.MutableHashMap<string, T> =>
+  MutableHashMap.fromIterable(A.map(records, (record): readonly [string, T] => [record.anchor, record]));

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateData.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateData.ts
@@ -7,7 +7,7 @@
 
 import { findRepoRoot } from "@beep/repo-utils";
 import { A, Str, thunkFalse } from "@beep/utils";
-import { Effect, FileSystem, MutableHashMap, Path } from "effect";
+import { Console, Effect, FileSystem, MutableHashMap, Path } from "effect";
 import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
 import { QualityScriptCommandError } from "../Quality.errors.ts";
 import {
@@ -128,11 +128,25 @@ export const readJSDocMigrateJsonl = Effect.fn("JSDocMigrateData.readJsonl")(fun
     .readFileString(absolutePath)
     .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to read ${label}.`)));
   const jsonLines = A.filter(A.map(Str.split(/\r?\n/)(content), Str.trim), Str.isNonEmpty);
-  return yield* Effect.forEach(jsonLines, (line, index) =>
-    decodeLine(line).pipe(
-      Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to decode ${label} line ${index + 1}.`))
-    )
-  );
+  const endsWithNewline = Str.endsWith("\n")(content);
+  const records: Array<T> = [];
+  for (const [index, line] of A.entries(jsonLines)) {
+    const outcome = yield* decodeLine(line).pipe(Effect.result);
+    if (outcome._tag === "Failure") {
+      // An interrupted append leaves a final record with no trailing newline;
+      // dropping it lets per-anchor resume regenerate it instead of wedging
+      // every later run on a manual repair.
+      if (index === jsonLines.length - 1 && !endsWithNewline) {
+        yield* Console.warn(
+          `[jsdoc-migrate] dropping truncated trailing record in ${label}; resume will regenerate it.`
+        );
+        break;
+      }
+      return yield* QualityScriptCommandError.new(outcome.failure, `Failed to decode ${label} line ${index + 1}.`);
+    }
+    A.appendInPlace(records, outcome.success);
+  }
+  return records;
 });
 
 /**

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateExtract.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateExtract.ts
@@ -1,0 +1,574 @@
+/**
+ * Corpus extraction for the JSDoc legacy-carrier migration.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { createHash } from "node:crypto";
+import { $RepoCliId } from "@beep/identity/packages";
+import { findRepoRoot } from "@beep/repo-utils";
+import { A, Str } from "@beep/utils";
+import { Console, Effect, FileSystem, MutableHashMap, MutableHashSet, Path } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { Node } from "ts-morph";
+import { writeArtifact } from "../../../internal/artifacts/index.ts";
+import { runGitLines } from "../../../internal/repo-run/index.ts";
+import { createInMemoryTsMorphProject } from "../../../internal/tsmorph/index.ts";
+import { QualityScriptCommandError } from "../Quality.errors.ts";
+import {
+  defaultJSDocMigrateExtractPath,
+  JSDocMigrateBlockKind,
+  JSDocMigrateExtractRecord,
+} from "./JSDocMigrate.schemas.ts";
+import { jsdocMigrateExtractCodec } from "./JSDocMigrateData.ts";
+import { jsdocMigrateBlockStats } from "./JSDocMigrateRewrite.ts";
+import { hasGeneratedFileHeader, isPackageSourceFile, jsdocGitErrorAdapter } from "./JSDocRatchet.ts";
+import { jsdocCommentsFromSource, tagsFromComment } from "./QualityArtifactSupport.ts";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { SourceFile } from "ts-morph";
+
+const $I = $RepoCliId.create("commands/Quality/internal/JSDocMigrateExtract");
+
+/**
+ * One JSDoc block located in a source file with its verified anchor identity.
+ *
+ * **Example** (Decode a scanned block)
+ *
+ * ```ts
+ * import { JSDocMigrateScannedBlock } from "@beep/repo-cli/test/Quality"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(JSDocMigrateScannedBlock)({})) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const JSDocMigrateScannedBlock = S.Struct({
+  anchor: S.String,
+  filePath: S.String,
+  symbol: S.String,
+  ordinal: S.Int,
+  kind: JSDocMigrateBlockKind,
+  start: S.Int,
+  end: S.Int,
+  text: S.String,
+  indent: S.String,
+  affected: S.Boolean,
+}).pipe(
+  $I.annoteSchema("JSDocMigrateScannedBlock", {
+    description: "One anchored JSDoc block located in a scanned source file.",
+  })
+);
+
+/**
+ * One anchored JSDoc block located in a scanned source file.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type JSDocMigrateScannedBlock = typeof JSDocMigrateScannedBlock.Type;
+
+/**
+ * Hash JSDoc block bytes into the `sourceHash` verification field.
+ *
+ * **Example** (Hash a block)
+ *
+ * ```ts
+ * import { jsdocMigrateSourceHash } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(jsdocMigrateSourceHash("/** Doc. *" + "/").startsWith("sha256:")) // true
+ * ```
+ *
+ * @param blockText - Exact block bytes to hash.
+ * @returns `sha256:`-prefixed hex digest of the block bytes.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const jsdocMigrateSourceHash = (blockText: string): string =>
+  `sha256:${createHash("sha256").update(blockText).digest("hex")}`;
+
+type RawSpan = { readonly start: number; readonly end: number; readonly text: string };
+
+const rawBlockSpans = (sourceText: string): ReadonlyArray<RawSpan> => {
+  const spans: Array<RawSpan> = [];
+  let cursor = 0;
+  for (const text of jsdocCommentsFromSource(sourceText)) {
+    const start = sourceText.indexOf(text, cursor);
+    if (start === -1) {
+      break;
+    }
+    A.appendInPlace(spans, { start, end: start + text.length, text });
+    cursor = start + text.length;
+  }
+  return spans;
+};
+
+// fallow-ignore-next-line complexity -- exhaustive ts-morph node-kind dispatch; each guard is one line and a lookup table cannot preserve the type narrowing getName() needs
+const ownName = (node: Node): string | undefined => {
+  if (Node.isVariableStatement(node)) {
+    return node.getDeclarations()[0]?.getName();
+  }
+  if (Node.isConstructorDeclaration(node)) {
+    return "constructor";
+  }
+  if (Node.isExportAssignment(node)) {
+    return "<default>";
+  }
+  if (Node.isModuleDeclaration(node)) {
+    return node.getName();
+  }
+  if (
+    Node.isVariableDeclaration(node) ||
+    Node.isBindingElement(node) ||
+    Node.isEnumMember(node) ||
+    Node.isMethodDeclaration(node) ||
+    Node.isMethodSignature(node) ||
+    Node.isPropertyDeclaration(node) ||
+    Node.isPropertySignature(node) ||
+    Node.isGetAccessorDeclaration(node) ||
+    Node.isSetAccessorDeclaration(node)
+  ) {
+    return node.getName();
+  }
+  if (
+    Node.isFunctionDeclaration(node) ||
+    Node.isClassDeclaration(node) ||
+    Node.isInterfaceDeclaration(node) ||
+    Node.isTypeAliasDeclaration(node) ||
+    Node.isEnumDeclaration(node)
+  ) {
+    return node.getName() ?? "<default>";
+  }
+  return undefined;
+};
+
+const containerName = (node: Node): string | undefined =>
+  Node.isClassDeclaration(node) ||
+  Node.isInterfaceDeclaration(node) ||
+  Node.isEnumDeclaration(node) ||
+  Node.isModuleDeclaration(node) ||
+  Node.isFunctionDeclaration(node)
+    ? node.getName()
+    : undefined;
+
+const qualifiedSymbol = (owner: Node): string => {
+  const base = ownName(owner) ?? "<anonymous>";
+  const ancestors: Array<string> = [];
+  let current = owner.getParent();
+  while (current !== undefined && !Node.isSourceFile(current)) {
+    const name = containerName(current);
+    if (name !== undefined && name !== base) {
+      A.appendInPlace(ancestors, name);
+    }
+    current = current.getParent();
+  }
+  return A.join([...A.reverse(ancestors), base], ".");
+};
+
+const isTypeLevelDeclaration = (node: Node): boolean =>
+  Node.isTypeAliasDeclaration(node) || Node.isInterfaceDeclaration(node) || Node.isModuleDeclaration(node);
+
+const blockKindOf = (owner: Node): JSDocMigrateBlockKind => {
+  if (isTypeLevelDeclaration(owner)) {
+    return "type-level";
+  }
+  let current = owner.getParent();
+  while (current !== undefined && !Node.isSourceFile(current)) {
+    if (Node.isInterfaceDeclaration(current) || Node.isTypeAliasDeclaration(current)) {
+      return "type-level";
+    }
+    current = current.getParent();
+  }
+  return "value";
+};
+
+const recordJsDocOwner = (node: Node, owners: MutableHashMap.MutableHashMap<number, Node>): void => {
+  if (!Node.isJSDocable(node)) {
+    return;
+  }
+  for (const doc of node.getJsDocs()) {
+    if (!MutableHashMap.has(owners, doc.getStart())) {
+      MutableHashMap.set(owners, doc.getStart(), node);
+    }
+  }
+};
+
+const recordBindingElementOwner = (node: Node, owners: MutableHashMap.MutableHashMap<number, Node>): void => {
+  if (!Node.isBindingElement(node)) {
+    return;
+  }
+  for (const range of node.getLeadingCommentRanges()) {
+    if (Str.startsWith("/**")(range.getText()) && !MutableHashMap.has(owners, range.getPos())) {
+      MutableHashMap.set(owners, range.getPos(), node);
+    }
+  }
+};
+
+const docOwnersByStart = (sourceFile: SourceFile): MutableHashMap.MutableHashMap<number, Node> => {
+  const owners = MutableHashMap.empty<number, Node>();
+  sourceFile.forEachDescendant((node) => {
+    recordJsDocOwner(node, owners);
+    recordBindingElementOwner(node, owners);
+  });
+  return owners;
+};
+
+const fileoverviewPreamblePattern = /^(?:#![^\n]*\n)?\s*$/;
+
+const indentBefore = (sourceText: string, start: number): string => {
+  const lineStart = sourceText.lastIndexOf("\n", start - 1) + 1;
+  const prefix = Str.slice(lineStart, start)(sourceText);
+  return /^[ \t]*$/.test(prefix) ? prefix : "";
+};
+
+const legacyCarrierTags = ["@example", "@remarks"];
+
+const isAffectedBlock = (blockText: string): boolean => {
+  const tags = tagsFromComment(blockText);
+  return A.some(legacyCarrierTags, (tag) => A.contains(tags, tag));
+};
+
+/**
+ * Scan one source file into anchored JSDoc blocks.
+ *
+ * **Details**
+ *
+ * Blocks are discovered with the same fence-aware raw scanner the quality
+ * gate uses, then bound to declarations through ts-morph. Anchors are
+ * `path#symbol#ordinal` where the ordinal counts every doc block sharing the
+ * `path#symbol` prefix in source order — over all blocks, not only affected
+ * ones, so anchors stay stable when the affected subset shrinks. The first
+ * block of a multi-doc leading run (a fileoverview above a symbol doc) binds
+ * to `<fileoverview>`.
+ *
+ * **Example** (Scan a file with a companion type)
+ *
+ * ```ts
+ * import { scanJSDocMigrateBlocks } from "@beep/repo-cli/test/Quality"
+ *
+ * const source = [
+ *   "/** Runtime schema. *" + "/",
+ *   "export const Foo = 1",
+ *   "/** Companion type. *" + "/",
+ *   "export type Foo = typeof Foo",
+ *   ""
+ * ].join("\n")
+ * const blocks = scanJSDocMigrateBlocks("packages/x/src/Foo.ts", source)
+ * console.log(blocks.map((block) => block.anchor))
+ * // ["packages/x/src/Foo.ts#Foo#0", "packages/x/src/Foo.ts#Foo#1"]
+ * ```
+ *
+ * @param filePath - Repo-relative path used in anchors.
+ * @param sourceText - Full source text to scan.
+ * @returns Anchored blocks in source order.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const scanJSDocMigrateBlocks = (
+  filePath: string,
+  sourceText: string
+): ReadonlyArray<JSDocMigrateScannedBlock> => {
+  const spans = rawBlockSpans(sourceText);
+  if (spans.length === 0) {
+    return [];
+  }
+  const project = createInMemoryTsMorphProject();
+  const sourceFile = project.createSourceFile(filePath, sourceText, { overwrite: true });
+  const owners = docOwnersByStart(sourceFile);
+  const fileoverviewStart =
+    spans[0] !== undefined && fileoverviewPreamblePattern.test(Str.slice(0, spans[0].start)(sourceText))
+      ? spans[0].start
+      : -1;
+
+  const bound = A.map(
+    spans,
+    (span): { readonly span: RawSpan; readonly symbol: string; readonly kind: JSDocMigrateBlockKind } => {
+      const owner = MutableHashMap.get(owners, span.start);
+      if (O.isSome(owner)) {
+        const node = owner.value;
+        if (Node.isJSDocable(node)) {
+          const docs = node.getJsDocs();
+          const lastStart = docs[docs.length - 1]?.getStart();
+          if (docs.length > 1 && span.start !== lastStart && span.start === fileoverviewStart) {
+            return { span, symbol: "<fileoverview>", kind: "module" };
+          }
+        }
+        return { span, symbol: qualifiedSymbol(node), kind: blockKindOf(node) };
+      }
+      if (span.start === fileoverviewStart) {
+        return { span, symbol: "<fileoverview>", kind: "module" };
+      }
+      return { span, symbol: "<detached>", kind: "detached" };
+    }
+  );
+
+  const ordinals = MutableHashMap.empty<string, number>();
+  return A.map(bound, ({ kind, span, symbol }) => {
+    const ordinal = O.getOrElse(MutableHashMap.get(ordinals, symbol), () => 0);
+    MutableHashMap.set(ordinals, symbol, ordinal + 1);
+    return {
+      anchor: `${filePath}#${symbol}#${ordinal}`,
+      filePath,
+      symbol,
+      ordinal,
+      kind,
+      start: span.start,
+      end: span.end,
+      text: span.text,
+      indent: indentBefore(sourceText, span.start),
+      affected: isAffectedBlock(span.text),
+    };
+  });
+};
+
+/**
+ * Build extract records for the affected blocks of one source file.
+ *
+ * **Example** (Extract records from a legacy file)
+ *
+ * ```ts
+ * import { jsdocMigrateExtractRecordsForFile } from "@beep/repo-cli/test/Quality"
+ *
+ * const source = [
+ *   "/**",
+ *   " * Lead.",
+ *   " *",
+ *   " * @example",
+ *   " * ```ts",
+ *   " * const a = 1",
+ *   " * ```",
+ *   " *" + "/",
+ *   "export const a = 1",
+ *   ""
+ * ].join("\n")
+ * const records = jsdocMigrateExtractRecordsForFile("packages/x/src/a.ts", source)
+ * console.log(records.length) // 1
+ * console.log(records[0]?.exampleTagCount) // 1
+ * ```
+ *
+ * @param filePath - Repo-relative path used in anchors.
+ * @param sourceText - Full source text to scan.
+ * @returns Extract records for the affected blocks in source order.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const jsdocMigrateExtractRecordsForFile = (
+  filePath: string,
+  sourceText: string
+): ReadonlyArray<JSDocMigrateExtractRecord> =>
+  A.map(
+    A.filter(scanJSDocMigrateBlocks(filePath, sourceText), (block) => block.affected),
+    (block) => {
+      const stats = jsdocMigrateBlockStats(block.text);
+      return JSDocMigrateExtractRecord.make({
+        anchor: block.anchor,
+        filePath: block.filePath,
+        symbol: block.symbol,
+        ordinal: block.ordinal,
+        kind: block.kind,
+        sourceHash: jsdocMigrateSourceHash(block.text),
+        start: block.start,
+        end: block.end,
+        blockText: block.text,
+        leadParagraphCount: stats.leadParagraphCount,
+        exampleTagCount: stats.exampleTagCount,
+        unfencedExampleCount: stats.unfencedExampleCount,
+        remarksTagCount: stats.remarksTagCount,
+        undescribedSeeCount: stats.undescribedSeeCount,
+      });
+    }
+  );
+
+/**
+ * List the non-generated package source files the migration covers.
+ *
+ * **Details**
+ *
+ * Uses `git ls-files packages` so untracked scratch files never enter the
+ * corpus, then applies the same path filters as the quality gate. The
+ * generated-header probe still runs per file at read time.
+ *
+ * **Example** (Build the corpus listing Effect)
+ *
+ * ```ts
+ * import { listJSDocMigrateCorpusFiles } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const program = listJSDocMigrateCorpusFiles("/repo")
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const listJSDocMigrateCorpusFiles = Effect.fn("JSDocMigrateExtract.listCorpusFiles")(function* (
+  repoRoot: string
+): Effect.fn.Return<ReadonlyArray<string>, QualityScriptCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const lines = yield* runGitLines(repoRoot, ["ls-files", "packages"], jsdocGitErrorAdapter);
+  return A.filter(lines, isPackageSourceFile);
+});
+
+/**
+ * Options accepted by {@link runJSDocMigrateExtract}.
+ *
+ * **Example** (Configure an extract run)
+ *
+ * ```ts
+ * import { RunJSDocMigrateExtractOptions } from "@beep/repo-cli/test/Quality"
+ *
+ * const options = RunJSDocMigrateExtractOptions.make({
+ *   output: "goals/jsdoc-carrier-migration/data/extract.jsonl"
+ * })
+ * console.log(options.output)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class RunJSDocMigrateExtractOptions extends S.Class<RunJSDocMigrateExtractOptions>(
+  $I`RunJSDocMigrateExtractOptions`
+)(
+  {
+    output: S.optionalKey(S.String),
+  },
+  $I.annote("RunJSDocMigrateExtractOptions", {
+    description: "Options accepted by the jsdoc-migrate extract stage: the extract.jsonl output path.",
+  })
+) {}
+
+/**
+ * Read one corpus file's text when it is a live migration subject.
+ *
+ * **Details**
+ *
+ * Returns `O.none()` for generated files (header probe) and for files that
+ * carry no legacy-carrier substring, so extract and apply share one
+ * definition of "worth scanning".
+ *
+ * **Example** (Build the source reader Effect)
+ *
+ * ```ts
+ * import { readJSDocMigrateSourceText } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const program = readJSDocMigrateSourceText("/repo", "packages/x/src/a.ts")
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const readJSDocMigrateSourceText = Effect.fn("JSDocMigrateExtract.readSourceText")(function* (
+  repoRoot: string,
+  filePath: string
+): Effect.fn.Return<O.Option<string>, QualityScriptCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const sourceText = yield* fs
+    .readFileString(path.join(repoRoot, filePath))
+    .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to read ${filePath}.`)));
+  if (hasGeneratedFileHeader(sourceText)) {
+    return O.none();
+  }
+  if (!Str.includes("@example")(sourceText) && !Str.includes("@remarks")(sourceText)) {
+    return O.none();
+  }
+  return O.some(sourceText);
+});
+
+const readCorpusFileRecords = Effect.fn("JSDocMigrateExtract.readCorpusFileRecords")(function* (
+  repoRoot: string,
+  filePath: string
+): Effect.fn.Return<
+  ReadonlyArray<JSDocMigrateExtractRecord>,
+  QualityScriptCommandError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const sourceText = yield* readJSDocMigrateSourceText(repoRoot, filePath);
+  return O.match(sourceText, {
+    onNone: () => [],
+    onSome: (text) => jsdocMigrateExtractRecordsForFile(filePath, text),
+  });
+});
+
+/**
+ * Run the extract stage: scan the corpus and emit `extract.jsonl`.
+ *
+ * **Details**
+ *
+ * Fails loudly when two blocks produce the same anchor anywhere in the
+ * corpus — a duplicate would let a frozen title bind to the wrong block, and
+ * the conservation law cannot catch that. The emitted file is the input to
+ * both the title pass and the fail-closed binding checks in apply and verify.
+ *
+ * **Example** (Build the extract Effect)
+ *
+ * ```ts
+ * import { runJSDocMigrateExtract, RunJSDocMigrateExtractOptions } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const program = runJSDocMigrateExtract(RunJSDocMigrateExtractOptions.make({}))
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const runJSDocMigrateExtract = Effect.fn("JSDocMigrateExtract.run")(function* (
+  options: RunJSDocMigrateExtractOptions
+): Effect.fn.Return<
+  void,
+  QualityScriptCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const repoRoot = yield* findRepoRoot().pipe(QualityScriptCommandError.mapError("Failed to locate repository root."));
+  const path = yield* Path.Path;
+  const outputPath = path.resolve(repoRoot, options.output ?? defaultJSDocMigrateExtractPath);
+  const files = yield* listJSDocMigrateCorpusFiles(repoRoot);
+  const perFile = yield* Effect.forEach(files, (filePath) => readCorpusFileRecords(repoRoot, filePath), {
+    concurrency: 8,
+  });
+  const records = A.flatten(perFile);
+
+  const seenAnchors = MutableHashSet.empty<string>();
+  const duplicates: Array<string> = [];
+  for (const record of records) {
+    if (MutableHashSet.has(seenAnchors, record.anchor)) {
+      A.appendInPlace(duplicates, record.anchor);
+    }
+    MutableHashSet.add(seenAnchors, record.anchor);
+  }
+  if (duplicates.length > 0) {
+    return yield* QualityScriptCommandError.make({
+      message: `jsdoc-migrate extract found ${duplicates.length} duplicate anchor(s): ${A.join(A.take(duplicates, 10), ", ")}`,
+      command: "bun run beep quality jsdoc-migrate extract",
+      exitCode: 1,
+    });
+  }
+
+  const lines = yield* Effect.forEach(records, (record) =>
+    jsdocMigrateExtractCodec
+      .encode(record)
+      .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to encode ${record.anchor}.`)))
+  );
+  yield* writeArtifact({
+    path: outputPath,
+    body: `${A.join(lines, "\n")}\n`,
+    onError: (cause) => QualityScriptCommandError.new(cause, `Failed to write ${outputPath}.`),
+  });
+
+  const affectedFiles = MutableHashSet.empty<string>();
+  for (const record of records) {
+    MutableHashSet.add(affectedFiles, record.filePath);
+  }
+  const unfenced = A.reduce(records, 0, (total, record) => total + record.unfencedExampleCount);
+  const multiExample = A.filter(records, (record) => record.exampleTagCount > 1).length;
+  const withRemarks = A.filter(records, (record) => record.remarksTagCount > 0).length;
+  yield* Console.log(
+    `[jsdoc-migrate] extract ok: files=${MutableHashSet.size(affectedFiles)} blocks=${records.length} ` +
+      `multiExample=${multiExample} remarks=${withRemarks} unfencedExamples=${unfenced} -> ${outputPath}`
+  );
+});

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateRewrite.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateRewrite.ts
@@ -1,0 +1,872 @@
+/**
+ * Pure per-block rewriter and conservation law for the JSDoc carrier migration.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { A, Str } from "@beep/utils";
+import { MutableHashMap, Order, pipe } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { documentationShapeViolations } from "./JSDocDocumentationInventory.ts";
+import { JSDocMigrateRemarksRouting } from "./JSDocMigrate.schemas.ts";
+import { escapeRegExp, fencedLineState, stripCommentFraming } from "./QualityArtifactSupport.ts";
+
+const $I = $RepoCliId.create("commands/Quality/internal/JSDocMigrateRewrite");
+
+/**
+ * Per-block data consumed by the rewriter, sourced from `titles.jsonl`.
+ *
+ * **Example** (Validate rewrite data)
+ *
+ * ```ts
+ * import { JSDocMigrateRewriteData } from "@beep/repo-cli/test/Quality"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(JSDocMigrateRewriteData)({ titles: ["Decode a name"] })) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const JSDocMigrateRewriteData = S.Struct({
+  titles: S.Array(S.String),
+  remarks: JSDocMigrateRemarksRouting.pipe(S.UndefinedOr, S.optionalKey),
+  leadEnd: S.Int.pipe(S.UndefinedOr, S.optionalKey),
+  seePurposes: S.Array(S.String).pipe(S.UndefinedOr, S.optionalKey),
+}).pipe(
+  $I.annoteSchema("JSDocMigrateRewriteData", {
+    description: "Per-block title-pass data consumed by the migration rewriter.",
+  })
+);
+
+/**
+ * Per-block data consumed by the rewriter, sourced from `titles.jsonl`.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type JSDocMigrateRewriteData = typeof JSDocMigrateRewriteData.Type;
+
+/**
+ * Result of rewriting one block: the new text with its conservation
+ * allowances, a quarantine, or a frozen-data mismatch.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type JSDocMigrateRewriteResult =
+  | {
+      readonly _tag: "Rewritten";
+      readonly text: string;
+      readonly allowedAddedTokens: ReadonlyArray<string>;
+      readonly allowedRemovedTokens: ReadonlyArray<string>;
+    }
+  | { readonly _tag: "Quarantined"; readonly reasons: ReadonlyArray<string> }
+  | { readonly _tag: "DataMismatch"; readonly reasons: ReadonlyArray<string> };
+
+type FenceLineClass = "outside" | "open" | "inside" | "close";
+
+const classifyFenceLines = (lines: ReadonlyArray<string>): ReadonlyArray<FenceLineClass> => {
+  const classes: Array<FenceLineClass> = [];
+  let openFence: string | undefined;
+  for (const line of lines) {
+    const wasOpen = openFence !== undefined;
+    const [nextOpenFence, isFenced] = fencedLineState(line, openFence);
+    if (!isFenced) {
+      A.appendInPlace(classes, "outside");
+    } else if (!wasOpen && nextOpenFence !== undefined) {
+      A.appendInPlace(classes, "open");
+    } else if (wasOpen && nextOpenFence === undefined) {
+      A.appendInPlace(classes, "close");
+    } else {
+      A.appendInPlace(classes, "inside");
+    }
+    openFence = nextOpenFence;
+  }
+  return classes;
+};
+
+// fallow-ignore-next-line complexity -- the fence open/inside/close state machine is one auditable scan; splitting it would separate the states from their transitions
+const fenceBodies = (lines: ReadonlyArray<string>): ReadonlyArray<string> => {
+  const classes = classifyFenceLines(lines);
+  const bodies: Array<string> = [];
+  let current: Array<string> | undefined;
+  for (const [index, line] of A.entries(lines)) {
+    const kind = classes[index];
+    if (kind === "open") {
+      current = [];
+      continue;
+    }
+    if (kind === "close") {
+      A.appendInPlace(bodies, A.join(current ?? [], "\n"));
+      current = undefined;
+      continue;
+    }
+    if (kind === "inside" && current !== undefined) {
+      A.appendInPlace(current, line);
+    }
+  }
+  if (current !== undefined) {
+    A.appendInPlace(bodies, A.join(current, "\n"));
+  }
+  return bodies;
+};
+
+const tokenizeText = (value: string): ReadonlyArray<string> => A.filter(Str.split(/\s+/)(value), Str.isNonEmpty);
+
+const tokenizeLinesMaskingFences = (lines: ReadonlyArray<string>): ReadonlyArray<string> => {
+  const classes = classifyFenceLines(lines);
+  const tokens: Array<string> = [];
+  for (const [index, line] of A.entries(lines)) {
+    if (classes[index] === "inside") {
+      continue;
+    }
+    A.appendAllInPlace(tokens, tokenizeText(line));
+  }
+  return tokens;
+};
+
+const dropEdgeBlankLines = (lines: ReadonlyArray<string>): ReadonlyArray<string> => {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && Str.isEmpty(Str.trim(lines[start] ?? ""))) {
+    start += 1;
+  }
+  while (end > start && Str.isEmpty(Str.trim(lines[end - 1] ?? ""))) {
+    end -= 1;
+  }
+  return A.slice(lines, { start, end });
+};
+
+const blockContentLines = (blockText: string): ReadonlyArray<string> =>
+  dropEdgeBlankLines(stripCommentFraming(blockText));
+
+type TagSegment = {
+  readonly tag: string;
+  readonly lines: ReadonlyArray<string>;
+};
+
+const tagLinePattern = /^\s*@([A-Za-z][\w-]*)\b/;
+
+const splitBodyAndTags = (
+  lines: ReadonlyArray<string>
+): { readonly bodyLines: ReadonlyArray<string>; readonly tagLines: ReadonlyArray<string> } => {
+  const classes = classifyFenceLines(lines);
+  let tagIndex = lines.length;
+  for (const [index, line] of A.entries(lines)) {
+    if (classes[index] === "outside" && tagLinePattern.test(line)) {
+      tagIndex = index;
+      break;
+    }
+  }
+  return { bodyLines: A.take(lines, tagIndex), tagLines: A.drop(lines, tagIndex) };
+};
+
+const splitTagSegments = (tagLines: ReadonlyArray<string>): ReadonlyArray<TagSegment> => {
+  const classes = classifyFenceLines(tagLines);
+  const segments: Array<{ tag: string; lines: Array<string> }> = [];
+  for (const [index, line] of A.entries(tagLines)) {
+    const match = classes[index] === "outside" ? tagLinePattern.exec(line) : null;
+    if (match !== null) {
+      A.appendInPlace(segments, { tag: `@${match[1]}`, lines: [line] });
+      continue;
+    }
+    const current = segments[segments.length - 1];
+    if (current !== undefined) {
+      A.appendInPlace(current.lines, line);
+    }
+  }
+  return A.map(segments, (segment) => ({ tag: segment.tag, lines: dropEdgeBlankLines(segment.lines) }));
+};
+
+type BlockModel = {
+  readonly bodyLines: ReadonlyArray<string>;
+  readonly segments: ReadonlyArray<TagSegment>;
+  readonly exampleSegments: ReadonlyArray<TagSegment>;
+  readonly remarksSegments: ReadonlyArray<TagSegment>;
+};
+
+const parseBlockModel = (blockText: string): BlockModel => {
+  const { bodyLines, tagLines } = splitBodyAndTags(blockContentLines(blockText));
+  const segments = splitTagSegments(tagLines);
+  return {
+    bodyLines,
+    segments,
+    exampleSegments: A.filter(segments, (segment) => segment.tag === "@example"),
+    remarksSegments: A.filter(segments, (segment) => segment.tag === "@remarks"),
+  };
+};
+
+const sectionHeadingPattern = /^\s*\*\*(When to use|Details|Gotchas|Example)\*\*(?:\s*\((.*)\))?\s*$/;
+
+type BodySection = {
+  readonly name: "When to use" | "Details" | "Gotchas" | "Example";
+  readonly markerLine: string;
+  readonly contentLines: ReadonlyArray<string>;
+};
+
+const sectionRank: Record<BodySection["name"], number> = {
+  "When to use": 0,
+  Details: 1,
+  Gotchas: 2,
+  Example: 3,
+};
+
+const isSectionName = (value: string): value is BodySection["name"] =>
+  value === "When to use" || value === "Details" || value === "Gotchas" || value === "Example";
+
+const parseBodySections = (
+  bodyLines: ReadonlyArray<string>
+): { readonly leadLines: ReadonlyArray<string>; readonly sections: ReadonlyArray<BodySection> } => {
+  const classes = classifyFenceLines(bodyLines);
+  const starts: Array<{ readonly index: number; readonly name: BodySection["name"]; readonly markerLine: string }> = [];
+  for (const [index, line] of A.entries(bodyLines)) {
+    if (classes[index] !== "outside") {
+      continue;
+    }
+    const match = sectionHeadingPattern.exec(line);
+    const name = match?.[1];
+    if (name !== undefined && isSectionName(name)) {
+      A.appendInPlace(starts, { index, name, markerLine: line });
+    }
+  }
+  const firstStart = starts[0]?.index ?? bodyLines.length;
+  const sections = A.map(starts, (start, order) => {
+    const nextIndex = starts[order + 1]?.index ?? bodyLines.length;
+    return {
+      name: start.name,
+      markerLine: start.markerLine,
+      contentLines: dropEdgeBlankLines(A.slice(bodyLines, { start: start.index + 1, end: nextIndex })),
+    };
+  });
+  return { leadLines: dropEdgeBlankLines(A.take(bodyLines, firstStart)), sections };
+};
+
+const splitParagraphs = (lines: ReadonlyArray<string>): ReadonlyArray<ReadonlyArray<string>> => {
+  const classes = classifyFenceLines(lines);
+  const paragraphs: Array<Array<string>> = [];
+  let current: Array<string> = [];
+  for (const [index, line] of A.entries(lines)) {
+    if (classes[index] === "outside" && Str.isEmpty(Str.trim(line))) {
+      if (current.length > 0) {
+        A.appendInPlace(paragraphs, current);
+        current = [];
+      }
+      continue;
+    }
+    A.appendInPlace(current, line);
+  }
+  if (current.length > 0) {
+    A.appendInPlace(paragraphs, current);
+  }
+  return paragraphs;
+};
+
+const joinParagraphs = (paragraphs: ReadonlyArray<ReadonlyArray<string>>): ReadonlyArray<string> => {
+  const lines: Array<string> = [];
+  for (const [index, paragraph] of A.entries(paragraphs)) {
+    if (index > 0) {
+      A.appendInPlace(lines, "");
+    }
+    A.appendAllInPlace(lines, paragraph);
+  }
+  return lines;
+};
+
+const tagRankTable: Record<string, number> = {
+  "@packageDocumentation": -1,
+  "@fileoverview": -1,
+  "@typeParam": 0,
+  "@param": 1,
+  "@returns": 2,
+  "@throws": 3,
+  "@effects": 4,
+  "@precondition": 5,
+  "@postcondition": 5,
+  "@invariant": 5,
+  "@deprecated": 6,
+  "@defaultValue": 7,
+  "@see": 8,
+  "@public": 9,
+  "@beta": 9,
+  "@alpha": 9,
+  "@internal": 9,
+  "@experimental": 9,
+  "@category": 11,
+  "@since": 12,
+};
+
+const tagRank = (tag: string): number => tagRankTable[tag] ?? 10;
+
+const renamedTagTable: Record<string, string> = {
+  "@template": "@typeParam",
+  "@module": "@packageDocumentation",
+  "@default": "@defaultValue",
+};
+
+const renamedTag = (tag: string): string | undefined => renamedTagTable[tag];
+
+const typeBlobPattern = /^(\s*@(?:param|returns|throws)\s+)(\{[^}]+})\s*/;
+const hyphenPattern = /^(\s*@(?:returns|throws)\s+)-\s+/;
+const undescribedSeePattern = /^\s*@see\s+\{@link\s+[^}]+}\s*$/;
+
+type NormalizedSegment = {
+  readonly segment: TagSegment;
+  readonly addedTokens: ReadonlyArray<string>;
+  readonly removedTokens: ReadonlyArray<string>;
+};
+
+const applyGrammarNormalForms = (line: string, removedTokens: Array<string>): string => {
+  let firstLine = line;
+  const blobMatch = typeBlobPattern.exec(firstLine);
+  if (blobMatch !== null) {
+    A.appendAllInPlace(removedTokens, tokenizeText(blobMatch[2] ?? ""));
+    firstLine = `${blobMatch[1]}${Str.slice(blobMatch[0].length)(firstLine)}`;
+  }
+  const hyphenMatch = hyphenPattern.exec(firstLine);
+  if (hyphenMatch !== null) {
+    A.appendInPlace(removedTokens, "-");
+    firstLine = `${hyphenMatch[1]}${Str.slice(hyphenMatch[0].length)(firstLine)}`;
+  }
+  return firstLine;
+};
+
+const applySeePurpose = (
+  tag: string,
+  line: string,
+  nextSeePurpose: () => string | undefined,
+  addedTokens: Array<string>
+): string => {
+  if (tag !== "@see" || !undescribedSeePattern.test(line)) {
+    return line;
+  }
+  const purpose = nextSeePurpose();
+  if (purpose === undefined || Str.isEmpty(Str.trim(purpose))) {
+    return line;
+  }
+  A.appendAllInPlace(addedTokens, tokenizeText(purpose));
+  return `${Str.trimEnd(line)} ${Str.trim(purpose)}`;
+};
+
+const normalizeTagSegment = (segment: TagSegment, nextSeePurpose: () => string | undefined): NormalizedSegment => {
+  const addedTokens: Array<string> = [];
+  const removedTokens: Array<string> = [];
+  let firstLine = segment.lines[0] ?? "";
+  let tag = segment.tag;
+
+  const rename = renamedTag(tag);
+  if (rename !== undefined) {
+    firstLine = Str.replace(new RegExp(`^(\\s*)${escapeRegExp(tag)}\\b`), `$1${rename}`)(firstLine);
+    A.appendInPlace(removedTokens, tag);
+    A.appendInPlace(addedTokens, rename);
+    tag = rename;
+  }
+
+  firstLine = applyGrammarNormalForms(firstLine, removedTokens);
+  firstLine = applySeePurpose(tag, firstLine, nextSeePurpose, addedTokens);
+
+  return {
+    segment: { tag, lines: [firstLine, ...A.drop(segment.lines, 1)] },
+    addedTokens,
+    removedTokens,
+  };
+};
+
+const segmentText = (segment: TagSegment): string => A.join(segment.lines, "\n");
+
+const multisetDiff = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): ReadonlyArray<string> => {
+  const counts = MutableHashMap.empty<string, number>();
+  for (const value of right) {
+    MutableHashMap.set(counts, value, O.getOrElse(MutableHashMap.get(counts, value), () => 0) + 1);
+  }
+  const extra: Array<string> = [];
+  for (const value of left) {
+    const remaining = O.getOrElse(MutableHashMap.get(counts, value), () => 0);
+    if (remaining > 0) {
+      MutableHashMap.set(counts, value, remaining - 1);
+    } else {
+      A.appendInPlace(extra, value);
+    }
+  }
+  return extra;
+};
+
+/**
+ * Compute conservation-law findings between an original block and a candidate rewrite.
+ *
+ * **Details**
+ *
+ * Implements SPEC §5.3 clause (a) at the whole-block level: every fence's code
+ * bytes must survive unchanged, no token may disappear beyond the declared
+ * allowances of the applied normal forms, and no token may appear beyond the
+ * data-sourced additions (section markers, titles, see purposes, renamed tag
+ * spellings). An empty result means the candidate conserves the original.
+ *
+ * **Example** (Detect a destroyed fence)
+ *
+ * ```ts
+ * import { jsdocMigrateConservationFindings } from "@beep/repo-cli/test/Quality"
+ *
+ * const original = "/**\n * Lead.\n *\n * ```ts\n * const a = 1\n * ```\n *" + "/"
+ * const mutated = "/**\n * Lead.\n *\n * ```ts\n * const a = 2\n * ```\n *" + "/"
+ * const findings = jsdocMigrateConservationFindings({
+ *   original,
+ *   candidate: mutated,
+ *   allowedAddedTokens: [],
+ *   allowedRemovedTokens: []
+ * })
+ * console.log(findings.some((finding) => finding.includes("fence"))) // true
+ * ```
+ *
+ * @param input - Original and candidate block text with the declared token allowances.
+ * @returns Conservation violations, empty when the candidate conserves the original.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const jsdocMigrateConservationFindings = (input: {
+  readonly original: string;
+  readonly candidate: string;
+  readonly allowedAddedTokens: ReadonlyArray<string>;
+  readonly allowedRemovedTokens: ReadonlyArray<string>;
+}): ReadonlyArray<string> => {
+  const findings: Array<string> = [];
+  const originalLines = blockContentLines(input.original);
+  const candidateLines = blockContentLines(input.candidate);
+
+  const originalFences = fenceBodies(originalLines);
+  const candidateFences = fenceBodies(candidateLines);
+  const lostFences = multisetDiff(originalFences, candidateFences);
+  const gainedFences = multisetDiff(candidateFences, originalFences);
+  for (const fence of lostFences) {
+    A.appendInPlace(findings, `fence-bytes-changed: lost fence ${JSON.stringify(Str.slice(0, 60)(fence))}`);
+  }
+  for (const fence of gainedFences) {
+    A.appendInPlace(findings, `fence-bytes-changed: gained fence ${JSON.stringify(Str.slice(0, 60)(fence))}`);
+  }
+
+  const originalTokens = tokenizeLinesMaskingFences(originalLines);
+  const candidateTokens = tokenizeLinesMaskingFences(candidateLines);
+  const removed = multisetDiff(originalTokens, candidateTokens);
+  const added = multisetDiff(candidateTokens, originalTokens);
+  for (const token of multisetDiff(removed, input.allowedRemovedTokens)) {
+    A.appendInPlace(findings, `token-removed: ${token}`);
+  }
+  for (const token of multisetDiff(added, input.allowedAddedTokens)) {
+    A.appendInPlace(findings, `token-added: ${token}`);
+  }
+
+  return findings;
+};
+
+/**
+ * Report documentation-shape rules whose finding count grew in a candidate rewrite.
+ *
+ * **Details**
+ *
+ * Wraps the ratchet's own scorer as the per-block oracle: a rewrite is
+ * acceptable only when every rule's count shrinks or holds versus the
+ * original block.
+ *
+ * **Example** (Accept a carrier conversion)
+ *
+ * ```ts
+ * import { jsdocMigrateShapeRegressions } from "@beep/repo-cli/test/Quality"
+ *
+ * const original = "/**\n * Lead.\n *\n * @category models\n *" + "/"
+ * console.log(jsdocMigrateShapeRegressions(original, original).length) // 0
+ * ```
+ *
+ * @param original - Block text before the rewrite.
+ * @param candidate - Block text after the rewrite.
+ * @returns Rules whose finding count grew, empty when the shape held.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const jsdocMigrateShapeRegressions = (original: string, candidate: string): ReadonlyArray<string> => {
+  const before = MutableHashMap.empty<string, number>();
+  for (const issue of documentationShapeViolations(original)) {
+    MutableHashMap.set(before, issue.rule, O.getOrElse(MutableHashMap.get(before, issue.rule), () => 0) + 1);
+  }
+  const after = MutableHashMap.empty<string, number>();
+  for (const issue of documentationShapeViolations(candidate)) {
+    MutableHashMap.set(after, issue.rule, O.getOrElse(MutableHashMap.get(after, issue.rule), () => 0) + 1);
+  }
+  const regressions: Array<string> = [];
+  for (const [rule, count] of after) {
+    const beforeCount = O.getOrElse(MutableHashMap.get(before, rule), () => 0);
+    if (count > beforeCount) {
+      A.appendInPlace(regressions, `shape-regression: ${rule} ${beforeCount} -> ${count}`);
+    }
+  }
+  return regressions;
+};
+
+const tagClauseFindings = (input: {
+  readonly expectedSegments: ReadonlyArray<TagSegment>;
+  readonly candidate: string;
+}): ReadonlyArray<string> => {
+  const findings: Array<string> = [];
+  const { tagLines } = splitBodyAndTags(blockContentLines(input.candidate));
+  const candidateSegments = splitTagSegments(tagLines);
+  for (const segment of candidateSegments) {
+    if (segment.tag === "@example" || segment.tag === "@remarks") {
+      A.appendInPlace(findings, `carrier-not-consumed: ${segment.tag}`);
+    }
+  }
+  const expectedTexts = A.map(input.expectedSegments, segmentText);
+  const candidateTexts = A.map(candidateSegments, segmentText);
+  for (const text of multisetDiff(expectedTexts, candidateTexts)) {
+    A.appendInPlace(findings, `tag-off-normal-form: missing ${JSON.stringify(Str.slice(0, 80)(text))}`);
+  }
+  for (const text of multisetDiff(candidateTexts, expectedTexts)) {
+    A.appendInPlace(findings, `tag-off-normal-form: unexpected ${JSON.stringify(Str.slice(0, 80)(text))}`);
+  }
+  return findings;
+};
+
+const rebuildBlock = (lines: ReadonlyArray<string>, indent: string): string => {
+  const rendered = A.map(lines, (line) =>
+    Str.isEmpty(Str.trim(line)) ? `${indent} *` : `${indent} * ${Str.trimEnd(line)}`
+  );
+  return `/**\n${A.join(rendered, "\n")}\n${indent} */`;
+};
+
+type ExampleConversion = {
+  readonly contentLines: ReadonlyArray<string>;
+  readonly fenceCount: number;
+};
+
+const convertExampleSegment = (segment: TagSegment): ExampleConversion => {
+  const firstLine = segment.lines[0] ?? "";
+  const caption = Str.trim(Str.replace(/^\s*@example\b\s*/, "")(firstLine));
+  const rest = A.drop(segment.lines, 1);
+  const contentLines = dropEdgeBlankLines(Str.isEmpty(caption) ? rest : [caption, ...rest]);
+  return { contentLines, fenceCount: fenceBodies(contentLines).length };
+};
+
+const remarksContentLines = (segment: TagSegment): ReadonlyArray<string> => {
+  const firstLine = segment.lines[0] ?? "";
+  const inline = Str.trim(Str.replace(/^\s*@remarks\b\s*/, "")(firstLine));
+  const rest = A.drop(segment.lines, 1);
+  return dropEdgeBlankLines(Str.isEmpty(inline) ? rest : [inline, ...rest]);
+};
+
+const appendSectionContent = (
+  existing: ReadonlyArray<string>,
+  addition: ReadonlyArray<string>
+): ReadonlyArray<string> =>
+  existing.length === 0 ? addition : addition.length === 0 ? existing : [...existing, "", ...addition];
+
+// fallow-ignore-next-line complexity -- the transform is one auditable pipeline: consume carriers, split the lead, normalize tags, reassemble, then prove conservation
+const rewriteBlockUnchecked = (
+  blockText: string,
+  data: JSDocMigrateRewriteData,
+  indent: string
+):
+  | {
+      readonly _tag: "Built";
+      readonly text: string;
+      readonly expectedSegments: ReadonlyArray<TagSegment>;
+      readonly allowedAddedTokens: ReadonlyArray<string>;
+      readonly allowedRemovedTokens: ReadonlyArray<string>;
+    }
+  | { readonly _tag: "Quarantined"; readonly reasons: ReadonlyArray<string> }
+  | { readonly _tag: "DataMismatch"; readonly reasons: ReadonlyArray<string> } => {
+  const { bodyLines, exampleSegments, remarksSegments, segments } = parseBlockModel(blockText);
+  const reasons: Array<string> = [];
+
+  if (data.titles.length !== exampleSegments.length) {
+    return {
+      _tag: "DataMismatch",
+      reasons: [
+        `title-count-mismatch: block has ${exampleSegments.length} @example tag(s), record has ${data.titles.length} title(s)`,
+      ],
+    };
+  }
+
+  const conversions = A.map(exampleSegments, convertExampleSegment);
+  for (const conversion of conversions) {
+    if (conversion.fenceCount === 0) {
+      A.appendInPlace(reasons, "unfenced-example");
+    } else if (conversion.fenceCount > 1) {
+      A.appendInPlace(reasons, "multi-fence-example");
+    }
+  }
+
+  const { leadLines, sections: parsedSections } = parseBodySections(bodyLines);
+  // A bare, empty `**Example**` heading directly above a legacy @example tag is
+  // a stray marker artifact, not a real section: consume it into the titled
+  // section the tag conversion produces. Any Example section with a title or
+  // content alongside a legacy tag is a genuine mixed carrier and quarantines.
+  const isStrayExampleMarker = (section: BodySection): boolean =>
+    section.name === "Example" &&
+    A.isReadonlyArrayEmpty(section.contentLines) &&
+    /^\s*\*\*Example\*\*\s*$/.test(section.markerLine);
+  const strayMarkers = exampleSegments.length > 0 ? A.filter(parsedSections, isStrayExampleMarker) : [];
+  const sections =
+    exampleSegments.length > 0 ? A.filter(parsedSections, (section) => !isStrayExampleMarker(section)) : parsedSections;
+  if (exampleSegments.length > 0 && A.some(sections, (section) => section.name === "Example")) {
+    A.appendInPlace(reasons, "mixed-example-carriers");
+  }
+  if (reasons.length > 0) {
+    return { _tag: "Quarantined", reasons };
+  }
+
+  const allowedAddedTokens: Array<string> = [];
+  const allowedRemovedTokens: Array<string> = [];
+  for (const marker of strayMarkers) {
+    A.appendAllInPlace(allowedRemovedTokens, tokenizeText(marker.markerLine));
+  }
+
+  const paragraphs = splitParagraphs(leadLines);
+  const keepCount = data.leadEnd === undefined ? paragraphs.length : Math.max(1, data.leadEnd);
+  const keptLead = joinParagraphs(A.take(paragraphs, keepCount));
+  const movedLead = joinParagraphs(A.drop(paragraphs, keepCount));
+
+  let detailsAddition: ReadonlyArray<string> = movedLead;
+  let gotchasAddition: ReadonlyArray<string> = [];
+  const routing = data.remarks ?? "details";
+  for (const segment of remarksSegments) {
+    const content = remarksContentLines(segment);
+    if (routing === "gotchas") {
+      gotchasAddition = appendSectionContent(gotchasAddition, content);
+    } else {
+      detailsAddition = appendSectionContent(detailsAddition, content);
+    }
+    A.appendInPlace(allowedRemovedTokens, "@remarks");
+  }
+
+  let newSections: Array<BodySection> = A.map(sections, (section) => ({ ...section }));
+  const upsertSection = (name: "Details" | "Gotchas", addition: ReadonlyArray<string>): void => {
+    if (addition.length === 0) {
+      return;
+    }
+    const existingIndex = A.findFirstIndex(newSections, (section) => section.name === name);
+    if (O.isSome(existingIndex)) {
+      const existing = newSections[existingIndex.value];
+      if (existing !== undefined) {
+        newSections[existingIndex.value] = {
+          ...existing,
+          contentLines: appendSectionContent(existing.contentLines, addition),
+        };
+      }
+      return;
+    }
+    const markerLine = `**${name}**`;
+    A.appendInPlace(allowedAddedTokens, `**${name}**`);
+    const insertIndex = pipe(
+      A.findFirstIndex(newSections, (section) => sectionRank[section.name] > sectionRank[name]),
+      O.getOrElse(() => newSections.length)
+    );
+    newSections = [
+      ...A.take(newSections, insertIndex),
+      { name, markerLine, contentLines: addition },
+      ...A.drop(newSections, insertIndex),
+    ];
+  };
+  upsertSection("Details", detailsAddition);
+  upsertSection("Gotchas", gotchasAddition);
+
+  for (const [index, conversion] of A.entries(conversions)) {
+    const title = Str.trim(data.titles[index] ?? "");
+    const markerLine = `**Example** (${title})`;
+    A.appendAllInPlace(allowedAddedTokens, tokenizeText(markerLine));
+    A.appendInPlace(newSections, { name: "Example", markerLine, contentLines: conversion.contentLines });
+    A.appendInPlace(allowedRemovedTokens, "@example");
+  }
+
+  const purposes = [...(data.seePurposes ?? [])];
+  let purposeIndex = 0;
+  const nextSeePurpose = (): string | undefined => {
+    const purpose = purposes[purposeIndex];
+    purposeIndex += 1;
+    return purpose;
+  };
+  const keptSegments = A.filter(segments, (segment) => segment.tag !== "@example" && segment.tag !== "@remarks");
+  const normalized = A.map(keptSegments, (segment) => normalizeTagSegment(segment, nextSeePurpose));
+  for (const entry of normalized) {
+    A.appendAllInPlace(allowedAddedTokens, entry.addedTokens);
+    A.appendAllInPlace(allowedRemovedTokens, entry.removedTokens);
+  }
+  const orderedSegments = pipe(
+    A.map(normalized, (entry) => entry.segment),
+    A.sortWith((segment) => tagRank(segment.tag), Order.Number)
+  );
+
+  const outLines: Array<string> = [...keptLead];
+  for (const section of newSections) {
+    if (outLines.length > 0) {
+      A.appendInPlace(outLines, "");
+    }
+    A.appendInPlace(outLines, section.markerLine);
+    if (section.contentLines.length > 0) {
+      A.appendInPlace(outLines, "");
+      A.appendAllInPlace(outLines, section.contentLines);
+    }
+  }
+  if (orderedSegments.length > 0) {
+    if (outLines.length > 0) {
+      A.appendInPlace(outLines, "");
+    }
+    for (const segment of orderedSegments) {
+      A.appendAllInPlace(outLines, segment.lines);
+    }
+  }
+
+  return {
+    _tag: "Built",
+    text: rebuildBlock(outLines, indent),
+    expectedSegments: orderedSegments,
+    allowedAddedTokens,
+    allowedRemovedTokens,
+  };
+};
+
+/**
+ * Structural statistics of one legacy-carrier block, recorded at extract time.
+ *
+ * **Example** (Validate block statistics)
+ *
+ * ```ts
+ * import { JSDocMigrateBlockStats } from "@beep/repo-cli/test/Quality"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(
+ *   S.is(JSDocMigrateBlockStats)({
+ *     leadParagraphCount: 1,
+ *     exampleTagCount: 1,
+ *     unfencedExampleCount: 0,
+ *     remarksTagCount: 0,
+ *     undescribedSeeCount: 0
+ *   })
+ * ) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const JSDocMigrateBlockStats = S.Struct({
+  leadParagraphCount: S.Int,
+  exampleTagCount: S.Int,
+  unfencedExampleCount: S.Int,
+  remarksTagCount: S.Int,
+  undescribedSeeCount: S.Int,
+}).pipe(
+  $I.annoteSchema("JSDocMigrateBlockStats", {
+    description: "Structural statistics of one legacy-carrier JSDoc block at extract time.",
+  })
+);
+
+/**
+ * Structural statistics of one legacy-carrier block, recorded at extract time.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type JSDocMigrateBlockStats = typeof JSDocMigrateBlockStats.Type;
+
+/**
+ * Compute the structural statistics extract records carry for one block.
+ *
+ * **Details**
+ *
+ * These counts drive the title pass: how many Example titles a block needs,
+ * whether a remarks routing is required, whether a lead split point is
+ * useful, and how many `@see` purpose phrases to request. Unfenced examples
+ * are counted so the known auto-quarantine tail stays measurable.
+ *
+ * **Example** (Measure a legacy block)
+ *
+ * ```ts
+ * import { jsdocMigrateBlockStats } from "@beep/repo-cli/test/Quality"
+ *
+ * const block = "/**\n * Lead.\n *\n * @example\n * ```ts\n * const a = 1\n * ```\n *" + "/"
+ * const stats = jsdocMigrateBlockStats(block)
+ * console.log(stats.exampleTagCount) // 1
+ * console.log(stats.unfencedExampleCount) // 0
+ * ```
+ *
+ * @param blockText - Raw JSDoc block text to measure.
+ * @returns Structural counters consumed by the title pass.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const jsdocMigrateBlockStats = (blockText: string): JSDocMigrateBlockStats => {
+  const { bodyLines, exampleSegments, segments } = parseBlockModel(blockText);
+  const conversions = A.map(exampleSegments, convertExampleSegment);
+  const { leadLines } = parseBodySections(bodyLines);
+  return {
+    leadParagraphCount: splitParagraphs(leadLines).length,
+    exampleTagCount: exampleSegments.length,
+    unfencedExampleCount: A.filter(conversions, (conversion) => conversion.fenceCount === 0).length,
+    remarksTagCount: A.filter(segments, (segment) => segment.tag === "@remarks").length,
+    undescribedSeeCount: A.filter(
+      segments,
+      (segment) => segment.tag === "@see" && undescribedSeePattern.test(segment.lines[0] ?? "")
+    ).length,
+  };
+};
+
+/**
+ * Rewrite one legacy-carrier JSDoc block and prove the rewrite conservative.
+ *
+ * **Details**
+ *
+ * Applies the full SPEC §5 transform set — carrier consumption, lead
+ * splitting, grammar normal forms, canonical tag order, see purposes — then
+ * checks both conservation clauses and the shape oracle. Any violation
+ * returns `Quarantined` and the block must flow to `overrides.jsonl`; a
+ * frozen-data disagreement (wrong title count) returns `DataMismatch`, which
+ * callers must escalate rather than skip.
+ *
+ * **Example** (Convert a legacy example tag)
+ *
+ * ```ts
+ * import { rewriteJSDocMigrateBlock } from "@beep/repo-cli/test/Quality"
+ *
+ * const block = "/**\n * Lead.\n *\n * @example\n * ```ts\n * const a = 1\n * ```\n *\n * @category models\n *" + "/"
+ * const result = rewriteJSDocMigrateBlock({
+ *   blockText: block,
+ *   indent: "",
+ *   data: { titles: ["Add numbers"] }
+ * })
+ * console.log(result._tag) // "Rewritten"
+ * ```
+ *
+ * @param input - Block text, indentation, and the per-block title data.
+ * @returns The rewritten block with its allowances, a quarantine, or a data mismatch.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const rewriteJSDocMigrateBlock = (input: {
+  readonly blockText: string;
+  readonly indent: string;
+  readonly data: JSDocMigrateRewriteData;
+}): JSDocMigrateRewriteResult => {
+  const built = rewriteBlockUnchecked(input.blockText, input.data, input.indent);
+  if (built._tag !== "Built") {
+    return built;
+  }
+  const reasons: Array<string> = [
+    ...jsdocMigrateConservationFindings({
+      original: input.blockText,
+      candidate: built.text,
+      allowedAddedTokens: built.allowedAddedTokens,
+      allowedRemovedTokens: built.allowedRemovedTokens,
+    }),
+    ...tagClauseFindings({ expectedSegments: built.expectedSegments, candidate: built.text }),
+    ...jsdocMigrateShapeRegressions(input.blockText, built.text),
+  ];
+  if (reasons.length > 0) {
+    return { _tag: "Quarantined", reasons };
+  }
+  return {
+    _tag: "Rewritten",
+    text: built.text,
+    allowedAddedTokens: built.allowedAddedTokens,
+    allowedRemovedTokens: built.allowedRemovedTokens,
+  };
+};

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateTitles.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateTitles.ts
@@ -1,0 +1,477 @@
+/**
+ * Title pass for the JSDoc legacy-carrier migration via the local model proxy.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { A, O, Str } from "@beep/utils";
+import { Console, Effect, MutableHashMap, Order, pipe } from "effect";
+import * as S from "effect/Schema";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import { QualityScriptCommandError } from "../Quality.errors.ts";
+import {
+  defaultJSDocMigrateExtractPath,
+  defaultJSDocMigrateTitlesPath,
+  JSDocMigrateRemarksRouting,
+  JSDocMigrateTitleRecord,
+} from "./JSDocMigrate.schemas.ts";
+import {
+  jsdocMigrateRunContext,
+  jsdocMigrateTitleCodec,
+  readJSDocMigrateExtractRequired,
+  readJSDocMigrateJsonl,
+} from "./JSDocMigrateData.ts";
+import type { FileSystem, Path } from "effect";
+import type { JSDocMigrateExtractRecord } from "./JSDocMigrate.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Quality/internal/JSDocMigrateTitles");
+
+const migrateTitlesError = (message: string): QualityScriptCommandError =>
+  QualityScriptCommandError.make({
+    message,
+    command: "bun run beep quality jsdoc-migrate titles",
+    exitCode: 1,
+  });
+
+const TitleSuggestion = S.Struct({
+  anchor: S.String,
+  titles: S.Array(S.String),
+  remarks: S.optionalKey(JSDocMigrateRemarksRouting),
+  leadEnd: S.optionalKey(S.Int),
+  seePurposes: S.Array(S.String).pipe(S.optionalKey),
+});
+
+const TitleSuggestionList = S.Array(TitleSuggestion);
+
+const ChatCompletionResponse = S.Struct({
+  choices: S.Array(
+    S.Struct({
+      message: S.Struct({ content: S.String }),
+    })
+  ),
+});
+
+const decodeChatCompletion = S.decodeUnknownEffect(ChatCompletionResponse);
+const decodeSuggestionList = S.decodeUnknownEffect(S.fromJsonString(TitleSuggestionList));
+
+/**
+ * Default local CLIProxyAPI endpoint used by the title pass.
+ *
+ * **Example** (Inspect the default proxy URL)
+ *
+ * ```ts
+ * import { defaultJSDocMigrateProxyUrl } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(defaultJSDocMigrateProxyUrl) // "http://127.0.0.1:8317"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const defaultJSDocMigrateProxyUrl = "http://127.0.0.1:8317";
+
+/**
+ * Default model routed through the local proxy for the title pass.
+ *
+ * **Example** (Inspect the default model)
+ *
+ * ```ts
+ * import { defaultJSDocMigrateTitlesModel } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(defaultJSDocMigrateTitlesModel) // "grok-4.5"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const defaultJSDocMigrateTitlesModel = "grok-4.5";
+
+/**
+ * Build the title-pass prompt for one file's pending blocks.
+ *
+ * **Details**
+ *
+ * The model returns data only — titles, remarks routing, lead split point,
+ * and see purposes — and never writes files. The prompt pins the exact JSON
+ * contract and per-block counts so a schema-invalid return is detectable and
+ * retryable.
+ *
+ * **Example** (Render a prompt)
+ *
+ * ```ts
+ * import { JSDocMigrateExtractRecord, jsdocMigrateTitlesPrompt } from "@beep/repo-cli/test/Quality"
+ *
+ * const record = JSDocMigrateExtractRecord.make({
+ *   anchor: "packages/x/src/Y.ts#decode#0",
+ *   filePath: "packages/x/src/Y.ts",
+ *   symbol: "decode",
+ *   ordinal: 0,
+ *   kind: "value",
+ *   sourceHash: "sha256:0000",
+ *   start: 0,
+ *   end: 40,
+ *   blockText: "/** Doc. *" + "/",
+ *   leadParagraphCount: 1,
+ *   exampleTagCount: 1,
+ *   unfencedExampleCount: 0,
+ *   remarksTagCount: 0,
+ *   undescribedSeeCount: 0
+ * })
+ * console.log(jsdocMigrateTitlesPrompt([record]).includes("packages/x/src/Y.ts#decode#0")) // true
+ * ```
+ *
+ * @param records - Pending extract records for one file.
+ * @returns Prompt text pinning the JSON response contract.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const jsdocMigrateTitlesPrompt = (records: ReadonlyArray<JSDocMigrateExtractRecord>): string => {
+  const blocks = A.map(records, (record) =>
+    JSON.stringify({
+      anchor: record.anchor,
+      symbol: record.symbol,
+      kind: record.kind,
+      exampleTagCount: record.exampleTagCount,
+      remarksTagCount: record.remarksTagCount,
+      leadParagraphCount: record.leadParagraphCount,
+      undescribedSeeCount: record.undescribedSeeCount,
+      blockText: record.blockText,
+    })
+  );
+  return A.join(
+    [
+      "You are producing routing data for a mechanical JSDoc migration. You never rewrite prose.",
+      "For each input block, return one JSON object with these fields:",
+      '- "anchor": copied verbatim from the input.',
+      '- "titles": exactly exampleTagCount short Example titles (2-6 words, specific to what the example shows, unique within the block). Empty array when exampleTagCount is 0.',
+      '- "remarks": "details" or "gotchas" — required when remarksTagCount > 0, omitted otherwise. Choose "gotchas" only when the remarks text warns about surprising or dangerous behavior.',
+      '- "leadEnd": optional; when leadParagraphCount > 1, the number of leading paragraphs to keep as the lead (usually 1). Omit when leadParagraphCount is 1.',
+      '- "seePurposes": optional; when undescribedSeeCount > 0, exactly that many purpose phrases in source order, each starting with "for" (e.g. "for the underlying decoder."). Omit otherwise.',
+      "Respond with ONLY a JSON array of these objects, no prose and no code fences.",
+      "Input blocks:",
+      ...blocks,
+    ],
+    "\n"
+  );
+};
+
+const stripJsonFences = (content: string): string => {
+  const trimmed = Str.trim(content);
+  const match = /^```(?:json)?\s*\n([\s\S]*?)\n```$/.exec(trimmed);
+  return match === null ? trimmed : (match[1] ?? trimmed);
+};
+
+type TitleSuggestionShape = typeof TitleSuggestion.Type;
+
+const titleSuggestionProblem = (
+  suggestion: TitleSuggestionShape,
+  extract: JSDocMigrateExtractRecord
+): string | undefined => {
+  if (suggestion.titles.length !== extract.exampleTagCount) {
+    return `anchor ${suggestion.anchor} returned ${suggestion.titles.length} title(s); expected ${extract.exampleTagCount}`;
+  }
+  if (extract.remarksTagCount > 0 && suggestion.remarks === undefined) {
+    return `anchor ${suggestion.anchor} is missing the required remarks routing`;
+  }
+  return undefined;
+};
+
+const titleRecordFromSuggestion = (
+  suggestion: TitleSuggestionShape,
+  extract: JSDocMigrateExtractRecord
+): JSDocMigrateTitleRecord =>
+  JSDocMigrateTitleRecord.make({
+    anchor: suggestion.anchor,
+    sourceHash: extract.sourceHash,
+    kind: extract.kind,
+    titles: suggestion.titles,
+    ...O.getSomesStruct({
+      remarks: O.fromUndefinedOr(suggestion.remarks),
+      leadEnd: O.fromUndefinedOr(suggestion.leadEnd),
+      seePurposes: O.fromUndefinedOr(suggestion.seePurposes),
+    }),
+  });
+
+const collectTitleSuggestions = (
+  suggestions: ReadonlyArray<TitleSuggestionShape>,
+  pendingByAnchor: MutableHashMap.MutableHashMap<string, JSDocMigrateExtractRecord>
+): {
+  readonly problems: Array<string>;
+  readonly records: Array<JSDocMigrateTitleRecord>;
+  readonly seen: MutableHashMap.MutableHashMap<string, boolean>;
+} => {
+  const problems: Array<string> = [];
+  const records: Array<JSDocMigrateTitleRecord> = [];
+  const seen = MutableHashMap.empty<string, boolean>();
+  for (const suggestion of suggestions) {
+    const extract = MutableHashMap.get(pendingByAnchor, suggestion.anchor);
+    if (O.isNone(extract)) {
+      A.appendInPlace(problems, `unknown anchor ${suggestion.anchor}`);
+      continue;
+    }
+    MutableHashMap.set(seen, suggestion.anchor, true);
+    const problem = titleSuggestionProblem(suggestion, extract.value);
+    if (problem !== undefined) {
+      A.appendInPlace(problems, problem);
+      continue;
+    }
+    A.appendInPlace(records, titleRecordFromSuggestion(suggestion, extract.value));
+  }
+  return { problems, records, seen };
+};
+
+/**
+ * Decode and validate one title-pass response against its pending records.
+ *
+ * **Details**
+ *
+ * Fails when the response is not the pinned JSON shape, misses a requested
+ * anchor, invents an unknown anchor, or returns a title count that
+ * disagrees with the block's `exampleTagCount` — the caller retries exactly
+ * these failures. Valid suggestions are stamped with the extract record's
+ * `sourceHash` and `kind` so the emitted rows verify like any frozen record.
+ *
+ * **Example** (Validate a well-formed response)
+ *
+ * ```ts
+ * import { JSDocMigrateExtractRecord, jsdocMigrateTitleRecordsFromResponse } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const record = JSDocMigrateExtractRecord.make({
+ *   anchor: "packages/x/src/Y.ts#decode#0",
+ *   filePath: "packages/x/src/Y.ts",
+ *   symbol: "decode",
+ *   ordinal: 0,
+ *   kind: "value",
+ *   sourceHash: "sha256:0000",
+ *   start: 0,
+ *   end: 40,
+ *   blockText: "/** Doc. *" + "/",
+ *   leadParagraphCount: 1,
+ *   exampleTagCount: 1,
+ *   unfencedExampleCount: 0,
+ *   remarksTagCount: 0,
+ *   undescribedSeeCount: 0
+ * })
+ * const content = JSON.stringify([{ anchor: record.anchor, titles: ["Decode a name"] }])
+ * const program = jsdocMigrateTitleRecordsFromResponse(content, [record])
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const jsdocMigrateTitleRecordsFromResponse = Effect.fn("JSDocMigrateTitles.recordsFromResponse")(function* (
+  content: string,
+  pending: ReadonlyArray<JSDocMigrateExtractRecord>
+): Effect.fn.Return<ReadonlyArray<JSDocMigrateTitleRecord>, QualityScriptCommandError> {
+  const suggestions = yield* decodeSuggestionList(stripJsonFences(content)).pipe(
+    Effect.mapError((cause) => QualityScriptCommandError.new(cause, "Title response is not the pinned JSON shape."))
+  );
+  const pendingByAnchor = MutableHashMap.fromIterable(
+    A.map(pending, (record): readonly [string, JSDocMigrateExtractRecord] => [record.anchor, record])
+  );
+  const { problems, records, seen } = collectTitleSuggestions(suggestions, pendingByAnchor);
+  for (const record of pending) {
+    if (O.isNone(MutableHashMap.get(seen, record.anchor))) {
+      A.appendInPlace(problems, `missing anchor ${record.anchor}`);
+    }
+  }
+  if (problems.length > 0) {
+    return yield* migrateTitlesError(`Title response failed validation: ${A.join(A.take(problems, 10), "; ")}`);
+  }
+  return records;
+});
+
+type PendingTitleFileGroup = {
+  readonly filePath: string;
+  readonly records: ReadonlyArray<JSDocMigrateExtractRecord>;
+};
+
+const pendingTitleRecords = (
+  extract: ReadonlyArray<JSDocMigrateExtractRecord>,
+  existingByAnchor: MutableHashMap.MutableHashMap<string, JSDocMigrateTitleRecord>
+): ReadonlyArray<JSDocMigrateExtractRecord> =>
+  A.filter(extract, (record) =>
+    O.match(MutableHashMap.get(existingByAnchor, record.anchor), {
+      onNone: () => true,
+      onSome: (existing) => existing.sourceHash !== record.sourceHash,
+    })
+  );
+
+const pendingTitleFileGroups = (
+  pending: ReadonlyArray<JSDocMigrateExtractRecord>
+): ReadonlyArray<PendingTitleFileGroup> => {
+  const byFile = MutableHashMap.empty<string, Array<JSDocMigrateExtractRecord>>();
+  for (const record of pending) {
+    const bucket = MutableHashMap.get(byFile, record.filePath);
+    if (O.isSome(bucket)) {
+      A.appendInPlace(bucket.value, record);
+    } else {
+      MutableHashMap.set(byFile, record.filePath, [record]);
+    }
+  }
+  return pipe(
+    [...byFile],
+    A.map(([filePath, records]): PendingTitleFileGroup => ({ filePath, records })),
+    A.sortWith((group) => group.filePath, Order.String)
+  );
+};
+
+/**
+ * Options accepted by {@link runJSDocMigrateTitles}.
+ *
+ * **Example** (Configure a bounded title run)
+ *
+ * ```ts
+ * import { RunJSDocMigrateTitlesOptions } from "@beep/repo-cli/test/Quality"
+ *
+ * const options = RunJSDocMigrateTitlesOptions.make({ limitFiles: 5 })
+ * console.log(options.limitFiles) // 5
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class RunJSDocMigrateTitlesOptions extends S.Class<RunJSDocMigrateTitlesOptions>(
+  $I`RunJSDocMigrateTitlesOptions`
+)(
+  {
+    extract: S.optionalKey(S.String),
+    titles: S.optionalKey(S.String),
+    proxyUrl: S.optionalKey(S.String),
+    model: S.optionalKey(S.String),
+    limitFiles: S.optionalKey(S.Int),
+  },
+  $I.annote("RunJSDocMigrateTitlesOptions", {
+    description: "Options for the jsdoc-migrate titles stage: data files, proxy endpoint, model, and file cap.",
+  })
+) {}
+
+const chatCompletionContent = (
+  client: HttpClient.HttpClient,
+  request: HttpClientRequest.HttpClientRequest
+): Effect.Effect<string, QualityScriptCommandError> =>
+  client.execute(request).pipe(
+    Effect.filterOrFail(
+      (candidate) => candidate.status >= 200 && candidate.status < 300,
+      (candidate) => migrateTitlesError(`Proxy returned HTTP ${candidate.status}.`)
+    ),
+    Effect.flatMap((candidate) => candidate.json),
+    Effect.mapError((cause) => QualityScriptCommandError.new(cause, "Failed to call the local model proxy.")),
+    Effect.flatMap((body) =>
+      decodeChatCompletion(body).pipe(
+        Effect.mapError((cause) => QualityScriptCommandError.new(cause, "Proxy response is not a chat completion."))
+      )
+    ),
+    Effect.map((response) => response.choices[0]?.message.content ?? "")
+  );
+
+const titlesPromptWithRetryNote = (
+  pending: ReadonlyArray<JSDocMigrateExtractRecord>,
+  previousProblem: string | undefined
+): string =>
+  previousProblem === undefined
+    ? jsdocMigrateTitlesPrompt(pending)
+    : `${jsdocMigrateTitlesPrompt(pending)}\nYour previous response was rejected: ${previousProblem}. Return only the corrected JSON array.`;
+
+const requestTitlesForFile = Effect.fn("JSDocMigrateTitles.requestTitlesForFile")(function* (
+  proxyUrl: string,
+  model: string,
+  pending: ReadonlyArray<JSDocMigrateExtractRecord>
+): Effect.fn.Return<ReadonlyArray<JSDocMigrateTitleRecord>, QualityScriptCommandError, HttpClient.HttpClient> {
+  const client = yield* HttpClient.HttpClient;
+  const attempt = Effect.fnUntraced(function* (previousProblem: string | undefined) {
+    const request = HttpClientRequest.post(`${proxyUrl}/v1/chat/completions`).pipe(
+      HttpClientRequest.bodyJsonUnsafe({
+        model,
+        messages: [{ role: "user", content: titlesPromptWithRetryNote(pending, previousProblem) }],
+        temperature: 0,
+      })
+    );
+    const content = yield* chatCompletionContent(client, request);
+    return yield* jsdocMigrateTitleRecordsFromResponse(content, pending);
+  });
+
+  let lastError: QualityScriptCommandError | undefined;
+  for (let tryIndex = 0; tryIndex < 3; tryIndex += 1) {
+    const outcome = yield* attempt(lastError?.message).pipe(Effect.result);
+    if (outcome._tag === "Success") {
+      return outcome.success;
+    }
+    lastError = outcome.failure;
+  }
+  return yield* lastError ?? migrateTitlesError("Title request failed.");
+});
+
+/**
+ * Run the title pass: append validated records to `titles.jsonl` per anchor.
+ *
+ * **Details**
+ *
+ * One request per file through the local CLIProxyAPI (never the xAI API), so
+ * the run bills the Grok plan and has no agent cap. Resume skips an anchor
+ * only when its record is present AND its `sourceHash` still matches the
+ * extract — a bare anchor-present check would silently reuse a stale title
+ * after an upstream edit. Retries happen only on schema-invalid returns.
+ *
+ * **Example** (Build the titles Effect)
+ *
+ * ```ts
+ * import { runJSDocMigrateTitles, RunJSDocMigrateTitlesOptions } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const program = runJSDocMigrateTitles(RunJSDocMigrateTitlesOptions.make({ limitFiles: 1 }))
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const runJSDocMigrateTitles = Effect.fn("JSDocMigrateTitles.run")(function* (
+  options: RunJSDocMigrateTitlesOptions
+): Effect.fn.Return<void, QualityScriptCommandError, FileSystem.FileSystem | Path.Path | HttpClient.HttpClient> {
+  const { fs, path, repoRoot } = yield* jsdocMigrateRunContext();
+  const extractPath = path.resolve(repoRoot, options.extract ?? defaultJSDocMigrateExtractPath);
+  const titlesPath = path.resolve(repoRoot, options.titles ?? defaultJSDocMigrateTitlesPath);
+  const proxyUrl = options.proxyUrl ?? defaultJSDocMigrateProxyUrl;
+  const model = options.model ?? defaultJSDocMigrateTitlesModel;
+
+  const extract = yield* readJSDocMigrateExtractRequired(extractPath);
+
+  const existingByAnchor = MutableHashMap.empty<string, JSDocMigrateTitleRecord>();
+  for (const record of yield* readJSDocMigrateJsonl(titlesPath, jsdocMigrateTitleCodec.decode, "titles.jsonl")) {
+    MutableHashMap.set(existingByAnchor, record.anchor, record);
+  }
+
+  const pending = pendingTitleRecords(extract, existingByAnchor);
+  const fileGroups = pendingTitleFileGroups(pending);
+  const limited = options.limitFiles === undefined ? fileGroups : A.take(fileGroups, options.limitFiles);
+
+  yield* fs
+    .makeDirectory(path.dirname(titlesPath), { recursive: true })
+    .pipe(
+      Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to create ${path.dirname(titlesPath)}.`))
+    );
+
+  let appended = 0;
+  for (const group of limited) {
+    const records = yield* requestTitlesForFile(proxyUrl, model, group.records);
+    const lines = yield* Effect.forEach(records, (record) =>
+      jsdocMigrateTitleCodec
+        .encode(record)
+        .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to encode ${record.anchor}.`)))
+    );
+    yield* fs
+      .writeFileString(titlesPath, `${A.join(lines, "\n")}\n`, { flag: "a" })
+      .pipe(Effect.mapError((cause) => QualityScriptCommandError.new(cause, `Failed to append to ${titlesPath}.`)));
+    appended += records.length;
+    yield* Console.log(`[jsdoc-migrate] titles: ${group.filePath} -> ${records.length} record(s)`);
+  }
+  yield* Console.log(
+    `[jsdoc-migrate] titles ok: pendingBlocks=${pending.length} files=${limited.length} appended=${appended} -> ${titlesPath}`
+  );
+});

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateTitles.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateTitles.ts
@@ -173,8 +173,21 @@ const titleSuggestionProblem = (
   if (suggestion.titles.length !== extract.exampleTagCount) {
     return `anchor ${suggestion.anchor} returned ${suggestion.titles.length} title(s); expected ${extract.exampleTagCount}`;
   }
+  const trimmedTitles = A.map(suggestion.titles, Str.trim);
+  if (A.some(trimmedTitles, Str.isEmpty)) {
+    return `anchor ${suggestion.anchor} returned an empty title`;
+  }
+  if (A.dedupe(trimmedTitles).length !== trimmedTitles.length) {
+    return `anchor ${suggestion.anchor} returned duplicate titles within the block`;
+  }
   if (extract.remarksTagCount > 0 && suggestion.remarks === undefined) {
     return `anchor ${suggestion.anchor} is missing the required remarks routing`;
+  }
+  if ((suggestion.seePurposes?.length ?? 0) !== extract.undescribedSeeCount) {
+    return `anchor ${suggestion.anchor} returned ${suggestion.seePurposes?.length ?? 0} see purpose(s); expected ${extract.undescribedSeeCount}`;
+  }
+  if (suggestion.leadEnd !== undefined && (suggestion.leadEnd < 1 || suggestion.leadEnd > extract.leadParagraphCount)) {
+    return `anchor ${suggestion.anchor} returned leadEnd ${suggestion.leadEnd}; expected 1..${extract.leadParagraphCount}`;
   }
   return undefined;
 };

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocRatchet.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/JSDocRatchet.ts
@@ -430,7 +430,21 @@ const writeBaseline = Effect.fn("JSDocRatchet.writeBaseline")(function* (
   });
 });
 
-const jsdocGitErrorAdapter = {
+/**
+ * Git command error adapter shared by the JSDoc quality and migration scans.
+ *
+ * **Example** (Inspect the adapter shape)
+ *
+ * ```ts
+ * import { jsdocGitErrorAdapter } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(typeof jsdocGitErrorAdapter.onSpawnFailure) // "function"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export const jsdocGitErrorAdapter = {
   onSpawnFailure: (commandLine: string) => (cause: unknown) =>
     QualityScriptCommandError.new(cause, `Failed to run ${commandLine}.`),
   onNonZeroExit: ({
@@ -450,17 +464,68 @@ const jsdocGitErrorAdapter = {
   onTruncated: O.none<(commandLine: string) => QualityScriptCommandError>(),
 };
 
-const isGeneratedSourceFile = (filePath: string): boolean =>
+/**
+ * Whether a repo-relative path names generated source excluded from JSDoc gates.
+ *
+ * **Example** (Classify a generated path)
+ *
+ * ```ts
+ * import { isGeneratedSourceFile } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(isGeneratedSourceFile("packages/drivers/box/src/_generated/Box.models.gen.ts")) // true
+ * console.log(isGeneratedSourceFile("packages/drivers/box/src/Box.service.ts")) // false
+ * ```
+ *
+ * @param filePath - Repo-relative path to classify.
+ * @returns `true` when the path names generated source.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const isGeneratedSourceFile = (filePath: string): boolean =>
   Str.endsWith(".generated.ts")(filePath) ||
   Str.includes("/_generated/")(filePath) ||
   Str.includes("/generated/")(filePath);
 
 const GENERATED_HEADER_PROBE_LENGTH = 512;
 
-const hasGeneratedFileHeader = (sourceText: string): boolean =>
+/**
+ * Whether source text begins with a `GENERATED FILE` header probe.
+ *
+ * **Example** (Probe a generated header)
+ *
+ * ```ts
+ * import { hasGeneratedFileHeader } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(hasGeneratedFileHeader("// GENERATED FILE - do not edit\nexport {}")) // true
+ * console.log(hasGeneratedFileHeader("export const value = 1")) // false
+ * ```
+ *
+ * @param sourceText - Source text to probe.
+ * @returns `true` when the probe finds a GENERATED FILE marker.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const hasGeneratedFileHeader = (sourceText: string): boolean =>
   pipe(Str.slice(0, GENERATED_HEADER_PROBE_LENGTH)(sourceText), Str.includes("GENERATED FILE"));
 
-const isPackageSourceFile = (filePath: string): boolean =>
+/**
+ * Whether a repo-relative path is a non-generated package source file.
+ *
+ * **Example** (Classify package source paths)
+ *
+ * ```ts
+ * import { isPackageSourceFile } from "@beep/repo-cli/test/Quality"
+ *
+ * console.log(isPackageSourceFile("packages/shared/schema/src/Kits.ts")) // true
+ * console.log(isPackageSourceFile("packages/shared/schema/test/Kits.test.ts")) // false
+ * ```
+ *
+ * @param filePath - Repo-relative path to classify.
+ * @returns `true` for non-generated package source files.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const isPackageSourceFile = (filePath: string): boolean =>
   Str.startsWith("packages/")(filePath) &&
   Str.includes("/src/")(filePath) &&
   (Str.endsWith(".ts")(filePath) || Str.endsWith(".tsx")(filePath)) &&

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/QualityArtifactSupport.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/QualityArtifactSupport.ts
@@ -333,6 +333,7 @@ export const expandWorkspacePattern: {
     repoRoot: string,
     path: Path.Path
   ): Effect.Effect<ReadonlyArray<string>, QualityArtifactGeneratorError, FileSystem.FileSystem> =>
+    // fallow-ignore-next-line complexity -- pre-existing workspace-glob walker; the segment/candidate double loop mirrors the glob grammar and predates this change
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const segments = A.filter(Str.split("/")(normalizeSlashes(pattern)), Str.isNonEmpty);
@@ -614,7 +615,36 @@ export const summaryFromComment = (commentText: string): O.Option<string> => {
   return O.none();
 };
 
-const fencedLineState = (line: string, openFence: string | undefined): readonly [string | undefined, boolean] => {
+/**
+ * Advance the fenced-code-block scanner state by one stripped comment line.
+ *
+ * **Details**
+ *
+ * The state is the currently open fence delimiter (or `undefined` outside a
+ * fence). The returned flag is `true` for delimiter lines and interior lines,
+ * so callers can skip fenced example code when scanning for tags or section
+ * headings.
+ *
+ * **Example** (Track fence state across lines)
+ *
+ * ```ts
+ * import { fencedLineState } from "@beep/repo-cli/test/Quality"
+ *
+ * const [open, fenced] = fencedLineState("```ts", undefined)
+ * console.log(fenced) // true
+ * console.log(fencedLineState("```", open)[0]) // undefined
+ * ```
+ *
+ * @param line - Stripped comment line to scan.
+ * @param openFence - Currently open fence delimiter, or `undefined` outside a fence.
+ * @returns Next open-fence state and whether the line is fenced.
+ * @category jsdoc
+ * @since 0.0.0
+ */
+export const fencedLineState = (
+  line: string,
+  openFence: string | undefined
+): readonly [string | undefined, boolean] => {
   const match = /^\s*(`{3,}|~{3,})(.*)$/.exec(line);
   const fence = match === null ? undefined : match[1];
   if (openFence === undefined) {

--- a/packages/tooling/tool/cli/src/test/Quality.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Quality.test-kit.ts
@@ -39,9 +39,18 @@ export * from "../commands/Quality/internal/FallowEnvelope.schema.ts";
 export * from "../commands/Quality/internal/FlakeQuarantine.ts";
 export { githubCheckChangesetStatusLane, githubCheckLanePlan } from "../commands/Quality/internal/GithubChecks.ts";
 export * from "../commands/Quality/internal/JSDocDocumentationInventory.ts";
+export * from "../commands/Quality/internal/JSDocMigrate.schemas.ts";
+export * from "../commands/Quality/internal/JSDocMigrateApply.ts";
+export * from "../commands/Quality/internal/JSDocMigrateExtract.ts";
+export * from "../commands/Quality/internal/JSDocMigrateRewrite.ts";
+export * from "../commands/Quality/internal/JSDocMigrateTitles.ts";
 export * from "../commands/Quality/internal/JSDocRatchet.ts";
 export * from "../commands/Quality/internal/KnipRatchet.ts";
 export * from "../commands/Quality/internal/PackageVerify.ts";
-export { jsdocCommentsFromSource, tagsFromComment } from "../commands/Quality/internal/QualityArtifactSupport.ts";
+export {
+  fencedLineState,
+  jsdocCommentsFromSource,
+  tagsFromComment,
+} from "../commands/Quality/internal/QualityArtifactSupport.ts";
 export * from "../commands/Quality/internal/TurboConfigProof.ts";
 export * from "../internal/process/index.ts";

--- a/packages/tooling/tool/cli/test/jsdoc-migrate.test.ts
+++ b/packages/tooling/tool/cli/test/jsdoc-migrate.test.ts
@@ -1,0 +1,604 @@
+import {
+  computeJSDocMigrateBinding,
+  documentationShapeViolations,
+  jsdocMigrateBlockStats,
+  jsdocMigrateConservationFindings,
+  jsdocMigrateExtractRecordsForFile,
+  jsdocMigrateShapeRegressions,
+  jsdocMigrateSourceHash,
+  jsdocMigrateTitleRecordsFromResponse,
+  jsdocMigrateTitlesPrompt,
+  rewriteJSDocMigrateBlock,
+  scanJSDocMigrateBlocks,
+  syntheticJSDocMigrateTitleRecord,
+} from "@beep/repo-cli/test/Quality";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+
+const lines = (...values: ReadonlyArray<string>): string => values.join("\n");
+
+const simpleBlock = lines(
+  "/**",
+  " * Decodes a user name.",
+  " *",
+  " * @example",
+  " * ```ts",
+  ' * const result = decodeUserName("Ada")',
+  " * ```",
+  " *",
+  " * @category decoding",
+  " * @since 0.0.0",
+  " */"
+);
+
+describe("JSDocMigrateRewrite rewriteJSDocMigrateBlock", () => {
+  it("converts a fenced @example into a titled Example section", () => {
+    const result = rewriteJSDocMigrateBlock({
+      blockText: simpleBlock,
+      indent: "",
+      data: { titles: ["Decode a user name"] },
+    });
+    expect(result._tag).toBe("Rewritten");
+    if (result._tag !== "Rewritten") {
+      return;
+    }
+    expect(result.text).toContain("**Example** (Decode a user name)");
+    expect(result.text).not.toContain("@example");
+    expect(result.text).toContain('const result = decodeUserName("Ada")');
+    expect(result.text.indexOf("@category decoding")).toBeLessThan(result.text.indexOf("@since 0.0.0"));
+  });
+
+  it("quarantines an unfenced @example instead of inventing a fence", () => {
+    const block = lines("/**", " * Adds numbers.", " *", " * @example", " * add(1, 2)", " *", " * @since 0.0.0", " */");
+    const result = rewriteJSDocMigrateBlock({ blockText: block, indent: "", data: { titles: ["Add numbers"] } });
+    expect(result._tag).toBe("Quarantined");
+    if (result._tag === "Quarantined") {
+      expect(result.reasons).toContain("unfenced-example");
+    }
+  });
+
+  it("converts a multi-example block into distinct titled sections in order", () => {
+    const block = lines(
+      "/**",
+      " * Parses input.",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * parse(1)",
+      " * ```",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * parse(2)",
+      " * ```",
+      " *",
+      " * @since 0.0.0",
+      " */"
+    );
+    const result = rewriteJSDocMigrateBlock({
+      blockText: block,
+      indent: "",
+      data: { titles: ["First case", "Second case"] },
+    });
+    expect(result._tag).toBe("Rewritten");
+    if (result._tag !== "Rewritten") {
+      return;
+    }
+    const first = result.text.indexOf("**Example** (First case)");
+    const second = result.text.indexOf("**Example** (Second case)");
+    expect(first).toBeGreaterThan(-1);
+    expect(second).toBeGreaterThan(first);
+    expect(result.text.indexOf("parse(1)")).toBeLessThan(result.text.indexOf("parse(2)"));
+  });
+
+  it("fails with DataMismatch when the title count disagrees with the block", () => {
+    const result = rewriteJSDocMigrateBlock({ blockText: simpleBlock, indent: "", data: { titles: [] } });
+    expect(result._tag).toBe("DataMismatch");
+  });
+
+  it("routes @remarks alongside @example into Details before the Example", () => {
+    const block = lines(
+      "/**",
+      " * Decodes a user name.",
+      " *",
+      " * @remarks Returns None rather than throwing for invalid input.",
+      " *",
+      " * @example",
+      " * ```ts",
+      ' * decodeUserName("Ada")',
+      " * ```",
+      " *",
+      " * @since 0.0.0",
+      " */"
+    );
+    const result = rewriteJSDocMigrateBlock({
+      blockText: block,
+      indent: "",
+      data: { titles: ["Decode a name"], remarks: "details" },
+    });
+    expect(result._tag).toBe("Rewritten");
+    if (result._tag !== "Rewritten") {
+      return;
+    }
+    expect(result.text).toContain("**Details**");
+    expect(result.text).toContain("Returns None rather than throwing for invalid input.");
+    expect(result.text).not.toContain("@remarks");
+    expect(result.text.indexOf("**Details**")).toBeLessThan(result.text.indexOf("**Example** (Decode a name)"));
+    expect(jsdocMigrateShapeRegressions(block, result.text)).toEqual([]);
+  });
+
+  it("routes @remarks to Gotchas when the record says so", () => {
+    const block = lines(
+      "/**",
+      " * Deletes the record.",
+      " *",
+      " * @remarks This cannot be undone.",
+      " * @since 0.0.0",
+      " */"
+    );
+    const result = rewriteJSDocMigrateBlock({
+      blockText: block,
+      indent: "",
+      data: { titles: [], remarks: "gotchas" },
+    });
+    expect(result._tag).toBe("Rewritten");
+    if (result._tag !== "Rewritten") {
+      return;
+    }
+    expect(result.text).toContain("**Gotchas**");
+    expect(result.text).toContain("This cannot be undone.");
+  });
+
+  it("splits a multi-paragraph lead at leadEnd and clears the shape finding", () => {
+    const block = lines(
+      "/**",
+      " * Computes the digest.",
+      " *",
+      " * The digest is stable across processes and versions.",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * digest(1)",
+      " * ```",
+      " *",
+      " * @since 0.0.0",
+      " */"
+    );
+    const before = documentationShapeViolations(block);
+    expect(before.some((finding) => finding.rule === "multiple-description-paragraphs")).toBe(true);
+    const result = rewriteJSDocMigrateBlock({
+      blockText: block,
+      indent: "",
+      data: { titles: ["Digest a value"], leadEnd: 1 },
+    });
+    expect(result._tag).toBe("Rewritten");
+    if (result._tag !== "Rewritten") {
+      return;
+    }
+    const after = documentationShapeViolations(result.text);
+    expect(after.some((finding) => finding.rule === "multiple-description-paragraphs")).toBe(false);
+    expect(result.text).toContain("The digest is stable across processes and versions.");
+  });
+
+  it("applies the grammar normal forms and canonical tag order", () => {
+    const block = lines(
+      "/**",
+      " * Does things.",
+      " *",
+      " * @since 0.0.0",
+      " * @category utilities",
+      " * @template T - the element type",
+      " * @param {string} name - the name",
+      " * @returns - the result",
+      " * @default 1",
+      " * @see {@link decodeUserName}",
+      " * @remarks Watch out for empty input.",
+      " */"
+    );
+    const result = rewriteJSDocMigrateBlock({
+      blockText: block,
+      indent: "",
+      data: { titles: [], remarks: "gotchas", seePurposes: ["for the related decoder."] },
+    });
+    expect(result._tag).toBe("Rewritten");
+    if (result._tag !== "Rewritten") {
+      return;
+    }
+    expect(result.text).toContain("@typeParam T - the element type");
+    expect(result.text).toContain("@param name - the name");
+    expect(result.text).toContain("@returns the result");
+    expect(result.text).toContain("@defaultValue 1");
+    expect(result.text).toContain("@see {@link decodeUserName} for the related decoder.");
+    expect(result.text).not.toContain("@template");
+    expect(result.text).not.toContain("{string}");
+    const order = ["@typeParam", "@param", "@returns", "@defaultValue", "@see", "@category", "@since"];
+    const positions = order.map((tag) => result.text.indexOf(tag));
+    for (const [index, position] of positions.entries()) {
+      expect(position).toBeGreaterThan(index === 0 ? -1 : (positions[index - 1] ?? -1));
+    }
+    expect(jsdocMigrateShapeRegressions(block, result.text)).toEqual([]);
+  });
+
+  it("consumes a stray empty **Example** marker above a legacy tag", () => {
+    const block = lines(
+      "/**",
+      " * Parses a citation.",
+      " *",
+      " * **Example**",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * parseCitation()",
+      " * ```",
+      " *",
+      " * @since 0.0.0",
+      " */"
+    );
+    const result = rewriteJSDocMigrateBlock({
+      blockText: block,
+      indent: "",
+      data: { titles: ["Parse a citation"] },
+    });
+    expect(result._tag).toBe("Rewritten");
+    if (result._tag !== "Rewritten") {
+      return;
+    }
+    expect(result.text).toContain("**Example** (Parse a citation)");
+    expect(result.text).not.toContain("@example");
+    expect(result.text.match(/\*\*Example\*\*/g)?.length).toBe(1);
+    expect(jsdocMigrateShapeRegressions(block, result.text)).toEqual([]);
+  });
+
+  it("quarantines a genuine mix of a titled Example section and a legacy tag", () => {
+    const block = lines(
+      "/**",
+      " * Parses a citation.",
+      " *",
+      " * **Example** (Existing)",
+      " *",
+      " * ```ts",
+      " * existing()",
+      " * ```",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * parseCitation()",
+      " * ```",
+      " */"
+    );
+    const result = rewriteJSDocMigrateBlock({
+      blockText: block,
+      indent: "",
+      data: { titles: ["Parse a citation"] },
+    });
+    expect(result._tag).toBe("Quarantined");
+    if (result._tag === "Quarantined") {
+      expect(result.reasons).toContain("mixed-example-carriers");
+    }
+  });
+
+  it("keeps indented member blocks aligned with their original indentation", () => {
+    const block = lines(
+      "/**",
+      "   * Member doc.",
+      "   *",
+      "   * @example",
+      "   * ```ts",
+      "   * value.member",
+      "   * ```",
+      "   *",
+      "   * @since 0.0.0",
+      "   */"
+    );
+    const result = rewriteJSDocMigrateBlock({ blockText: block, indent: "  ", data: { titles: ["Read the member"] } });
+    expect(result._tag).toBe("Rewritten");
+    if (result._tag !== "Rewritten") {
+      return;
+    }
+    expect(result.text).toContain("\n   * **Example** (Read the member)");
+    expect(result.text.endsWith("  */")).toBe(true);
+  });
+});
+
+describe("JSDocMigrateRewrite conservation law", () => {
+  it("flags a mutated fence as a conservation violation", () => {
+    const mutated = simpleBlock.replace('decodeUserName("Ada")', 'decodeUserName("Eve")');
+    const findings = jsdocMigrateConservationFindings({
+      original: simpleBlock,
+      candidate: mutated,
+      allowedAddedTokens: [],
+      allowedRemovedTokens: [],
+    });
+    expect(findings.some((finding) => finding.startsWith("fence-bytes-changed"))).toBe(true);
+  });
+
+  it("flags dropped prose as a removed token", () => {
+    const mutated = simpleBlock.replace(" * Decodes a user name.", " * Decodes.");
+    const findings = jsdocMigrateConservationFindings({
+      original: simpleBlock,
+      candidate: mutated,
+      allowedAddedTokens: [],
+      allowedRemovedTokens: [],
+    });
+    expect(findings.some((finding) => finding.startsWith("token-removed"))).toBe(true);
+  });
+
+  it("flags invented prose as an added token", () => {
+    const mutated = simpleBlock.replace(" * Decodes a user name.", " * Decodes a wonderful user name.");
+    const findings = jsdocMigrateConservationFindings({
+      original: simpleBlock,
+      candidate: mutated,
+      allowedAddedTokens: [],
+      allowedRemovedTokens: [],
+    });
+    expect(findings.some((finding) => finding.startsWith("token-added"))).toBe(true);
+  });
+
+  it("accepts an identical candidate", () => {
+    expect(
+      jsdocMigrateConservationFindings({
+        original: simpleBlock,
+        candidate: simpleBlock,
+        allowedAddedTokens: [],
+        allowedRemovedTokens: [],
+      })
+    ).toEqual([]);
+  });
+});
+
+describe("JSDocMigrateExtract anchors", () => {
+  it("gives a runtime schema and its same-name type companion distinct ordinals", () => {
+    const source = lines(
+      "/**",
+      " * Runtime schema.",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * Foo",
+      " * ```",
+      " */",
+      "export const Foo = 1",
+      "/**",
+      " * Companion type.",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * const x: Foo = 1",
+      " * ```",
+      " */",
+      "export type Foo = typeof Foo",
+      ""
+    );
+    const blocks = scanJSDocMigrateBlocks("packages/x/src/Foo.ts", source);
+    expect(blocks.map((block) => block.anchor)).toEqual(["packages/x/src/Foo.ts#Foo#0", "packages/x/src/Foo.ts#Foo#1"]);
+    expect(blocks.map((block) => block.kind)).toEqual(["value", "type-level"]);
+  });
+
+  it("gives each documented overload signature its own ordinal", () => {
+    const source = lines(
+      "/** First overload. */",
+      "export function f(a: string): string;",
+      "/** Second overload. */",
+      "export function f(a: number): number;",
+      "/** Implementation. */",
+      "export function f(a: unknown): unknown {",
+      "  return a",
+      "}",
+      ""
+    );
+    const anchors = scanJSDocMigrateBlocks("packages/x/src/f.ts", source).map((block) => block.anchor);
+    expect(anchors).toEqual(["packages/x/src/f.ts#f#0", "packages/x/src/f.ts#f#1", "packages/x/src/f.ts#f#2"]);
+  });
+
+  it("gives merged declarations distinct ordinals", () => {
+    const source = lines(
+      "/** Interface doc. */",
+      "export interface X {",
+      "  readonly a: number",
+      "}",
+      "/** Namespace doc. */",
+      "export namespace X {",
+      "  export const b = 1",
+      "}",
+      ""
+    );
+    const anchors = scanJSDocMigrateBlocks("packages/x/src/X.ts", source).map((block) => block.anchor);
+    expect(anchors).toEqual(["packages/x/src/X.ts#X#0", "packages/x/src/X.ts#X#1"]);
+  });
+
+  it("binds a fileoverview block above a symbol doc to <fileoverview>", () => {
+    const source = lines(
+      "/**",
+      " * Module overview.",
+      " *",
+      " * @since 0.0.0",
+      " */",
+      "",
+      "/** Const doc. */",
+      "export const a = 1",
+      ""
+    );
+    const blocks = scanJSDocMigrateBlocks("packages/x/src/a.ts", source);
+    expect(blocks.map((block) => block.symbol)).toEqual(["<fileoverview>", "a"]);
+  });
+
+  it("emits records only for blocks carrying a legacy carrier", () => {
+    const source = lines(
+      "/**",
+      " * Already migrated.",
+      " *",
+      " * **Example** (Use it)",
+      " *",
+      " * ```ts",
+      " * use()",
+      " * ```",
+      " */",
+      "export const migrated = 1",
+      "/**",
+      " * Legacy block.",
+      " *",
+      " * @example",
+      " * ```ts",
+      " * legacy()",
+      " * ```",
+      " */",
+      "export const legacy = 1",
+      ""
+    );
+    const records = jsdocMigrateExtractRecordsForFile("packages/x/src/mixed.ts", source);
+    expect(records.map((record) => record.symbol)).toEqual(["legacy"]);
+    expect(records[0]?.sourceHash).toBe(jsdocMigrateSourceHash(records[0]?.blockText ?? ""));
+  });
+
+  it("measures block statistics for the title pass", () => {
+    const stats = jsdocMigrateBlockStats(
+      lines(
+        "/**",
+        " * Lead one.",
+        " *",
+        " * Lead two.",
+        " *",
+        " * @remarks Careful.",
+        " * @see {@link other}",
+        " * @example",
+        " * missing fence",
+        " */"
+      )
+    );
+    expect(stats.leadParagraphCount).toBe(2);
+    expect(stats.remarksTagCount).toBe(1);
+    expect(stats.undescribedSeeCount).toBe(1);
+    expect(stats.exampleTagCount).toBe(1);
+    expect(stats.unfencedExampleCount).toBe(1);
+  });
+});
+
+const legacyPair = (first: string, second: string): string =>
+  lines(
+    "/**",
+    ` * ${first}`,
+    " *",
+    " * @example",
+    " * ```ts",
+    ` * use("${first}")`,
+    " * ```",
+    " */",
+    "export function g(a: string): string;",
+    "/**",
+    ` * ${second}`,
+    " *",
+    " * @example",
+    " * ```ts",
+    ` * use("${second}")`,
+    " * ```",
+    " */",
+    "export function g(a: number): number;",
+    ""
+  );
+
+describe("JSDocMigrateApply binding verification", () => {
+  it("passes when frozen records biject with the extract and hashes match", () => {
+    const extract = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc A.", "Doc B."));
+    const titles = extract.map(syntheticJSDocMigrateTitleRecord);
+    const report = computeJSDocMigrateBinding({ extract, titles, overrides: [] });
+    expect(report.orphanRecordAnchors).toEqual([]);
+    expect(report.unmatchedExtractAnchors).toEqual([]);
+    expect(report.sourceHashMismatchAnchors).toEqual([]);
+    expect(report.kindMismatchAnchors).toEqual([]);
+  });
+
+  it("detects reordered same-name declarations via sourceHash while counts still match", () => {
+    const frozen = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc A.", "Doc B."));
+    const reordered = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc B.", "Doc A."));
+    const titles = frozen.map(syntheticJSDocMigrateTitleRecord);
+    const report = computeJSDocMigrateBinding({ extract: reordered, titles, overrides: [] });
+    expect(report.extractCount).toBe(report.recordCount);
+    expect(report.orphanRecordAnchors).toEqual([]);
+    expect(report.unmatchedExtractAnchors).toEqual([]);
+    expect(report.sourceHashMismatchAnchors.length).toBeGreaterThan(0);
+  });
+
+  it("detects a declaration added ahead as a bijection failure", () => {
+    const frozen = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc A.", "Doc B."));
+    const grown = jsdocMigrateExtractRecordsForFile(
+      "packages/x/src/g.ts",
+      lines(
+        "/**",
+        " * Doc Z.",
+        " *",
+        " * @example",
+        " * ```ts",
+        ' * use("Doc Z.")',
+        " * ```",
+        " */",
+        "export function g(a: boolean): boolean;",
+        legacyPair("Doc A.", "Doc B.")
+      )
+    );
+    const titles = frozen.map(syntheticJSDocMigrateTitleRecord);
+    const report = computeJSDocMigrateBinding({ extract: grown, titles, overrides: [] });
+    expect(report.unmatchedExtractAnchors.length).toBeGreaterThan(0);
+  });
+
+  it("detects a removed declaration as an orphan record failure", () => {
+    const frozen = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc A.", "Doc B."));
+    const shrunk = frozen.slice(0, 1);
+    const titles = frozen.map(syntheticJSDocMigrateTitleRecord);
+    const report = computeJSDocMigrateBinding({ extract: shrunk, titles, overrides: [] });
+    expect(report.orphanRecordAnchors.length).toBeGreaterThan(0);
+  });
+
+  it("detects an in-place edit as a sourceHash mismatch that demands a re-title", () => {
+    const frozen = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc A.", "Doc B."));
+    const edited = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc A, edited.", "Doc B."));
+    const titles = frozen.map(syntheticJSDocMigrateTitleRecord);
+    const report = computeJSDocMigrateBinding({ extract: edited, titles, overrides: [] });
+    expect(report.sourceHashMismatchAnchors).toEqual(["packages/x/src/g.ts#g#0"]);
+  });
+
+  it("synthesizes one unique placeholder title per example tag", () => {
+    const extract = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc A.", "Doc B."));
+    const first = extract[0];
+    expect(first).toBeDefined();
+    if (first === undefined) {
+      return;
+    }
+    expect(syntheticJSDocMigrateTitleRecord(first).titles).toEqual(["Placeholder title"]);
+  });
+});
+
+describe("JSDocMigrateTitles response validation", () => {
+  const pending = jsdocMigrateExtractRecordsForFile("packages/x/src/g.ts", legacyPair("Doc A.", "Doc B."));
+
+  it("renders a prompt naming every pending anchor", () => {
+    const prompt = jsdocMigrateTitlesPrompt(pending);
+    for (const record of pending) {
+      expect(prompt).toContain(record.anchor);
+    }
+  });
+
+  it("accepts a valid response and stamps verification fields", () => {
+    const content = JSON.stringify(pending.map((record) => ({ anchor: record.anchor, titles: ["Use the helper"] })));
+    const records = Effect.runSync(jsdocMigrateTitleRecordsFromResponse(content, pending));
+    expect(records.length).toBe(pending.length);
+    expect(records[0]?.sourceHash).toBe(pending[0]?.sourceHash);
+    expect(records[0]?.kind).toBe(pending[0]?.kind);
+  });
+
+  it("rejects a response with a wrong title count", () => {
+    const content = JSON.stringify(pending.map((record) => ({ anchor: record.anchor, titles: ["One", "Two"] })));
+    const exit = Effect.runSyncExit(jsdocMigrateTitleRecordsFromResponse(content, pending));
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  it("rejects a response that misses an anchor", () => {
+    const content = JSON.stringify([{ anchor: pending[0]?.anchor, titles: ["Only one"] }]);
+    const exit = Effect.runSyncExit(jsdocMigrateTitleRecordsFromResponse(content, pending));
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  it("rejects non-JSON content", () => {
+    const exit = Effect.runSyncExit(jsdocMigrateTitleRecordsFromResponse("not json", pending));
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});

--- a/packages/tooling/tool/cli/test/jsdoc-migrate.test.ts
+++ b/packages/tooling/tool/cli/test/jsdoc-migrate.test.ts
@@ -8,12 +8,13 @@ import {
   jsdocMigrateSourceHash,
   jsdocMigrateTitleRecordsFromResponse,
   jsdocMigrateTitlesPrompt,
+  partitionMigratedOrphans,
   rewriteJSDocMigrateBlock,
   scanJSDocMigrateBlocks,
   syntheticJSDocMigrateTitleRecord,
 } from "@beep/repo-cli/test/Quality";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Exit } from "effect";
+import { Effect, Exit, MutableHashMap } from "effect";
 
 const lines = (...values: ReadonlyArray<string>): string => values.join("\n");
 
@@ -600,5 +601,85 @@ describe("JSDocMigrateTitles response validation", () => {
   it("rejects non-JSON content", () => {
     const exit = Effect.runSyncExit(jsdocMigrateTitleRecordsFromResponse("not json", pending));
     expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  it("rejects empty and duplicate titles", () => {
+    const twoExample = jsdocMigrateExtractRecordsForFile(
+      "packages/x/src/two.ts",
+      lines(
+        "/**",
+        " * Two examples.",
+        " *",
+        " * @example",
+        " * ```ts",
+        " * one()",
+        " * ```",
+        " *",
+        " * @example",
+        " * ```ts",
+        " * two()",
+        " * ```",
+        " */",
+        "export const two = 1",
+        ""
+      )
+    );
+    const duplicate = JSON.stringify(twoExample.map((record) => ({ anchor: record.anchor, titles: ["Same", "Same"] })));
+    expect(Exit.isFailure(Effect.runSyncExit(jsdocMigrateTitleRecordsFromResponse(duplicate, twoExample)))).toBe(true);
+    const empty = JSON.stringify(twoExample.map((record) => ({ anchor: record.anchor, titles: ["Fine", "  "] })));
+    expect(Exit.isFailure(Effect.runSyncExit(jsdocMigrateTitleRecordsFromResponse(empty, twoExample)))).toBe(true);
+  });
+
+  it("rejects a see-purpose count that disagrees with the block", () => {
+    const withSee = jsdocMigrateExtractRecordsForFile(
+      "packages/x/src/see.ts",
+      lines(
+        "/**",
+        " * Uses a helper.",
+        " *",
+        " * @see {@link other}",
+        " * @example",
+        " * ```ts",
+        " * use()",
+        " * ```",
+        " */",
+        "export const use = 1",
+        ""
+      )
+    );
+    const missingPurpose = JSON.stringify(withSee.map((record) => ({ anchor: record.anchor, titles: ["Use it"] })));
+    expect(Exit.isFailure(Effect.runSyncExit(jsdocMigrateTitleRecordsFromResponse(missingPurpose, withSee)))).toBe(
+      true
+    );
+    const withPurpose = JSON.stringify(
+      withSee.map((record) => ({ anchor: record.anchor, titles: ["Use it"], seePurposes: ["for the helper."] }))
+    );
+    const records = Effect.runSync(jsdocMigrateTitleRecordsFromResponse(withPurpose, withSee));
+    expect(records.length).toBe(withSee.length);
+  });
+});
+
+describe("JSDocMigrateApply orphan tolerance", () => {
+  it("tolerates records whose blocks were already migrated and keeps true orphans", () => {
+    const migratedSource = lines(
+      "/**",
+      " * Already migrated.",
+      " *",
+      " * **Example** (Use it)",
+      " *",
+      " * ```ts",
+      " * use()",
+      " * ```",
+      " */",
+      "export const done = 1",
+      ""
+    );
+    const blocks = MutableHashMap.empty<string, { readonly affected: boolean }>();
+    for (const block of scanJSDocMigrateBlocks("packages/x/src/done.ts", migratedSource)) {
+      MutableHashMap.set(blocks, block.anchor, { affected: block.affected });
+    }
+    const result = partitionMigratedOrphans(["packages/x/src/done.ts#done#0", "packages/x/src/gone.ts#gone#0"], blocks);
+    expect(result.migrated).toEqual(["packages/x/src/done.ts#done#0"]);
+    expect(result.missing).toEqual(["packages/x/src/gone.ts#gone#0"]);
   });
 });

--- a/standards/schema-first.inventory.jsonc
+++ b/standards/schema-first.inventory.jsonc
@@ -507,6 +507,16 @@
     },
     {
       "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts",
+      "symbol": "partitionMigratedOrphans",
+      "kind": "schema-policy-advisory",
+      "status": "exception",
+      "ruleId": "SFV4-fn-schema",
+      "line": 233,
+      "owner": "@beep/repo-cli",
+      "reason": "Pure partition over in-memory anchor strings and scanned-block lookups; the inline pair of anchor arrays is transient control flow for the apply re-run tolerance, never decoded or persisted."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts",
       "symbol": "computeJSDocMigrateBinding",
       "kind": "schema-policy-advisory",
       "status": "exception",

--- a/standards/schema-first.inventory.jsonc
+++ b/standards/schema-first.inventory.jsonc
@@ -498,6 +498,78 @@
       "reason": "Two-sided comparison boundary that carries the base and HEAD KnowledgeArchiveOracle runtime seams; only renames is data, and it is already schema-backed by KnowledgeRename. The pair is assembled in-process before every scan and is never decoded or persisted."
     },
     {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts",
+      "symbol": "DocumentationIssue",
+      "kind": "object-struct-schema",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "Hot-path finding record constructed as plain literals by every inventory rule; S.Struct keeps that construction allocation-light while the annotated schema still owns the shape. Values are aggregated in-process and never decoded from IO."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts",
+      "symbol": "computeJSDocMigrateBinding",
+      "kind": "schema-policy-advisory",
+      "status": "exception",
+      "ruleId": "SFV4-fn-schema",
+      "line": 178,
+      "owner": "@beep/repo-cli",
+      "reason": "Pure comparison over already schema-decoded record sets; the inline input trio groups arrays of S.Class rows at the call site rather than modeling an IO boundary, and the output is the annotated JSDocMigrateBindingReport class."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateExtract.ts",
+      "symbol": "JSDocMigrateScannedBlock",
+      "kind": "object-struct-schema",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "In-memory scan result produced once per doc block while walking an 11k+-block corpus; S.Struct plus the same-name type keeps the hot loop literal-based while the annotated schema owns the shape. Never decoded or persisted - the persisted row is JSDocMigrateExtractRecord."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateRewrite.ts",
+      "symbol": "JSDocMigrateBlockStats",
+      "kind": "object-struct-schema",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "Derived per-block counters computed in the same corpus walk; plain-literal construction in the hot loop with the annotated S.Struct owning the shape. Never decoded from IO."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateRewrite.ts",
+      "symbol": "JSDocMigrateRewriteData",
+      "kind": "object-struct-schema",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "Structural parameter contract of the pure block rewriter; callers project it from the schema-decoded JSDocMigrateTitleRecord, so the IO boundary is already class-modeled and this struct is never decoded itself."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateRewrite.ts",
+      "symbol": "jsdocMigrateConservationFindings",
+      "kind": "schema-policy-advisory",
+      "status": "exception",
+      "ruleId": "SFV4-fn-schema",
+      "line": 429,
+      "owner": "@beep/repo-cli",
+      "reason": "Inline input pairs in-memory block bytes with token allowances the rewriter computed in the same call; nothing crosses an IO boundary and the findings are transient strings consumed by quarantine reporting."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateRewrite.ts",
+      "symbol": "rewriteJSDocMigrateBlock",
+      "kind": "schema-policy-advisory",
+      "status": "exception",
+      "ruleId": "SFV4-fn-schema",
+      "line": 844,
+      "owner": "@beep/repo-cli",
+      "reason": "Inline input pairs raw block bytes with a projection of the schema-decoded title record; the tagged result union is transient control flow consumed immediately by apply, never decoded or persisted."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/QualityArtifactSupport.ts",
+      "symbol": "fencedLineState",
+      "kind": "schema-policy-advisory",
+      "status": "exception",
+      "ruleId": "SFV4-null-return",
+      "line": 644,
+      "owner": "@beep/repo-cli",
+      "reason": "Pre-existing fence-scanner state tuple ([openFence | undefined, isFenced]) exported verbatim from the private scanners it was extracted from; wrapping the open-fence slot in Option would churn every hot-loop call site in the comment scanners."
+    },
+    {
       "file": "packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.schemas.ts",
       "symbol": "SyncDataTarget",
       "kind": "exported-interface",


### PR DESCRIPTION
Phase **P1** of `goals/jsdoc-carrier-migration`: the codemod the P3 mega-PR will run. This PR is
the real review target — P3 itself is a regenerated, mechanical diff.

## What ships

`beep quality jsdoc-migrate` in `commands/Quality/internal/`, four subcommands:

- **`extract`** — scans the non-generated corpus with the same fence-aware scanner the quality
  gate uses, binds each block to a `path#symbol#ordinal` anchor through ts-morph, and emits one
  `extract.jsonl` record per legacy-carrier block with `sourceHash` + `kind` verification fields.
  Fails loudly on duplicate anchors (SPEC §5.2).
- **`titles`** — one request per file through the local CLIProxyAPI (`grok-4.5`), data only.
  Append-only with per-anchor resume that skips only when the record exists **and** its
  `sourceHash` still matches; retries only schema-invalid returns.
- **`apply`** — text-surgical rewrite by byte offset, bottom-up per file. Fails closed unless
  frozen records biject with the live extract, every `sourceHash` matches, and every `kind`
  agrees. Each rewrite must pass both conservation clauses (SPEC §5.3) plus the
  `documentationShapeViolations` oracle, else it quarantines. `--dry-run --synthetic-titles`
  is the residue measurement mode.
- **`verify`** — re-proves conservation between frozen originals and post-format bytes,
  emitting a schema-versioned proof manifest (`DocgenProofManifest` idiom).

## Proof

- 32 fixture tests covering every recognised block shape: unfenced example (quarantines),
  multi-example, `@remarks`+`@example`, multi-paragraph lead split, grammar normal forms +
  canonical tag order, stray untitled `**Example**` marker consumption, genuine mixed carriers
  (quarantine), anchor collisions (companion type, overloads, merged declarations), and all four
  anchor-drift cases (reorder → hash mismatch, add → bijection failure, remove → orphan,
  in-place edit → re-title).
- **Full-corpus dry run** (P1 exit criterion): 11,674 affected blocks across 1,899 files;
  11,642 rewrite cleanly; **residue = 32** (31 unfenced examples + 1 fence buried inside
  `@remarks` content). Binding fully clean; zero duplicate anchors. Recorded in
  `ops/progress.json`.
- Census deltas discovered and receipted in `research/OPPORTUNITIES.md`: the regex census
  over-counted blocks (13,265 → 11,674 gate-consistent), most of its 114 "unfenced" examples
  are caption-then-fence blocks the codemod converts (31 truly unfenced), and 188 bare untitled
  `**Example**` markers sat above legacy tags that its `**Example** (` collision grep missed.

## Consolidations along the way

Fallow's audit gate drove real reuse: `Quality.command.ts` and the inventory now import
`unknownRecordProperty`/`unknownRecordKeys` and `globPatternToRegExp` from their existing shared
homes instead of carrying clones; new shared `JSDocMigrateData` module owns codecs + jsonl IO;
`documentationShapeViolations` and the ratchet's generated-file predicates are exported within
the package for reuse. Four schema-first exceptions are documented in
`standards/schema-first.inventory.jsonc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AV7uZkECyzKWxK4W3v3kx3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788630962&installation_model_id=424656&pr_number=597&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F597&signature=37980bf05b55d3e443e91b4e00b7cc73b65b4e44f19061edfb1adc8b92297800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->