### PR TITLE
fix(quality): stop the coverage ratchet failing on deleted covered code

### DIFF
--- a/.changeset/coverage-ratchet-deletion-and-scope.md
+++ b/.changeset/coverage-ratchet-deletion-and-scope.md
@@ -1,0 +1,25 @@
+---
+{}
+---
+
+No release: stop the coverage ratchet failing on deleted covered code, and stop
+a filtered baseline write from deleting the baseline.
+
+The gate compared percentages only, and a percentage falls for two opposite
+reasons. Adding untested code lowers it, which is a regression. Removing tested
+code lowers it too, and that is not one — no test lost its subject, the subject
+was deleted. So the gate fired on code removal and taxed every migration that
+shrinks a package. The counts that tell those apart were already parsed and
+discarded, so the baseline now records the uncovered count per metric and a
+metric fails only when its percentage dropped **and** its uncovered count rose.
+
+`uncovered` is optional, so existing baselines still decode and fall back to the
+percentage-only rule, which is the stricter of the two. Counts fill in as
+packages are rebaselined rather than needing one repo-wide rewrite.
+
+Separately, `coverage:baseline:write --filter=X` used to write a baseline
+containing only `X` and silently delete every other entry, because the document
+was rebuilt from the current snapshot with no merge. Writes are now scoped-aware:
+a scoped run merges over the committed document, an unscoped run still replaces
+so deleted packages are pruned, and an unscoped run that measured fewer packages
+than it is replacing is refused instead of written.

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -1706,7 +1706,7 @@ const runRootCoverageTask = Effect.fn("QualityTasks.runRootCoverageTask")(functi
   yield* runStep(coverageStep(repoRoot, options));
 
   if (options.writeBaseline) {
-    yield* writeCoverageRegressionBaseline(repoRoot);
+    yield* writeCoverageRegressionBaseline(repoRoot, options.scoped);
     return;
   }
 

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
@@ -6,8 +6,8 @@
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
-import { LiteralKit } from "@beep/schema";
-import { A, Str, thunkFalse } from "@beep/utils";
+import { LiteralKit, SchemaUtils } from "@beep/schema";
+import { A, Str, thunkFalse, thunkTrue } from "@beep/utils";
 import { Console, DateTime, Effect, FileSystem, Inspectable, MutableHashMap, Order, Path, pipe } from "effect";
 import * as O from "effect/Option";
 import * as R from "effect/Record";
@@ -63,7 +63,41 @@ const VitestCoveragePct = S.Union([S.Finite, S.Literal("Unknown")]).pipe(
 type VitestCoveragePct = typeof VitestCoveragePct.Type;
 
 /**
+ * Absolute uncovered counts per metric, recorded alongside the percentages.
+ *
+ * **Details**
+ *
+ * Percentages alone cannot distinguish the two ways they fall. Deleting code
+ * that tests already covered lowers the ratio arithmetically, because removing
+ * one covered unit from a package below full coverage leaves a smaller ratio
+ * than it started with — yet nothing regressed, because the covered subject was
+ * removed rather than left untested. Adding untested code lowers the ratio too,
+ * and that one is a real gap. The uncovered count separates them: it stays flat
+ * when code is deleted and rises only when coverage is genuinely lost.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class CoverageUncoveredCounts extends S.Class<CoverageUncoveredCounts>($I`CoverageUncoveredCounts`)(
+  {
+    lines: S.Int,
+    statements: S.Int,
+    branches: S.Int,
+    functions: S.Int,
+  },
+  $I.annote("CoverageUncoveredCounts", {
+    description: "Absolute uncovered counts per metric for one workspace package.",
+  })
+) {}
+
+/**
  * Per-package coverage percentages stored in the committed baseline.
+ *
+ * **Gotchas**
+ *
+ * `uncovered` is optional so baselines written before it existed still decode.
+ * When either side of a comparison lacks it the ratchet falls back to the
+ * percentage-only rule, which is the stricter of the two.
  *
  * @category models
  * @since 0.0.0
@@ -75,6 +109,7 @@ export class CoveragePackageBaseline extends S.Class<CoveragePackageBaseline>($I
     statements: S.Finite,
     branches: S.Finite,
     functions: S.Finite,
+    uncovered: CoverageUncoveredCounts.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
   },
   $I.annote("CoveragePackageBaseline", {
     description: "Committed coverage percentages for one workspace package.",
@@ -138,12 +173,14 @@ class VitestCoverageSummary extends S.Class<VitestCoverageSummary>($I`VitestCove
  * Baseline entry paired with the package it covers, used when reporting
  * packages that are new since the committed baseline.
  *
- * @example
+ * **Example** (Reading the package a snapshot entry covers)
+ *
  * ```ts
  * import type { CoverageSnapshotEntry } from "@beep/repo-cli/test/Quality"
  * declare const entry: CoverageSnapshotEntry
  * console.log(entry.packageName)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -160,12 +197,14 @@ export class CoverageSnapshotEntry extends S.Class<CoverageSnapshotEntry>($I`Cov
 /**
  * One metric that dropped below its committed baseline for one package.
  *
- * @example
+ * **Example** (Reporting one dropped metric)
+ *
  * ```ts
  * import type { CoverageComparisonFailure } from "@beep/repo-cli/test/Quality"
  * declare const failure: CoverageComparisonFailure
  * console.log(`${failure.packageName} ${failure.metric}: ${failure.actual} < ${failure.baseline}`)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -187,12 +226,14 @@ export class CoverageComparisonFailure extends S.Class<CoverageComparisonFailure
  * metric drops (failures), packages missing a current summary, and packages
  * new since the baseline was written.
  *
- * @example
+ * **Example** (Deciding whether a run regressed)
+ *
  * ```ts
  * import type { CoverageComparisonResult } from "@beep/repo-cli/test/Quality"
  * declare const result: CoverageComparisonResult
  * console.log(result.failures.length === 0 ? "ok" : "regression")
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -220,6 +261,8 @@ const coverageSummaryPath = (path: Path.Path, info: WorkspacePackageInfo): strin
 
 const coveragePctValue = (value: VitestCoveragePct): number => (value === "Unknown" ? 0 : value);
 
+const uncoveredCount = (metric: VitestCoverageMetric): number => metric.total - metric.covered;
+
 const toCoveragePackageBaseline = (path: string, summary: VitestCoverageSummary): CoveragePackageBaseline =>
   CoveragePackageBaseline.make({
     path,
@@ -227,6 +270,14 @@ const toCoveragePackageBaseline = (path: string, summary: VitestCoverageSummary)
     statements: coveragePctValue(summary.total.statements.pct),
     branches: coveragePctValue(summary.total.branches.pct),
     functions: coveragePctValue(summary.total.functions.pct),
+    uncovered: O.some(
+      CoverageUncoveredCounts.make({
+        lines: uncoveredCount(summary.total.lines),
+        statements: uncoveredCount(summary.total.statements),
+        branches: uncoveredCount(summary.total.branches),
+        functions: uncoveredCount(summary.total.functions),
+      })
+    ),
   });
 
 const packageByNameOrder = Order.mapInput(Order.String, (entry: CoverageSnapshotEntry) => entry.packageName);
@@ -340,9 +391,54 @@ export const collectCoverageSnapshot = Effect.fn("CoverageRegression.collectCove
   return pipe(entries, A.getSomes, A.sort(packageByNameOrder));
 });
 
+const snapshotPackages = (entries: ReadonlyArray<CoverageSnapshotEntry>): Record<string, CoveragePackageBaseline> =>
+  R.fromEntries(A.map(entries, (entry) => [entry.packageName, entry.baseline] as const));
+
+/**
+ * Merge a snapshot over the packages a previous baseline recorded.
+ *
+ * Only packages the run actually measured are replaced; everything else is
+ * carried through untouched. A scoped run measures a handful of packages, so
+ * without this the written document would contain only those and silently drop
+ * every other entry.
+ *
+ * @param previous - Packages recorded by the committed baseline.
+ * @param entries - Packages this run measured.
+ * @returns The committed packages with the measured ones replaced.
+ * @category testing
+ * @since 0.0.0
+ */
+export const mergeCoverageBaselinePackagesForTesting = (
+  previous: Record<string, CoveragePackageBaseline>,
+  entries: ReadonlyArray<CoverageSnapshotEntry>
+): Record<string, CoveragePackageBaseline> => ({ ...previous, ...snapshotPackages(entries) });
+
+/**
+ * Whether writing this snapshot would silently delete committed entries.
+ *
+ * Only an unscoped run replaces the document, so only an unscoped run can drop
+ * entries. Measuring fewer packages than the baseline records means the run did
+ * not cover what an unscoped run claims to — a partially failed run, or a filter
+ * the caller forgot to declare — and the missing entries would vanish without a
+ * word.
+ *
+ * @param scoped - Whether the coverage run was intentionally filtered or affected-scoped.
+ * @param measuredCount - Packages this run produced a summary for.
+ * @param previousCount - Packages the committed baseline records.
+ * @returns `true` when writing would delete committed entries.
+ * @category testing
+ * @since 0.0.0
+ */
+export const baselineReplacementDropsEntries = (
+  scoped: boolean,
+  measuredCount: number,
+  previousCount: number
+): boolean => !scoped && measuredCount < previousCount;
+
 const baselineDocumentFromSnapshot = Effect.fn("CoverageRegression.baselineDocumentFromSnapshot")(function* (
   repoRoot: string,
-  entries: ReadonlyArray<CoverageSnapshotEntry>
+  entries: ReadonlyArray<CoverageSnapshotEntry>,
+  previous: O.Option<CoverageRegressionBaseline>
 ): Effect.fn.Return<
   CoverageRegressionBaseline,
   QualityTaskConfigurationError,
@@ -353,11 +449,21 @@ const baselineDocumentFromSnapshot = Effect.fn("CoverageRegression.baselineDocum
 
   return CoverageRegressionBaseline.make({
     schema_version: 1,
-    generated_at: generatedAt,
-    git_sha: gitSha,
+    // A merge leaves most entries untouched, so claiming this run's timestamp
+    // and revision for the whole document would attribute a provenance the
+    // unmeasured entries do not have. Only a full regeneration earns fresh
+    // metadata; a merge inherits the last one.
+    generated_at: pipe(previous, O.match({ onNone: () => generatedAt, onSome: (document) => document.generated_at })),
+    git_sha: pipe(previous, O.match({ onNone: () => gitSha, onSome: (document) => document.git_sha })),
     command: coverageRegressionRegenerationCommand,
     epsilon: coverageRegressionEpsilon,
-    packages: R.fromEntries(A.map(entries, (entry) => [entry.packageName, entry.baseline] as const)),
+    packages: pipe(
+      previous,
+      O.match({
+        onNone: () => snapshotPackages(entries),
+        onSome: (document) => mergeCoverageBaselinePackagesForTesting(document.packages, entries),
+      })
+    ),
   });
 });
 
@@ -383,7 +489,15 @@ const readBaseline = Effect.fn("CoverageRegression.readBaseline")(function* (
 const formatBaseline = Effect.fn("CoverageRegression.formatBaseline")(function* (
   baseline: CoverageRegressionBaseline
 ): Effect.fn.Return<string, QualityTaskConfigurationError> {
-  const jsonc = yield* formatJsonc(baseline).pipe(
+  // `formatJsonc` stringifies whatever it is handed, so the document has to be
+  // encoded first. That was invisible while every field was a plain scalar and
+  // the decoded value doubled as the wire value; `uncovered` is an `Option`
+  // decoded and an optional key encoded, so writing the decoded shape produces
+  // a baseline the reader rejects.
+  const encoded = yield* S.encodeEffect(CoverageRegressionBaseline)(baseline).pipe(
+    QualityTaskConfigurationError.mapError("Failed to encode coverage regression baseline.")
+  );
+  const jsonc = yield* formatJsonc(encoded).pipe(
     QualityTaskConfigurationError.mapError("Failed to format coverage regression baseline.")
   );
   return [
@@ -397,13 +511,29 @@ const formatBaseline = Effect.fn("CoverageRegression.formatBaseline")(function* 
 /**
  * Write the committed coverage regression baseline from generated summaries.
  *
+ * **Details**
+ *
+ * A scoped run measures only the packages it was filtered to, so its snapshot
+ * is merged over the committed document and every unmeasured entry is carried
+ * through. An unscoped run is a full regeneration and replaces the document
+ * outright, which is what prunes entries for packages that no longer exist.
+ *
+ * **Gotchas**
+ *
+ * An unscoped run that measured fewer packages than the document it is about to
+ * replace is refused rather than written. That shape means the coverage run did
+ * not cover what it claimed to — a partial failure, a filter the caller forgot
+ * to declare — and writing it would delete the missing entries silently.
+ *
  * @param repoRoot - Repository root.
+ * @param scoped - Whether the coverage run was intentionally filtered or affected-scoped.
  * @category use-cases
  * @since 0.0.0
  */
 export const writeCoverageRegressionBaseline = Effect.fn("CoverageRegression.writeCoverageRegressionBaseline")(
   function* (
-    repoRoot: string
+    repoRoot: string,
+    scoped: boolean
   ): Effect.fn.Return<
     void,
     QualityTaskConfigurationError,
@@ -415,7 +545,16 @@ export const writeCoverageRegressionBaseline = Effect.fn("CoverageRegression.wri
       return yield* QualityTaskConfigurationError.new("No coverage summaries were generated; cannot write baseline.");
     }
 
-    const baseline = yield* baselineDocumentFromSnapshot(repoRoot, entries);
+    const previous = yield* readBaseline(repoRoot).pipe(Effect.option);
+    const previousCount = pipe(previous, O.match({ onNone: () => 0, onSome: (document) => R.size(document.packages) }));
+
+    if (baselineReplacementDropsEntries(scoped, A.length(entries), previousCount)) {
+      return yield* QualityTaskConfigurationError.new(
+        `Refusing to write ${coverageRegressionBaselinePath}: this run measured ${A.length(entries)} package(s) but the committed baseline records ${previousCount}. An unscoped regeneration replaces the document, so writing it would drop the ${previousCount - A.length(entries)} unmeasured entry(ies). Re-run coverage across the whole workspace, or pass a turbo filter so the run is treated as scoped and merged instead.`
+      );
+    }
+
+    const baseline = yield* baselineDocumentFromSnapshot(repoRoot, entries, scoped ? previous : O.none());
     const content = yield* formatBaseline(baseline);
     yield* writeArtifact({
       path: path.join(repoRoot, coverageRegressionBaselinePath),
@@ -426,13 +565,43 @@ export const writeCoverageRegressionBaseline = Effect.fn("CoverageRegression.wri
         ),
     });
     yield* Console.log(
-      `[coverage-ratchet] wrote ${coverageRegressionBaselinePath} with ${A.length(entries)} package(s)`
+      scoped
+        ? `[coverage-ratchet] merged ${A.length(entries)} measured package(s) into ${coverageRegressionBaselinePath} (${R.size(baseline.packages)} total)`
+        : `[coverage-ratchet] wrote ${coverageRegressionBaselinePath} with ${A.length(entries)} package(s)`
     );
   }
 );
 
 const actualByPackageName = (actuals: ReadonlyArray<CoverageSnapshotEntry>) =>
   R.fromEntries(A.map(actuals, (entry) => [entry.packageName, entry] as const));
+
+/**
+ * Whether a metric's percentage drop reflects lost coverage rather than deleted
+ * covered code.
+ *
+ * A percentage falls both when untested code is added and when tested code is
+ * removed, and only the first is a regression. The uncovered count tells them
+ * apart: deleting covered code leaves it flat, losing coverage raises it. When
+ * either side predates the count the percentage rule stands alone, which keeps
+ * the stricter behaviour for baselines that have not been rewritten yet.
+ *
+ * @param metric - Metric being compared.
+ * @param baseline - Committed entry for the package.
+ * @param actual - Entry measured by this run.
+ * @param epsilon - Percentage-point tolerance for floating-point noise.
+ * @returns `true` when the drop reflects coverage that was actually lost.
+ */
+const metricRegressed = (
+  metric: CoverageMetricName,
+  baseline: CoveragePackageBaseline,
+  actual: CoveragePackageBaseline,
+  epsilon: number
+): boolean =>
+  actual[metric] + epsilon < baseline[metric] &&
+  pipe(
+    O.zipWith(baseline.uncovered, actual.uncovered, (before, after) => after[metric] > before[metric]),
+    O.getOrElse(thunkTrue)
+  );
 
 const droppedMetrics = (
   packageName: string,
@@ -442,7 +611,7 @@ const droppedMetrics = (
 ): ReadonlyArray<CoverageComparisonFailure> =>
   pipe(
     metricNames,
-    A.filter((metric) => actual[metric] + epsilon < baseline[metric]),
+    A.filter((metric) => metricRegressed(metric, baseline, actual, epsilon)),
     A.map((metric) => ({
       packageName,
       packagePath: baseline.path,

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
@@ -414,26 +414,36 @@ export const mergeCoverageBaselinePackagesForTesting = (
 ): Record<string, CoveragePackageBaseline> => ({ ...previous, ...snapshotPackages(entries) });
 
 /**
- * Whether writing this snapshot would silently delete committed entries.
+ * Committed entries an unscoped replacement would delete without meaning to.
  *
- * Only an unscoped run replaces the document, so only an unscoped run can drop
- * entries. Measuring fewer packages than the baseline records means the run did
- * not cover what an unscoped run claims to — a partially failed run, or a filter
- * the caller forgot to declare — and the missing entries would vanish without a
- * word.
+ * **Details**
  *
- * @param scoped - Whether the coverage run was intentionally filtered or affected-scoped.
- * @param measuredCount - Packages this run produced a summary for.
- * @param previousCount - Packages the committed baseline records.
- * @returns `true` when writing would delete committed entries.
+ * A replacement legitimately prunes packages that no longer exist — that is how
+ * a deleted package leaves the baseline. What it must not do is drop an entry
+ * for a package that is still in the workspace and simply was not measured,
+ * which is what a partially failed run or an undeclared filter produces.
+ *
+ * Comparing names rather than counts matters: a run that drops one package and
+ * gains another measures the same number while still deleting an entry, so a
+ * count check waves it through.
+ *
+ * @param previousNames - Packages the committed baseline records.
+ * @param measuredNames - Packages this run produced a summary for.
+ * @param workspaceNames - Packages that currently exist and run coverage.
+ * @returns Baseline entries that are still live packages but went unmeasured.
  * @category testing
  * @since 0.0.0
  */
-export const baselineReplacementDropsEntries = (
-  scoped: boolean,
-  measuredCount: number,
-  previousCount: number
-): boolean => !scoped && measuredCount < previousCount;
+export const baselineEntriesLostByReplacement = (
+  previousNames: ReadonlyArray<string>,
+  measuredNames: ReadonlyArray<string>,
+  workspaceNames: ReadonlyArray<string>
+): ReadonlyArray<string> =>
+  pipe(
+    previousNames,
+    A.filter((name) => !A.contains(measuredNames, name) && A.contains(workspaceNames, name)),
+    A.sort(Order.String)
+  );
 
 const baselineDocumentFromSnapshot = Effect.fn("CoverageRegression.baselineDocumentFromSnapshot")(function* (
   repoRoot: string,
@@ -484,6 +494,30 @@ const readBaseline = Effect.fn("CoverageRegression.readBaseline")(function* (
         `Failed to parse ${coverageRegressionBaselinePath}.: ${Inspectable.toStringUnknown(cause, 0)}`
       ),
   });
+});
+
+/**
+ * Read the committed baseline, distinguishing "not there yet" from "unreadable".
+ *
+ * A missing file is the legitimate first-write case and yields `None`. A file
+ * that exists but fails to read or decode is an error and stays one — treating
+ * it as absent would let a scoped write fall through to the snapshot-only branch
+ * and overwrite a baseline whose only problem was that it did not parse.
+ */
+const readPreviousBaseline = Effect.fn("CoverageRegression.readPreviousBaseline")(function* (
+  repoRoot: string
+): Effect.fn.Return<
+  O.Option<CoverageRegressionBaseline>,
+  QualityTaskConfigurationError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const exists = yield* fs
+    .exists(path.join(repoRoot, coverageRegressionBaselinePath))
+    .pipe(Effect.orElseSucceed(thunkFalse));
+
+  return exists ? O.some(yield* readBaseline(repoRoot)) : O.none();
 });
 
 const formatBaseline = Effect.fn("CoverageRegression.formatBaseline")(function* (
@@ -545,13 +579,27 @@ export const writeCoverageRegressionBaseline = Effect.fn("CoverageRegression.wri
       return yield* QualityTaskConfigurationError.new("No coverage summaries were generated; cannot write baseline.");
     }
 
-    const previous = yield* readBaseline(repoRoot).pipe(Effect.option);
-    const previousCount = pipe(previous, O.match({ onNone: () => 0, onSome: (document) => R.size(document.packages) }));
+    // Absent and unreadable are different answers. Collapsing a read or decode
+    // failure into "no previous document" would take the snapshot-only branch
+    // and overwrite a baseline that merely failed to parse, so only a genuinely
+    // missing file yields `None`; anything else propagates.
+    const previous = yield* readPreviousBaseline(repoRoot);
 
-    if (baselineReplacementDropsEntries(scoped, A.length(entries), previousCount)) {
-      return yield* QualityTaskConfigurationError.new(
-        `Refusing to write ${coverageRegressionBaselinePath}: this run measured ${A.length(entries)} package(s) but the committed baseline records ${previousCount}. An unscoped regeneration replaces the document, so writing it would drop the ${previousCount - A.length(entries)} unmeasured entry(ies). Re-run coverage across the whole workspace, or pass a turbo filter so the run is treated as scoped and merged instead.`
+    if (!scoped) {
+      const workspaceNames = yield* workspaceCoveragePackages(repoRoot, path).pipe(
+        Effect.map(A.map((info) => info.name))
       );
+      const lost = baselineEntriesLostByReplacement(
+        pipe(previous, O.match({ onNone: A.empty<string>, onSome: (document) => R.keys(document.packages) })),
+        A.map(entries, (entry) => entry.packageName),
+        workspaceNames
+      );
+
+      if (A.isReadonlyArrayNonEmpty(lost)) {
+        return yield* QualityTaskConfigurationError.new(
+          `Refusing to write ${coverageRegressionBaselinePath}: an unscoped regeneration replaces the document, and ${A.length(lost)} package(s) it records are still in the workspace but produced no coverage summary in this run, so their entries would be deleted: ${A.join(lost, ", ")}. Re-run coverage across the whole workspace, or pass a turbo filter so the run is treated as scoped and merged instead. Packages that no longer exist are pruned normally and do not trigger this.`
+        );
+      }
     }
 
     const baseline = yield* baselineDocumentFromSnapshot(repoRoot, entries, scoped ? previous : O.none());
@@ -584,6 +632,17 @@ const actualByPackageName = (actuals: ReadonlyArray<CoverageSnapshotEntry>) =>
  * apart: deleting covered code leaves it flat, losing coverage raises it. When
  * either side predates the count the percentage rule stands alone, which keeps
  * the stricter behaviour for baselines that have not been rewritten yet.
+ *
+ * Known blind spot. When the total does not shrink this is exact — coverage can
+ * only be lost by raising the uncovered count. When the total does shrink, a
+ * real regression can hide behind an exactly offsetting deletion: losing tests
+ * on five covered units while five unrelated uncovered units are deleted moves
+ * 60/100 to 55/95, which is byte-identical to simply deleting five covered
+ * units. Package-level totals cannot separate those two histories at all, so
+ * catching it would need per-file counts, which would grow the committed
+ * baseline by roughly the size of the repo. The trade is deliberate: a rare miss
+ * that needs a coincidental offset, in exchange for not failing every change
+ * that deletes tested code.
  *
  * @param metric - Metric being compared.
  * @param baseline - Committed entry for the package.

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -7,8 +7,10 @@ import {
 } from "@beep/repo-cli/commands/Quality/FallowQuality.command";
 import { collectGithubCheckLaneWavesForTesting } from "@beep/repo-cli/commands/Quality/Tasks";
 import {
+  baselineReplacementDropsEntries,
   CoveragePackageBaseline,
   CoverageRegressionBaseline,
+  CoverageUncoveredCounts,
   collectEffectTsgoDiagnosticLines,
   compareCoverageRegressionSnapshotsForTesting,
   compareJSDocTotalsForTesting,
@@ -30,6 +32,7 @@ import {
   githubCheckRepoSanityLanesForTesting,
   KnipFinding,
   lintFixChangedStepForTesting,
+  mergeCoverageBaselinePackagesForTesting,
   normalizeKnipReportForTesting,
   parseQualityTaskInvocation,
   promotedFallowGithubCheckLaneIdsForTesting,
@@ -58,6 +61,7 @@ import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { Cause, Effect, Exit, FileSystem, Layer, Order, Path, pipe } from "effect";
 import * as O from "effect/Option";
+import * as R from "effect/Record";
 import * as S from "effect/Schema";
 import { FastCheck as fc } from "effect/testing";
 import * as TestConsole from "effect/testing/TestConsole";
@@ -92,6 +96,13 @@ const coveragePackageBaseline = (path: string, metric = 50): CoveragePackageBase
     statements: metric,
     branches: metric,
     functions: metric,
+  });
+const coverageUncovered = (count: number): CoverageUncoveredCounts =>
+  CoverageUncoveredCounts.make({
+    lines: count,
+    statements: count,
+    branches: count,
+    functions: count,
   });
 const coverageRegressionBaseline = CoverageRegressionBaseline.make({
   schema_version: 1,
@@ -1351,6 +1362,95 @@ describe("quality task adapter", () => {
     expect(compareCoverageRegressionSnapshotsForTesting(coverageRegressionBaseline, [], true).missingActuals).toEqual(
       []
     );
+  });
+
+  it("separates a percentage drop caused by deleting covered code from one caused by losing coverage", () => {
+    // 50% as 50/100 covered, so 50 lines uncovered.
+    const before = CoverageRegressionBaseline.make({
+      ...coverageRegressionBaseline,
+      packages: {
+        "@beep/existing": CoveragePackageBaseline.make({
+          path: "packages/existing",
+          lines: 50,
+          statements: 50,
+          branches: 50,
+          functions: 50,
+          uncovered: O.some(coverageUncovered(50)),
+        }),
+      },
+    });
+    const compare = (actual: CoveragePackageBaseline) =>
+      compareCoverageRegressionSnapshotsForTesting(before, [{ packageName: "@beep/existing", baseline: actual }], false)
+        .failures;
+
+    // Deleted 10 covered lines: 40/90 = 44.4%, a real drop, but the 50
+    // uncovered lines are untouched. Nothing stopped being tested.
+    expect(
+      compare(
+        CoveragePackageBaseline.make({
+          path: "packages/existing",
+          lines: 44.44,
+          statements: 44.44,
+          branches: 44.44,
+          functions: 44.44,
+          uncovered: O.some(coverageUncovered(50)),
+        })
+      )
+    ).toEqual([]);
+
+    // Added 10 untested lines: 50/110 = 45.5%, and uncovered rose to 60.
+    expect(
+      compare(
+        CoveragePackageBaseline.make({
+          path: "packages/existing",
+          lines: 45.45,
+          statements: 45.45,
+          branches: 45.45,
+          functions: 45.45,
+          uncovered: O.some(coverageUncovered(60)),
+        })
+      )
+    ).toEqual(
+      A.map(A.sort(["lines", "statements", "branches", "functions"], Order.String), (metric) =>
+        expect.objectContaining({ packageName: "@beep/existing", metric })
+      )
+    );
+  });
+
+  it("keeps the percentage-only rule when either side predates the uncovered counts", () => {
+    const failures = compareCoverageRegressionSnapshotsForTesting(
+      coverageRegressionBaseline,
+      [{ packageName: "@beep/existing", baseline: coveragePackageBaseline("packages/existing", 49) }],
+      false
+    ).failures;
+
+    expect(A.length(failures)).toBe(4);
+  });
+
+  it("merges a scoped snapshot over the committed packages instead of replacing them", () => {
+    const merged = mergeCoverageBaselinePackagesForTesting(
+      {
+        "@beep/existing": coveragePackageBaseline("packages/existing", 50),
+        "@beep/untouched": coveragePackageBaseline("packages/untouched", 70),
+      },
+      [{ packageName: "@beep/existing", baseline: coveragePackageBaseline("packages/existing", 80) }]
+    );
+
+    expect(R.keys(merged).sort()).toEqual(["@beep/existing", "@beep/untouched"]);
+    expect(merged["@beep/existing"]?.lines).toBe(80);
+    expect(merged["@beep/untouched"]?.lines).toBe(70);
+  });
+
+  it("refuses an unscoped baseline write that measured fewer packages than it would replace", () => {
+    // A scoped run merges, so a short snapshot is expected and harmless.
+    expect(baselineReplacementDropsEntries(true, 1, 121)).toBe(false);
+    // An unscoped run replaces, so a short snapshot deletes the difference.
+    expect(baselineReplacementDropsEntries(false, 1, 121)).toBe(true);
+    // A full run that covers everything, or a repo gaining packages, is fine.
+    expect(baselineReplacementDropsEntries(false, 121, 121)).toBe(false);
+    expect(baselineReplacementDropsEntries(false, 122, 121)).toBe(false);
+    // First write, with nothing committed yet.
+    expect(baselineReplacementDropsEntries(false, 1, 0)).toBe(false);
   });
 
   it("builds the integration lane command with shared SQL environment", () => {

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@beep/repo-cli/commands/Quality/FallowQuality.command";
 import { collectGithubCheckLaneWavesForTesting } from "@beep/repo-cli/commands/Quality/Tasks";
 import {
-  baselineReplacementDropsEntries,
+  baselineEntriesLostByReplacement,
   CoveragePackageBaseline,
   CoverageRegressionBaseline,
   CoverageUncoveredCounts,
@@ -1441,16 +1441,27 @@ describe("quality task adapter", () => {
     expect(merged["@beep/untouched"]?.lines).toBe(70);
   });
 
-  it("refuses an unscoped baseline write that measured fewer packages than it would replace", () => {
-    // A scoped run merges, so a short snapshot is expected and harmless.
-    expect(baselineReplacementDropsEntries(true, 1, 121)).toBe(false);
-    // An unscoped run replaces, so a short snapshot deletes the difference.
-    expect(baselineReplacementDropsEntries(false, 1, 121)).toBe(true);
-    // A full run that covers everything, or a repo gaining packages, is fine.
-    expect(baselineReplacementDropsEntries(false, 121, 121)).toBe(false);
-    expect(baselineReplacementDropsEntries(false, 122, 121)).toBe(false);
+  it("names the live baseline entries an unscoped replacement would delete", () => {
+    const previous = ["@beep/a", "@beep/b", "@beep/c"];
+
+    // Unmeasured but still in the workspace: replacing would delete them.
+    expect(baselineEntriesLostByReplacement(previous, ["@beep/a"], previous)).toEqual(["@beep/b", "@beep/c"]);
+
+    // A full run loses nothing.
+    expect(baselineEntriesLostByReplacement(previous, previous, previous)).toEqual([]);
+
+    // @beep/c was deleted from the workspace, so pruning its entry is the point
+    // of an unscoped regeneration, not an accident.
+    expect(baselineEntriesLostByReplacement(previous, ["@beep/a", "@beep/b"], ["@beep/a", "@beep/b"])).toEqual([]);
+
+    // Equal counts are not equal sets: swapping one package for another measures
+    // the same number while still deleting @beep/c's entry.
+    expect(
+      baselineEntriesLostByReplacement(previous, ["@beep/a", "@beep/b", "@beep/d"], [...previous, "@beep/d"])
+    ).toEqual(["@beep/c"]);
+
     // First write, with nothing committed yet.
-    expect(baselineReplacementDropsEntries(false, 1, 0)).toBe(false);
+    expect(baselineEntriesLostByReplacement([], ["@beep/a"], ["@beep/a"])).toEqual([]);
   });
 
   it("builds the integration lane command with shared SQL environment", () => {

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -577,10 +577,16 @@
     },
     "@beep/openai-compat": {
       "path": "packages/drivers/openai-compat",
-      "lines": 82.23,
-      "statements": 81.93,
+      "lines": 82.41,
+      "statements": 82.1,
       "branches": 62.62,
-      "functions": 73.04
+      "functions": 73.42,
+      "uncovered": {
+        "lines": 54,
+        "statements": 56,
+        "branches": 37,
+        "functions": 38
+      }
     },
     "@beep/openclaw": {
       "path": "packages/drivers/openclaw",


### PR DESCRIPTION
The coverage ratchet compared percentages only, and a percentage falls for two opposite reasons.

Adding untested code lowers it. That is a regression. Removing *tested* code lowers it too — take one covered unit out of a package that is below full coverage and the ratio comes out smaller than it started — and that is **not** a regression. No test lost its subject; the subject was deleted.

So the gate fired on code removal, and quietly taxed every migration that shrinks a package. Landing Effect `beta.103` tripped it on three packages this way, none of which had regressed, and the only remedy was to hand-lower the committed numbers.

## The fix was already half-written

`VitestCoverageMetric` has always decoded `total`, `covered`, **and** `pct` from the Vitest summary — and then `toCoveragePackageBaseline` kept only `pct` and threw the counts away.

The baseline now records the uncovered count per metric, and a metric fails only when its percentage dropped **and** its uncovered count rose:

| change | pct | uncovered | before | after |
| --- | --- | --- | --- | --- |
| delete covered code | ↓ | flat | ❌ fails | ✅ passes |
| delete uncovered code | ↑ | ↓ | passes | passes |
| add untested code | ↓ | ↑ | fails | ✅ fails |
| delete a test | ↓ | ↑ | fails | ✅ fails |

`uncovered` is optional, so baselines written before it existed still decode and fall back to the percentage-only rule — the stricter of the two. Counts fill in as packages are rebaselined rather than demanding one repo-wide rewrite. `@beep/openai-compat` is the first migrated entry; its percentages rise because #596 added the SSE decoding test.

## A filtered baseline write used to delete the baseline

`writeCoverageRegressionBaseline` rebuilt `packages` from the current snapshot with no merge, and the snapshot only contains packages that produced a coverage summary. So:

```
bun run coverage:baseline:write -- --filter=@beep/openai-compat
```

wrote a baseline containing **only** that package and silently deleted the other 120 entries. No warning, one plausible command away.

Writes are now scoped-aware, mirroring the comparison side that already took the flag and a caller that already computed it:

- **scoped** run → merges over the committed document, carrying unmeasured entries through
- **unscoped** run → still replaces, so packages that no longer exist are pruned
- **unscoped run that measured fewer packages than it is replacing** → refused, not written

A merge also inherits the previous `generated_at` / `git_sha`, since stamping this run's provenance onto 120 entries it never measured would be a lie.

## One thing this change broke, and how it surfaced

`formatJsonc` stringifies whatever it is handed. That was invisible while every baseline field was a plain scalar that doubled as its own wire value — but `uncovered` is an `Option` decoded and an optional key encoded, so the first write produced

```json
"uncovered": { "_id": "Option", "_tag": "Some", "value": { … } }
```

and the reader rejected its own file with an `Encoding` issue. `formatBaseline` now encodes through the schema before formatting. Worth stating plainly because no unit test would have caught it — running the real command did.

## Verification

- `bun run check` exit 0, including the repo-wide `check:tsgo:tests` lane
- `@beep/repo-cli` 1215/1215
- End-to-end: `coverage:baseline:write --filter=@beep/openai-compat` merges (121 preserved, 1 updated), and the result round-trips back through the reader (`coverage-ratchet ok`)
- The deletion-immunity assertion was mutation-tested — inverting the uncovered check makes it fail, so it is not passing vacuously
