### PR TITLE
ci(security+cost): harden workflows, pin actions, and move off blacksmith

### DIFF
--- a/.changeset/harden-workflows.md
+++ b/.changeset/harden-workflows.md
@@ -1,0 +1,7 @@
+---
+{}
+---
+
+No release: CI workflow hardening — least-privilege job permissions, SHA-pinned
+third-party actions, PR-event Turbo cache posture in Storybook, and Blacksmith-scoped
+disk cleanup.

--- a/.github/actions/setup-monorepo-ci/action.yml
+++ b/.github/actions/setup-monorepo-ci/action.yml
@@ -24,20 +24,20 @@ runs:
         echo "BEEP_SETUP_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
 
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version-file: .bun-version
 
     - name: Setup Node.js
       if: ${{ inputs.use-node == 'true' }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: .nvmrc
 
     - name: Restore Bun dependencies cache
       id: bun-cache-restore
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.bun/install/cache
         key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -47,7 +47,7 @@ runs:
       if: ${{ inputs.cache-turbo == 'true' && (env.TURBO_TOKEN == '' || env.TURBO_TEAM == '') }}
       id: turbo-cache-restore
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .turbo/cache
         key: turbo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('turbo.json', 'package.json', 'bun.lock') }}
@@ -67,7 +67,7 @@ runs:
     - name: Save Bun dependencies cache
       if: ${{ inputs.cache-write == 'true' && steps.bun-cache-restore.outputs.cache-hit != 'true' }}
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.bun/install/cache
         key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -75,7 +75,7 @@ runs:
     - name: Save Turbo cache (local fallback only)
       if: ${{ inputs.cache-write == 'true' && inputs.cache-turbo == 'true' && (env.TURBO_TOKEN == '' || env.TURBO_TEAM == '') && steps.turbo-cache-restore.outputs.cache-hit != 'true' }}
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .turbo/cache
         key: turbo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('turbo.json', 'package.json', 'bun.lock') }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   pr-size:
@@ -20,9 +19,11 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 2
+    permissions:
+      pull-requests: write
     steps:
       - name: Label PR by size
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -47,6 +48,8 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -122,9 +125,10 @@ jobs:
       LIVEBLOCKS_SECRET_KEY: ${{ github.event_name == 'push' && secrets.LIVEBLOCKS_SECRET_KEY || '' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch pull request base
         if: github.event_name == 'pull_request'
@@ -162,7 +166,10 @@ jobs:
           echo "docgen_mode=$docgen_mode" >> "$GITHUB_OUTPUT"
 
       - name: Free runner disk for verification lanes
-        if: steps.lane-gate.outputs.should_run == 'true' && runner.os == 'Linux'
+        # startsWith(runner.name) scopes the destructive image cleanup to
+        # ephemeral Blacksmith VMs; any other runner (owned, workstation,
+        # GitHub-hosted) keeps its filesystem.
+        if: steps.lane-gate.outputs.should_run == 'true' && runner.os == 'Linux' && startsWith(runner.name, 'blacksmith-')
         shell: bash
         run: |
           set -euo pipefail
@@ -188,7 +195,7 @@ jobs:
 
       - name: Install typos
         if: steps.lane-gate.outputs.should_run == 'true' && matrix.install_typos == 'true'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
         with:
           tool: typos-cli@1.44.0
 
@@ -252,9 +259,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 100
+          persist-credentials: false
 
       - name: Fetch pull request base
         if: github.event_name == 'pull_request'
@@ -284,7 +292,7 @@ jobs:
 
       - name: Setup Rust toolchain
         if: steps.lane-gate.outputs.should_run == 'true'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
           cache: true
@@ -323,9 +331,10 @@ jobs:
       TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || '' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch pull request base
         if: github.event_name == 'pull_request'
@@ -365,7 +374,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 100
           persist-credentials: false
@@ -393,7 +402,9 @@ jobs:
           echo "base_fetch_status=$fetch_status" >> "$GITHUB_OUTPUT"
 
       - name: Free runner disk for Fallow
-        if: runner.os == 'Linux'
+        # Same scoping as the verify matrix: destructive cleanup only on
+        # ephemeral Blacksmith VMs.
+        if: runner.os == 'Linux' && startsWith(runner.name, 'blacksmith-')
         shell: bash
         run: |
           set -euo pipefail
@@ -491,9 +502,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup monorepo CI
         uses: ./.github/actions/setup-monorepo-ci
@@ -513,9 +525,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup monorepo CI
         uses: ./.github/actions/setup-monorepo-ci
@@ -543,6 +556,8 @@ jobs:
     if: github.event_name == 'push'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
+    permissions:
+      contents: read
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM || secrets.TURBO_TEAM }}
@@ -556,9 +571,10 @@ jobs:
       LIVEBLOCKS_SECRET_KEY: ${{ secrets.LIVEBLOCKS_SECRET_KEY }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup monorepo CI
         uses: ./.github/actions/setup-monorepo-ci
@@ -577,11 +593,14 @@ jobs:
     name: Commitlint
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Determine commit range
         id: range
@@ -634,11 +653,14 @@ jobs:
     name: Secret Scanning
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch pull request base
         if: github.event_name == 'pull_request'
@@ -690,14 +712,18 @@ jobs:
     name: Security
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: OSV vulnerability scan
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
+        uses: google/osv-scanner-action/osv-scanner-action@c5996e0193a3df57d695c1b8a1dec2a4c62e8730 # v2.3.3
         with:
           scan-args: |-
             --lockfile=bun.lock
@@ -763,7 +789,7 @@ jobs:
 
       - name: Dependency review
         if: github.event_name == 'pull_request' && steps.dependency-graph.outputs.enabled == 'true'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high
           deny-licenses: AGPL-3.0, GPL-3.0
@@ -773,9 +799,13 @@ jobs:
     name: Nix Shell
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup monorepo CI
         uses: ./.github/actions/setup-monorepo-ci
@@ -784,20 +814,20 @@ jobs:
           cache-write: "false"
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup Cachix (read-only)
         if: github.event_name != 'push'
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         with:
           name: beep-effect
         continue-on-error: true
 
       - name: Setup Cachix (trusted push)
         if: github.event_name == 'push'
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         with:
           name: beep-effect
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -815,9 +845,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch pull request base
         if: github.event_name == 'pull_request'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,8 +17,8 @@ jobs:
   pr-size:
     name: PR Size Label
     if: github.event_name == 'pull_request'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 2
+    runs-on: ubuntu-24.04
+    timeout-minutes: 4
     permissions:
       pull-requests: write
     steps:
@@ -56,56 +56,56 @@ jobs:
         include:
           - id: lint
             name: Lint
-            runner: blacksmith-8vcpu-ubuntu-2404
-            timeout_minutes: 30
+            runner: ubuntu-24.04
+            timeout_minutes: 60
             uses_turbo: "true"
             install_typos: "true"
           - id: lint-policy
             name: Lint Policy
-            runner: blacksmith-8vcpu-ubuntu-2404
-            timeout_minutes: 25
+            runner: ubuntu-24.04
+            timeout_minutes: 50
             uses_turbo: "false"
             install_typos: "true"
           - id: repo-sanity
             name: Repo Sanity
-            runner: blacksmith-4vcpu-ubuntu-2404
-            timeout_minutes: 15
+            runner: ubuntu-24.04
+            timeout_minutes: 30
             uses_turbo: "false"
             install_typos: "false"
           - id: check
             name: Check
-            runner: blacksmith-8vcpu-ubuntu-2404
-            timeout_minutes: 60
+            runner: ubuntu-24.04
+            timeout_minutes: 120
             uses_turbo: "true"
             install_typos: "false"
           - id: test-unit
             name: Test Unit
-            runner: blacksmith-4vcpu-ubuntu-2404
-            timeout_minutes: 30
+            runner: ubuntu-24.04
+            timeout_minutes: 60
             uses_turbo: "true"
             install_typos: "false"
           - id: test-integration
             name: Test Integration
-            runner: blacksmith-8vcpu-ubuntu-2404
-            timeout_minutes: 20
+            runner: ubuntu-24.04
+            timeout_minutes: 40
             uses_turbo: "true"
             install_typos: "false"
           - id: coverage
             name: Coverage Regression
-            runner: blacksmith-8vcpu-ubuntu-2404
-            timeout_minutes: 40
+            runner: ubuntu-24.04
+            timeout_minutes: 80
             uses_turbo: "true"
             install_typos: "false"
           - id: docgen
             name: Docgen
-            runner: blacksmith-4vcpu-ubuntu-2404
-            timeout_minutes: 30
+            runner: ubuntu-24.04
+            timeout_minutes: 60
             uses_turbo: "false"
             install_typos: "false"
           - id: codegen
             name: Codegen Drift
-            runner: blacksmith-4vcpu-ubuntu-2404
-            timeout_minutes: 15
+            runner: ubuntu-24.04
+            timeout_minutes: 30
             uses_turbo: "false"
             install_typos: "false"
     env:
@@ -166,10 +166,10 @@ jobs:
           echo "docgen_mode=$docgen_mode" >> "$GITHUB_OUTPUT"
 
       - name: Free runner disk for verification lanes
-        # startsWith(runner.name) scopes the destructive image cleanup to
-        # ephemeral Blacksmith VMs; any other runner (owned, workstation,
-        # GitHub-hosted) keeps its filesystem.
-        if: steps.lane-gate.outputs.should_run == 'true' && runner.os == 'Linux' && startsWith(runner.name, 'blacksmith-')
+        # Destructive image cleanup runs on ephemeral hosted images (GitHub-
+        # hosted and lookalikes); owned/workstation runners (beep- prefix)
+        # keep their filesystem.
+        if: steps.lane-gate.outputs.should_run == 'true' && runner.os == 'Linux' && !startsWith(runner.name, 'beep-')
         shell: bash
         run: |
           set -euo pipefail
@@ -253,8 +253,8 @@ jobs:
 
   professional-desktop-ipc-stdio:
     name: Professional Desktop IPC Stdio
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
     permissions:
       contents: read
     steps:
@@ -319,8 +319,8 @@ jobs:
     # addition) is a P4 close criterion after a stable green history. The
     # nightly sweep (property-laws-nightly.yml) covers ALL suites at 1000+.
     name: Property Laws
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: read
     env:
@@ -368,8 +368,8 @@ jobs:
 
   fallow-advisory:
     name: Fallow Advisory Envelopes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -403,8 +403,8 @@ jobs:
 
       - name: Free runner disk for Fallow
         # Same scoping as the verify matrix: destructive cleanup only on
-        # ephemeral Blacksmith VMs.
-        if: runner.os == 'Linux' && startsWith(runner.name, 'blacksmith-')
+        # ephemeral hosted images, never owned (beep-) runners.
+        if: runner.os == 'Linux' && !startsWith(runner.name, 'beep-')
         shell: bash
         run: |
           set -euo pipefail
@@ -496,8 +496,8 @@ jobs:
 
   knip:
     name: Knip
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -519,8 +519,8 @@ jobs:
 
   jsdoc-ratchet:
     name: JSDoc Ratchet
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -554,8 +554,8 @@ jobs:
   build:
     name: Build
     if: github.event_name == 'push'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
     permissions:
       contents: read
     env:
@@ -591,8 +591,8 @@ jobs:
 
   commitlint:
     name: Commitlint
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -651,8 +651,8 @@ jobs:
 
   secrets:
     name: Secret Scanning
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -710,8 +710,8 @@ jobs:
 
   security:
     name: Security
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -797,8 +797,8 @@ jobs:
 
   nix:
     name: Nix Shell
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -838,8 +838,8 @@ jobs:
 
   sast:
     name: SAST
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/data-sync.yml
+++ b/.github/workflows/data-sync.yml
@@ -12,8 +12,8 @@ permissions:
 jobs:
   sync-data:
     name: Sync Official Data
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM || secrets.TURBO_TEAM }}

--- a/.github/workflows/data-sync.yml
+++ b/.github/workflows/data-sync.yml
@@ -19,7 +19,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM || secrets.TURBO_TEAM }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
         run: bun run beep sync-data-to-ts --all --include-authenticated --report-dir "$RUNNER_TEMP/data-sync-report"
 
       - name: Upload data sync report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: data-sync-report
           path: ${{ runner.temp }}/data-sync-report
@@ -79,7 +79,7 @@ jobs:
         run: bun run beep ci append-turbo-summary
 
       - name: Create or update pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.BEEP_DATA_SYNC_TOKEN != '' && secrets.BEEP_DATA_SYNC_TOKEN || github.token }}
           branch: automation/data-sync

--- a/.github/workflows/property-laws-nightly.yml
+++ b/.github/workflows/property-laws-nightly.yml
@@ -31,8 +31,8 @@ permissions:
 jobs:
   property-sweep:
     name: Property Laws Sweep
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 90
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM || secrets.TURBO_TEAM }}

--- a/.github/workflows/property-laws-nightly.yml
+++ b/.github/workflows/property-laws-nightly.yml
@@ -38,7 +38,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM || secrets.TURBO_TEAM }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Open or update the tracking issue
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const title = "Nightly property-law sweep failures";

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -123,13 +123,13 @@ jobs:
             updater-suffixes: '[".msi.zip",".nsis.zip"]'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.version) || github.ref }}
 
       - name: Verify release tag checkout
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const { execFileSync } = require("node:child_process");
@@ -177,7 +177,7 @@ jobs:
             libssl-dev
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
           target: ${{ matrix.rust-target }}
@@ -241,7 +241,7 @@ jobs:
           args: ${{ matrix.args }}
 
       - name: Stage desktop bundle artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
           RELEASE_DESKTOP_ASSET_ARCH: ${{ matrix.asset-arch }}
@@ -367,7 +367,7 @@ jobs:
       RELEASE_DESKTOP_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
       - name: Create or update release pull request
         id: changesets-release
         if: steps.release-diff.outputs.has_release_diff == 'true'
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         continue-on-error: true
         with:
           version: bun run changeset:version
@@ -120,7 +120,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM || secrets.TURBO_TEAM }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -130,7 +130,7 @@ jobs:
           cache-turbo: true
 
       - name: Configure npm registry access
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           registry-url: https://registry.npmjs.org
           node-version-file: .nvmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
   release-pr:
     name: Release PR
     if: github.event_name == 'push'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -110,8 +110,8 @@ jobs:
     name: Publish (Manual Approval Required)
     if: github.event_name == 'workflow_dispatch' && inputs.confirm_publish ==
       'PUBLISH'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     environment:
       # Configure this environment with required reviewers to enforce approval.
       name: release-publish

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,8 +16,8 @@ permissions:
 jobs:
   build-and-test:
     name: Build And Test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     env:
       # Same secret posture as check.yml's verify matrix: this job executes
       # PR-authored turbo tasks, so the remote-cache write token stays on
@@ -36,8 +36,8 @@ jobs:
       # exhaust the runner's disk ("No space left on device"). Mirror the
       # cleanup that check.yml already performs for its verification lanes.
       - name: Free runner disk
-        # Destructive image cleanup only on ephemeral Blacksmith VMs.
-        if: runner.os == 'Linux' && startsWith(runner.name, 'blacksmith-')
+        # Destructive image cleanup only on ephemeral hosted images, never owned (beep-) runners.
+        if: runner.os == 'Linux' && !startsWith(runner.name, 'beep-')
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -19,8 +19,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM || secrets.TURBO_TEAM }}
+      # Same secret posture as check.yml's verify matrix: this job executes
+      # PR-authored turbo tasks, so the remote-cache write token stays on
+      # trusted push events only; PR runs get local cache.
+      TURBO_TOKEN: ${{ github.event_name == 'push' && secrets.TURBO_TOKEN || '' }}
+      TURBO_TEAM: ${{ github.event_name == 'push' && (vars.TURBO_TEAM || secrets.TURBO_TEAM) || '' }}
+      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -32,7 +36,8 @@ jobs:
       # exhaust the runner's disk ("No space left on device"). Mirror the
       # cleanup that check.yml already performs for its verification lanes.
       - name: Free runner disk
-        if: runner.os == 'Linux'
+        # Destructive image cleanup only on ephemeral Blacksmith VMs.
+        if: runner.os == 'Linux' && startsWith(runner.name, 'blacksmith-')
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What

Two commits, one CI surface:

**e9c97e43a9 — hardening** (phase 1 of the owned-runners plan,
`goals/speed-loop/research/o6-execution-plan.md`):
- `pull-requests: write` moves off workflow scope in check.yml to the two jobs that use it
  (`pr-size`, `security`); explicit `contents: read` on verify/build/commitlint/secrets/nix.
- `persist-credentials: false` on every checkout in check.yml and storybook.yml.
- All third-party actions SHA-pinned (resolved from their current tags; zero behavior change).
- storybook.yml adopts check.yml's PR-event Turbo cache posture: remote-cache write token on
  trusted push only; PR runs get `local:rw` — closes a cache-poisoning primitive where
  PR-authored turbo tasks ran with the write token in env.
- Destructive disk-cleanup steps gated away from non-ephemeral runners.

**d7b4c7895a — Blacksmith exit** (operator decision 2026-08-06: full stop, not hybrid):
- Every `blacksmith-{2,4,8}vcpu-ubuntu-2404` label becomes `ubuntu-24.04` — free standard
  runners on a public repo. Timeouts double (halved cores; caps are inert when unused).
- Cleanup guard inverts to `!startsWith(runner.name, 'beep-')`: hosted images get the cleanup
  they were written for; only future owned (beep-) runners skip it.
- Heavy trusted lanes move to owned EC2 spot runners in a later phase (infra stack in flight);
  fork/untrusted PRs stay on free GitHub-hosted permanently.

## Follow-ups (not this PR)
- `beep ci lint-workflows` regression gate for permissions/pins.
- Post-merge repo settings flips: `sha_pinning_required: true`, outside-collaborator approval.
- Owned EC2 runner stack (`infra/ci-runners`, separate PR).

provenance: clone=scratchpad-bridge-worktree session-home=beep-effect3

🤖 Generated with [Claude Code](https://claude.com/claude-code)