### PR TITLE
fix(test-utils): bound the schedule.max retry idiom and ignore session worktrees in eslint

### DIFF
--- a/.changeset/schedule-max-unbounded-retries.md
+++ b/.changeset/schedule-max-unbounded-retries.md
@@ -1,0 +1,11 @@
+---
+"@beep/test-utils": patch
+---
+
+Replace the unbounded `Schedule.max([spaced, recurs])` retry idiom with a genuinely bounded
+`Schedule.recurs(n).pipe(Schedule.addDelay(...))`: `Schedule.max` continues while any
+sub-schedule continues, so an infinite `spaced` leg kept `recurs` from ever terminating the
+policy. `PgConnectRetryPolicy` now stops after its 20 attempts instead of relying on an outer
+timeout to end an infinite loop. The same hardening lands at the two repo-cli sites (OTLP capture
+polling in tests, the Runpod Ollama readiness retry), and eslint now ignores session-local
+`.claude/worktrees/**` so other checkouts' files cannot fail this clone's docs lint.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,4 +19,7 @@ const selectedESLintConfig = (() => {
   throw new Error(`Unsupported BEEP_ESLINT_PROFILE: ${eslintProfile}`);
 })();
 
-export default [globalIgnores(["**/src-tauri/target/**"]), ...selectedESLintConfig];
+// `.claude/worktrees/**` holds session-local linked worktrees (other checkouts'
+// files that CI never sees); linting them couples this clone's gate to whatever
+// those sessions have checked out.
+export default [globalIgnores(["**/src-tauri/target/**", ".claude/worktrees/**"]), ...selectedESLintConfig];

--- a/packages/tooling/test-kit/test-utils/src/SqlTest.ts
+++ b/packages/tooling/test-kit/test-utils/src/SqlTest.ts
@@ -823,7 +823,9 @@ const loadPgModule = Effect.tryPromise({
   catch: (cause) => toHarnessError("pg-external", "provision", "Failed to load pg support for SQL tests.", cause),
 }).pipe(Effect.withSpan("SqlTest.PgExternalTestDriver.loadPg"));
 
-const PgConnectRetryPolicy = Schedule.max([Schedule.spaced(Duration.millis(250)), Schedule.recurs(20)]);
+// Schedule.max continues while ANY sub-schedule continues, so an infinite `spaced` leg would
+// keep `recurs` from ever bounding the policy; the delay must ride on `recurs` itself.
+const PgConnectRetryPolicy = Schedule.recurs(20).pipe(Schedule.addDelay(() => Effect.succeed(Duration.millis(250))));
 
 const makePgliteConfig = Effect.fn("SqlTest.PgliteTestcontainersTestDriver.makeConfig")(function* (
   configInput: PgliteTestcontainersTestDriverConfigInput

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts
@@ -631,7 +631,10 @@ const waitForOllamaReady = Effect.fn("DocgenQualityWorkerRunpodEval.waitForOllam
         ? Effect.succeed(true)
         : Effect.fail(DomainError.make({ message: `Ollama model "${model}" is not ready at ${baseUrl}.` }))
     ),
-    Effect.retry(Schedule.max([Schedule.spaced(Duration.seconds(5)), Schedule.recurs(attempts)])),
+    // Schedule.max continues while ANY sub-schedule continues, so the old
+    // `max([spaced, recurs])` form was unbounded and only the outer timeout saved it;
+    // the delay must ride on `recurs` itself for the attempt cap to be real.
+    Effect.retry(Schedule.recurs(attempts).pipe(Schedule.addDelay(() => Effect.succeed(Duration.seconds(5))))),
     Effect.timeoutOrElse({
       duration: timeout,
       orElse: () =>

--- a/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
+++ b/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
@@ -252,7 +252,9 @@ const waitForCapturedOtlpTraceRequest = (
   requests: ReadonlyArray<CapturedOtlpRequest>
 ): Effect.Effect<CapturedOtlpRequest, string> =>
   findCapturedOtlpTraceRequest(requests).pipe(
-    Effect.retry(Schedule.max([Schedule.spaced(Duration.millis(25)), Schedule.recurs(200)]))
+    // Schedule.max continues while ANY sub-schedule continues, so pairing an infinite
+    // `spaced` with `recurs` never terminates; the delay must ride on `recurs` itself.
+    Effect.retry(Schedule.recurs(200).pipe(Schedule.addDelay(() => Effect.succeed(Duration.millis(25)))))
   );
 
 describe("ai-metrics command", () => {


### PR DESCRIPTION
## fix(test-utils): bound the schedule.max retry idiom and ignore session worktrees in eslint

Schedule.max continues while ANY sub-schedule continues, so the repo idiom
max([spaced, recurs(n)]) never terminates: the infinite spaced leg keeps the
recurs cap from ever ending the policy. Three sites relied on it — the SqlTest
Postgres connect policy, the repo-cli OTLP capture poll, and the Runpod Ollama
readiness retry (saved only by its outer timeout). All three now use
recurs(n).pipe(addDelay(...)), the bounded form the identity-registry lock
proved out. eslint additionally ignores .claude/worktrees/** so other
checkouts session-local files cannot fail this clones docs lint.

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_schedule-max-unbounded-retries-15c9ed0e7276/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788782609&installation_model_id=424656&pr_number=623&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F623&signature=44a4bf9153bcf52182e3da5d17644c75dec61610d4ec823548e6a5b60dd0e8dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->