### PR TITLE
docs(goals): land P1 refs-census friction receipts in the packet ledger

### DIFF
--- a/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
+++ b/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
@@ -129,3 +129,45 @@ measurement first). Reviewed at each grill.
    until something executes them; a lane that runs each packet's declared
    commands on touched packets (Workstream E's doctor is the natural home) would
    have caught this at the introducing PR.
+
+10. **Three publish attempts burned on yeet publish ordering semantics.** `unowned`
+
+    Closing out PR #613 cost three failed publish invocations before the working
+    form: `--push-only` rejects `--message` (it never creates a commit); plain
+    `publish` refuses a dirty-but-unstaged worktree ("requires reviewed staged
+    changes") because it does not auto-stage; and staging files AFTER a green
+    verify flips "diff fingerprint changed", invalidating `--reuse-verified` and
+    forcing a fresh ~18-minute proof. The working sequence is stage first, then
+    `yeet verify && yeet publish --reuse-verified --message ...` chained in one
+    shell.
+
+    **What would have prevented it:** either a stage-aware proof fingerprint
+    (index-only transitions over identical content should not invalidate a
+    proof) or a `publish` preflight that names the required order in one message
+    instead of one constraint per failed attempt.
+
+11. **`lint schema-first --write` records entries that still fail the gate.** `unowned`
+
+    The refs census added five exported scanner-machinery types; the policy
+    finding's remediation says "Run bun run beep lint schema-first --write after
+    reviewing the finding". `--write` appended them with `status: "candidate"`
+    and the finding text as `reason` — and candidate entries still fail the
+    lint. The undocumented second step is hand-flipping each entry to
+    `status: "exception"` with a real justification (existing entries show the
+    expected quality bar).
+
+    **What would have prevented it:** `--write` emitting exception scaffolds
+    with an explicit `TODO-justify` reason, or the remediation text stating that
+    candidate entries keep the gate red until upgraded by hand.
+
+12. **docgen rejects an unregistered `@category` without naming the valid set.** `unowned`
+
+    `docgen check` failed with `invalid category: Unknown @category value
+    scanning.` — no list of registered values in the error or the finding. Two
+    agents hit it independently in one PR: the first migrated its symbols and
+    the second reintroduced the same unregistered value on a new export because
+    nothing at the authoring site says which categories exist.
+
+    **What would have prevented it:** the error enumerating the registered
+    category values (they are known to the checker), or the JSDoc skill carrying
+    the list.


### PR DESCRIPTION
## What

Docs-only: three friction receipts from the PR #613 (knowledge refs census) closeout, appended to `goals/knowledge-surface-automation/research/OPPORTUNITIES.md` per the friction-first-class law. They were observed during the publish/closeout of that PR and are recorded here as the session's wrap-up:

1. **yeet publish ordering gauntlet** — `--push-only` rejects `--message`; `publish` does not auto-stage; staging after a green verify invalidates the `--reuse-verified` fingerprint. Three proof cycles burned; the working order is stage → chained `verify && publish`.
2. **`lint schema-first --write` records `status: "candidate"` entries that still fail the gate** — the undocumented second step is hand-flipping to `"exception"` with a real justification.
3. **docgen rejects an unregistered `@category` without naming the registered set** — two agents hit it independently in one PR.

No code changes; the packet's redaction grep stays green (receipts quote no host paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788782844&installation_model_id=424656&pr_number=624&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F624&signature=8818cbf146aefe7f834f4623693fed7ee17ff22b17d2ea8de7e00b7b939315a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->