### PR TITLE
fix(ai-metrics): content-address session identity and drop the inert export flag

### DIFF
--- a/.changeset/ai-metrics-identity-and-export-scope.md
+++ b/.changeset/ai-metrics-identity-and-export-scope.md
@@ -1,0 +1,46 @@
+---
+"@beep/repo-ai-metrics": patch
+---
+
+Content-address `agent_session_id` and drop the inert `--ingest-run` flag.
+
+**Session identity.** `agent_session_id` still embedded `ingestRunId`, so a transcript that
+grew between runs minted a fresh session row every run and its turns scattered across all
+of them — the same defect `turn_id` shed earlier, and the last place an ingest run was
+still doing duty as identity. It now keys on `[sourceKind, sourcePathHash]`.
+
+`source_role` is deliberately **not** in the key. `turn_id` does not carry it, and turns are
+`INSERT OR IGNORE`, so a turn's session pointer freezes at the first run that saw its line.
+Because `source_role` is derived from transcript content — codex subagent detection — a
+transcript that later reveals subagent metadata would flip role and mint a second session
+row while the already-ingested turns kept pointing at the first. That is the fragmentation
+being removed, only rarer. Under a two-part key a role flip merely rewrites the row's
+descriptive column.
+
+Existing turns keep the per-run session id written by the run that first saw them, so
+nothing self-heals: `ai-metrics-agent-session-id-v2` repoints turns onto the
+content-addressed id, drops the duplicate session rows, then rewrites the survivors.
+Ordering is load-bearing — turns are repointed while the legacy rows still exist, because
+the mapping is computed from those rows. Unlike the agent-task rewrite it models, this
+collapse is many-to-one, so the duplicates must be dropped before the rewrite or it
+violates the primary key on any store that ingested a transcript twice.
+
+**Retention.** A session row is upserted with `OR REPLACE`, so its `ingest_run_id` now names
+the run that *last* saw the transcript rather than the run that created it. Pruning sessions
+by run id alone could therefore delete a row whose turns from other runs survive, and the
+exporter joins `ai_metrics_sessions` INNER — those turns would leave every future export
+silently, watermark still open. Retention now refuses to delete a session that still has
+turns. Reachable through out-of-order ingest or clock skew, not under strictly monotonic
+runs, but the invariant it relied on no longer holds.
+
+**`--ingest-run` removed.** It advertised run-scoped export while selecting nothing: the
+drain has been watermark-based since the at-least-once change. `AiMetricsOtlpExportInput`,
+`AiMetricsOtlpSpanProjectionBatch`, and `AiMetricsOtlpExportResult` lose their `ingestRunId`,
+`readAiMetricsOtlpSpanProjections` becomes a plain effect, and the export result reports
+counts instead of a run it never scoped to. The forwarder's own `ingestRunId` is untouched —
+that is real lineage, and `AiMetricsForwarderOtlpExported` now sources it from the forwarder
+run rather than from the export result. The `ai_metrics.ingest_run_id` span attribute is
+likewise untouched.
+
+One visible Phoenix effect: `session.id` stops depending on which drain a turn landed in, so
+a session span and its turn spans finally agree on it.

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -430,6 +430,60 @@ const legacyAgentTaskIdExpression = (tableAlias: string): string =>
 const currentAgentTaskIdExpression = (tableAlias: string): string =>
   `concat('agent-task-', sha256(concat('agent-task', chr(0), ${tableAlias}.config_snapshot_id, chr(0), ${tableAlias}.source_kind, chr(0), ${tableAlias}.source_role, chr(0), ${tableAlias}.source_path_hash)))`;
 
+// Deliberately two parts, not three. `turn_id` keys on
+// [sourceKind, sourcePathHash, lineNumber, rawEventHash] and turns are INSERT OR IGNORE,
+// so a turn's session pointer freezes at the first run that saw that line. The session key
+// therefore has to be the file-identifying prefix of the turn key and nothing more.
+//
+// `source_role` is excluded for that reason: it is derived from transcript content, not
+// from the file, so a transcript that later reveals subagent metadata flips role. Were role
+// part of the key, that flip would mint a second session row while the already-ingested
+// turns kept pointing at the first -- reintroducing exactly the fragmentation this removes,
+// only rarer and harder to see. Under a two-part key a role flip just rewrites the row's
+// descriptive `source_role` column, which is what it should do.
+const legacyAgentSessionIdExpression = (tableAlias: string): string =>
+  `concat('session-', sha256(concat('session', chr(0), ${tableAlias}.ingest_run_id, chr(0), ${tableAlias}.source_kind, chr(0), ${tableAlias}.source_path_hash)))`;
+
+const currentAgentSessionIdExpression = (tableAlias: string): string =>
+  `concat('session-', sha256(concat('session', chr(0), ${tableAlias}.source_kind, chr(0), ${tableAlias}.source_path_hash)))`;
+
+// Order is load-bearing. Turns are repointed while the legacy session rows still exist,
+// because the mapping is computed from those rows' columns; only then can the duplicates be
+// dropped. Reversing it would strand every turn behind the exporter's INNER JOIN on
+// `ai_metrics_sessions`, which drops unmatched turns silently and without a watermark.
+const legacyAgentSessionIdMigrationStatements = [
+  `UPDATE ai_metrics_turns AS turns
+   SET agent_session_id = ${currentAgentSessionIdExpression("sessions")}
+   FROM ai_metrics_sessions AS sessions
+   WHERE turns.agent_session_id = sessions.agent_session_id
+     AND sessions.agent_session_id = ${legacyAgentSessionIdExpression("sessions")}`,
+  // Unlike the agent-task rewrite above, this collapse is many-to-one: the legacy key
+  // embeds `ingest_run_id`, so one transcript owns one row per run and they all map onto a
+  // single content-addressed id. Without dropping the losers first, the rewrite below would
+  // violate the primary key on any store that ingested a transcript twice -- which is every
+  // real store. The tiebreak keeps the greatest legacy digest: deterministic, and it does
+  // not consult `ai_metrics_ingest_runs`, which retention may already have pruned.
+  `DELETE FROM ai_metrics_sessions AS legacy
+   WHERE legacy.agent_session_id = ${legacyAgentSessionIdExpression("legacy")}
+     AND EXISTS (
+       SELECT 1
+       FROM ai_metrics_sessions AS keeper
+       WHERE keeper.agent_session_id <> legacy.agent_session_id
+         AND (
+           keeper.agent_session_id = ${currentAgentSessionIdExpression("legacy")}
+           OR (
+             keeper.agent_session_id = ${legacyAgentSessionIdExpression("keeper")}
+             AND keeper.source_kind = legacy.source_kind
+             AND keeper.source_path_hash = legacy.source_path_hash
+             AND keeper.agent_session_id > legacy.agent_session_id
+           )
+         )
+     )`,
+  `UPDATE ai_metrics_sessions AS sessions
+   SET agent_session_id = ${currentAgentSessionIdExpression("sessions")}
+   WHERE sessions.agent_session_id = ${legacyAgentSessionIdExpression("sessions")}`,
+] as const;
+
 const legacyAgentTaskIdMigrationStatements = [
   `UPDATE ai_metrics_sessions AS sessions
    SET agent_task_id = ${currentAgentTaskIdExpression("task")}
@@ -576,6 +630,21 @@ const derivedStorageMigrations = [
       { columnName: "agent_task_id", tableName: "ai_metrics_outcome_labels" },
     ],
     statements: legacyAgentTaskIdMigrationStatements,
+    transactional: true,
+  },
+  {
+    // Existing turns are INSERT OR IGNORE, so they keep the per-run session id written by
+    // the first run that saw them. Nothing self-heals; without this migration a store stays
+    // fragmented forever no matter how the id is minted going forward.
+    migrationId: "ai-metrics-agent-session-id-v2",
+    requiredColumns: [
+      { columnName: "agent_session_id", tableName: "ai_metrics_sessions" },
+      { columnName: "ingest_run_id", tableName: "ai_metrics_sessions" },
+      { columnName: "source_kind", tableName: "ai_metrics_sessions" },
+      { columnName: "source_path_hash", tableName: "ai_metrics_sessions" },
+      { columnName: "agent_session_id", tableName: "ai_metrics_turns" },
+    ],
+    statements: legacyAgentSessionIdMigrationStatements,
     transactional: true,
   },
   {
@@ -1225,7 +1294,11 @@ const upsertSessionAndTurns = Effect.fn("AiMetrics.derivedStorage.upsertSessionA
 ) {
   const duckdb = yield* DuckDb;
   const sanitized = record.privacy.sanitized;
-  const agentSessionId = yield* rowId("session", [input.ingestRunId, sanitized.sourceKind, sanitized.sourcePathHash]);
+  // Content-addressed, like `turn_id` and for the same reason: an ingest run is lineage,
+  // never identity. With the run id in this key a transcript that grew between runs minted
+  // a fresh session row every run, so one conversation accumulated one row per run and its
+  // turns scattered across all of them.
+  const agentSessionId = yield* rowId("session", [sanitized.sourceKind, sanitized.sourcePathHash]);
   yield* duckdb.run(
     `INSERT OR REPLACE INTO ai_metrics_sessions (
       agent_session_id,

--- a/packages/tooling/library/ai-metrics/src/otlp.ts
+++ b/packages/tooling/library/ai-metrics/src/otlp.ts
@@ -140,7 +140,7 @@ export class AiMetricsOtlpExportError extends TaggedErrorClass<AiMetricsOtlpExpo
 ) {}
 
 /**
- * Input for exporting one derived ingest run as OTLP spans.
+ * Input for exporting every derived turn still awaiting OTLP export.
  *
  * **Example** (Construct AiMetricsOtlpExportInput)
  *
@@ -168,7 +168,6 @@ export class AiMetricsOtlpExportInput extends S.Class<AiMetricsOtlpExportInput>(
   {
     duckDbPath: S.String,
     endpoint: AiMetricsOtlpEndpointSpec,
-    ingestRunId: S.optionalKey(S.String),
     target: AiMetricsDeployTarget,
   },
   $I.annote("AiMetricsOtlpExportInput", {
@@ -226,7 +225,7 @@ export class AiMetricsOtlpSpanProjection extends S.Class<AiMetricsOtlpSpanProjec
 ) {}
 
 /**
- * Span projection batch resolved for one derived ingest run.
+ * Span projections for every derived turn still awaiting OTLP export.
  *
  * **Example** (Construct AiMetricsOtlpSpanProjectionBatch)
  *
@@ -237,7 +236,6 @@ export class AiMetricsOtlpSpanProjection extends S.Class<AiMetricsOtlpSpanProjec
  * } from "@beep/repo-ai-metrics"
  *
  * const batch = AiMetricsOtlpSpanProjectionBatch.make({
- *   ingestRunId: "forwarder-1",
  *   projections: [
  *     AiMetricsOtlpSpanProjection.make({
  *       attributes: { "ai_metrics.event_name": "codex.event_msg" },
@@ -260,7 +258,6 @@ export class AiMetricsOtlpSpanProjectionBatch extends S.Class<AiMetricsOtlpSpanP
   $I`AiMetricsOtlpSpanProjectionBatch`
 )(
   {
-    ingestRunId: S.String,
     projections: S.Array(AiMetricsOtlpSpanProjection),
     sessionSpanCount: S.Finite,
     /**
@@ -272,7 +269,7 @@ export class AiMetricsOtlpSpanProjectionBatch extends S.Class<AiMetricsOtlpSpanP
     turnSpanCount: S.Finite,
   },
   $I.annote("AiMetricsOtlpSpanProjectionBatch", {
-    description: "Redacted OTLP span projections grouped by one AI metrics ingest run.",
+    description: "Redacted OTLP span projections for every AI metrics turn still awaiting export.",
   })
 ) {}
 
@@ -286,7 +283,6 @@ export class AiMetricsOtlpSpanProjectionBatch extends S.Class<AiMetricsOtlpSpanP
  *
  * const result = AiMetricsOtlpExportResult.make({
  *   endpointTraceUrl: "http://127.0.0.1:6006/projects/default/traces",
- *   ingestRunId: "forwarder-1",
  *   sessionSpanCount: 2,
  *   spanCount: 12,
  *   target: "local",
@@ -301,7 +297,6 @@ export class AiMetricsOtlpSpanProjectionBatch extends S.Class<AiMetricsOtlpSpanP
 export class AiMetricsOtlpExportResult extends S.Class<AiMetricsOtlpExportResult>($I`AiMetricsOtlpExportResult`)(
   {
     endpointTraceUrl: S.String,
-    ingestRunId: S.String,
     sessionSpanCount: S.Finite,
     spanCount: S.Finite,
     target: AiMetricsDeployTarget,
@@ -309,15 +304,6 @@ export class AiMetricsOtlpExportResult extends S.Class<AiMetricsOtlpExportResult
   },
   $I.annote("AiMetricsOtlpExportResult", {
     description: "Safe counts returned after emitting redacted AI metrics spans to the active tracer.",
-  })
-) {}
-
-class LatestIngestRunRow extends S.Class<LatestIngestRunRow>($I`LatestIngestRunRow`)(
-  {
-    ingestRunId: S.String,
-  },
-  $I.annote("LatestIngestRunRow", {
-    description: "Latest AI metrics ingest run selected from derived DuckDB storage.",
   })
 ) {}
 
@@ -347,7 +333,6 @@ class AiMetricsOtlpTurnExportRow extends S.Class<AiMetricsOtlpTurnExportRow>($I`
   })
 ) {}
 
-const decodeLatestRows = S.decodeUnknownEffect(S.Array(LatestIngestRunRow));
 const decodeTurnRows = S.decodeUnknownEffect(S.Array(AiMetricsOtlpTurnExportRow));
 const encodeOtlpExportJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsOtlpExportResult));
 
@@ -391,34 +376,6 @@ const openInferenceSpanKindFor = (row: AiMetricsOtlpTurnExportRow): string => {
   const eventName = Str.toLowerCase(row.eventName);
   return A.some(llmEventNameFragments, (fragment) => Str.includes(fragment)(eventName)) ? "LLM" : "CHAIN";
 };
-
-const resolveIngestRunId = Effect.fn("AiMetrics.otlp.resolveIngestRunId")(function* (ingestRunId: string | undefined) {
-  if (ingestRunId !== undefined && Str.trim(ingestRunId) !== "latest") {
-    return ingestRunId;
-  }
-
-  const duckdb = yield* DuckDb;
-  const rows = yield* duckdb
-    .query(
-      `SELECT ingest_run_id AS "ingestRunId"
-       FROM ai_metrics_ingest_runs
-       ORDER BY started_at_epoch_ms DESC
-       LIMIT 1`
-    )
-    .pipe(Effect.mapError((cause) => exportFailure("Failed to select the latest AI metrics ingest run.", cause)));
-  const decoded = yield* decodeLatestRows(rows).pipe(
-    Effect.mapError((cause) => exportFailure("Failed to decode the latest AI metrics ingest run row.", cause))
-  );
-  const latest = A.head(decoded);
-
-  if (O.isNone(latest)) {
-    return yield* exportFailure("No AI metrics ingest runs are available for OTLP export.", {
-      ingestRunId: ingestRunId ?? "latest",
-    });
-  }
-
-  return latest.value.ingestRunId;
-});
 
 // Selects every turn that has not yet been exported, rather than the turns belonging
 // to one ingest run. Run-scoping silently dropped work: a run that committed turns and
@@ -480,16 +437,16 @@ const otlpIdFor = Effect.fnUntraced(function* (seed: string, hexLength: number) 
   return otlpIdFrom(digest, hexLength);
 });
 
-// Seeded from the transcript the session belongs to, NOT from `agent_session_id`.
-// That column still embeds the ingest run (`rowId("session", [ingestRunId, ...])`),
-// so a transcript that grows between runs mints a fresh session row every time. Seeding
-// trace identity from it would hand each run its own trace id, and one long agent
-// session would arrive in Phoenix as N disconnected roots -- with ids that differ
-// genuinely, so `uq_spans_span_id` could not reunite them either.
+// Seeded from the transcript, NOT read off `agent_session_id`. That column is now
+// content-addressed too, but a store migrated in place is not guaranteed to be uniform:
+// until `ai-metrics-agent-session-id-v2` has run, rows still carry per-run ids. Deriving
+// trace identity from the transcript keeps a half-migrated store tracing correctly, and
+// keeps trace ids stable across the migration itself.
 //
-// These three fields are what `agent_session_id` hashes minus the run id, and they are
-// already on the export row, so one transcript keeps one trace across every run at no
-// cost. Fixing the column itself needs a migration and is deliberately left alone.
+// This seed also carries `sourceRole`, which the session row key deliberately does not.
+// They are allowed to diverge: dropping it here would change the trace id of every
+// transcript and detach future spans from traces Phoenix already holds, which costs far
+// more than the rare role flip it would tidy up.
 const sessionSeed = (row: AiMetricsOtlpTurnExportRow): string =>
   `${row.sourceKind}\u0000${row.sourceRole}\u0000${row.sourcePathHash}`;
 
@@ -587,22 +544,18 @@ const sessionGroupProjections = Effect.fnUntraced(function* (
 // ids are digested once and shared by every turn beneath it. A run can carry tens of
 // thousands of turns, and `crypto.subtle` is not free.
 //
-// The key is the content seed, not `agent_session_id`. One drain can hold turns from
-// several session rows for the same transcript -- that column embeds the ingest run, so
-// a growing transcript mints one per run. Grouping on it would emit that many session
-// projections all carrying the same content-addressed span id, and a single OTLP request
-// containing a duplicate span id is one the collector may reject outright rather than
-// deduplicate.
-const spanProjectionsFor = Effect.fnUntraced(function* (
-  ingestRunId: string,
-  rows: ReadonlyArray<AiMetricsOtlpTurnExportRow>
-) {
+// The key is the content seed, not `agent_session_id`. Grouping must not depend on that
+// column, because a store migrated in place can still hold legacy per-run ids alongside
+// content-addressed ones until `ai-metrics-agent-session-id-v2` has run. On such a store,
+// grouping by the column would emit one session projection per legacy row, all carrying
+// the same content-addressed span id -- and a single OTLP request containing a duplicate
+// span id is one the collector may reject outright rather than deduplicate.
+const spanProjectionsFor = Effect.fnUntraced(function* (rows: ReadonlyArray<AiMetricsOtlpTurnExportRow>) {
   const groups = yield* Effect.forEach(R.values(A.groupBy(rows, sessionSeed)), sessionGroupProjections);
   const sessionProjections = A.map(groups, (group) => group.session);
   const turnProjections = A.flatMap(groups, (group) => group.turns);
 
   return AiMetricsOtlpSpanProjectionBatch.make({
-    ingestRunId,
     projections: A.appendAll(sessionProjections, turnProjections),
     sessionSpanCount: A.length(sessionProjections),
     turnIds: A.map(rows, (row) => row.turnId),
@@ -613,29 +566,18 @@ const spanProjectionsFor = Effect.fnUntraced(function* (
 /**
  * Read derived DuckDB rows and build redacted OTLP span projections.
  *
- * **Example** (Construct AiMetricsOtlpExportInput)
+ * **Example** (Read every pending projection)
  *
  * ```ts
- * import {
- *   AiMetricsOtlpEndpointSpec,
- *   AiMetricsOtlpExportInput,
- *   readAiMetricsOtlpSpanProjections
- * } from "@beep/repo-ai-metrics"
+ * import { readAiMetricsOtlpSpanProjections } from "@beep/repo-ai-metrics"
  * import { DuckDb, DuckDbConnectionOptions } from "@beep/duckdb"
  * import { Effect } from "effect"
- * const input = AiMetricsOtlpExportInput.make({
- *   duckDbPath: ".beep/ai-metrics/derived/ai-metrics.duckdb",
- *   endpoint: AiMetricsOtlpEndpointSpec.make({
- *     baseUrl: "http://127.0.0.1:6006",
- *     protocol: "http/protobuf",
- *     resourceAttributes: {},
- *     signalScope: "traces_only",
- *     traceUrl: "http://127.0.0.1:6006/projects/default/traces"
- *   }),
- *   target: "local"
- * })
- * const program = readAiMetricsOtlpSpanProjections(input).pipe(
- *   Effect.provide(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: input.duckDbPath })))
+ * const program = readAiMetricsOtlpSpanProjections.pipe(
+ *   Effect.provide(
+ *     DuckDb.makeNodeLayer(
+ *       DuckDbConnectionOptions.make({ databasePath: ".beep/ai-metrics/derived/ai-metrics.duckdb" })
+ *     )
+ *   )
  * )
  * console.log(program)
  * ```
@@ -644,11 +586,11 @@ const spanProjectionsFor = Effect.fnUntraced(function* (
  * @category services
  * @since 0.0.0
  */
-export const readAiMetricsOtlpSpanProjections: (
-  input: AiMetricsOtlpExportInput
-) => Effect.Effect<AiMetricsOtlpSpanProjectionBatch, AiMetricsOtlpExportError, DuckDb> = Effect.fn(
-  "AiMetrics.readAiMetricsOtlpSpanProjections"
-)(function* (input) {
+export const readAiMetricsOtlpSpanProjections: Effect.Effect<
+  AiMetricsOtlpSpanProjectionBatch,
+  AiMetricsOtlpExportError,
+  DuckDb
+> = Effect.gen(function* () {
   // The export path has to migrate the store itself. It reads
   // `otlp_exported_at_epoch_ms`, a column added by the schema migration rather than by
   // the base DDL, and the only other caller of the migration is the ingest write. A
@@ -662,10 +604,9 @@ export const readAiMetricsOtlpSpanProjections: (
       )
     )
   );
-  const ingestRunId = yield* resolveIngestRunId(input.ingestRunId);
   const rows = yield* readTurnRows();
 
-  return yield* spanProjectionsFor(ingestRunId, rows);
+  return yield* spanProjectionsFor(rows);
 });
 
 /**
@@ -946,7 +887,6 @@ const runAiMetricsOtlpProjectionBatchExportUntraced: (
 
   return AiMetricsOtlpExportResult.make({
     endpointTraceUrl: input.endpoint.traceUrl,
-    ingestRunId: batch.ingestRunId,
     sessionSpanCount: batch.sessionSpanCount,
     spanCount: A.length(batch.projections),
     target: input.target,
@@ -986,7 +926,6 @@ const runAiMetricsOtlpProjectionBatchExportUntraced: (
  *   target: "local"
  * })
  * const batch = AiMetricsOtlpSpanProjectionBatch.make({
- *   ingestRunId: "forwarder-1",
  *   projections: [],
  *   sessionSpanCount: 0,
  *   turnIds: [],
@@ -1072,7 +1011,7 @@ export const runAiMetricsOtlpExport: (
   "AiMetrics.runAiMetricsOtlpExport"
 )(
   function* (input) {
-    const batch = yield* readAiMetricsOtlpSpanProjections(input);
+    const batch = yield* readAiMetricsOtlpSpanProjections;
     // Ordering is the whole point: delivery first, and only an acknowledged delivery
     // reaches the mark. A rejected batch fails here, leaving the watermark open so the
     // next run re-reads exactly these turns. Marking before or without confirmation is
@@ -1102,7 +1041,6 @@ export const runAiMetricsOtlpExport: (
  *   otlpExportResultToJson(
  *     AiMetricsOtlpExportResult.make({
  *       endpointTraceUrl: "http://127.0.0.1:6006/projects/default/traces",
- *       ingestRunId: "forwarder-1",
  *       sessionSpanCount: 0,
  *       spanCount: 0,
  *       target: "local",

--- a/packages/tooling/library/ai-metrics/src/retention.ts
+++ b/packages/tooling/library/ai-metrics/src/retention.ts
@@ -803,20 +803,6 @@ const deleteRowsForPlan = Effect.fn("AiMetrics.retention.deleteRowsForPlan")(fun
     yield* duckdb.run(`DELETE
 	                   FROM ai_metrics_turns
 	                   WHERE ingest_run_id IN (${runIds})`);
-    // Not `WHERE ingest_run_id IN (...)` alone. A session row is content-addressed now and
-    // upserted with OR REPLACE, so its `ingest_run_id` names the run that LAST saw the
-    // transcript, not the run that created it. Pruning the newest run would delete the
-    // transcript's only session row while turns from earlier runs survive, and the exporter
-    // joins sessions INNER -- those turns would vanish from every future export with no
-    // error and no watermark to show for it.
-    yield* duckdb.run(`DELETE
-	                   FROM ai_metrics_sessions
-	                   WHERE ingest_run_id IN (${runIds})
-	                     AND NOT EXISTS (
-	                       SELECT 1
-	                       FROM ai_metrics_turns
-	                       WHERE ai_metrics_turns.agent_session_id = ai_metrics_sessions.agent_session_id
-	                     )`);
     yield* duckdb.run(`DELETE
 	                   FROM ai_metrics_source_files
 	                   WHERE ingest_run_id IN (${runIds})`);
@@ -829,6 +815,31 @@ const deleteRowsForPlan = Effect.fn("AiMetrics.retention.deleteRowsForPlan")(fun
     yield* duckdb.run(`DELETE
 	                   FROM ai_metrics_ingest_runs
 	                   WHERE ingest_run_id IN (${runIds})`);
+    // Sessions are pruned last, and keyed on neither the prune set nor the run column.
+    // A session row is content-addressed and upserted OR REPLACE, so its `ingest_run_id`
+    // names the run that LAST saw the transcript, not the one that created it -- pruning by
+    // that column would delete a row whose turns from other runs survive, and the exporter
+    // joins sessions INNER, so those turns would leave every future export silently.
+    //
+    // Scoping it to the prune set instead leaks the mirror image: a row kept because it
+    // still had turns is tagged with an already-pruned run, so when the last of its turns
+    // goes in a later prune, no predicate matches it again and the empty row lives forever
+    // -- pinning its agent task alive through the GC below. Running after the ingest-run
+    // delete lets this ask the only two questions that matter: are there turns left, and
+    // does the run this row points at still exist. That also sweeps up rows already leaked
+    // by an earlier prune.
+    yield* duckdb.run(`DELETE
+	                   FROM ai_metrics_sessions
+	                   WHERE NOT EXISTS (
+	                       SELECT 1
+	                       FROM ai_metrics_turns
+	                       WHERE ai_metrics_turns.agent_session_id = ai_metrics_sessions.agent_session_id
+	                     )
+	                     AND NOT EXISTS (
+	                       SELECT 1
+	                       FROM ai_metrics_ingest_runs
+	                       WHERE ai_metrics_ingest_runs.ingest_run_id = ai_metrics_sessions.ingest_run_id
+	                     )`);
   }
   if (Str.isNonEmpty(runIds) || Str.isNonEmpty(labelIds)) {
     yield* duckdb.run(`DELETE

--- a/packages/tooling/library/ai-metrics/src/retention.ts
+++ b/packages/tooling/library/ai-metrics/src/retention.ts
@@ -803,9 +803,20 @@ const deleteRowsForPlan = Effect.fn("AiMetrics.retention.deleteRowsForPlan")(fun
     yield* duckdb.run(`DELETE
 	                   FROM ai_metrics_turns
 	                   WHERE ingest_run_id IN (${runIds})`);
+    // Not `WHERE ingest_run_id IN (...)` alone. A session row is content-addressed now and
+    // upserted with OR REPLACE, so its `ingest_run_id` names the run that LAST saw the
+    // transcript, not the run that created it. Pruning the newest run would delete the
+    // transcript's only session row while turns from earlier runs survive, and the exporter
+    // joins sessions INNER -- those turns would vanish from every future export with no
+    // error and no watermark to show for it.
     yield* duckdb.run(`DELETE
 	                   FROM ai_metrics_sessions
-	                   WHERE ingest_run_id IN (${runIds})`);
+	                   WHERE ingest_run_id IN (${runIds})
+	                     AND NOT EXISTS (
+	                       SELECT 1
+	                       FROM ai_metrics_turns
+	                       WHERE ai_metrics_turns.agent_session_id = ai_metrics_sessions.agent_session_id
+	                     )`);
     yield* duckdb.run(`DELETE
 	                   FROM ai_metrics_source_files
 	                   WHERE ingest_run_id IN (${runIds})`);

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -1985,6 +1985,26 @@ volumes:
             expect(turns).toEqual([{ turnId: "turn-late" }]);
             expect(sessions).toEqual([{ agentSessionId: "session-shared" }]);
           }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
+
+          // ...and the row must not then leak. It is still tagged with run-early, which is
+          // already gone, so a prune scoped to the current run set would never match it
+          // again once its last turn goes -- an empty session row surviving forever and
+          // pinning its agent task alive through the task GC.
+          yield* runAiMetricsRetentionDelete(
+            AiMetricsRetentionSelector.make({ beforeEpochMillis: 200, dataRoot }),
+            false
+          );
+
+          yield* Effect.gen(function* () {
+            const duckdb = yield* DuckDb;
+            const turns = yield* duckdb.query(`SELECT turn_id AS "turnId" FROM ai_metrics_turns`);
+            const sessions = yield* duckdb.query(
+              `SELECT agent_session_id AS "agentSessionId" FROM ai_metrics_sessions`
+            );
+
+            expect(turns).toEqual([]);
+            expect(sessions).toEqual([]);
+          }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
         })
       ).pipe(provideScopedLayer(NodeServices.layer));
     })

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -15,8 +15,11 @@ import {
   AiMetricsLabelQueueInput,
   AiMetricsMirrorBundleInput,
   AiMetricsOtlpAttributeValue,
+  AiMetricsOtlpEndpointSpec,
   AiMetricsOtlpExportError,
   AiMetricsOtlpExportInput,
+  AiMetricsOtlpSpanProjection,
+  AiMetricsOtlpSpanProjectionBatch,
   AiMetricsOtlpSpanSender,
   AiMetricsOutcomeLabelInput,
   AiMetricsParquetExportMode,
@@ -92,7 +95,6 @@ import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
 import { FastCheck as fc } from "effect/testing";
-import type { AiMetricsOtlpSpanProjection } from "@beep/repo-ai-metrics";
 import type { TUnsafe } from "@beep/types";
 
 const provideScopedLayer =
@@ -1823,6 +1825,84 @@ volumes:
         })
       ).pipe(provideScopedLayer(NodeServices.layer));
     })
+  );
+
+  it.effect(
+    "delivers projections to a real OTLP endpoint as chunked protobuf",
+    Effect.fn(function* () {
+      yield* Effect.acquireUseRelease(
+        Effect.sync(() => {
+          const requests: Array<{ readonly contentType: string }> = [];
+          const server = Bun.serve({
+            fetch: (request) => {
+              A.appendInPlace(requests, { contentType: request.headers.get("content-type") ?? "" });
+              const rejecting = Str.includes("reject")(new URL(request.url).pathname);
+              return new Response(null, { status: rejecting ? 415 : 200 });
+            },
+            hostname: "127.0.0.1",
+            port: 0,
+          });
+          return { requests, server };
+        }),
+        Effect.fnUntraced(function* ({ requests, server }) {
+          const endpointFor = (path: string) =>
+            AiMetricsOtlpEndpointSpec.make({
+              baseUrl: `http://127.0.0.1:${server.port}`,
+              protocol: "http/protobuf",
+              resourceAttributes: { "beep.test": "otlp-wire" },
+              signalScope: "traces_only",
+              traceUrl: `http://127.0.0.1:${server.port}${path}`,
+            });
+          const inputFor = (path: string) =>
+            AiMetricsOtlpExportInput.make({
+              duckDbPath: "unused.duckdb",
+              endpoint: endpointFor(path),
+              target: AiMetricsDeployTarget.Enum.local,
+            });
+          // 1200 spans crosses the 512-span chunk boundary twice. A drain can carry tens of
+          // thousands of turns, and one request that large is the backpressure collapse this
+          // work exists to prevent -- the retired BatchSpanProcessor used to chunk for us.
+          const projections = A.makeBy(1200, (index) =>
+            AiMetricsOtlpSpanProjection.make({
+              attributes: { "ai_metrics.line_number": index + 1, "openinference.span.kind": "CHAIN" },
+              parentSpanId: "aabbccddeeff0011",
+              spanId: Str.padStart(16, "0")(globalThis.String(index + 1)),
+              spanName: "ai_metrics.agent.turn",
+              traceId: "0123456789abcdef0123456789abcdef",
+            })
+          );
+          const batch = AiMetricsOtlpSpanProjectionBatch.make({
+            projections,
+            sessionSpanCount: 0,
+            turnIds: [],
+            turnSpanCount: projections.length,
+          });
+
+          // The live sender, not a stub: real ReadableSpan construction through the real
+          // protobuf exporter. Protobuf is not a preference -- Phoenix answers OTLP/JSON
+          // with HTTP 415, which is also what the rejection path below asserts.
+          const exported = yield* runAiMetricsOtlpProjectionBatchExport(inputFor("/v1/traces"), batch).pipe(
+            provideScopedLayer(AiMetricsOtlpSpanSender.layer)
+          );
+
+          expect(exported.spanCount).toBe(1200);
+          expect(requests.length).toBe(3);
+          expect(A.every(requests, (request) => request.contentType === "application/x-protobuf")).toBe(true);
+
+          // A collector that rejects the batch must surface as a typed failure, never a
+          // silent success. That confirmation is the whole reason delivery moved off
+          // fire-and-forget span emission.
+          const rejected = yield* runAiMetricsOtlpProjectionBatchExport(inputFor("/v1/traces-reject"), batch).pipe(
+            provideScopedLayer(AiMetricsOtlpSpanSender.layer),
+            Effect.flip
+          );
+
+          expect(rejected.message).toContain("did not accept the exported spans");
+        }),
+        ({ server }) => Effect.promise(() => server.stop(true))
+      );
+    }),
+    AI_METRICS_LONG_TEST_TIMEOUT
   );
 
   it.effect(

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -655,7 +655,11 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/repo-ai-metrics", (
             expect(sourceRows).toEqual([{ count: "3" }]);
             expect(archiveRows).toEqual([{ count: "3" }]);
             expect(agentTaskRows).toEqual([{ configSnapshotCount: 2, count: "2" }]);
-            expect(sessionRows).toEqual([{ count: "3" }]);
+            // Sessions collapse for the same reason turns do: `agent_session_id` is
+            // content-addressed now, so three runs over one transcript own one row, not
+            // three. Note sourceRows/archiveRows below stay at 3 -- those ids still embed
+            // the run id by design, and if they moved this change hit more than intended.
+            expect(sessionRows).toEqual([{ count: "1" }]);
             // Three runs over byte-identical content must yield ONE turn row. This
             // previously asserted "3", encoding the duplication that grew the store to
             // 5.43M rows over ~516K distinct raw_event_hash across 1,222 runs.
@@ -680,20 +684,19 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/repo-ai-metrics", (
             const exportInput = AiMetricsOtlpExportInput.make({
               duckDbPath,
               endpoint: phoenix.value.otlp,
-              ingestRunId: "latest",
               target: AiMetricsDeployTarget.Enum.local,
             });
 
             // Un-exported turns are visible even though they belong to forwarder-1 and
             // the latest run is forwarder-3.
-            const pending = yield* readAiMetricsOtlpSpanProjections(exportInput);
+            const pending = yield* readAiMetricsOtlpSpanProjections;
             expect(pending.turnIds.length).toBe(1);
 
             // Span identity is content-addressed, so re-reading identical content yields
             // byte-identical ids. That is what lets Phoenix's uq_spans_span_id collapse a
             // redelivery instead of storing a second copy -- and it is why correctness no
             // longer depends on the watermark being perfectly accurate.
-            const rereadPending = yield* readAiMetricsOtlpSpanProjections(exportInput);
+            const rereadPending = yield* readAiMetricsOtlpSpanProjections;
             expect(spanIdsByName(rereadPending.projections, "ai_metrics.agent.turn")).toEqual(
               spanIdsByName(pending.projections, "ai_metrics.agent.turn")
             );
@@ -734,7 +737,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/repo-ai-metrics", (
               Effect.exit
             );
             expect(Exit.isFailure(rejectedExit)).toBe(true);
-            const afterRejectedExport = yield* readAiMetricsOtlpSpanProjections(exportInput);
+            const afterRejectedExport = yield* readAiMetricsOtlpSpanProjections;
             expect(afterRejectedExport.turnIds).toEqual(pending.turnIds);
 
             // The forwarder exports through runAiMetricsOtlpExport, which reads and
@@ -747,7 +750,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/repo-ai-metrics", (
             );
             expect(exported.turnSpanCount).toBe(1);
 
-            const afterSuccessfulExport = yield* readAiMetricsOtlpSpanProjections(exportInput);
+            const afterSuccessfulExport = yield* readAiMetricsOtlpSpanProjections;
             expect(afterSuccessfulExport.turnIds).toEqual([]);
             expect(afterSuccessfulExport.projections).toEqual([]);
 
@@ -1222,11 +1225,10 @@ volumes:
             const input = AiMetricsOtlpExportInput.make({
               duckDbPath,
               endpoint: phoenix.value.otlp,
-              ingestRunId: "latest",
               target: AiMetricsDeployTarget.Enum.local,
             });
             const delivered = yield* Ref.make<ReadonlyArray<ReadonlyArray<AiMetricsOtlpSpanProjection>>>([]);
-            const batch = yield* readAiMetricsOtlpSpanProjections(input);
+            const batch = yield* readAiMetricsOtlpSpanProjections;
             const result = yield* runAiMetricsOtlpExport(input).pipe(
               provideScopedLayer(recordingSpanSender(delivered))
             );
@@ -1237,7 +1239,6 @@ volumes:
             );
             const json = yield* otlpExportResultToJson(result);
 
-            expect(batch.ingestRunId).toBe("forwarder-otlp");
             expect(batch.sessionSpanCount).toBe(1);
             expect(batch.turnSpanCount).toBe(3);
             expect(batch.projections).toEqual(
@@ -1269,7 +1270,11 @@ volumes:
             );
             expect(result.spanCount).toBe(4);
             expect(pipeableResult).toEqual(result);
-            expect(json).toContain("forwarder-otlp");
+            // The result no longer carries an ingest run id -- the export drains every
+            // pending turn regardless of which run committed it, so a run id would have
+            // described the request rather than the batch. Counts are what it reports now.
+            expect(json).toContain('"spanCount":4');
+            expect(json).not.toContain("forwarder-otlp");
             expect(json).not.toContain("private-input");
             expect(json).not.toContain("private-model-output");
             expect(json).not.toContain("private-output");
@@ -1821,6 +1826,178 @@ volumes:
   );
 
   it.effect(
+    "keeps a session row whose turns outlive the run that last touched it",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const fs = yield* FileSystem.FileSystem;
+          const dataRoot = path.join(tmpDir, "metrics");
+          const duckDbPath = path.join(dataRoot, "derived/ai-metrics.duckdb");
+          yield* fs.makeDirectory(path.dirname(duckDbPath), { recursive: true });
+
+          yield* Effect.gen(function* () {
+            const duckdb = yield* DuckDb;
+            yield* ensureAiMetricsDerivedStorage;
+
+            // A content-addressed session row carries the run that LAST wrote it, which is
+            // not necessarily the newest run: an out-of-order ingest (a backfill, or clock
+            // skew between hosts) can leave an early-completing run as the last writer.
+            // Once that happens, "this session belongs to that run" stops being true, and
+            // pruning by run id alone would delete the row while its other turns live on.
+            yield* Effect.forEach(
+              [
+                { completedAt: 100, ingestRunId: "run-late" },
+                { completedAt: 1, ingestRunId: "run-early" },
+              ],
+              Effect.fnUntraced(function* (run) {
+                yield* duckdb.run(
+                  `INSERT INTO ai_metrics_ingest_runs VALUES (
+                     $ingestRunId, 'local', 'snapshot', 'hash', $completedAt, $completedAt, 0, 0, 1
+                   )`,
+                  run
+                );
+              }),
+              { discard: true }
+            );
+            yield* duckdb.run(
+              `INSERT INTO ai_metrics_sessions (
+                 agent_session_id, ingest_run_id, source_kind, source_path_hash, source_role, config_snapshot_id
+               ) VALUES ('session-shared', 'run-early', 'codex', 'shared-transcript', 'primary', 'snapshot')`
+            );
+            yield* Effect.forEach(
+              [
+                { ingestRunId: "run-early", lineNumber: 1, turnId: "turn-early" },
+                { ingestRunId: "run-late", lineNumber: 2, turnId: "turn-late" },
+              ],
+              Effect.fnUntraced(function* (turn) {
+                yield* duckdb.run(
+                  `INSERT INTO ai_metrics_turns (
+                     turn_id, ingest_run_id, agent_session_id, source_kind, source_path_hash,
+                     source_role, line_number, event_name, raw_event_hash, timestamp
+                   ) VALUES (
+                     $turnId, $ingestRunId, 'session-shared', 'codex', 'shared-transcript',
+                     'primary', $lineNumber, 'event', $turnId, NULL
+                   )`,
+                  turn
+                );
+              }),
+              { discard: true }
+            );
+          }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
+
+          // Prune only run-early.
+          yield* runAiMetricsRetentionDelete(
+            AiMetricsRetentionSelector.make({ beforeEpochMillis: 50, dataRoot }),
+            false
+          );
+
+          yield* Effect.gen(function* () {
+            const duckdb = yield* DuckDb;
+            const sessions = yield* duckdb.query(
+              `SELECT agent_session_id AS "agentSessionId" FROM ai_metrics_sessions`
+            );
+            const turns = yield* duckdb.query(`SELECT turn_id AS "turnId" FROM ai_metrics_turns ORDER BY turn_id`);
+
+            // turn-late survives the prune, so its session must survive with it. The
+            // exporter joins ai_metrics_sessions INNER: drop the row and turn-late leaves
+            // every future export silently, with its watermark still open forever.
+            expect(turns).toEqual([{ turnId: "turn-late" }]);
+            expect(sessions).toEqual([{ agentSessionId: "session-shared" }]);
+          }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
+        })
+      ).pipe(provideScopedLayer(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "collapses per-run session rows and repoints their turns",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const duckDbPath = path.join(tmpDir, "ai-metrics.duckdb");
+
+          yield* Effect.gen(function* () {
+            const duckdb = yield* DuckDb;
+            yield* ensureAiMetricsDerivedStorage;
+
+            // Ids exactly as the previous release minted them: rowId("session", [runId,
+            // kind, pathHash]) => `session-${sha256("session\0<parts joined by \0>")}`.
+            const legacySessionId = (ingestRunId: string) =>
+              hashPublicTextSha256(`session ${ingestRunId} codex grown-transcript`).pipe(
+                Effect.map((digest) => `session-${digest}`)
+              );
+            const expectedSessionId = yield* hashPublicTextSha256("session codex grown-transcript").pipe(
+              Effect.map((digest) => `session-${digest}`)
+            );
+
+            // One transcript, ingested across three runs as it grew. Turns are INSERT OR
+            // IGNORE, so each turn froze onto whichever run first saw its line.
+            yield* Effect.forEach(
+              [
+                { ingestRunId: "run-1", lineNumber: 1, turnId: "turn-1" },
+                { ingestRunId: "run-2", lineNumber: 2, turnId: "turn-2" },
+                { ingestRunId: "run-3", lineNumber: 3, turnId: "turn-3" },
+              ],
+              Effect.fnUntraced(function* (row) {
+                const agentSessionId = yield* legacySessionId(row.ingestRunId);
+                yield* duckdb.run(
+                  `INSERT INTO ai_metrics_sessions (
+                     agent_session_id, ingest_run_id, source_kind, source_path_hash, source_role, config_snapshot_id
+                   ) VALUES ($agentSessionId, $ingestRunId, 'codex', 'grown-transcript', 'primary', 'snapshot')`,
+                  { agentSessionId, ingestRunId: row.ingestRunId }
+                );
+                yield* duckdb.run(
+                  `INSERT INTO ai_metrics_turns (
+                     turn_id, ingest_run_id, agent_session_id, source_kind, source_path_hash,
+                     source_role, line_number, event_name, raw_event_hash, timestamp
+                   ) VALUES (
+                     $turnId, $ingestRunId, $agentSessionId, 'codex', 'grown-transcript',
+                     'primary', $lineNumber, 'event', $turnId, NULL
+                   )`,
+                  { agentSessionId, ingestRunId: row.ingestRunId, lineNumber: row.lineNumber, turnId: row.turnId }
+                );
+              }),
+              { discard: true }
+            );
+            // A different transcript must be left alone.
+            yield* duckdb.run(
+              `INSERT INTO ai_metrics_sessions (
+                 agent_session_id, ingest_run_id, source_kind, source_path_hash, source_role, config_snapshot_id
+               ) VALUES ('session-untouched', 'run-1', 'claude', 'other-transcript', 'primary', 'snapshot')`
+            );
+            yield* duckdb.run(
+              `DELETE FROM ai_metrics_schema_migrations
+               WHERE migration_id = 'ai-metrics-agent-session-id-v2'`
+            );
+
+            yield* ensureAiMetricsDerivedStorage;
+
+            const sessions = yield* duckdb.query(
+              `SELECT agent_session_id AS "agentSessionId" FROM ai_metrics_sessions ORDER BY agent_session_id`
+            );
+            const turns = yield* duckdb.query(
+              `SELECT turn_id AS "turnId", agent_session_id AS "agentSessionId"
+               FROM ai_metrics_turns ORDER BY turn_id`
+            );
+
+            // Three rows collapse to one, and every turn follows it. Repointing the turns
+            // before deleting the losers is what keeps them reachable: the exporter joins
+            // ai_metrics_sessions INNER, so an orphaned turn is dropped silently forever.
+            expect(sessions).toEqual([{ agentSessionId: expectedSessionId }, { agentSessionId: "session-untouched" }]);
+            expect(turns).toEqual([
+              { agentSessionId: expectedSessionId, turnId: "turn-1" },
+              { agentSessionId: expectedSessionId, turnId: "turn-2" },
+              { agentSessionId: expectedSessionId, turnId: "turn-3" },
+            ]);
+          }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
+        })
+      ).pipe(provideScopedLayer(NodeServices.layer));
+    })
+  );
+
+  it.effect(
     "reopens turns a store already buried under the shipped watermark backfill",
     Effect.fn(function* () {
       yield* withTempDirectory(
@@ -1974,7 +2151,6 @@ volumes:
               AiMetricsOtlpExportInput.make({
                 duckDbPath,
                 endpoint: phoenix.value.otlp,
-                ingestRunId: "latest",
                 target: AiMetricsDeployTarget.Enum.local,
               })
             ).pipe(provideScopedLayer(recordingSpanSender(delivered)));
@@ -2049,14 +2225,7 @@ volumes:
               return;
             }
 
-            const batch = yield* readAiMetricsOtlpSpanProjections(
-              AiMetricsOtlpExportInput.make({
-                duckDbPath,
-                endpoint: phoenix.value.otlp,
-                ingestRunId: "latest",
-                target: AiMetricsDeployTarget.Enum.local,
-              })
-            );
+            const batch = yield* readAiMetricsOtlpSpanProjections;
 
             // Both turns land on one trace under one session span, even though they were
             // ingested under different runs and carry different `agent_session_id`s.

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
@@ -247,10 +247,6 @@ const otlpBaseUrlFlag = Flag.string("otlp-base-url").pipe(
   Flag.optional
 );
 
-const ingestRunFlag = Flag.string("ingest-run").pipe(
-  Flag.withDefault("latest"),
-  Flag.withDescription("Derived ingest run id to export, or latest")
-);
 const installPreviewCommand = Command.make(
   "preview",
   {
@@ -653,18 +649,16 @@ const otlpExportCommand = Command.make(
   {
     dataRoot: dataRootFlag,
     hashSaltSecretRef: hashSaltSecretRefFlag,
-    ingestRunId: ingestRunFlag,
     json: jsonFlag,
     otlpBaseUrl: otlpBaseUrlFlag,
     rawArchiveKeySecretRef: rawArchiveKeySecretRefFlag,
     target: targetFlag,
   },
-  ({ dataRoot, hashSaltSecretRef, ingestRunId, json, otlpBaseUrl, rawArchiveKeySecretRef, target }) =>
+  ({ dataRoot, hashSaltSecretRef, json, otlpBaseUrl, rawArchiveKeySecretRef, target }) =>
     runAiMetricsProgram(
       makeOtlpExportProgram({
         dataRoot,
         hashSaltSecretRef,
-        ingestRunId,
         json,
         otlpBaseUrl,
         rawArchiveKeySecretRef,
@@ -674,7 +668,7 @@ const otlpExportCommand = Command.make(
 ).pipe(Command.withDescription("Export redacted derived AI metrics spans through OTLP"));
 
 const otlpCommand = Command.make("otlp", {}, () =>
-  printLines(["AI metrics OTLP commands:", "- bun run beep ai-metrics otlp export --target local --ingest-run latest"])
+  printLines(["AI metrics OTLP commands:", "- bun run beep ai-metrics otlp export --target local"])
 ).pipe(Command.withDescription("AI metrics OTLP export workflow"), Command.withSubcommands([otlpExportCommand]));
 
 const benchmarkRunCommand = Command.make(

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/internal/Programs.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/internal/Programs.ts
@@ -1387,10 +1387,16 @@ const forwarderRunCommandToJson = Effect.fn("AIMetrics.forwarderRunCommandToJson
   });
 });
 
-const forwarderOtlpExported = (result: AiMetricsOtlpExportResult): AiMetricsForwarderOtlpExported =>
+// The run id comes from the forwarder pass, not from the export result. Export no longer
+// carries one: it drains every pending turn regardless of which run committed it, so a run
+// id on the result would have described the request rather than the batch.
+const forwarderOtlpExported = (
+  ingestRunId: string,
+  result: AiMetricsOtlpExportResult
+): AiMetricsForwarderOtlpExported =>
   AiMetricsForwarderOtlpExported.make({
     endpointTraceUrl: result.endpointTraceUrl,
-    ingestRunId: result.ingestRunId,
+    ingestRunId,
     sessionSpanCount: result.sessionSpanCount,
     spanCount: result.spanCount,
     status: "exported",
@@ -1478,7 +1484,6 @@ const exportForwarderDerivedOtlp = Effect.fn("AIMetrics.exportForwarderDerivedOt
     AiMetricsOtlpExportInput.make({
       duckDbPath: forwarderResult.duckDbPath,
       endpoint,
-      ingestRunId: forwarderResult.ingestRunId,
       target,
     })
   ).pipe(
@@ -1494,7 +1499,7 @@ const exportForwarderDerivedOtlp = Effect.fn("AIMetrics.exportForwarderDerivedOt
           target,
         });
       }),
-      onSuccess: (result) => Effect.succeed(forwarderOtlpExported(result)),
+      onSuccess: (result) => Effect.succeed(forwarderOtlpExported(forwarderResult.ingestRunId, result)),
     })
   );
 });
@@ -1833,21 +1838,19 @@ class MakeOtlpExportProgramOptions extends S.Class<MakeOtlpExportProgramOptions>
   {
     dataRoot: S.Option(S.String),
     hashSaltSecretRef: S.Option(S.String),
-    ingestRunId: S.String,
     json: S.Boolean,
     otlpBaseUrl: S.Option(S.String),
     rawArchiveKeySecretRef: S.Option(S.String),
     target: AiMetricsDeployTarget,
   },
   $I.annote("MakeOtlpExportProgramOptions", {
-    description: "CLI flags for exporting one derived ingest run to the configured OTLP endpoint.",
+    description: "CLI flags for exporting every pending derived AI metrics turn to the configured OTLP endpoint.",
   })
 ) {}
 
 const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(function* ({
   dataRoot,
   hashSaltSecretRef,
-  ingestRunId,
   json,
   otlpBaseUrl,
   rawArchiveKeySecretRef,
@@ -1874,7 +1877,6 @@ const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(funct
   const input = AiMetricsOtlpExportInput.make({
     duckDbPath: spec.storage.duckDbPath,
     endpoint,
-    ingestRunId,
     target,
   });
   // The same entry point the forwarder uses. Reading, delivering, and marking used to be
@@ -1896,7 +1898,6 @@ const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(funct
 
   yield* printLines([
     `ai-metrics otlp export: target=${target}`,
-    `ingest run: ${result.ingestRunId}`,
     `spans: ${result.spanCount}`,
     `sessions: ${result.sessionSpanCount}`,
     `turns: ${result.turnSpanCount}`,

--- a/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
+++ b/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
@@ -1207,8 +1207,6 @@ describe("ai-metrics command", () => {
             "local",
             "--data-root",
             dataRoot,
-            "--ingest-run",
-            "latest",
             "--json",
           ]);
 
@@ -1262,7 +1260,7 @@ describe("ai-metrics command", () => {
                 "--json",
               ])
             );
-            const forwarderResult = yield* decodeForwarderResult(yield* lastLoggedLine());
+            yield* decodeForwarderResult(yield* lastLoggedLine());
 
             yield* runAiMetricsCommand([
               "otlp",
@@ -1271,8 +1269,6 @@ describe("ai-metrics command", () => {
               "local",
               "--data-root",
               dataRoot,
-              "--ingest-run",
-              "latest",
               "--otlp-base-url",
               otlpBaseUrl,
               "--json",
@@ -1287,7 +1283,6 @@ describe("ai-metrics command", () => {
             expect(traceRequest.bodyText).not.toContain("private-otlp-fixture");
             expect(traceRequest.bodyText).not.toContain(tmpDir);
             expect(result.endpointTraceUrl).toBe(`${otlpBaseUrl}/v1/traces`);
-            expect(result.ingestRunId).toBe(forwarderResult.ingestRunId);
             expect(result.spanCount).toBeGreaterThan(0);
             expect(resultJson).not.toContain("private-otlp-fixture");
             expect(resultJson).not.toContain(rawArchiveKey);
@@ -1304,7 +1299,7 @@ describe("ai-metrics command", () => {
         withTempDirectory((tmpDir) =>
           Effect.gen(function* () {
             const rawArchiveKey = Encoding.encodeBase64(new Uint8Array(32).fill(31));
-            const { dataRoot, forwarderResult } = yield* withRawArchiveKeyEnv(rawArchiveKey, seedAiMetricsData(tmpDir));
+            const { dataRoot } = yield* withRawArchiveKeyEnv(rawArchiveKey, seedAiMetricsData(tmpDir));
 
             yield* runAiMetricsCommand([
               "otlp",
@@ -1313,8 +1308,6 @@ describe("ai-metrics command", () => {
               "local",
               "--data-root",
               dataRoot,
-              "--ingest-run",
-              forwarderResult.ingestRunId,
               "--otlp-base-url",
               otlpBaseUrl,
               "--json",
@@ -1324,7 +1317,6 @@ describe("ai-metrics command", () => {
             const traceRequest = yield* waitForCapturedOtlpTraceRequest(requests);
 
             expect(traceRequest.contentType).toContain("application/x-protobuf");
-            expect(result.ingestRunId).toBe(forwarderResult.ingestRunId);
             expect(result.spanCount).toBeGreaterThan(0);
           })
         )
@@ -1349,8 +1341,6 @@ describe("ai-metrics command", () => {
                 "dankserver",
                 "--data-root",
                 dataRoot,
-                "--ingest-run",
-                "latest",
                 "--hash-salt-secret-ref",
                 "op://TBK/ai-metrics/hash-salt",
                 "--raw-archive-key-secret-ref",


### PR DESCRIPTION
## fix(ai-metrics): content-address session identity and drop the inert export flag

Closes out the ai-metrics identity work. Two changes plus one regression they expose.

agent_session_id still embedded ingestRunId, the last place an ingest run was doing duty as
identity, so a transcript that grew between runs minted a fresh session row every run and
its turns scattered across all of them. It now keys on [sourceKind, sourcePathHash].

source_role is deliberately excluded. turn_id does not carry it and turns are INSERT OR
IGNORE, so a turn's session pointer freezes at the first run that saw its line. source_role
is derived from transcript content, so a transcript that later reveals subagent metadata
would flip role and mint a second session row while already-ingested turns kept pointing at
the first - the same fragmentation, only rarer.

Existing turns keep the per-run id written by the run that first saw them, so nothing
self-heals. ai-metrics-agent-session-id-v2 repoints turns onto the content-addressed id,
drops the duplicate session rows, then rewrites the survivors. Order is load-bearing: turns
are repointed while the legacy rows still exist, because the mapping is computed from those
rows. Unlike the agent-task rewrite it models, this collapse is many-to-one, so the losers
must go before the rewrite or it violates the primary key on any store that ingested a
transcript twice.

Retention needed a fix for the same reason. A session row is upserted OR REPLACE, so its
ingest_run_id now names the run that last saw the transcript, not the one that created it.
Pruning sessions by run id could delete a row whose turns from other runs survive, and the
exporter joins ai_metrics_sessions INNER - those turns would leave every future export
silently with their watermark still open. Retention now refuses to delete a session that
still has turns. Reachable through out-of-order ingest or clock skew rather than under
strictly monotonic runs, but the invariant it leaned on no longer holds.

--ingest-run advertised run-scoped export while selecting nothing; the drain has been
watermark-based since the at-least-once change. The flag goes, along with ingestRunId on
the export input, batch, and result, and readAiMetricsOtlpSpanProjections becomes a plain
effect. The forwarder's own run id is untouched - that is real lineage - and
AiMetricsForwarderOtlpExported now sources it from the forwarder run instead of the export
result. The ai_metrics.ingest_run_id span attribute is untouched.

Visible in Phoenix: session.id stops depending on which drain a turn landed in, so a session
span and its turn spans finally agree on it.

Each new test is mutation-verified. Neutering the legacy id expression leaves 4 session rows
instead of 2; reverting the retention predicate deletes the shared session and orphans
turn-late.

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_ai-metrics-identity-and-export-scope-a7868f186521/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788666076&installation_model_id=424656&pr_number=610&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F610&signature=42dc218f04fa6bc65aeca551762a9a25d57b82b1d4d75eb8521785c9b2a4650a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->