### PR TITLE
fix(infra): validate subnet geometry and use canonical jsdoc categories

### DIFF
--- a/.changeset/ci-runners-review-fixes.md
+++ b/.changeset/ci-runners-review-fixes.md
@@ -1,0 +1,7 @@
+---
+"@beep/infra": patch
+---
+
+Reject CI-runner network configs whose subnet CIDR blocks fall outside the VPC
+CIDR or overlap each other, failing at config decode instead of mid-`pulumi up`;
+retag the new ci-runners public surface with canonical JSDoc categories.

--- a/infra/src/CiRunners.ts
+++ b/infra/src/CiRunners.ts
@@ -421,14 +421,64 @@ const CiRunnersNetworkZonesWithinRegionCheck = S.makeFilter<typeof ciRunnersNetw
   }
 );
 
+type CidrRange = {
+  readonly start: number;
+  readonly end: number;
+};
+
+// Ipv4Cidr guarantees the dotted-quad/prefix shape, so the numeric range math
+// needs no re-validation. Math (not bitwise) keeps the 32-bit values unsigned.
+const cidrRange = (cidr: string): CidrRange => {
+  const [quadText = "", prefixText = ""] = Str.split(cidr, "/");
+  const value = A.reduce(Str.split(quadText, "."), 0, (total, part) => total * 256 + Number(part));
+  const size = 2 ** (32 - Number(prefixText));
+  const start = Math.floor(value / size) * size;
+  return { start, end: start + size - 1 };
+};
+
+const cidrRangeContains = (outer: CidrRange, inner: CidrRange): boolean =>
+  Bool.and(outer.start <= inner.start, inner.end <= outer.end);
+
+const CiRunnersSubnetsWithinVpcCheck = S.makeFilter<typeof ciRunnersNetworkConfigStruct.Type>(
+  (network) => {
+    const vpc = cidrRange(network.vpcCidr);
+    return Bool.and(
+      cidrRangeContains(vpc, cidrRange(network.publicSubnetACidr)),
+      cidrRangeContains(vpc, cidrRange(network.publicSubnetBCidr))
+    );
+  },
+  {
+    identifier: $I`CiRunnersSubnetsWithinVpcCheck`,
+    title: "Subnets Within VPC",
+    description: "Both public subnet CIDR blocks must be contained within the VPC CIDR block.",
+    message: "Expected both public subnet CIDR blocks to be contained within the VPC CIDR block",
+  }
+);
+
+const CiRunnersSubnetsDisjointCheck = S.makeFilter<typeof ciRunnersNetworkConfigStruct.Type>(
+  (network) => {
+    const subnetA = cidrRange(network.publicSubnetACidr);
+    const subnetB = cidrRange(network.publicSubnetBCidr);
+    return Bool.or(subnetA.end < subnetB.start, subnetB.end < subnetA.start);
+  },
+  {
+    identifier: $I`CiRunnersSubnetsDisjointCheck`,
+    title: "Subnets Disjoint",
+    description: "The two public subnet CIDR blocks must not overlap each other.",
+    message: "Expected the two public subnet CIDR blocks not to overlap",
+  }
+);
+
 /**
  * Dedicated egress-only VPC geometry for the CI runner fleet.
  *
  * **Details**
  *
- * A class-level check rejects availability zones outside the configured
- * region, so a partial override such as `awsRegion` alone fails fast at
- * config-load time instead of deep inside `pulumi up`.
+ * Class-level checks reject availability zones outside the configured
+ * region, subnet CIDR blocks that fall outside the VPC CIDR block, and
+ * subnet CIDR blocks that overlap each other — so a partial override such
+ * as `awsRegion` or `vpcCidr` alone fails fast at config-load time instead
+ * of deep inside `pulumi up` after earlier resources have provisioned.
  *
  * **Example** (Apply the network defaults)
  *
@@ -442,7 +492,9 @@ const CiRunnersNetworkZonesWithinRegionCheck = S.makeFilter<typeof ciRunnersNetw
  * @since 0.0.0
  */
 export class CiRunnersNetworkConfig extends S.Class<CiRunnersNetworkConfig>($I`CiRunnersNetworkConfig`)(
-  ciRunnersNetworkConfigStruct.pipe(S.check(CiRunnersNetworkZonesWithinRegionCheck)),
+  ciRunnersNetworkConfigStruct.pipe(
+    S.check(CiRunnersNetworkZonesWithinRegionCheck, CiRunnersSubnetsWithinVpcCheck, CiRunnersSubnetsDisjointCheck)
+  ),
   $I.annote("CiRunnersNetworkConfig", {
     description: "Dedicated egress-only VPC geometry for the CI runner fleet.",
   })
@@ -845,6 +897,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Dedicated fleet VPC identifier.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly vpcId: pulumi.Output<string>;
@@ -852,6 +905,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Dedicated fleet VPC CIDR block.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly vpcCidr: pulumi.Output<string>;
@@ -859,6 +913,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * AWS region hosting the fleet.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly region: pulumi.Output<string>;
@@ -866,6 +921,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Public subnet id in the first availability zone.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly publicSubnetAId: pulumi.Output<string>;
@@ -873,6 +929,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Public subnet id in the second availability zone.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly publicSubnetBId: pulumi.Output<string>;
@@ -880,6 +937,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Zero-ingress worker security group id.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly workerSecurityGroupId: pulumi.Output<string>;
@@ -887,6 +945,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Worker launch template id.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly launchTemplateId: pulumi.Output<string>;
@@ -894,6 +953,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Stable AWS-side launch template name for the future controller.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly launchTemplateName: pulumi.Output<string>;
@@ -902,6 +962,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
    * Latest launch template version; the controller passes this number to
    * RunInstances because default-version promotion is deliberate.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly launchTemplateLatestVersion: pulumi.Output<number>;
@@ -909,6 +970,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * AMI id the launch template resolved (pinned override or SSM lookup).
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly resolvedAmiId: pulumi.Output<string>;
@@ -916,6 +978,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Worker EC2 instance type.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly instanceType: pulumi.Output<string>;
@@ -923,6 +986,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * Name of the reaper Lambda enforcing the fleet TTL.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly reaperFunctionName: pulumi.Output<string>;
@@ -930,6 +994,7 @@ export class CiRunnersStack extends pulumi.ComponentResource {
   /**
    * CloudWatch Logs group receiving VPC flow logs.
    *
+   * @category resources
    * @since 0.0.0
    */
   public readonly flowLogGroupName: pulumi.Output<string>;

--- a/infra/src/internal/ci-runners-entry.ts
+++ b/infra/src/internal/ci-runners-entry.ts
@@ -12,7 +12,7 @@ const stack = new CiRunnersStack("ci-runners", loadCiRunnersStackArgs());
 /**
  * Dedicated fleet VPC identifier.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const vpcId = stack.vpcId;
@@ -20,7 +20,7 @@ export const vpcId = stack.vpcId;
 /**
  * Dedicated fleet VPC CIDR block.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const vpcCidr = stack.vpcCidr;
@@ -28,7 +28,7 @@ export const vpcCidr = stack.vpcCidr;
 /**
  * AWS region hosting the fleet.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const region = stack.region;
@@ -36,7 +36,7 @@ export const region = stack.region;
 /**
  * Public subnet id in the first availability zone.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const publicSubnetAId = stack.publicSubnetAId;
@@ -44,7 +44,7 @@ export const publicSubnetAId = stack.publicSubnetAId;
 /**
  * Public subnet id in the second availability zone.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const publicSubnetBId = stack.publicSubnetBId;
@@ -52,7 +52,7 @@ export const publicSubnetBId = stack.publicSubnetBId;
 /**
  * Zero-ingress worker security group id.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const workerSecurityGroupId = stack.workerSecurityGroupId;
@@ -60,7 +60,7 @@ export const workerSecurityGroupId = stack.workerSecurityGroupId;
 /**
  * Worker launch template id.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const launchTemplateId = stack.launchTemplateId;
@@ -68,7 +68,7 @@ export const launchTemplateId = stack.launchTemplateId;
 /**
  * Stable AWS-side launch template name for the future controller.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const launchTemplateName = stack.launchTemplateName;
@@ -76,7 +76,7 @@ export const launchTemplateName = stack.launchTemplateName;
 /**
  * Latest launch template version for controller RunInstances calls.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const launchTemplateLatestVersion = stack.launchTemplateLatestVersion;
@@ -84,7 +84,7 @@ export const launchTemplateLatestVersion = stack.launchTemplateLatestVersion;
 /**
  * AMI id the launch template resolved (pinned override or SSM lookup).
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const resolvedAmiId = stack.resolvedAmiId;
@@ -92,7 +92,7 @@ export const resolvedAmiId = stack.resolvedAmiId;
 /**
  * Worker EC2 instance type.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const instanceType = stack.instanceType;
@@ -100,7 +100,7 @@ export const instanceType = stack.instanceType;
 /**
  * Name of the reaper Lambda enforcing the fleet TTL.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const reaperFunctionName = stack.reaperFunctionName;
@@ -108,7 +108,7 @@ export const reaperFunctionName = stack.reaperFunctionName;
 /**
  * CloudWatch Logs group receiving VPC flow logs.
  *
- * @category outputs
+ * @category resources
  * @since 0.0.0
  */
 export const flowLogGroupName = stack.flowLogGroupName;

--- a/infra/test/CiRunners.test.ts
+++ b/infra/test/CiRunners.test.ts
@@ -82,6 +82,27 @@ describe("@beep/infra CiRunners", () => {
     expect(() => makeCiRunnersStackArgsFromConfigValues({ availabilityZoneA: "us-west-2a" })).toThrow();
   });
 
+  it("rejects subnet geometry outside the VPC or overlapping", () => {
+    // VPC override alone strands the default 10.88.x subnets outside it.
+    expect(() => makeCiRunnersStackArgsFromConfigValues({ vpcCidr: "10.99.0.0/16" })).toThrow();
+    // A subnet outside the default VPC CIDR is rejected.
+    expect(() => makeCiRunnersStackArgsFromConfigValues({ publicSubnetACidr: "192.168.0.0/20" })).toThrow();
+    // Overlapping subnets are rejected even when both sit inside the VPC.
+    expect(() =>
+      makeCiRunnersStackArgsFromConfigValues({
+        publicSubnetACidr: "10.88.0.0/20",
+        publicSubnetBCidr: "10.88.8.0/21",
+      })
+    ).toThrow();
+    // Adjacent, non-overlapping subnets inside the VPC remain valid.
+    expect(
+      makeCiRunnersStackArgsFromConfigValues({
+        publicSubnetACidr: "10.88.32.0/20",
+        publicSubnetBCidr: "10.88.48.0/20",
+      }).network.publicSubnetACidr
+    ).toBe("10.88.32.0/20");
+  });
+
   it("keeps stack args import-safe", () => {
     const args = CiRunnersStackArgs.make({});
 


### PR DESCRIPTION
## fix(infra): validate subnet geometry and use canonical jsdoc categories

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit:amend: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_ci-runners-review-fixes-e0ad8f60eb50/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788666336&installation_model_id=424656&pr_number=611&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F611&signature=4c2075c450af355db1cb33d13e59e9d8f841647093d0774a483035ae543c7970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->