### PR TITLE
feat(repo-cli): stamp yeet PRs with a provenance footer

### DIFF
--- a/.changeset/ai-metrics-transcript-path-export.md
+++ b/.changeset/ai-metrics-transcript-path-export.md
@@ -1,0 +1,7 @@
+---
+"@beep/repo-ai-metrics": patch
+---
+
+Export the shared transcript path helpers through the package barrel so the
+Yeet PR provenance footer reuses the canonical `repoPathToClaudeProjectName`
+converter instead of maintaining a diverging copy.

--- a/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
@@ -1,5 +1,24 @@
 # Opportunities
 
+## Burst reaper kills busy workers mid-job
+
+- **Work:** Post-merge main run for PR #633 on the manual burst fleet.
+- **Friction:** The TTL reaper terminates on age alone, without checking
+  whether the runner is executing a job. All three burst workers launched
+  04:33Z were terminated at 06:05:19Z (TTL-90 plus reaper period) exactly 90
+  seconds after the heavy lanes started on them: main run `31360612950` lost
+  Check and Coverage Regression mid-step and cancelled Test Integration,
+  turning an infrastructure event into a red main run needing manual
+  relaunch-and-rerun.
+- **Evidence:** Instances `i-047e8aef0ce1cb51b`, `i-0e13088d0c37de391`,
+  `i-0b32615510035c84e`, all `User initiated (2026-08-10 06:05:19 GMT)`; job
+  steps `Run verification lane` conclusion `cancelled` at 06:05:2x.
+- **Proposal:** Retire the class via P2 cutover — the controller's scale-down
+  only retires idle runners, and ephemeral one-job-one-VM workers cannot be
+  reaped mid-job by design. If the burst path must live longer, teach the
+  reaper to skip runners whose GitHub registration reports `busy` and sweep
+  them on the next cycle instead.
+
 ## Prove worker east-west isolation with two live workers
 
 - **Work:** P1 red-team review of the worker network-isolation evidence.

--- a/packages/tooling/library/ai-metrics/src/index.ts
+++ b/packages/tooling/library/ai-metrics/src/index.ts
@@ -141,6 +141,21 @@ export * from "./ingest.ts";
  */
 export * from "./install.ts";
 /**
+ * Shared transcript path helpers.
+ *
+ * **Example** (Convert a repository path to Claude's project key)
+ *
+ * ```ts
+ * import { repoPathToClaudeProjectName } from "@beep/repo-ai-metrics"
+ *
+ * console.log(repoPathToClaudeProjectName("/workspace/beep-effect"))
+ * ```
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export { repoPathToClaudeProjectName } from "./internal/transcript-utils.ts";
+/**
  * P7 sanitized mirror bundle helpers.
  *
  * **Example** (Import mirror bundle builder)

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/GateStaleness.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/GateStaleness.ts
@@ -13,20 +13,22 @@
  * The generalizable fix is to make a gate result carry provenance, and the
  * cheapest honest provenance a cached artifact already has is its modification
  * time. This module compares each cached gate artifact against the newest file
- * this branch changed: an artifact older than the branch's newest edit cannot
- * have observed that edit, whatever its contents claim.
+ * this branch changed that the gate actually reads: an artifact older than a
+ * relevant edit cannot have observed that edit, whatever its contents claim.
  *
  * **Gotchas**
  *
  * Freshness here is necessary, not sufficient. An artifact newer than every
- * changed file *may* still have been produced by a run that skipped the gate;
- * this catches the ordering failure, not every vacuous proof. It is a warning
- * surface for that reason, and a stale verdict names the command that
- * regenerates it rather than guessing at intent.
+ * relevant changed file *may* still have been produced by a run that skipped
+ * the gate; this catches the ordering failure, not every vacuous proof. It is
+ * a warning surface for that reason, and a stale verdict names the command
+ * that regenerates it rather than guessing at intent.
  *
- * The comparison set is the branch's changed files rather than the whole source
- * tree, which keeps the check bounded by the size of the diff and targets the
- * actual failure: a gate that ran before *this branch's* edits landed.
+ * The comparison set is the branch's relevant changed files rather than the
+ * whole source tree. Relevance is scoped per artifact because an input can only
+ * invalidate a gate that reads it: changesets do not feed code gates, while
+ * goal packets feed goals-doctor but not code gates. This keeps the check
+ * bounded by the diff without turning unrelated edits into false warnings.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -38,6 +40,7 @@ import { Effect, FileSystem, Order, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { sortedUniquePaths } from "../../../internal/repo-run/index.ts";
 import { GOALS_DOCTOR_BASELINE_PATH } from "../../Goals/Doctor.ts";
 import {
@@ -97,6 +100,27 @@ export const GateArtifactKind = LiteralKit(["baseline", "inventory", "manifest",
 export type GateArtifactKind = typeof GateArtifactKind.Type;
 
 /**
+ * The changed-input family that can invalidate a cached gate artifact.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const GateInputScope = LiteralKit(["repo-code", "goals-packets"]).pipe(
+  $I.annoteSchema("GateInputScope", {
+    title: "Gate Input Scope",
+    description: "The changed-input family that can invalidate one cached gate artifact.",
+  })
+);
+
+/**
+ * The changed-input family that can invalidate a cached gate artifact.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GateInputScope = typeof GateInputScope.Type;
+
+/**
  * One file observed on disk with the modification time it carried.
  *
  * **Example** (Witness one artifact)
@@ -134,6 +158,7 @@ export class GateFileWitness extends S.Class<GateFileWitness>($I`GateFileWitness
  *   gateId: "coverage-regression",
  *   kind: "baseline",
  *   regenerateCommand: "bun run beep quality coverage --write-baseline",
+ *   scope: "repo-code",
  * })
  * console.log(descriptor.gateId)
  * ```
@@ -147,6 +172,7 @@ export class GateArtifactDescriptor extends S.Class<GateArtifactDescriptor>($I`G
     gateId: S.NonEmptyString,
     kind: GateArtifactKind,
     regenerateCommand: S.NonEmptyString,
+    scope: GateInputScope,
   },
   $I.annote("GateArtifactDescriptor", {
     description: "One cached verification-gate artifact paired with the command that regenerates it.",
@@ -154,7 +180,8 @@ export class GateArtifactDescriptor extends S.Class<GateArtifactDescriptor>($I`G
 ) {}
 
 /**
- * A gate artifact newer than every file this branch changed.
+ * A gate artifact newer than every relevant file this branch changed, or one
+ * whose gate has no relevant changed input.
  *
  * @category models
  * @since 0.0.0
@@ -165,12 +192,12 @@ export class GateFresh extends S.Class<GateFresh>($I`GateFresh`)(
     gateId: S.NonEmptyString,
   },
   $I.annote("GateFresh", {
-    description: "A gate artifact at least as new as every file this branch changed.",
+    description: "A gate artifact at least as new as every relevant file this branch changed.",
   })
 ) {}
 
 /**
- * A gate artifact that predates a file this branch changed.
+ * A gate artifact that predates a relevant file this branch changed.
  *
  * @category models
  * @since 0.0.0
@@ -186,18 +213,20 @@ export class GateStale extends S.Class<GateStale>($I`GateStale`)(
     skewMs: S.Finite,
   },
   $I.annote("GateStale", {
-    description: "A gate artifact older than the newest file this branch changed, so it cannot have observed it.",
+    description:
+      "A gate artifact older than the newest relevant file this branch changed, so it cannot have observed it.",
   })
 ) {}
 
 /**
- * A gate whose freshness could not be established either way.
+ * A gate whose proof artifact does not exist.
  *
  * **Details**
  *
- * Two different absences land here and both are honest non-answers: the
- * artifact does not exist yet (nothing has been proven, so nothing is stale),
- * and the branch changed nothing observable (no input to be older than).
+ * Only a missing artifact lands here: without an artifact, the gate has no
+ * cached proof to preserve or compare. No relevant changed input instead means
+ * an existing artifact remains fresh because this branch cannot have
+ * invalidated it.
  *
  * @category models
  * @since 0.0.0
@@ -209,7 +238,7 @@ export class GateUnproven extends S.Class<GateUnproven>($I`GateUnproven`)(
     detail: S.String,
   },
   $I.annote("GateUnproven", {
-    description: "A gate whose freshness could not be established because the artifact or the inputs are absent.",
+    description: "A gate whose freshness could not be established because its proof artifact is absent.",
   })
 ) {}
 
@@ -278,41 +307,47 @@ export const YEET_GATE_ARTIFACT_DESCRIPTORS: ReadonlyArray<GateArtifactDescripto
     gateId: "coverage-regression",
     kind: "baseline",
     regenerateCommand: coverageRegressionRegenerationCommand,
+    scope: "repo-code",
   }),
   GateArtifactDescriptor.make({
     artifactPath: defaultJSDocTotalsBaselinePath,
     gateId: "jsdoc-totals-ratchet",
     kind: "baseline",
     regenerateCommand: `${jsdocInventoryRegenerationCommand} && ${jsdocTotalsSnapshotCommand}`,
+    scope: "repo-code",
   }),
   GateArtifactDescriptor.make({
     artifactPath: "standards/knip.regression-baseline.jsonc",
     gateId: "knip-ratchet",
     kind: "baseline",
     regenerateCommand: "bun run beep quality knip --write-baseline",
+    scope: "repo-code",
   }),
   GateArtifactDescriptor.make({
     artifactPath: "standards/test-typecheck.blindspot-baseline.jsonc",
     gateId: "test-typecheck-blindspot",
     kind: "baseline",
     regenerateCommand: "bun run beep lint package-test-typecheck --write-baseline",
+    scope: "repo-code",
   }),
   GateArtifactDescriptor.make({
     artifactPath: GOALS_DOCTOR_BASELINE_PATH,
     gateId: "goals-doctor",
     kind: "baseline",
     regenerateCommand: "bun run beep goals doctor --write-baseline",
+    scope: "goals-packets",
   }),
   GateArtifactDescriptor.make({
     artifactPath: ".beep/ci/jsdoc-documentation.inventory.jsonc",
     gateId: "jsdoc-documentation-inventory",
     kind: "inventory",
     regenerateCommand: "bun run beep ci lane jsdoc-inventory",
+    scope: "repo-code",
   }),
 ];
 
 /**
- * Judge one gate artifact against the newest file this branch changed.
+ * Judge one gate artifact against the newest relevant file this branch changed.
  *
  * **Details**
  *
@@ -333,6 +368,7 @@ export const YEET_GATE_ARTIFACT_DESCRIPTORS: ReadonlyArray<GateArtifactDescripto
  *   gateId: "coverage-regression",
  *   kind: "baseline",
  *   regenerateCommand: "bun run beep quality coverage",
+ *   scope: "repo-code",
  * })
  * const verdict = assessGateStaleness(
  *   descriptor,
@@ -344,7 +380,7 @@ export const YEET_GATE_ARTIFACT_DESCRIPTORS: ReadonlyArray<GateArtifactDescripto
  *
  * @param descriptor - The gate artifact being judged.
  * @param artifact - The artifact as observed on disk, when it exists.
- * @param newestInput - The newest file this branch changed, when there is one.
+ * @param newestInput - The newest relevant file this branch changed, when there is one.
  * @returns Whether the artifact predates the change it gates.
  * @category detection
  * @since 0.0.0
@@ -358,7 +394,7 @@ export const assessGateStaleness = (
     return GateUnproven.make({ detail: `${descriptor.artifactPath} does not exist`, gateId: descriptor.gateId });
   }
   if (O.isNone(newestInput)) {
-    return GateUnproven.make({ detail: "no changed files to compare against", gateId: descriptor.gateId });
+    return GateFresh.make({ gateId: descriptor.gateId });
   }
   const skewMs = newestInput.value.modifiedAtMs - artifact.value.modifiedAtMs;
   return skewMs > 0
@@ -393,7 +429,7 @@ export const staleGateVerdicts = (verdicts: ReadonlyArray<GateStalenessVerdict>)
   A.filter(verdicts, isGateStale);
 
 /**
- * Keep only verdicts whose proof artifact or comparison input is absent.
+ * Keep only verdicts whose proof artifact is absent.
  *
  * **Example** (Filter an unproven verdict)
  *
@@ -429,7 +465,7 @@ export const unprovenGateVerdicts = (verdicts: ReadonlyArray<GateStalenessVerdic
  * ```
  *
  * @param stale - Stale verdicts from one staleness pass.
- * @param unproven - Verdicts whose proof artifact or comparison input is absent.
+ * @param unproven - Verdicts whose proof artifact is absent.
  * @returns The `gate staleness:` line plus one indented line per stale gate.
  * @category formatting
  * @since 0.0.0
@@ -454,6 +490,28 @@ export const renderYeetGateStalenessBlock = (
       );
 
 const witnessOrder = Order.mapInput(Order.Number, (witness: GateFileWitness) => witness.modifiedAtMs);
+
+const REPO_CODE_IRRELEVANT_PREFIXES = [".changeset/", "goals/", "explorations/", "docs/", "scratchpad/"];
+
+const isRepoCodeInput = (repoRelativePath: string): boolean =>
+  !A.some(REPO_CODE_IRRELEVANT_PREFIXES, (prefix) => Str.startsWith(prefix)(repoRelativePath));
+
+const isGoalsPacketInput = (repoRelativePath: string): boolean => Str.startsWith("goals/")(repoRelativePath);
+
+/**
+ * Test whether a repo-relative changed path can invalidate one gate scope.
+ *
+ * @param scope - The input family consumed by the gate.
+ * @param repoRelativePath - One changed path relative to the repository root.
+ * @returns Whether the gate reads that path family.
+ * @category detection
+ * @since 0.0.0
+ */
+export const isGateInputRelevant = (scope: GateInputScope, repoRelativePath: string): boolean =>
+  GateInputScope.$match(scope, {
+    "repo-code": () => isRepoCodeInput(repoRelativePath),
+    "goals-packets": () => isGoalsPacketInput(repoRelativePath),
+  });
 
 const witnessFile = Effect.fn("Yeet.witnessGateFile")(function* (
   repoRoot: string,
@@ -501,7 +559,7 @@ export const collectYeetGateInputPaths = Effect.fn("Yeet.collectYeetGateInputPat
 });
 
 /**
- * Judge every known gate artifact against this branch's newest change.
+ * Judge every known gate artifact against this branch's newest relevant change.
  *
  * **When to use**
  *
@@ -514,6 +572,9 @@ export const collectYeetGateInputPaths = Effect.fn("Yeet.collectYeetGateInputPat
  * Artifacts this branch itself changed are excluded from the input set before
  * the comparison, because a regenerated baseline is both an artifact and a
  * changed file and would otherwise be reported as stale against itself.
+ * Each descriptor then keeps only the changed paths in its input scope. An
+ * existing artifact with no relevant changed input remains fresh because an
+ * input can only invalidate a gate that reads it.
  *
  * **Example** (Collect staleness through the test seam)
  *
@@ -554,11 +615,17 @@ export const collectYeetGateStaleness = Effect.fn("Yeet.collectYeetGateStaleness
   const inputWitnesses = yield* Effect.forEach(inputPaths, (candidate) => witnessFile(context.repoRoot, candidate), {
     concurrency: 8,
   });
-  const newestInput = pipe(A.getSomes(inputWitnesses), A.sort(witnessOrder), A.last);
+  const witnessedInputs = A.getSomes(inputWitnesses);
   return yield* Effect.forEach(
     YEET_GATE_ARTIFACT_DESCRIPTORS,
     Effect.fnUntraced(function* (descriptor: GateArtifactDescriptor) {
       const artifact = yield* witnessFile(context.repoRoot, descriptor.artifactPath);
+      const newestInput = pipe(
+        witnessedInputs,
+        A.filter((witness) => isGateInputRelevant(descriptor.scope, witness.path)),
+        A.sort(witnessOrder),
+        A.last
+      );
       return assessGateStaleness(descriptor, artifact, newestInput);
     }),
     { concurrency: 4 }

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
@@ -1,0 +1,414 @@
+/**
+ * Pull request provenance detection and Markdown rendering for Yeet publish.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { shellQuote } from "@beep/repo-ai-metrics";
+import { LiteralKit } from "@beep/schema";
+import { Clock, Config, ConfigProvider, Context, Duration, Effect, FileSystem, Order, Path, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as P from "effect/Predicate";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { runGitOutput } from "./GitExec.ts";
+import type { PlatformError } from "effect";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Provenance");
+const recentClaudeSessionWindow = Duration.hours(6);
+const provenanceDetectionTimeout = Duration.seconds(2);
+const PrProvenanceAbsolutePath = S.String.check(
+  S.isPattern(/^\//u, {
+    identifier: "PrProvenanceAbsolutePath",
+    title: "PR provenance absolute path",
+    description: "An absolute filesystem path recorded in pull request provenance.",
+    message: "Expected an absolute path starting with '/'",
+  })
+).pipe(
+  $I.annoteSchema("PrProvenanceAbsolutePath", {
+    description: "Absolute clone or linked-worktree path recorded in pull request provenance.",
+  })
+);
+
+/**
+ * Harness that originated a Yeet publish invocation.
+ *
+ * **Example** (Inspect supported harnesses)
+ *
+ * ```ts
+ * import { PrProvenanceHarness } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(PrProvenanceHarness.Options)
+ * ```
+ *
+ * **Details**
+ *
+ * Unknown is the safe fallback when bounded detection cannot identify a live
+ * Claude Code or Codex session.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PrProvenanceHarness = LiteralKit(["claude-code", "codex", "unknown"]).pipe(
+  $I.annoteSchema("PrProvenanceHarness", {
+    description: "Harness that originated a Yeet pull request publish invocation.",
+  })
+);
+
+/**
+ * Runtime type for {@link PrProvenanceHarness}.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PrProvenanceHarness = typeof PrProvenanceHarness.Type;
+
+/**
+ * Clone, worktree, branch, and resumable harness identity for a Yeet PR.
+ *
+ * **Example** (Construct Codex provenance)
+ *
+ * ```ts
+ * import { PrProvenance } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const provenance = PrProvenance.make({
+ *   branch: "feat/example",
+ *   clonePath: "/home/user/beep-effect",
+ *   harness: "codex",
+ *   resumeCommand: "cd '/home/user/beep-effect' && codex resume --last",
+ *   sessionId: O.none(),
+ *   worktreePath: O.none(),
+ * })
+ * console.log(provenance.harness)
+ * ```
+ *
+ * **Details**
+ *
+ * `clonePath` is the absolute main clone path. `worktreePath` is present only
+ * when publish runs from a linked worktree.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class PrProvenance extends S.Class<PrProvenance>($I`PrProvenance`)(
+  {
+    branch: S.String,
+    clonePath: PrProvenanceAbsolutePath,
+    harness: PrProvenanceHarness,
+    resumeCommand: S.String,
+    sessionId: S.Option(S.String),
+    worktreePath: S.Option(PrProvenanceAbsolutePath),
+  },
+  $I.annote("PrProvenance", {
+    description: "Origin and paste-ready resume command recorded in a Yeet pull request body.",
+  })
+) {}
+
+/**
+ * Convert an absolute launch path to Claude Code's project-directory key.
+ *
+ * **Example** (Munge a launch path)
+ *
+ * ```ts
+ * import { mungeClaudeProjectPath } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(mungeClaudeProjectPath("/home/user/beep.effect"))
+ * // -home-user-beep-effect
+ * ```
+ *
+ * @param launchPath - Absolute path the harness session was launched from.
+ * @returns The munged directory name under `~/.claude/projects`.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const mungeClaudeProjectPath = (launchPath: string): string => Str.replace(/[/.]/gu, "-")(launchPath);
+
+const sessionOrder = Order.mapInput(
+  Order.Number,
+  (candidate: readonly [launchPath: string, sessionId: string, modifiedAtMillis: number]) => -candidate[2]
+);
+
+/**
+ * Find the newest recent Claude Code transcript across launch-path candidates.
+ *
+ * **Example** (Search fixture project directories)
+ *
+ * ```ts
+ * import { findRecentClaudeSession } from "@beep/repo-cli/test/Yeet"
+ *
+ * const session = findRecentClaudeSession("/tmp/projects", ["/tmp/repo"], 0)
+ * console.log(session.pipe !== undefined)
+ * ```
+ *
+ * @param projectsRoot - Fixture-safe root containing Claude project folders.
+ * @param launchPaths - Absolute checkout and clone paths to inspect.
+ * @param nowMillis - Current epoch milliseconds used for the six-hour bound.
+ * @returns The launch path and session id of the newest recent transcript.
+ * @category discovery
+ * @since 0.0.0
+ */
+export const findRecentClaudeSession = Effect.fn("PrProvenance.findRecentClaudeSession")(function* (
+  projectsRoot: string,
+  launchPaths: ReadonlyArray<string>,
+  nowMillis: number
+): Effect.fn.Return<
+  O.Option<readonly [launchPath: string, sessionId: string]>,
+  PlatformError.PlatformError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const candidates = yield* pipe(
+    launchPaths,
+    A.dedupe,
+    Effect.forEach(
+      Effect.fnUntraced(function* (launchPath) {
+        const directory = path.join(projectsRoot, mungeClaudeProjectPath(launchPath));
+        const exists = yield* fs.exists(directory);
+        if (!exists) {
+          return A.empty<readonly [string, string, number]>();
+        }
+        const names = yield* fs.readDirectory(directory);
+        return yield* pipe(
+          names,
+          A.filter(Str.endsWith(".jsonl")),
+          Effect.forEach(
+            Effect.fnUntraced(function* (name) {
+              const info = yield* fs.stat(path.join(directory, name));
+              return pipe(
+                info.mtime,
+                O.map((mtime) => [launchPath, path.basename(name, ".jsonl"), mtime.getTime()] as const)
+              );
+            }),
+            { concurrency: 8 }
+          ),
+          Effect.map(A.getSomes)
+        );
+      }),
+      { concurrency: 2 }
+    ),
+    Effect.map(A.flatten)
+  );
+  return pipe(
+    candidates,
+    A.filter((candidate) => nowMillis - candidate[2] <= Duration.toMillis(recentClaudeSessionWindow)),
+    A.sort(sessionOrder),
+    A.head,
+    O.map(([launchPath, sessionId]) => [launchPath, sessionId] as const)
+  );
+});
+
+/**
+ * Build the paste-ready command for a detected harness.
+ *
+ * **Example** (Build a Codex resume command)
+ *
+ * ```ts
+ * import { resumeCommandFor } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * console.log(resumeCommandFor("codex", "/repo", O.none()))
+ * ```
+ *
+ * @param harness - Detected harness the publish ran under.
+ * @param directory - Directory the resume command must start from.
+ * @param sessionId - Session identifier when the harness exposes one.
+ * @returns A paste-ready shell command resuming the originating session.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const resumeCommandFor = (
+  harness: PrProvenanceHarness,
+  directory: string,
+  sessionId: O.Option<string>
+): string =>
+  PrProvenanceHarness.$match(harness, {
+    "claude-code": () =>
+      O.match(sessionId, {
+        onNone: () => `cd ${shellQuote(directory)} && claude --resume`,
+        onSome: (id) => `cd ${shellQuote(directory)} && claude --resume ${shellQuote(id)}`,
+      }),
+    codex: () => `cd ${shellQuote(directory)} && codex resume --last`,
+    unknown: () => `cd ${shellQuote(directory)} && claude --resume`,
+  });
+
+/**
+ * Render provenance as the trailing Markdown section of a pull request body.
+ *
+ * **Example** (Render a generic footer)
+ *
+ * ```ts
+ * import { PrProvenance, renderPrProvenance } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const footer = renderPrProvenance(PrProvenance.make({
+ *   branch: "feat/example",
+ *   clonePath: "/repo",
+ *   harness: "unknown",
+ *   resumeCommand: "cd '/repo' && claude --resume",
+ *   sessionId: O.none(),
+ *   worktreePath: O.none(),
+ * }))
+ * console.log(footer)
+ * ```
+ *
+ * @param provenance - Detected origin facts for the publishing session.
+ * @returns The Markdown footer section appended to the pull request body.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderPrProvenance = (provenance: PrProvenance): string => {
+  const worktreeLine = pipe(
+    provenance.worktreePath,
+    O.map((worktreePath) => `- Worktree: \`${worktreePath}\`\n`),
+    O.getOrElse(() => "")
+  );
+  const command = Str.replace(" && ", " &&\n  ")(provenance.resumeCommand);
+  return `---
+
+## Provenance
+
+- Clone: \`${provenance.clonePath}\`
+${worktreeLine}- Branch: \`${provenance.branch}\`
+- Harness: \`${provenance.harness}\`
+
+Resume this session:
+
+\`\`\`sh
+${command}
+\`\`\`
+`;
+};
+
+/**
+ * Contract for bounded PR provenance detection.
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export interface PrProvenanceServiceShape {
+  readonly detect: (cwd: string, branch: string) => Effect.Effect<PrProvenance>;
+}
+
+/**
+ * Service tag for bounded PR provenance detection.
+ *
+ * **Example** (Access the detector)
+ *
+ * ```ts
+ * import { PrProvenanceService } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.map(PrProvenanceService, (service) => service.detect("/repo", "feat/example"))
+ * console.log(program.pipe !== undefined)
+ * ```
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export class PrProvenanceService extends Context.Service<PrProvenanceService, PrProvenanceServiceShape>()(
+  $I`PrProvenanceService`
+) {}
+
+type PrProvenanceRequirements = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner;
+
+const makeUnknownProvenance = (clonePath: string, branch: string): PrProvenance =>
+  PrProvenance.make({
+    branch,
+    clonePath,
+    harness: "unknown",
+    resumeCommand: resumeCommandFor("unknown", clonePath, O.none()),
+    sessionId: O.none(),
+    worktreePath: O.none(),
+  });
+
+const hasCodexEnvironment = Effect.fn("PrProvenance.hasCodexEnvironment")(function* () {
+  const provider = yield* ConfigProvider.ConfigProvider;
+  const root = yield* provider.load([]);
+  if (root === undefined || !P.isTagged("Record")(root)) {
+    return false;
+  }
+  return pipe(root.keys, A.fromIterable, A.some(Str.startsWith("CODEX_")));
+});
+
+const detectPrProvenanceImpl = Effect.fn("PrProvenance.detectImpl")(function* (cwd: string, branch: string) {
+  const path = yield* Path.Path;
+  const [commonDirectoryOutput, checkoutOutput] = yield* Effect.all(
+    [runGitOutput(cwd, ["rev-parse", "--git-common-dir"]), runGitOutput(cwd, ["rev-parse", "--show-toplevel"])],
+    { concurrency: 2 }
+  );
+  const checkoutPath = path.resolve(Str.trim(checkoutOutput));
+  const clonePath = path.dirname(path.resolve(checkoutPath, Str.trim(commonDirectoryOutput)));
+  const worktreePath = checkoutPath === clonePath ? O.none<string>() : O.some(checkoutPath);
+  const home = yield* Config.option(Config.string("HOME"));
+  const nowMillis = yield* Clock.currentTimeMillis;
+  const claudeSession = yield* pipe(
+    home,
+    O.map((value) =>
+      findRecentClaudeSession(path.join(value, ".claude", "projects"), [checkoutPath, clonePath], nowMillis)
+    ),
+    O.getOrElse(() => Effect.succeed(O.none<readonly [string, string]>()))
+  );
+
+  if (O.isSome(claudeSession)) {
+    const [launchPath, sessionId] = claudeSession.value;
+    return PrProvenance.make({
+      branch,
+      clonePath,
+      harness: "claude-code",
+      resumeCommand: resumeCommandFor("claude-code", launchPath, O.some(sessionId)),
+      sessionId: O.some(sessionId),
+      worktreePath,
+    });
+  }
+
+  const isCodex = yield* hasCodexEnvironment();
+  const harness = isCodex ? "codex" : "unknown";
+  return PrProvenance.make({
+    branch,
+    clonePath,
+    harness,
+    resumeCommand: resumeCommandFor(harness, clonePath, O.none()),
+    sessionId: O.none(),
+    worktreePath,
+  });
+});
+
+const makePrProvenanceService = Effect.fn("PrProvenanceService.make")(function* () {
+  const path = yield* Path.Path;
+  const runtimeContext = yield* Effect.context<PrProvenanceRequirements>();
+  return PrProvenanceService.of({
+    detect: Effect.fn("PrProvenanceService.detect")((cwd, branch) => {
+      const fallback = makeUnknownProvenance(path.resolve(cwd), branch);
+      return detectPrProvenanceImpl(cwd, branch).pipe(
+        Effect.provide(runtimeContext),
+        Effect.catchCause(() => Effect.succeed(fallback)),
+        Effect.timeoutOrElse({
+          duration: provenanceDetectionTimeout,
+          orElse: () => Effect.succeed(fallback),
+        })
+      );
+    }),
+  });
+});
+
+/**
+ * Construct the live bounded detector used by Yeet publish.
+ *
+ * **Example** (Reference the live layer)
+ *
+ * ```ts
+ * import { makePrProvenanceServiceLive } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(makePrProvenanceServiceLive.pipe !== undefined)
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const makePrProvenanceServiceLive = makePrProvenanceService;

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
@@ -1,25 +1,49 @@
 /**
  * Pull request provenance detection and Markdown rendering for Yeet publish.
  *
+ * **Gotchas**
+ *
+ * Claude transcript discovery is deliberately bounded to the current checkout
+ * and its main clone. Sessions launched from a third directory are left to the
+ * interactive `claude --resume` picker.
+ *
+ * When multiple Claude sessions share one checkout, the newest recent
+ * transcript wins. Modification time cannot honestly identify which concurrent
+ * session invoked publish, so the footer may select the other live session.
+ *
  * @packageDocumentation
  * @since 0.0.0
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
-import { shellQuote } from "@beep/repo-ai-metrics";
+import { repoPathToClaudeProjectName, shellQuote } from "@beep/repo-ai-metrics";
 import { LiteralKit } from "@beep/schema";
-import { Clock, Config, ConfigProvider, Context, Duration, Effect, FileSystem, Order, Path, pipe } from "effect";
+import {
+  Clock,
+  Config,
+  ConfigProvider,
+  Context,
+  Duration,
+  Effect,
+  FileSystem,
+  Order,
+  Path,
+  pipe,
+  Result,
+} from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
+import { renderPrettyCommandJson } from "../../../internal/cli/Json.ts";
 import { runGitOutput } from "./GitExec.ts";
 import type { PlatformError } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 
 const $I = $RepoCliId.create("commands/Yeet/internal/Provenance");
 const recentClaudeSessionWindow = Duration.hours(6);
+const futureClaudeSessionSkew = Duration.minutes(1);
 const provenanceDetectionTimeout = Duration.seconds(2);
 const PrProvenanceAbsolutePath = S.String.check(
   S.isPattern(/^\//u, {
@@ -80,7 +104,7 @@ export type PrProvenanceHarness = typeof PrProvenanceHarness.Type;
  *   branch: "feat/example",
  *   clonePath: "/home/user/beep-effect",
  *   harness: "codex",
- *   resumeCommand: "cd '/home/user/beep-effect' && codex resume --last",
+ *   resumeCommand: "cd '/home/user/beep-effect' &&\n  codex resume --last",
  *   sessionId: O.none(),
  *   worktreePath: O.none(),
  * })
@@ -101,8 +125,8 @@ export class PrProvenance extends S.Class<PrProvenance>($I`PrProvenance`)(
     clonePath: PrProvenanceAbsolutePath,
     harness: PrProvenanceHarness,
     resumeCommand: S.String,
-    sessionId: S.Option(S.String),
-    worktreePath: S.Option(PrProvenanceAbsolutePath),
+    sessionId: S.OptionFromNullOr(S.String),
+    worktreePath: S.OptionFromNullOr(PrProvenanceAbsolutePath),
   },
   $I.annote("PrProvenance", {
     description: "Origin and paste-ready resume command recorded in a Yeet pull request body.",
@@ -118,7 +142,7 @@ export class PrProvenance extends S.Class<PrProvenance>($I`PrProvenance`)(
  * import { mungeClaudeProjectPath } from "@beep/repo-cli/test/Yeet"
  *
  * console.log(mungeClaudeProjectPath("/home/user/beep.effect"))
- * // -home-user-beep-effect
+ * // -home-user-beep.effect
  * ```
  *
  * @param launchPath - Absolute path the harness session was launched from.
@@ -126,7 +150,7 @@ export class PrProvenance extends S.Class<PrProvenance>($I`PrProvenance`)(
  * @category utilities
  * @since 0.0.0
  */
-export const mungeClaudeProjectPath = (launchPath: string): string => Str.replace(/[/.]/gu, "-")(launchPath);
+export const mungeClaudeProjectPath = repoPathToClaudeProjectName;
 
 const sessionOrder = Order.mapInput(
   Order.Number,
@@ -149,7 +173,7 @@ const sessionOrder = Order.mapInput(
  * @param launchPaths - Absolute checkout and clone paths to inspect.
  * @param nowMillis - Current epoch milliseconds used for the six-hour bound.
  * @returns The launch path and session id of the newest recent transcript.
- * @category discovery
+ * @category detection
  * @since 0.0.0
  */
 export const findRecentClaudeSession = Effect.fn("PrProvenance.findRecentClaudeSession")(function* (
@@ -196,7 +220,11 @@ export const findRecentClaudeSession = Effect.fn("PrProvenance.findRecentClaudeS
   );
   return pipe(
     candidates,
-    A.filter((candidate) => nowMillis - candidate[2] <= Duration.toMillis(recentClaudeSessionWindow)),
+    A.filter(
+      (candidate) =>
+        candidate[2] >= nowMillis - Duration.toMillis(recentClaudeSessionWindow) &&
+        candidate[2] <= nowMillis + Duration.toMillis(futureClaudeSessionSkew)
+    ),
     A.sort(sessionOrder),
     A.head,
     O.map(([launchPath, sessionId]) => [launchPath, sessionId] as const)
@@ -230,12 +258,19 @@ export const resumeCommandFor = (
   PrProvenanceHarness.$match(harness, {
     "claude-code": () =>
       O.match(sessionId, {
-        onNone: () => `cd ${shellQuote(directory)} && claude --resume`,
-        onSome: (id) => `cd ${shellQuote(directory)} && claude --resume ${shellQuote(id)}`,
+        onNone: () => `cd ${shellQuote(directory)} &&\n  claude --resume`,
+        onSome: (id) => `cd ${shellQuote(directory)} &&\n  claude --resume ${shellQuote(id)}`,
       }),
-    codex: () => `cd ${shellQuote(directory)} && codex resume --last`,
-    unknown: () => `cd ${shellQuote(directory)} && claude --resume`,
+    codex: () =>
+      `cd ${shellQuote(directory)} &&\n  ${pipe(
+        sessionId,
+        O.map((id) => `codex resume ${shellQuote(id)}`),
+        O.getOrElse(() => "codex resume --last")
+      )}`,
+    unknown: () => `cd ${shellQuote(directory)} &&\n  claude --resume`,
   });
+
+const encodePrProvenanceJson = S.encodeUnknownResult(S.fromJsonString(PrProvenance));
 
 /**
  * Render provenance as the trailing Markdown section of a pull request body.
@@ -250,7 +285,7 @@ export const resumeCommandFor = (
  *   branch: "feat/example",
  *   clonePath: "/repo",
  *   harness: "unknown",
- *   resumeCommand: "cd '/repo' && claude --resume",
+ *   resumeCommand: "cd '/repo' &&\n  claude --resume",
  *   sessionId: O.none(),
  *   worktreePath: O.none(),
  * }))
@@ -268,7 +303,7 @@ export const renderPrProvenance = (provenance: PrProvenance): string => {
     O.map((worktreePath) => `- Worktree: \`${worktreePath}\`\n`),
     O.getOrElse(() => "")
   );
-  const command = Str.replace(" && ", " &&\n  ")(provenance.resumeCommand);
+  const encoded = pipe(provenance, encodePrProvenanceJson, Result.getOrThrow, renderPrettyCommandJson, Str.trimEnd);
   return `---
 
 ## Provenance
@@ -280,8 +315,12 @@ ${worktreeLine}- Branch: \`${provenance.branch}\`
 Resume this session:
 
 \`\`\`sh
-${command}
+${provenance.resumeCommand}
 \`\`\`
+
+<!-- yeet-provenance
+${encoded}
+-->
 `;
 };
 
@@ -317,26 +356,44 @@ export class PrProvenanceService extends Context.Service<PrProvenanceService, Pr
 
 type PrProvenanceRequirements = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner;
 
-const makeUnknownProvenance = (clonePath: string, branch: string): PrProvenance =>
+const makeUnknownProvenance = (
+  clonePath: string,
+  checkoutPath: string,
+  worktreePath: O.Option<string>,
+  branch: string
+): PrProvenance =>
   PrProvenance.make({
     branch,
     clonePath,
     harness: "unknown",
-    resumeCommand: resumeCommandFor("unknown", clonePath, O.none()),
+    resumeCommand: resumeCommandFor("unknown", checkoutPath, O.none()),
     sessionId: O.none(),
-    worktreePath: O.none(),
+    worktreePath,
   });
 
-const hasCodexEnvironment = Effect.fn("PrProvenance.hasCodexEnvironment")(function* () {
+/**
+ * Detect Codex markers and read its exact resumable thread id.
+ *
+ * **Example** (Inspect the active environment provider)
+ *
+ * ```ts
+ * import { detectCodexEnvironment } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(detectCodexEnvironment.pipe !== undefined)
+ * ```
+ *
+ * @returns Whether any `CODEX_` marker exists and the exact thread id when set.
+ * @category detection
+ * @since 0.0.0
+ */
+export const detectCodexEnvironment = Effect.fn("PrProvenance.detectCodexEnvironment")(function* () {
   const provider = yield* ConfigProvider.ConfigProvider;
-  const root = yield* provider.load([]);
-  if (root === undefined || !P.isTagged("Record")(root)) {
-    return false;
-  }
-  return pipe(root.keys, A.fromIterable, A.some(Str.startsWith("CODEX_")));
+  const codexNode = yield* provider.load(["CODEX"]);
+  const threadId = yield* Config.option(Config.string("CODEX_THREAD_ID"));
+  return [O.isSome(threadId) || P.isTagged("Record")(codexNode), threadId] as const;
 });
 
-const detectPrProvenanceImpl = Effect.fn("PrProvenance.detectImpl")(function* (cwd: string, branch: string) {
+const detectGitPaths = Effect.fn("PrProvenance.detectGitPaths")(function* (cwd: string) {
   const path = yield* Path.Path;
   const [commonDirectoryOutput, checkoutOutput] = yield* Effect.all(
     [runGitOutput(cwd, ["rev-parse", "--git-common-dir"]), runGitOutput(cwd, ["rev-parse", "--show-toplevel"])],
@@ -345,6 +402,49 @@ const detectPrProvenanceImpl = Effect.fn("PrProvenance.detectImpl")(function* (c
   const checkoutPath = path.resolve(Str.trim(checkoutOutput));
   const clonePath = path.dirname(path.resolve(checkoutPath, Str.trim(commonDirectoryOutput)));
   const worktreePath = checkoutPath === clonePath ? O.none<string>() : O.some(checkoutPath);
+  return [clonePath, checkoutPath, worktreePath] as const;
+});
+
+/**
+ * Detect harness provenance after Git has resolved clone and checkout paths.
+ *
+ * **Example** (Build a bounded harness detector)
+ *
+ * ```ts
+ * import { detectPrProvenanceFromPaths } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const detection = detectPrProvenanceFromPaths("/repo", "/repo", O.none(), "feat/example")
+ * console.log(detection.pipe !== undefined)
+ * ```
+ *
+ * @param clonePath - Absolute main clone path resolved by Git.
+ * @param checkoutPath - Absolute current checkout or linked-worktree path.
+ * @param worktreePath - Current checkout when it differs from the main clone.
+ * @param branch - Branch being published.
+ * @returns Detected harness provenance with Git identity preserved.
+ * @category detection
+ * @since 0.0.0
+ */
+export const detectPrProvenanceFromPaths = Effect.fn("PrProvenance.detectFromPaths")(function* (
+  clonePath: string,
+  checkoutPath: string,
+  worktreePath: O.Option<string>,
+  branch: string
+) {
+  const path = yield* Path.Path;
+  const [isCodex, codexThreadId] = yield* detectCodexEnvironment();
+  if (isCodex) {
+    return PrProvenance.make({
+      branch,
+      clonePath,
+      harness: "codex",
+      resumeCommand: resumeCommandFor("codex", checkoutPath, codexThreadId),
+      sessionId: codexThreadId,
+      worktreePath,
+    });
+  }
+
   const home = yield* Config.option(Config.string("HOME"));
   const nowMillis = yield* Clock.currentTimeMillis;
   const claudeSession = yield* pipe(
@@ -367,13 +467,11 @@ const detectPrProvenanceImpl = Effect.fn("PrProvenance.detectImpl")(function* (c
     });
   }
 
-  const isCodex = yield* hasCodexEnvironment();
-  const harness = isCodex ? "codex" : "unknown";
   return PrProvenance.make({
     branch,
     clonePath,
-    harness,
-    resumeCommand: resumeCommandFor(harness, clonePath, O.none()),
+    harness: "unknown",
+    resumeCommand: resumeCommandFor("unknown", checkoutPath, O.none()),
     sessionId: O.none(),
     worktreePath,
   });
@@ -384,13 +482,23 @@ const makePrProvenanceService = Effect.fn("PrProvenanceService.make")(function* 
   const runtimeContext = yield* Effect.context<PrProvenanceRequirements>();
   return PrProvenanceService.of({
     detect: Effect.fn("PrProvenanceService.detect")((cwd, branch) => {
-      const fallback = makeUnknownProvenance(path.resolve(cwd), branch);
-      return detectPrProvenanceImpl(cwd, branch).pipe(
+      const checkoutFallback = path.resolve(cwd);
+      const gitFallback = makeUnknownProvenance(checkoutFallback, checkoutFallback, O.none(), branch);
+      return detectGitPaths(cwd).pipe(
         Effect.provide(runtimeContext),
-        Effect.catchCause(() => Effect.succeed(fallback)),
-        Effect.timeoutOrElse({
-          duration: provenanceDetectionTimeout,
-          orElse: () => Effect.succeed(fallback),
+        Effect.matchCauseEffect({
+          onFailure: () => Effect.succeed(gitFallback),
+          onSuccess: ([clonePath, checkoutPath, worktreePath]) => {
+            const fallback = makeUnknownProvenance(clonePath, checkoutPath, worktreePath, branch);
+            return detectPrProvenanceFromPaths(clonePath, checkoutPath, worktreePath, branch).pipe(
+              Effect.provide(runtimeContext),
+              Effect.catchCause(() => Effect.succeed(fallback)),
+              Effect.timeoutOrElse({
+                duration: provenanceDetectionTimeout,
+                orElse: () => Effect.succeed(fallback),
+              })
+            );
+          },
         })
       );
     }),

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/PullRequest.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/PullRequest.ts
@@ -16,6 +16,7 @@ import { YeetCommandError } from "../Yeet.errors.ts";
 import { runIdForContext, runArtifactPathForContext as runOutputPathForContext } from "./ArtifactPaths.ts";
 import { runGitOutput } from "./GitExec.ts";
 import { writeTextFile } from "./IssueArtifacts.ts";
+import { makePrProvenanceServiceLive, renderPrProvenance } from "./Provenance.ts";
 import { YeetExecutedStep } from "./Verdict.ts";
 import type { FileSystem, Path } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
@@ -181,7 +182,11 @@ export const findOpenPullRequest = Effect.fn("Yeet.findOpenPullRequest")(functio
 export const buildPrBody = Effect.fn("Yeet.buildPrBody")(function* (
   context: RepoRunContext,
   recorder: Ref.Ref<ReadonlyArray<YeetExecutedStep>>
-): Effect.fn.Return<string, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+): Effect.fn.Return<
+  string,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
   const mergeBase = yield* runGitOutput(context.repoRoot, ["merge-base", context.base, "HEAD"]).pipe(
     Effect.map(Str.trim),
     Effect.orElseSucceed(() => "")
@@ -197,7 +202,9 @@ export const buildPrBody = Effect.fn("Yeet.buildPrBody")(function* (
   const proofSection = Str.isNonEmpty(laneSummary)
     ? laneSummary
     : "- full local proof still running (start-pr-early); see the verdict artifact for final lane results";
-  return `${Str.trim(commitLog)}\n\n## Local proof\n\n${proofSection}\n\nVerdict: .beep/yeet/runs/${runIdForContext(context)}/verdict.json\n`;
+  const provenanceService = yield* makePrProvenanceServiceLive();
+  const provenance = yield* provenanceService.detect(context.repoRoot, context.branch);
+  return `${Str.trim(commitLog)}\n\n## Local proof\n\n${proofSection}\n\nVerdict: .beep/yeet/runs/${runIdForContext(context)}/verdict.json\n\n${renderPrProvenance(provenance)}`;
 });
 
 /**

--- a/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
@@ -41,6 +41,7 @@ export * from "../commands/Yeet/internal/MonitorLoop.ts";
 export * from "../commands/Yeet/internal/Planner.ts";
 export * from "../commands/Yeet/internal/Porcelain.ts";
 export * from "../commands/Yeet/internal/ProofState.ts";
+export * from "../commands/Yeet/internal/Provenance.ts";
 export * from "../commands/Yeet/internal/PublishScope.ts";
 export * from "../commands/Yeet/internal/PullRequest.ts";
 export * from "../commands/Yeet/internal/QualityIssueIndex.ts";

--- a/packages/tooling/tool/cli/test/yeet-gate-staleness.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-gate-staleness.test.ts
@@ -5,6 +5,7 @@ import {
   GateFresh,
   GateStale,
   GateUnproven,
+  isGateInputRelevant,
   renderYeetGateStalenessBlock,
   staleGateVerdicts,
   unprovenGateVerdicts,
@@ -19,6 +20,15 @@ const descriptor = GateArtifactDescriptor.make({
   gateId: "coverage-regression",
   kind: "baseline",
   regenerateCommand: "bun run beep quality coverage",
+  scope: "repo-code",
+});
+
+const goalsDescriptor = GateArtifactDescriptor.make({
+  artifactPath: "goals/baselines/doctor.jsonc",
+  gateId: "goals-doctor",
+  kind: "baseline",
+  regenerateCommand: "bun run beep goals doctor --write-baseline",
+  scope: "goals-packets",
 });
 
 const artifactAt = (modifiedAtMs: number) =>
@@ -60,8 +70,55 @@ describe("gate staleness assessment", () => {
     expect(verdict.status === "unproven" ? verdict.detail : "").toContain(descriptor.artifactPath);
   });
 
-  it("refuses to judge when the branch changed nothing", () => {
-    expect(assessGateStaleness(descriptor, artifactAt(1_000), O.none()).status).toBe("unproven");
+  it("preserves an existing artifact when the branch has no relevant input", () => {
+    expect(assessGateStaleness(descriptor, artifactAt(1_000), O.none()).status).toBe("fresh");
+  });
+
+  it("keeps every repo-code gate fresh for a changeset-only change", () => {
+    const repoCodeDescriptors = A.filter(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.scope === "repo-code");
+
+    expect(A.every(repoCodeDescriptors, (entry) => !isGateInputRelevant(entry.scope, ".changeset/widget.md"))).toBe(
+      true
+    );
+    expect(
+      A.every(
+        repoCodeDescriptors,
+        (entry) =>
+          assessGateStaleness(
+            entry,
+            O.some(GateFileWitness.make({ modifiedAtMs: 1_000, path: entry.artifactPath })),
+            O.none()
+          ).status === "fresh"
+      )
+    ).toBe(true);
+  });
+
+  it("keeps repo-code gates fresh for a goals-only change but can stale goals-doctor", () => {
+    const goalsInput = "goals/widget/README.md";
+
+    expect(isGateInputRelevant(descriptor.scope, goalsInput)).toBe(false);
+    expect(assessGateStaleness(descriptor, artifactAt(1_000), O.none()).status).toBe("fresh");
+    expect(isGateInputRelevant(goalsDescriptor.scope, goalsInput)).toBe(true);
+    expect(
+      assessGateStaleness(
+        goalsDescriptor,
+        O.some(GateFileWitness.make({ modifiedAtMs: 1_000, path: goalsDescriptor.artifactPath })),
+        O.some(GateFileWitness.make({ modifiedAtMs: 2_000, path: goalsInput }))
+      ).status
+    ).toBe("stale");
+  });
+
+  it("still stales an older code baseline after a source change", () => {
+    const sourceInput = "packages/widgets/src/Widget.ts";
+
+    expect(isGateInputRelevant(descriptor.scope, sourceInput)).toBe(true);
+    expect(
+      assessGateStaleness(
+        descriptor,
+        artifactAt(1_000),
+        O.some(GateFileWitness.make({ modifiedAtMs: 2_000, path: sourceInput }))
+      ).status
+    ).toBe("stale");
   });
 });
 
@@ -121,6 +178,11 @@ describe("gate staleness reporting", () => {
 
     expect(A.length(YEET_GATE_ARTIFACT_DESCRIPTORS)).toBeGreaterThan(0);
     expect(A.length(A.dedupe(gateIds))).toBe(A.length(gateIds));
+    expect(A.filter(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.scope === "goals-packets")).toHaveLength(1);
+    expect(A.findFirst(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.gateId === "goals-doctor")).toMatchObject({
+      _tag: "Some",
+      value: { scope: "goals-packets" },
+    });
     expect(A.every(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.regenerateCommand.length > 0)).toBe(true);
     expect(A.map(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.regenerateCommand)).toStrictEqual([
       "bun run coverage:baseline:write",

--- a/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
@@ -1,0 +1,106 @@
+import {
+  findRecentClaudeSession,
+  mungeClaudeProjectPath,
+  PrProvenance,
+  renderPrProvenance,
+  resumeCommandFor,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Duration, Effect, FileSystem, Layer, Path, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+const withTempDirectory = <Result, Error, Requirements>(
+  use: (tmpDir: string) => Effect.Effect<Result, Error, Requirements>
+) =>
+  Effect.acquireUseRelease(
+    Effect.flatMap(FileSystem.FileSystem, (fs) => fs.makeTempDirectory()),
+    use,
+    (tmpDir) => Effect.flatMap(FileSystem.FileSystem, (fs) => fs.remove(tmpDir, { recursive: true }).pipe(Effect.orDie))
+  ).pipe(provideScopedLayer(PlatformLayer));
+
+describe("Yeet PR provenance", () => {
+  it("munges slashes and dots like Claude Code project directories", () => {
+    expect(mungeClaudeProjectPath("/home/operator/beep-effect/.claude/worktrees/end.game")).toBe(
+      "-home-operator-beep-effect--claude-worktrees-end-game"
+    );
+  });
+
+  it.effect("selects the newest candidate transcript and rejects stale transcripts", () =>
+    withTempDirectory((projectsRoot) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const clonePath = "/workspace/beep-effect";
+        const worktreePath = "/workspace/beep-effect/.claude/worktrees/feature";
+        const cloneDirectory = path.join(projectsRoot, mungeClaudeProjectPath(clonePath));
+        const worktreeDirectory = path.join(projectsRoot, mungeClaudeProjectPath(worktreePath));
+        const olderPath = path.join(worktreeDirectory, "older-session.jsonl");
+        const newestPath = path.join(cloneDirectory, "newest-session.jsonl");
+        const nowMillis = 2_000_000_000_000;
+
+        yield* fs.makeDirectory(cloneDirectory, { recursive: true });
+        yield* fs.makeDirectory(worktreeDirectory, { recursive: true });
+        yield* fs.writeFileString(olderPath, "{}\n");
+        yield* fs.writeFileString(newestPath, "{}\n");
+        const olderSeconds = (nowMillis - 10_000) / 1_000;
+        const newestSeconds = (nowMillis - 1_000) / 1_000;
+        yield* fs.utimes(olderPath, olderSeconds, olderSeconds);
+        yield* fs.utimes(newestPath, newestSeconds, newestSeconds);
+
+        expect(yield* findRecentClaudeSession(projectsRoot, [worktreePath, clonePath], nowMillis)).toStrictEqual(
+          O.some([clonePath, "newest-session"])
+        );
+        expect(
+          yield* findRecentClaudeSession(
+            projectsRoot,
+            [worktreePath, clonePath],
+            nowMillis + Duration.toMillis(Duration.hours(7))
+          )
+        ).toStrictEqual(O.none());
+      })
+    )
+  );
+
+  it("builds each harness resume command", () => {
+    expect(resumeCommandFor("claude-code", "/workspace/clone", O.some("session-123"))).toBe(
+      "cd '/workspace/clone' && claude --resume 'session-123'"
+    );
+    expect(resumeCommandFor("codex", "/workspace/clone", O.none())).toBe(
+      "cd '/workspace/clone' && codex resume --last"
+    );
+    expect(resumeCommandFor("unknown", "/workspace/clone", O.none())).toBe("cd '/workspace/clone' && claude --resume");
+  });
+
+  it("renders a trailing footer with linked-worktree provenance and a fenced command", () => {
+    const footer = renderPrProvenance(
+      PrProvenance.make({
+        branch: "feat/yeet-pr-provenance",
+        clonePath: "/workspace/beep-effect",
+        harness: "claude-code",
+        resumeCommand: resumeCommandFor("claude-code", "/workspace/beep-effect", O.some("session-123")),
+        sessionId: O.some("session-123"),
+        worktreePath: O.some("/workspace/beep-effect/.claude/worktrees/endgame"),
+      })
+    );
+
+    expect(footer).toContain("---\n\n## Provenance");
+    expect(footer).toContain("- Clone: `/workspace/beep-effect`");
+    expect(footer).toContain("- Worktree: `/workspace/beep-effect/.claude/worktrees/endgame`");
+    expect(footer).toContain("- Branch: `feat/yeet-pr-provenance`");
+    expect(footer).toContain("- Harness: `claude-code`");
+    expect(footer).toContain("```sh\ncd '/workspace/beep-effect' &&\n  claude --resume 'session-123'\n```");
+    expect(
+      pipe(
+        Str.split("\n")(footer),
+        A.every((line) => Str.length(line) < 100)
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
@@ -1,4 +1,6 @@
 import {
+  detectCodexEnvironment,
+  detectPrProvenanceFromPaths,
   findRecentClaudeSession,
   mungeClaudeProjectPath,
   PrProvenance,
@@ -9,9 +11,10 @@ import { provideScopedLayer } from "@beep/test-utils";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { Duration, Effect, FileSystem, Layer, Path, pipe } from "effect";
+import { ConfigProvider, Duration, Effect, FileSystem, Layer, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
+import * as S from "effect/Schema";
 import * as Str from "effect/String";
 
 const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
@@ -26,11 +29,55 @@ const withTempDirectory = <Result, Error, Requirements>(
   ).pipe(provideScopedLayer(PlatformLayer));
 
 describe("Yeet PR provenance", () => {
-  it("munges slashes and dots like Claude Code project directories", () => {
-    expect(mungeClaudeProjectPath("/home/operator/beep-effect/.claude/worktrees/end.game")).toBe(
-      "-home-operator-beep-effect--claude-worktrees-end-game"
+  it("delegates Claude project naming to the canonical slash converter", () => {
+    expect(mungeClaudeProjectPath("/home/operator/beep.effect\\.claude/worktrees/end.game")).toBe(
+      "-home-operator-beep.effect-.claude-worktrees-end.game"
     );
   });
+
+  it.effect("detects split Codex markers and reads CODEX_THREAD_ID by its exact environment key", () =>
+    Effect.gen(function* () {
+      expect(yield* detectCodexEnvironment()).toStrictEqual([true, O.some("thread-123")]);
+    }).pipe(
+      Effect.provideService(
+        ConfigProvider.ConfigProvider,
+        ConfigProvider.fromEnv({ env: { CODEX_HOME: "/tmp/codex", CODEX_THREAD_ID: "thread-123" } })
+      )
+    )
+  );
+
+  it.effect("classifies Codex before searching a newer Claude transcript", () =>
+    withTempDirectory((home) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const clonePath = "/workspace/beep-effect";
+        const checkoutPath = "/workspace/beep-effect/.claude/worktrees/endgame";
+        const transcriptDirectory = path.join(home, ".claude", "projects", mungeClaudeProjectPath(checkoutPath));
+
+        yield* fs.makeDirectory(transcriptDirectory, { recursive: true });
+        yield* fs.writeFileString(path.join(transcriptDirectory, "another-session.jsonl"), "{}\n");
+
+        const provenance = yield* detectPrProvenanceFromPaths(
+          clonePath,
+          checkoutPath,
+          O.some(checkoutPath),
+          "feat/yeet-pr-provenance"
+        ).pipe(
+          Effect.provideService(
+            ConfigProvider.ConfigProvider,
+            ConfigProvider.fromEnv({ env: { CODEX_THREAD_ID: "thread-123", HOME: home } })
+          )
+        );
+
+        expect(provenance.harness).toBe("codex");
+        expect(provenance.sessionId).toStrictEqual(O.some("thread-123"));
+        expect(provenance.resumeCommand).toBe(
+          "cd '/workspace/beep-effect/.claude/worktrees/endgame' &&\n  codex resume 'thread-123'"
+        );
+      })
+    )
+  );
 
   it.effect("selects the newest candidate transcript and rejects stale transcripts", () =>
     withTempDirectory((projectsRoot) =>
@@ -68,39 +115,88 @@ describe("Yeet PR provenance", () => {
     )
   );
 
+  it.effect("rejects far-future transcripts in favor of a valid recent candidate", () =>
+    withTempDirectory((projectsRoot) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const clonePath = "/workspace/beep-effect";
+        const directory = path.join(projectsRoot, mungeClaudeProjectPath(clonePath));
+        const recentPath = path.join(directory, "recent-session.jsonl");
+        const futurePath = path.join(directory, "future-session.jsonl");
+        const nowMillis = 2_000_000_000_000;
+
+        yield* fs.makeDirectory(directory, { recursive: true });
+        yield* fs.writeFileString(recentPath, "{}\n");
+        yield* fs.writeFileString(futurePath, "{}\n");
+        const recentSeconds = (nowMillis - 1_000) / 1_000;
+        const futureSeconds = (nowMillis + Duration.toMillis(Duration.hours(1))) / 1_000;
+        yield* fs.utimes(recentPath, recentSeconds, recentSeconds);
+        yield* fs.utimes(futurePath, futureSeconds, futureSeconds);
+
+        expect(yield* findRecentClaudeSession(projectsRoot, [clonePath], nowMillis)).toStrictEqual(
+          O.some([clonePath, "recent-session"])
+        );
+        yield* fs.remove(recentPath);
+        expect(yield* findRecentClaudeSession(projectsRoot, [clonePath], nowMillis)).toStrictEqual(O.none());
+      })
+    )
+  );
+
   it("builds each harness resume command", () => {
     expect(resumeCommandFor("claude-code", "/workspace/clone", O.some("session-123"))).toBe(
-      "cd '/workspace/clone' && claude --resume 'session-123'"
+      "cd '/workspace/clone' &&\n  claude --resume 'session-123'"
     );
-    expect(resumeCommandFor("codex", "/workspace/clone", O.none())).toBe(
-      "cd '/workspace/clone' && codex resume --last"
+    expect(resumeCommandFor("codex", "/workspace/worktree", O.some("thread-123"))).toBe(
+      "cd '/workspace/worktree' &&\n  codex resume 'thread-123'"
     );
-    expect(resumeCommandFor("unknown", "/workspace/clone", O.none())).toBe("cd '/workspace/clone' && claude --resume");
+    expect(resumeCommandFor("codex", "/workspace/worktree", O.none())).toBe(
+      "cd '/workspace/worktree' &&\n  codex resume --last"
+    );
+    expect(resumeCommandFor("unknown", "/workspace/clone", O.none())).toBe(
+      "cd '/workspace/clone' &&\n  claude --resume"
+    );
   });
 
-  it("renders a trailing footer with linked-worktree provenance and a fenced command", () => {
-    const footer = renderPrProvenance(
-      PrProvenance.make({
+  it("wraps only the command separator when the checkout path contains ampersands", () => {
+    expect(resumeCommandFor("codex", "/workspace/a && b", O.some("thread-123"))).toBe(
+      "cd '/workspace/a && b' &&\n  codex resume 'thread-123'"
+    );
+  });
+
+  it.effect("renders human and schema-decodable machine provenance twins", () =>
+    Effect.gen(function* () {
+      const provenance = PrProvenance.make({
         branch: "feat/yeet-pr-provenance",
         clonePath: "/workspace/beep-effect",
         harness: "claude-code",
         resumeCommand: resumeCommandFor("claude-code", "/workspace/beep-effect", O.some("session-123")),
         sessionId: O.some("session-123"),
         worktreePath: O.some("/workspace/beep-effect/.claude/worktrees/endgame"),
-      })
-    );
+      });
+      const footer = renderPrProvenance(provenance);
 
-    expect(footer).toContain("---\n\n## Provenance");
-    expect(footer).toContain("- Clone: `/workspace/beep-effect`");
-    expect(footer).toContain("- Worktree: `/workspace/beep-effect/.claude/worktrees/endgame`");
-    expect(footer).toContain("- Branch: `feat/yeet-pr-provenance`");
-    expect(footer).toContain("- Harness: `claude-code`");
-    expect(footer).toContain("```sh\ncd '/workspace/beep-effect' &&\n  claude --resume 'session-123'\n```");
-    expect(
-      pipe(
-        Str.split("\n")(footer),
-        A.every((line) => Str.length(line) < 100)
-      )
-    ).toBe(true);
-  });
+      expect(footer).toContain("---\n\n## Provenance");
+      expect(footer).toContain("- Clone: `/workspace/beep-effect`");
+      expect(footer).toContain("- Worktree: `/workspace/beep-effect/.claude/worktrees/endgame`");
+      expect(footer).toContain("- Branch: `feat/yeet-pr-provenance`");
+      expect(footer).toContain("- Harness: `claude-code`");
+      expect(footer).toContain("```sh\ncd '/workspace/beep-effect' &&\n  claude --resume 'session-123'\n```");
+
+      const encoded = pipe(
+        footer,
+        Str.split("<!-- yeet-provenance\n"),
+        A.get(1),
+        O.flatMap((tail) => pipe(tail, Str.split("\n-->"), A.head)),
+        O.getOrThrow
+      );
+      expect(yield* S.decodeUnknownEffect(S.fromJsonString(PrProvenance))(encoded)).toStrictEqual(provenance);
+      expect(
+        pipe(
+          Str.split("\n")(footer),
+          A.every((line) => Str.length(line) < 100)
+        )
+      ).toBe(true);
+    })
+  );
 });


### PR DESCRIPTION
## feat(repo-cli): stamp yeet PRs with a provenance footer

Every yeet-published PR now ends with a provenance section naming the clone,
the worktree when one is in play, the branch, and the originating harness,
plus a paste-ready resume command in a code block. Answering where a PR came
from and how to get back into that session stops requiring archaeology.

Detection never fails a publish. Claude Code sessions are identified from the
transcript store: the newest recent jsonl across the current checkout and the
main clone munged paths is the running session, and its filename stem is the
resume id. A session driving a linked worktree keys its transcript to the
main clone, so both candidates are searched. Codex exposes no thread id, so
its footer resumes with codex resume --last, and an unrecognized harness
degrades to the project session picker.

Also records the burst-reaper friction receipt in the ci-fleet-endgame
ledger: the TTL reaper terminates workers mid-job (all three burst workers
died at 06:05:19Z ninety seconds into main's heavy lanes), a class the P2
cutover retires by design.

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_yeet-pr-provenance-bc6e1128e067/verdict.json

---

## Provenance

- Clone: `/home/elpresidank/YeeBois/projects/beep-effect3`
- Worktree: `/home/elpresidank/YeeBois/projects/beep-effect3/.claude/worktrees/endgame`
- Branch: `feat/yeet-pr-provenance`
- Harness: `claude-code`

Resume this session:

```sh
cd '/home/elpresidank/YeeBois/projects/beep-effect3' &&
  claude --resume '3c433e5d-9721-4fa0-bc7b-91ca34ff745b'
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788944462&installation_model_id=424656&pr_number=637&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F637&signature=e7a6a8752592c1912919f7090d33e284a976e9595fbe265dd52a12654ef8f749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->