### PR TITLE
fix(ai-metrics): stop editing a shipped migration and correct it with a new one

### DIFF
--- a/.changeset/ai-metrics-watermark-migration-immutability.md
+++ b/.changeset/ai-metrics-watermark-migration-immutability.md
@@ -1,0 +1,27 @@
+---
+"@beep/repo-ai-metrics": patch
+---
+
+Restore the shipped OTLP export watermark migration and correct it with a new one.
+
+`ai-metrics-otlp-export-watermark-v1` shipped excluding the newest ingest run outright,
+which let a later zero-turn discovery pass shadow the newest run that had actually
+committed turns — burying exactly the rows most likely to be unexported. The correction
+was applied by editing that migration's SQL in place, which fixes nothing: the
+`ai_metrics_schema_migrations` ledger records a migration *id*, not its text, and
+`ensureAiMetricsDerivedStorage` skips any id it finds there. Every store that had already
+run v1 kept its buried turns, permanently — the watermark reads as closed and nothing
+reopens it.
+
+v1 is restored to exactly the SQL it shipped with and is now marked immutable in place,
+and `ai-metrics-otlp-export-watermark-v2` carries the correction. It reopens the turns v1
+should have spared, keyed on the backfill sentinel: v1 writes a literal `0`, a real export
+writes the wall-clock epoch, and rows ingested after v1 are `NULL`. So
+`otlp_exported_at_epoch_ms = 0` identifies the backfilled rows exactly, and among those the
+newest run by `started_at_epoch_ms` is the run v1 should not have marked — every run newer
+than it at v1 time had no turns, which is the bug condition.
+
+Both paths converge. On a store that already applied v1, v2 reopens the buried run. On a
+fresh store, v1 buries it and v2 immediately reopens it. The worst case either way is one
+run's worth of re-sent spans, and those carry content-addressed span ids the collector
+deduplicates.

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -481,19 +481,19 @@ const derivedStorageMigrations = [
     // lands would see millions of NULLs and flush the whole history to Phoenix in one
     // burst -- the exact backpressure collapse this work exists to prevent.
     //
-    // The newest ingest run that actually committed turns is deliberately excluded.
-    // Under the old scheme a run that committed turns and then died before exporting
-    // was rescued by the next run, which re-minted those rows under a fresh id and
-    // exported them -- so the content did reach Phoenix even though the original rows
-    // never did. The one case with no such rescue is the final turn-bearing run before
-    // this migration: if it crashed before exporting, nothing came after it. Leaving
-    // that run's turns unmarked costs at most one run's worth of re-sent spans if it
-    // had in fact succeeded -- and those carry content-addressed span ids the collector
-    // deduplicates -- while marking them would silently bury data.
+    // The newest ingest run is excluded. Under the old scheme a run that committed turns
+    // and then died before exporting was rescued by the next run, which re-minted those
+    // rows under a fresh id and exported them -- so the content did reach Phoenix even
+    // though the original rows never did. The one case with no such rescue is the final
+    // run before this migration: if it crashed before exporting, nothing came after it.
     //
-    // "That committed turns" is load-bearing. Scoping the exclusion to the newest run
-    // outright meant a later zero-turn run (a discovery pass that found nothing new)
-    // shadowed the real one, and the genuinely at-risk turns were marked after all.
+    // This SQL is WRONG -- it should have excluded the newest run that actually committed
+    // turns -- and it is preserved verbatim anyway. It shipped in #578, and the ledger
+    // records a migration id, not its text, so any store that already applied it will
+    // never re-run it no matter what this string says. Editing it in place therefore
+    // fixes nothing on the stores that need fixing while silently changing behaviour on
+    // fresh ones. `ai-metrics-otlp-export-watermark-v2` below carries the correction.
+    // Shipped migrations are immutable; treat this one as a historical record.
     //
     // The `ai_metrics_schema_migrations` ledger guarantees this runs once, and it is
     // applied before the run's inserts, so genuinely new turns are never swept up.
@@ -513,11 +513,46 @@ const derivedStorageMigrations = [
        SET otlp_exported_at_epoch_ms = 0
        WHERE otlp_exported_at_epoch_ms IS NULL
          AND ingest_run_id <> COALESCE(
-           (SELECT runs.ingest_run_id
-            FROM ai_metrics_ingest_runs runs
-            WHERE EXISTS (
-              SELECT 1 FROM ai_metrics_turns turns WHERE turns.ingest_run_id = runs.ingest_run_id
-            )
+           (SELECT ingest_run_id FROM ai_metrics_ingest_runs ORDER BY started_at_epoch_ms DESC LIMIT 1),
+           ''
+         )`,
+    ],
+    transactional: true,
+  },
+  {
+    // Corrects v1 above, which excluded the newest ingest run outright. A later zero-turn
+    // run -- a discovery pass that found nothing new -- shadowed the newest run that had
+    // actually committed turns, so exactly the rows most likely to be unexported were the
+    // ones marked. Those turns can never be exported again: the watermark reads as closed
+    // and nothing reopens it.
+    //
+    // The backfill sentinel is what makes this recoverable. v1 writes the literal `0`,
+    // while a real export writes the wall-clock epoch, and rows ingested after v1 ran are
+    // NULL rather than `0`. So `otlp_exported_at_epoch_ms = 0` identifies the backfilled
+    // rows exactly, and among those the newest run by `started_at_epoch_ms` is precisely
+    // the run v1 should have spared -- every run newer than it at v1 time had no turns,
+    // which is the bug condition.
+    //
+    // Runs after v1 on every store, so the two converge: on a store that already applied
+    // the buggy v1 this reopens the buried run, and on a fresh store v1 buries it and
+    // this immediately reopens it. Worst case is one run's worth of re-sent spans, which
+    // carry content-addressed ids the collector deduplicates.
+    migrationId: "ai-metrics-otlp-export-watermark-v2",
+    requiredColumns: [
+      { columnName: "otlp_exported_at_epoch_ms", tableName: "ai_metrics_turns" },
+      { columnName: "ingest_run_id", tableName: "ai_metrics_turns" },
+      { columnName: "ingest_run_id", tableName: "ai_metrics_ingest_runs" },
+      { columnName: "started_at_epoch_ms", tableName: "ai_metrics_ingest_runs" },
+    ],
+    statements: [
+      `UPDATE ai_metrics_turns
+       SET otlp_exported_at_epoch_ms = NULL
+       WHERE otlp_exported_at_epoch_ms = 0
+         AND ingest_run_id = COALESCE(
+           (SELECT backfilled.ingest_run_id
+            FROM ai_metrics_turns backfilled
+            JOIN ai_metrics_ingest_runs runs ON runs.ingest_run_id = backfilled.ingest_run_id
+            WHERE backfilled.otlp_exported_at_epoch_ms = 0
             ORDER BY runs.started_at_epoch_ms DESC
             LIMIT 1),
            ''

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -1797,8 +1797,8 @@ volumes:
             // run-old was rescued under the old scheme by the runs that followed it, so
             // marking it costs nothing. run-last-with-turns had no such rescue -- if it
             // died before exporting, nothing came after it -- so its turns stay pending.
-            // Scoping the exclusion to the newest run outright let run-empty-latest
-            // shadow it and buried exactly the rows most likely to be unexported.
+            // v1 buries it, because run-empty-latest shadows it; v2 reopens it. The net
+            // effect on a fresh store is the corrected behaviour.
             expect(watermarks).toEqual([
               { exportedAt: null, turnId: "turn-at-risk" },
               { exportedAt: 0, turnId: "turn-old" },
@@ -1807,9 +1807,101 @@ volumes:
             const migrationRows = yield* duckdb.query(
               `SELECT migration_id AS "migrationId"
                FROM ai_metrics_schema_migrations
-               WHERE migration_id = 'ai-metrics-otlp-export-watermark-v1'`
+               WHERE migration_id LIKE 'ai-metrics-otlp-export-watermark-%'
+               ORDER BY migration_id`
             );
-            expect(migrationRows).toEqual([{ migrationId: "ai-metrics-otlp-export-watermark-v1" }]);
+            expect(migrationRows).toEqual([
+              { migrationId: "ai-metrics-otlp-export-watermark-v1" },
+              { migrationId: "ai-metrics-otlp-export-watermark-v2" },
+            ]);
+          }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
+        })
+      ).pipe(provideScopedLayer(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "reopens turns a store already buried under the shipped watermark backfill",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const duckDbPath = path.join(tmpDir, "ai-metrics.duckdb");
+
+          yield* Effect.gen(function* () {
+            const duckdb = yield* DuckDb;
+            yield* ensureAiMetricsDerivedStorage;
+
+            // A store that already ran the watermark backfill as it shipped, and was left
+            // holding the bug: the newest turn-bearing run was marked because a zero-turn
+            // discovery pass shadowed it. The ledger records migration ids, not their SQL,
+            // so rewriting v1 in place could never reach this store -- only a new id can.
+            yield* Effect.forEach(
+              [
+                { ingestRunId: "run-old", startedAt: 1 },
+                { ingestRunId: "run-last-with-turns", startedAt: 2 },
+                { ingestRunId: "run-empty-latest", startedAt: 3 },
+              ],
+              Effect.fnUntraced(function* (run) {
+                yield* duckdb.run(
+                  `INSERT INTO ai_metrics_ingest_runs VALUES (
+                     $ingestRunId, 'local', 'snapshot', 'hash', $startedAt, $startedAt, 0, 0, 0
+                   )`,
+                  run
+                );
+              }),
+              { discard: true }
+            );
+            // Both already marked with the backfill sentinel, exactly as the shipped v1
+            // would have left them.
+            yield* Effect.forEach(
+              [
+                { ingestRunId: "run-old", turnId: "turn-old" },
+                { ingestRunId: "run-last-with-turns", turnId: "turn-buried" },
+              ],
+              Effect.fnUntraced(function* (turn) {
+                yield* duckdb.run(
+                  `INSERT INTO ai_metrics_turns (
+                     turn_id, ingest_run_id, agent_session_id, source_kind, source_path_hash,
+                     source_role, line_number, event_name, raw_event_hash, timestamp,
+                     otlp_exported_at_epoch_ms
+                   ) VALUES (
+                     $turnId, $ingestRunId, 'session-1', 'codex', 'source-hash',
+                     'primary', 1, 'event', $turnId, NULL, 0
+                   )`,
+                  turn
+                );
+              }),
+              { discard: true }
+            );
+            // v1 stays on the ledger and v2 comes off it: a store upgraded from the
+            // release that shipped v1 alone. v1 is skipped by id from here on no matter
+            // what its SQL says, which is the whole reason a second migration is needed.
+            yield* duckdb.run(
+              `DELETE FROM ai_metrics_schema_migrations
+               WHERE migration_id = 'ai-metrics-otlp-export-watermark-v2'`
+            );
+            const beforeUpgrade = yield* duckdb.query(
+              `SELECT migration_id AS "migrationId"
+               FROM ai_metrics_schema_migrations
+               WHERE migration_id LIKE 'ai-metrics-otlp-export-watermark-%'`
+            );
+            expect(beforeUpgrade).toEqual([{ migrationId: "ai-metrics-otlp-export-watermark-v1" }]);
+
+            yield* ensureAiMetricsDerivedStorage;
+
+            const watermarks = yield* duckdb.query(
+              `SELECT turn_id AS "turnId", otlp_exported_at_epoch_ms AS "exportedAt"
+               FROM ai_metrics_turns
+               ORDER BY turn_id`
+            );
+
+            // v2 reopens only the newest backfilled run. run-old stays marked: it was
+            // rescued under the old duplicating scheme, so its content did reach Phoenix.
+            expect(watermarks).toEqual([
+              { exportedAt: null, turnId: "turn-buried" },
+              { exportedAt: 0, turnId: "turn-old" },
+            ]);
           }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
         })
       ).pipe(provideScopedLayer(NodeServices.layer));


### PR DESCRIPTION
## fix(ai-metrics): stop editing a shipped migration and correct it with a new one

#595 fixed the watermark backfill by rewriting ai-metrics-otlp-export-watermark-v1's SQL
in place. That fixes nothing on the stores that need it. The ai_metrics_schema_migrations
ledger records a migration id, not its text, and ensureAiMetricsDerivedStorage returns
early on any id already present, so a store that had run v1 never re-runs it however the
string changes. Those stores keep the buried turns permanently: the watermark reads closed
and nothing reopens it. Caught by the PR reviewer on #595 after it had already merged.

v1 is restored byte-for-byte to what #578 shipped and annotated as immutable, and
ai-metrics-otlp-export-watermark-v2 carries the correction.

v2 keys on the backfill sentinel. v1 writes a literal 0, a real export writes the
wall-clock epoch, and rows ingested after v1 ran are NULL, so otlp_exported_at_epoch_ms = 0
identifies the backfilled rows exactly. Among those the newest run by started_at_epoch_ms
is precisely the run v1 should have spared, because every run newer than it at v1 time had
no turns - that is the bug condition.

Both paths converge: on an already-migrated store v2 reopens the buried run, and on a fresh
store v1 buries it and v2 immediately reopens it. Worst case either way is one run's worth
of re-sent spans, carrying content-addressed ids the collector deduplicates.

The new test drives the case an in-place edit can never reach - v1 on the ledger, v2 absent,
turns already sitting at the sentinel - and is mutation-verified: collapsing v2's id back
into v1 leaves turn-buried at 0 instead of reopening it.

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_ai-metrics-watermark-migration-immutability-9388a3e115a6/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788643415&installation_model_id=424656&pr_number=601&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F601&signature=cc3e04590257ded763de3acdf5d679d9b2a293dc906b65714b45465a3d704215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->