### PR TITLE
feat(worktree): harden fleet registry liveness

### DIFF
--- a/.changeset/fleet-mirror-registry-liveness.md
+++ b/.changeset/fleet-mirror-registry-liveness.md
@@ -1,0 +1,10 @@
+---
+{}
+---
+
+No release: harden `beep worktree fleet` with a positive-only Claude session-registry
+liveness probe guarded against PID reuse, rank truncated contested-path output by live
+claimants, and flag a checkout that swamps the index. Close the fleet-coordination
+exploration by assigning push-to-reachable plus pull-for-everyone delivery to the retained
+`goals/fleet-mirror` packet. Preserve large machine-readable CLI payloads by bypassing the
+Bun platform Console service's 64 KiB single-entry cap at the shared JSON print boundary.

--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -112,21 +112,6 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   capture-stage preservation of the paused goal’s load-bearing governance
   design: ordered law canon, explicit role authority, gated lifecycle,
   decision-complete artifacts, and expiring exception contracts.
-- [`fleet-coordination`](./fleet-coordination/README.md) — graduate-stage: ~13
-  agent checkouts on one workstation duplicating each other’s fixes and rotting
-  each other’s in-flight PRs. Research verdict is a derived **mirror**, not a
-  message board — derive early, deliver ambiently, enforce late — shipped
-  through the reserved `AgentBrief.fleet` field. First goal graduated 2026-08-06:
-  [`fleet-mirror`](../goals/fleet-mirror/README.md) (D6), scoped to the
-  **derivation rung**, which the capability check proved depends on nothing
-  unmerged, and shipped 2026-08-08 as `beep worktree fleet` (#621); the
-  **delivery rung** stays here, no longer gated on PR-I — Claude Code 2.1.224
-  shipped cross-session messaging, a non-hook push T3 had ruled out
-  ([`T6`](./fleet-coordination/research/T6-cross-session-messaging.md)). Grill #1
-  locked D1–D5 and disposed four questions; en route it killed `law-pulse.sh`
-  ever reaching the model (fixed here), `beep yeet` being a gate, `flock`
-  releasing on holder death, and merge queue at this repo’s measured shape (19%
-  main gauntlet pass rate).
 - [`model-artifact-admission`](./model-artifact-admission/README.md) —
   capture-stage: bind model qualification to the exact model, adapter,
   modality, prompt, wrapper, decoding configuration, and artifact digest —
@@ -361,6 +346,15 @@ The lego pieces already built. Authoritative inventories (link, never copy):
 
 ### Graduated
 
+- [`fleet-coordination`](./fleet-coordination/README.md) — graduated
+  2026-08-10 into the retained
+  [`fleet-mirror`](../goals/fleet-mirror/README.md) goal with no open design
+  questions. Rung 1 shipped 2026-08-08 as `beep worktree fleet` (#621); rung
+  1.5 adds the positive-only Claude session-registry liveness probe and
+  live-first contested rendering. D7 keeps rung 2 in the same goal as
+  **push-to-reachable plus pull-for-everyone**, with the mirror authoritative
+  because messaging cannot cover the full fleet. Research verdict: derive a
+  mirror, not a message board — derive early, deliver ambiently, enforce late.
 - [`graphnosis-prior-art`](./graphnosis-prior-art/README.md) — graduated
   2026-08-06 (opened same day) into
   [`goals/epistemic-contradiction-detection`](../goals/epistemic-contradiction-detection/README.md)

--- a/explorations/fleet-coordination/DECISIONS.md
+++ b/explorations/fleet-coordination/DECISIONS.md
@@ -303,3 +303,38 @@ with the fact/ignorance distinction, this generalizes to a law the build must
 follow: **every field in the fleet snapshot is either measured, or `unknown`.
 Nothing is inferred from a proxy, and nothing defaults to the safe-sounding
 value.**
+
+---
+
+## 2026-08-10 — D7. Harden rung 1 in place; keep delivery push-plus-pull in the same goal.
+
+**Question.** Does the registry liveness probe ship, and does rung 2 use
+push-to-reachable plus pull-for-everyone in a new packet or the retained
+`fleet-mirror` goal?
+
+**Answer.** Ship rung 1.5 in [`goals/fleet-mirror`](../../goals/fleet-mirror/README.md):
+add `claude-session` to the closed evidence domain, accept only registry entries
+whose `procStart` matches `/proc/<pid>/stat` field 22, and use the confirmed
+registry `cwd` only as positive `live` evidence. Rank the truncated text view of
+contested paths by live claimant count and note any checkout claiming more than
+half the rows; keep the canonical JSON ordering unchanged.
+
+Rung 2 also resumes in `goals/fleet-mirror`; it does **not** open a second
+packet. Its fixed shape is **push to reachable sessions plus pull for
+everyone**. Push is an opportunistic, targeted acceleration of the mirror's
+facts, never the authority and never the only delivery path.
+
+**Rationale.** The registry changes only `unknown → live`: no entry, unreadable
+state, malformed JSON, a dead PID, or a PID-reuse mismatch contributes nothing.
+That preserves the measured-or-`unknown` law while replacing a 13.2%-readable
+cwd lookup with a 99.7%-readable starttime guard for Claude sessions. Ranking is
+a renderer concern because the full contested index is already correct; changing
+the snapshot would conflate presentation priority with canonical data.
+
+Messaging does not justify a new ownership boundary. Detection, targeting,
+pull, and push all consume the same fleet snapshot, and T6's socket-less live
+session proves reachability is incomplete. Keeping both delivery halves beside
+the mirror avoids a competing source of truth. The socket's missing cause stays
+measured-and-unexplained, but is dispositioned rather than investigated: the
+pull fallback makes that cause non-blocking unless later coverage measurements
+show otherwise.

--- a/explorations/fleet-coordination/README.md
+++ b/explorations/fleet-coordination/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 Stage: `graduate`
-Status: `active`
+Status: `graduated`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -26,38 +26,18 @@ checkouts share one filesystem, one kernel, one user.
 
 ## Next Open Question
 
-**Rung 2 only, and not blocking — but the gate moved.** Claude Code 2.1.224
-shipped cross-session messaging, so delivery no longer waits on speed-loop PR-I
-landing `AgentBrief.fleet`. The question is now its shape: push reaches only
-sessions that bound a messaging socket, and whether a message is delivered,
-held, or dropped is decided by the **receiver's** permission mode, which the
-sender cannot see. So does rung 2 become *push to the reachable, pull for
-everyone*, and does it ride into
-[`goals/fleet-mirror`](../../goals/fleet-mirror/README.md) or open its own
-packet? See [`T6`](./research/T6-cross-session-messaging.md).
+None. [`D7`](./DECISIONS.md) closes the remaining branches in one ownership
+line: rung 1.5 ships as a bounded hardening of
+[`goals/fleet-mirror`](../../goals/fleet-mirror/README.md), and rung 2 returns to
+that same retained goal as **push to reachable sessions plus pull for
+everyone**. Cross-session push is an opportunistic accelerator; the derived
+mirror remains the source of truth and fallback.
 
-**Rung 1 shipped 2026-08-08** as `beep worktree fleet` (#621) — derivation only.
-This exploration stays `active` because rung 2 remains unbuilt, and now carries
-a bounded **rung 1.5**: adopt the on-disk session registry as the liveness probe
-(T6 §4), which converts `unknown → live` on a 99.7%-readable measurement where
-rung 1's `/proc` probe reaches 13.2%. Rung 1.5 is not a classifier tweak — the
-`evidence` field is a closed literal domain, so it needs a schema change first;
-T6 §4 carries the schema-first order. Needs an operator go before it opens.
-
-**Third question, open and unexplained.** `beep-effect3-e3` runs 2.1.226,
-`kind: interactive`, `status: busy`, and records `messagingSocketPath: null`, so
-it is unreachable by peer messaging while fully alive (T6 §3.1). The documented
-candidates are feature-flag evaluation being disabled for that session, bare
-mode, or provider. Recorded as **measured and unexplained** rather than guessed,
-per this packet's binding law. It matters because it bounds how much of the
-fleet rung 2's push half can ever cover.
-
-These three questions are mirrored in
-[`ops/manifest.json`](./ops/manifest.json) `openQuestions`; the manifest is the
-machine-readable copy and this section is the prose one. They are open
-questions, not decisions — [`DECISIONS.md`](./DECISIONS.md) is the align-stage
-log of questions already *answered* (question → answer → rationale), so nothing
-lands there until one of these resolves.
+The socket-less `beep-effect3-e3` specimen in [`T6`](./research/T6-cross-session-messaging.md)
+§3.1 stays measured-and-unexplained, but it is no longer an open design branch:
+the pull half is required precisely because reachability cannot be assumed.
+Investigate the missing socket only if measured push coverage later proves too
+low; do not guess at its cause now.
 
 ## Read This First
 
@@ -91,6 +71,14 @@ the capability is not the same as the capability covering the fleet.
 
 ## Trail
 
+- 2026-08-10: **packet closed with no open questions.** Rung 1.5 added the
+  positive-only Claude session-registry probe with the `/proc` `starttime`
+  PID-reuse guard, ranked contested text output by live claimants, and flags a
+  checkout that swamps the truncated index. D7 also fixed rung 2's shape and
+  ownership: push-to-reachable plus pull-for-everyone, continuing in
+  `goals/fleet-mirror` rather than opening a competing packet. The unexplained
+  socket-less live session is accepted as evidence for the pull fallback, not
+  retained as an investigation obligation. Status flipped to `graduated`.
 - 2026-08-10: friction ledger opened
   ([`research/OPPORTUNITIES.md`](./research/OPPORTUNITIES.md)) with three
   receipts, two of them found by **dogfooding rung 1 on a real question** —

--- a/explorations/fleet-coordination/ops/manifest.json
+++ b/explorations/fleet-coordination/ops/manifest.json
@@ -3,13 +3,9 @@
   "exploration": {
     "slug": "fleet-coordination",
     "title": "Fleet Coordination For Parallel Agent Checkouts",
-    "status": "active",
+    "status": "graduated",
     "stage": "graduate",
-    "openQuestions": [
-      "Rung 2 only: Claude Code 2.1.224 shipped cross-session messaging, so delivery no longer waits on speed-loop PR-I landing AgentBrief.fleet - but push reaches only sessions that bound a socket, and delivery outcome is set by the RECEIVER's permission mode. Does rung 2 become push-to-reachable plus pull-for-everyone, and does it open its own packet? Not blocking - rung 1 is graduated and shipped.",
-      "Rung 1.5: adopt the on-disk session registry as the liveness probe (T6 section 4). Bounded change to goals/fleet-mirror, pure unknown-to-live conversion. Needs an operator go before opening a packet.",
-      "Unexplained: beep-effect3-e3 runs 2.1.226 interactive and records messagingSocketPath null, so it is unreachable by peer messaging while fully alive. Cause not established (feature-flag evaluation, bare mode, provider). Measured in T6 section 3.1."
-    ],
+    "openQuestions": [],
     "sources": ["research/SOURCES.md"],
     "links": {
       "goals": ["goals/fleet-mirror"],

--- a/explorations/fleet-coordination/research/T6-cross-session-messaging.md
+++ b/explorations/fleet-coordination/research/T6-cross-session-messaging.md
@@ -220,6 +220,11 @@ fleet not-live.
 signal the mirror currently has no equivalent of. Worth a follow-up probe;
 out of scope for 1.5.
 
+**Resolved 2026-08-10 (D7).** Rung 1.5 ships in `goals/fleet-mirror` with the
+terse `claude-session` evidence member, PID-reuse guard, renderer join, and
+tests. It deliberately reads only `pid`, `procStart`, and `cwd`; session status
+freshness remains outside the liveness contract rather than becoming a proxy.
+
 ---
 
 ## 5. Delivery-class mechanics that constrain rung 2
@@ -277,6 +282,11 @@ ahead of time, or the bulletin must remain pull-derivable — which is the mirro
   "The negotiation had to be relayed by hand through the operator, because the
   capability this packet is about does not exist yet." It exists. And §0's
   specimen is why the 2026-08-08 CI notice *still* came by hand.
+
+**Resolved 2026-08-10 (D7).** Rung 2 is push-to-reachable plus
+pull-for-everyone and resumes in `goals/fleet-mirror`; no second packet opens.
+The socket-less live-session specimen is accepted as the proof that pull must
+remain authoritative, not retained as an open investigation.
 
 ---
 

--- a/goals/fleet-mirror/README.md
+++ b/goals/fleet-mirror/README.md
@@ -33,19 +33,21 @@ Use this command for execution-capable sessions:
 
 ## Scope Boundary — read before starting
 
-This packet is **rung 1: derivation only**. The command exists, the three signals
-are correct, and a human runs it.
+This retained packet owns the fleet mirror across its rungs. Rung 1 shipped the
+read-only derivation command; rung 1.5 hardens its liveness and contested-path
+presentation without changing the snapshot's measured-or-`unknown` contract.
 
-**Rung 2 — ambient delivery through `AgentBrief.fleet` — is not in this packet
-and cannot start here.** That field ships in speed-loop PR-I; re-verified against
-`main` at `b4a06cefa3` (2026-08-06, after PR-E landed as #569), `AgentBrief`,
-`OwnershipClaim`, and `beep agent report list` still have **zero source
-references**. Everything rung 1 needs — `worktree doctor`, `git merge-tree`,
-`/proc` — is already on `main`.
+Rung 2 is decided but unimplemented: **push to reachable sessions plus pull for
+everyone**, with the mirror remaining authoritative. It resumes here rather
+than opening a second packet; see fleet-coordination
+[`D7`](../../explorations/fleet-coordination/DECISIONS.md). Cross-session
+messaging removed the old PR-I dependency, but does not cover socket-less,
+non-Claude, dormant, exited, or container-isolated sessions, so push can never
+replace pull.
 
 ## Current Phase
 
-**Complete.** Rung 1 shipped: `beep worktree fleet` derives the read-only
+**Complete-retained.** Rung 1 shipped: `beep worktree fleet` derives the read-only
 snapshot (schema family in `Worktree.schemas.ts`, `FleetMirrorService` in
 `Fleet.service.ts`, subcommand in `Fleet.command.ts` — all under
 `packages/tooling/tool/cli/src/commands/Worktree/`). One siting deviation from
@@ -54,6 +56,14 @@ than inside `Worktree.command.ts`, because registering the subcommand from the
 same file the service imports schemas from is a TDZ-fatal ESM cycle (hit live
 on first run; see [`research/OPPORTUNITIES.md`](./research/OPPORTUNITIES.md)).
 Doctor's row schema is unchanged.
+
+Rung 1.5 adds a positive-only `claude-session` liveness probe from
+`~/.claude/sessions/<pid>.json`, guarded against PID reuse by comparing
+`procStart` with `/proc/<pid>/stat` field 22. Missing, unreadable, malformed,
+dead, or recycled entries contribute nothing, so existing `live`, `dormant`,
+and `unknown` verdicts can only gain measured live evidence. The text renderer
+also ranks contested rows by live claimants and notes a checkout that claims
+more than half an overflowing index; `--json` keeps its canonical path order.
 
 ## Latest Evidence
 
@@ -66,6 +76,10 @@ Doctor's row schema is unchanged.
   `unmoved` for a branch cut after the moved commits — and `dormant` proved
   unreachable on this host (1285/1816 `/proc` entries root-owned ⇒ scan never
   complete), which is the measured-or-`unknown` law behaving as specified.
+- Rung 1.5 proof (2026-08-10): focused fleet tests cover the registry decode,
+  real `/proc/self/stat` confirmation, subdirectory-to-checkout join, PID-reuse,
+  dead-PID and malformed-entry failures, unknown-to-live classification,
+  live-first contested ranking, and swamping notes.
 - [`research/p0-policy-surface-measurement.md`](./research/p0-policy-surface-measurement.md)
   (2026-08-06) — 26 paths measured over 300 first-parent `main` commits.
 - Friction ledger: [`research/OPPORTUNITIES.md`](./research/OPPORTUNITIES.md).

--- a/goals/fleet-mirror/research/OPPORTUNITIES.md
+++ b/goals/fleet-mirror/research/OPPORTUNITIES.md
@@ -70,3 +70,38 @@ and moved onto the measured policy surface — `.github/workflows/**`,
 which tripped yeet's stale-base publish guard. Signal 3 pointed at this exact
 window in the first live scan hours earlier. Fourth real specimen of the arc;
 resolved by fast-forward (no local commits yet) + INDEX regeneration.
+
+## 2026-08-10 — the advertised full JSON escape hatch truncated at 64 KiB
+
+The rung 1.5 live smoke test piped `beep worktree fleet --json` into `jq` and
+failed at byte 65,536 with an unfinished JSON string. The real 1,185-row
+contested snapshot exceeded the Bun platform Console service's output cap, so
+the text renderer's overflow instruction — "use `--json` for the full list" —
+pointed at invalid output exactly when the list was large enough to need it.
+
+- Evidence: both `bun run beep worktree fleet --json | wc -c` and direct
+  invocation of the CLI emitted exactly `65536`; a 70,000-byte
+  `Console.log` under `BunServices.layer` reproduced the cap, while
+  `Terminal.display` under the same layer emitted all 70,000 bytes.
+- Resolution: the shared `printCommandJson` process boundary now writes
+  directly to stdout. This fixes Fleet and prevents the same silent truncation
+  in Yeet's JSON status/plan output without spreading process I/O through
+  command logic.
+- What would have prevented it: a shared JSON-printer integration proof with a
+  payload above 64 KiB. Small-object formatting tests cannot exercise the
+  platform Console boundary.
+
+## 2026-08-10 — the package test tsconfig is not a direct test-typecheck entrypoint
+
+After the full Yeet lane found an Effect diagnostic in a CLI test, running
+`tsgo -p packages/tooling/tool/cli/test/tsconfig.json --noEmit` directly produced
+only `TS6059` noise because the package source config fixes `rootDir` to `src/`.
+The canonical `beep quality test-tsgo` lane builds its own per-package test
+profile and is the usable reproduction path.
+
+- Evidence: the direct command rejected every `test/**/*.test.ts` file as being
+  outside `packages/tooling/tool/cli/src`; `bun run beep quality test-tsgo`
+  instead reported the two actionable `TS377098` diagnostics.
+- What would have prevented it: a package-local `beep:check:tests` script, or a
+  short note in `test/tsconfig.json` naming `beep quality test-tsgo` as the
+  supported entrypoint.

--- a/packages/tooling/tool/cli/src/commands/Worktree/Fleet.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Worktree/Fleet.command.ts
@@ -14,8 +14,8 @@
  * @since 0.0.0
  */
 
-import { A } from "@beep/utils";
-import { Console, Effect } from "effect";
+import { A, O } from "@beep/utils";
+import { Console, Effect, MutableHashMap, MutableHashSet, Order } from "effect";
 import { Command } from "effect/unstable/cli";
 import { failWithReportedExit } from "../../internal/cli/ExitCodeError.ts";
 import { jsonFlagWith } from "../../internal/cli/Flags.ts";
@@ -139,17 +139,163 @@ const snapshotHeaderLines = (snapshot: FleetSnapshot): ReadonlyArray<string> => 
   `Coverage:   ${coverageLabel(snapshot.coverage)}`,
 ];
 
-const contestedLines = (contested: ReadonlyArray<FleetContestedPath>): ReadonlyArray<string> => {
+const liveCheckoutSet = (checkouts: ReadonlyArray<FleetCheckout>): MutableHashSet.MutableHashSet<string> => {
+  const live = MutableHashSet.empty<string>();
+  for (const row of checkouts) {
+    if (row.liveness === "live") {
+      MutableHashSet.add(live, row.path);
+    }
+  }
+  return live;
+};
+
+/**
+ * Rank contested paths for display: rows contested by more live checkouts
+ * first, then by more claimants overall, then by path.
+ *
+ * **Details**
+ *
+ * The snapshot's `contestedPaths` stay sorted by path — that is the canonical
+ * JSON ordering. Ranking is a display concern: an unweighted path sort lets
+ * one high-dirty checkout swamp the truncated text rendering with rows only
+ * it contests, burying the cross-live contention the mirror exists to
+ * surface.
+ *
+ * **Example** (A path claimed by a live checkout outranks an earlier-sorted stale one)
+ *
+ * ```ts
+ * import { FleetCheckout, FleetContestedPath, rankContestedPaths } from "@beep/repo-cli/commands/Worktree"
+ *
+ * const busy = FleetCheckout.make({
+ *   path: "/fleet/busy",
+ *   kind: "clone",
+ *   branch: null,
+ *   detached: null,
+ *   head: null,
+ *   dirtyCount: null,
+ *   mergeBase: null,
+ *   branchDiffCount: null,
+ *   liveness: "live",
+ *   livenessEvidence: ["claude-session"],
+ *   conflict: "unknown",
+ *   conflictReason: "head-unknown",
+ *   conflictPaths: [],
+ *   policyMovement: "unknown",
+ *   policyReason: "head-unknown",
+ *   policyPaths: [],
+ * })
+ * const stale = FleetContestedPath.make({ path: "a.ts", checkouts: ["/fleet/idle", "/fleet/other"] })
+ * const active = FleetContestedPath.make({ path: "b.ts", checkouts: ["/fleet/idle", "/fleet/busy"] })
+ * const ranked = rankContestedPaths([stale, active], [busy])
+ * console.log(ranked[0]?.path) // "b.ts"
+ * ```
+ *
+ * @param contested - Contested paths in canonical (path-sorted) order.
+ * @param checkouts - The snapshot's checkout rows, consulted for liveness.
+ * @returns The same entries ranked live-claimants-first for text rendering.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const rankContestedPaths = (
+  contested: ReadonlyArray<FleetContestedPath>,
+  checkouts: ReadonlyArray<FleetCheckout>
+): ReadonlyArray<FleetContestedPath> => {
+  const live = liveCheckoutSet(checkouts);
+  const liveClaimants = (entry: FleetContestedPath): number =>
+    A.length(A.filter(entry.checkouts, (checkout) => MutableHashSet.has(live, checkout)));
+  return A.sort(
+    contested,
+    Order.combine(
+      Order.mapInput(Order.flip(Order.Number), liveClaimants),
+      Order.combine(
+        Order.mapInput(Order.flip(Order.Number), (entry: FleetContestedPath) => A.length(entry.checkouts)),
+        Order.mapInput(Order.String, (entry: FleetContestedPath) => entry.path)
+      )
+    )
+  );
+};
+
+const CONTESTED_SWAMPING_SHARE = 0.5;
+
+const contestedClaims = (
+  contested: ReadonlyArray<FleetContestedPath>
+): MutableHashMap.MutableHashMap<string, number> => {
+  const claims = MutableHashMap.empty<string, number>();
+  for (const entry of contested) {
+    for (const checkout of entry.checkouts) {
+      MutableHashMap.set(claims, checkout, O.getOrElse(MutableHashMap.get(claims, checkout), () => 0) + 1);
+    }
+  }
+  return claims;
+};
+
+/**
+ * Note lines flagging checkouts that swamp the contested-path index.
+ *
+ * **Details**
+ *
+ * A note fires only when the contested list overflows the render limit —
+ * exactly when truncation can hide information — and a single checkout claims
+ * more than half the rows. The measured specimen: one checkout with 5,133
+ * dirty files occupied 895 of 1,185 contested rows, displacing every
+ * cross-live collision from the truncated rendering.
+ *
+ * **Example** (A short contested list never notes)
+ *
+ * ```ts
+ * import { contestedSwampingNotes, FleetContestedPath } from "@beep/repo-cli/commands/Worktree"
+ *
+ * const contested = [FleetContestedPath.make({ path: "a.ts", checkouts: ["/fleet/a", "/fleet/b"] })]
+ * console.log(contestedSwampingNotes(contested, [])) // []
+ * ```
+ *
+ * @param contested - The snapshot's full contested-path list.
+ * @param checkouts - The snapshot's checkout rows, consulted for dirty counts.
+ * @returns One note line per swamping checkout, in checkout order.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const contestedSwampingNotes = (
+  contested: ReadonlyArray<FleetContestedPath>,
+  checkouts: ReadonlyArray<FleetCheckout>
+): ReadonlyArray<string> => {
+  if (contested.length <= CONTESTED_RENDER_LIMIT) {
+    return A.empty();
+  }
+  const claims = contestedClaims(contested);
+  const claimCount = (checkoutPath: string): number => O.getOrElse(MutableHashMap.get(claims, checkoutPath), () => 0);
+  const swamping = A.filter(checkouts, (row) => claimCount(row.path) > contested.length * CONTESTED_SWAMPING_SHARE);
+  return A.map(
+    swamping,
+    (row) =>
+      `  note: ${row.path} claims ${claimCount(row.path)}/${contested.length} contested rows` +
+      ` (dirty: ${countLabel(row.dirtyCount)})`
+  );
+};
+
+const contestedLines = (
+  contested: ReadonlyArray<FleetContestedPath>,
+  checkouts: ReadonlyArray<FleetCheckout>
+): ReadonlyArray<string> => {
   if (contested.length === 0) {
     return A.empty();
   }
   const shown = A.map(
-    A.take(contested, CONTESTED_RENDER_LIMIT),
+    A.take(rankContestedPaths(contested, checkouts), CONTESTED_RENDER_LIMIT),
     (entry) => `  ${entry.path} — ${A.join(entry.checkouts, ", ")}`
   );
   const hidden = contested.length - CONTESTED_RENDER_LIMIT;
   const overflow = hidden > 0 ? [`  … and ${hidden} more (use --json for the full list)`] : A.empty<string>();
-  return A.appendAll(A.prepend(shown, `Contested paths (${contested.length}):`), overflow);
+  return A.appendAll(
+    A.appendAll(
+      A.prepend(
+        contestedSwampingNotes(contested, checkouts),
+        `Contested paths (${contested.length}, ranked by live claimants):`
+      ),
+      shown
+    ),
+    overflow
+  );
 };
 
 const renderFleetSnapshot = Effect.fn("Fleet.renderFleetSnapshot")(function* (snapshot: FleetSnapshot) {
@@ -159,7 +305,7 @@ const renderFleetSnapshot = Effect.fn("Fleet.renderFleetSnapshot")(function* (sn
     return;
   }
   yield* Effect.forEach(A.flatMap(snapshot.checkouts, fleetCheckoutLines), Console.log);
-  yield* Effect.forEach(contestedLines(snapshot.contestedPaths), Console.log);
+  yield* Effect.forEach(contestedLines(snapshot.contestedPaths, snapshot.checkouts), Console.log);
 });
 
 const runWorktreeFleet = Effect.fn("Fleet.runWorktreeFleet")(function* (json: boolean) {

--- a/packages/tooling/tool/cli/src/commands/Worktree/Fleet.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Worktree/Fleet.service.ts
@@ -38,6 +38,7 @@ import {
   Path,
   Result,
 } from "effect";
+import * as S from "effect/Schema";
 import { configStringOptionSync } from "../../internal/cli/EnvConfig.ts";
 import { repoRunOutputBound, runCapturedStreams } from "../../internal/process/StepExec.ts";
 import { WorktreeCommandError } from "./Worktree.errors.ts";
@@ -51,6 +52,7 @@ import {
   FleetLivenessVerdict,
   FleetScanCoverage,
   FleetScanOptions,
+  FleetSessionRegistryEntry,
   FleetSnapshot,
   parseWorktreePorcelain,
 } from "./Worktree.schemas.ts";
@@ -90,11 +92,16 @@ export const FLEET_SURFACE_EXCLUDE_PREFIXES = [".repos/", "node_modules/", ".git
  * **Details**
  *
  * `live` requires positive evidence from any probe. `dormant` requires every
- * probe to have measured a negative — a complete process scan with no match,
- * a transcript that is absent or older than the window, and a worktree mtime
- * older than the window. Anything else is `unknown`: an incomplete process
- * scan or a failed probe leaves open the possibility of a live agent, and a
- * falsely-`dormant` verdict is a silent miss.
+ * negative-capable probe to have measured a negative — a complete process
+ * scan with no match, a transcript that is absent or older than the window,
+ * and a worktree mtime older than the window. Anything else is `unknown`: an
+ * incomplete process scan or a failed probe leaves open the possibility of a
+ * live agent, and a falsely-`dormant` verdict is a silent miss.
+ *
+ * The session-registry probe (`sessionMatches`) is positive-only: a confirmed
+ * registry entry classifies `live` with `claude-session` evidence, but zero
+ * matches never counts toward `dormant` — the registry covers Claude Code
+ * sessions only, so its silence is not absence of activity.
  *
  * **Example** (An unreadable process entry yields unknown, never dormant)
  *
@@ -105,6 +112,7 @@ export const FLEET_SURFACE_EXCLUDE_PREFIXES = [".repos/", "node_modules/", ".git
  *   FleetLivenessReadings.make({
  *     processMatches: 0,
  *     processScanComplete: false,
+ *     sessionMatches: 0,
  *     transcript: { _tag: "absent" },
  *     worktreeMtime: { _tag: "measured", ageSeconds: 86_400 },
  *   })
@@ -122,16 +130,16 @@ export const classifyFleetLiveness = (
   readings: FleetLivenessReadings,
   windowSeconds: number = FLEET_LIVENESS_WINDOW_SECONDS
 ): FleetLivenessVerdict => {
-  const evidence: Array<FleetLivenessProbe> = [];
-  if (readings.processMatches > 0) {
-    evidence.push("process-cwd");
-  }
-  if (readings.transcript._tag === "measured" && readings.transcript.ageSeconds < windowSeconds) {
-    evidence.push("transcript-mtime");
-  }
-  if (readings.worktreeMtime._tag === "measured" && readings.worktreeMtime.ageSeconds < windowSeconds) {
-    evidence.push("worktree-mtime");
-  }
+  const candidates: ReadonlyArray<readonly [boolean, FleetLivenessProbe]> = [
+    [readings.processMatches > 0, "process-cwd"],
+    [readings.transcript._tag === "measured" && readings.transcript.ageSeconds < windowSeconds, "transcript-mtime"],
+    [readings.worktreeMtime._tag === "measured" && readings.worktreeMtime.ageSeconds < windowSeconds, "worktree-mtime"],
+    [readings.sessionMatches > 0, "claude-session"],
+  ];
+  const evidence = A.map(
+    A.filter(candidates, ([active]) => active),
+    ([, probe]) => probe
+  );
   if (evidence.length > 0) {
     return FleetLivenessVerdict.make({ status: "live", evidence });
   }
@@ -279,6 +287,43 @@ export const parseMergeTreeConflictNames = (output: string): ReadonlyArray<strin
  * @since 0.0.0
  */
 export const transcriptProjectDirName = (absolutePath: string): string => Str.replace(/[/_.]/g, "-")(absolutePath);
+
+/**
+ * Parse the `starttime` field (field 22) out of a `/proc/<pid>/stat` line.
+ *
+ * **Details**
+ *
+ * `stat` embeds the command name in parentheses as field 2, and the command
+ * name may itself contain spaces and parentheses, so fields are only
+ * addressable after the *last* `)`. Fields resume there at field 3 (`state`),
+ * which places `starttime` at index 19 of the remaining whitespace-split
+ * fields. This is the PID-reuse guard for the session-registry probe: a
+ * registry entry whose PID is alive but whose `starttime` differs is a stale
+ * file over a recycled PID.
+ *
+ * **Example** (Parse a stat line whose command name contains spaces)
+ *
+ * ```ts
+ * import { parseProcStatStartTime } from "@beep/repo-cli/commands/Worktree"
+ * import { A, O } from "@beep/utils"
+ *
+ * const fields = A.join(["S", ...A.makeBy(18, () => "0"), "220635", "0"], " ")
+ * console.log(O.getOrNull(parseProcStatStartTime(`244216 (tmux: server) ${fields}`))) // "220635"
+ * ```
+ *
+ * @param stat - Raw contents of a `/proc/<pid>/stat` file.
+ * @returns The `starttime` field as the string `/proc` reports, or `O.none()` when the line does not carry one.
+ * @category parsing
+ * @since 0.0.0
+ */
+export const parseProcStatStartTime = (stat: string): O.Option<string> => {
+  const closeParen = Str.lastIndexOf(")")(stat);
+  if (O.isNone(closeParen)) {
+    return O.none();
+  }
+  const fields = A.filter(Str.split(Str.trim(Str.slice(closeParen.value + 1)(stat)), /\s+/), Str.isNonEmpty);
+  return O.fromUndefinedOr(fields[19]);
+};
 
 type SurfaceIndex = MutableHashMap.MutableHashMap<string, MutableHashSet.MutableHashSet<string>>;
 
@@ -591,6 +636,71 @@ const scanProcesses = Effect.fn("Fleet.scanProcesses")(function* (
   return { counts, scanned: A.length(pids), unreadable, complete: unreadable === 0 };
 });
 
+const SESSION_REGISTRY_FILE = /^[0-9]+\.json$/;
+
+const decodeSessionRegistryEntry = S.decodeUnknownEffect(S.fromJsonString(FleetSessionRegistryEntry));
+
+/** A confirmed registry session's cwd, or `O.none()` for an unreadable, undecodable, or PID-recycled entry — never a negative. */
+const confirmedSessionCwd = Effect.fn("Fleet.confirmedSessionCwd")(function* (
+  registryDir: string,
+  name: string
+): Effect.fn.Return<O.Option<string>, never, FleetMirrorServiceRequirements> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const content = yield* fs.readFileString(path.join(registryDir, name)).pipe(Effect.option);
+  if (O.isNone(content)) {
+    return O.none();
+  }
+  const entry = yield* decodeSessionRegistryEntry(content.value).pipe(Effect.option);
+  if (O.isNone(entry)) {
+    return O.none();
+  }
+  const stat = yield* fs.readFileString(`/proc/${entry.value.pid}/stat`).pipe(Effect.option);
+  const startTime = O.flatMap(stat, parseProcStatStartTime);
+  return O.isSome(startTime) && startTime.value === entry.value.procStart ? O.some(entry.value.cwd) : O.none();
+});
+
+/**
+ * Count confirmed Claude Code session-registry entries per checkout.
+ *
+ * **Details**
+ *
+ * Reads `~/.claude/sessions/<pid>.json`, keeps only entries whose PID passes
+ * the `/proc/<pid>/stat` `starttime` reuse guard, and attributes each
+ * surviving entry's recorded working directory to the longest checkout path
+ * containing it — a session started in a subdirectory still belongs to its
+ * checkout. Every failure mode (missing registry, unreadable file, decode
+ * failure, dead or recycled PID) contributes nothing: this probe produces
+ * positive evidence only, so a checkout with no registry hit falls through to
+ * the other probes unchanged.
+ */
+const scanSessionRegistry = Effect.fn("Fleet.scanSessionRegistry")(function* (
+  homeDir: O.Option<string>,
+  checkoutPaths: ReadonlyArray<string>
+): Effect.fn.Return<MutableHashMap.MutableHashMap<string, number>, never, FleetMirrorServiceRequirements> {
+  const counts = MutableHashMap.empty<string, number>();
+  if (O.isNone(homeDir)) {
+    return counts;
+  }
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const registryDir = path.join(homeDir.value, ".claude", "sessions");
+  const names = yield* fs.readDirectory(registryDir).pipe(Effect.option);
+  if (O.isNone(names)) {
+    return counts;
+  }
+  const byLengthDesc = A.sort(
+    checkoutPaths,
+    Order.mapInput(Order.Number, (candidate: string) => -candidate.length)
+  );
+  const files = A.filter(names.value, (name) => O.isSome(Str.match(SESSION_REGISTRY_FILE)(name)));
+  const cwds = yield* Effect.forEach(files, (name) => confirmedSessionCwd(registryDir, name));
+  for (const cwd of A.getSomes(cwds)) {
+    attributeProcessCwd(counts, byLengthDesc, cwd);
+  }
+  return counts;
+});
+
 const PROBE_FAILED: FleetProbeReading = { _tag: "failed" };
 const PROBE_ABSENT: FleetProbeReading = { _tag: "absent" };
 
@@ -786,11 +896,12 @@ type CheckoutDerivation = {
   readonly degraded: boolean;
 };
 
-/** Everything one scan measured once and every checkout row reads: the scanner, epoch target, process scan, and clock. */
+/** Everything one scan measured once and every checkout row reads: the scanner, epoch target, process and registry scans, and clock. */
 type DerivationContext = {
   readonly scanner: ScannerContext;
   readonly target: FleetEpochTarget;
   readonly processScan: ProcessScan;
+  readonly sessionCounts: MutableHashMap.MutableHashMap<string, number>;
   readonly homeDir: O.Option<string>;
   readonly nowMillis: number;
   readonly windowSeconds: number;
@@ -840,6 +951,7 @@ const livenessFacts = Effect.fn("Fleet.livenessFacts")(function* (
     FleetLivenessReadings.make({
       processMatches: O.getOrElse(MutableHashMap.get(context.processScan.counts, checkoutPath), () => 0),
       processScanComplete: context.processScan.complete,
+      sessionMatches: O.getOrElse(MutableHashMap.get(context.sessionCounts, checkoutPath), () => 0),
       transcript,
       worktreeMtime,
     }),
@@ -1136,10 +1248,10 @@ const scanFleet = Effect.fn("Fleet.scanFleet")(function* (
     onSome: Effect.succeed,
     onNone: () =>
       Effect.map(runGitProbe(currentRoot, ["rev-parse", "--git-common-dir"]), (probe): string =>
-        O.match(gitStdout(probe), {
-          onNone: () => path.dirname(currentRoot),
-          onSome: (output) => path.dirname(path.dirname(path.resolve(currentRoot, Str.trim(output)))),
-        })
+        gitStdout(probe).pipe(
+          O.map((output) => path.dirname(path.dirname(path.resolve(currentRoot, Str.trim(output))))),
+          O.getOrElse(() => path.dirname(currentRoot))
+        )
       ),
   });
 
@@ -1153,10 +1265,14 @@ const scanFleet = Effect.fn("Fleet.scanFleet")(function* (
 
   const { clones, stubs } = yield* enumerateFleet(fleetRoot, normalizedOrigin);
   const processScan = yield* scanProcesses(A.map(stubs, (stub) => stub.path));
+  const sessionCounts = yield* scanSessionRegistry(
+    homeDir,
+    A.map(stubs, (stub) => stub.path)
+  );
   const scanner = yield* ensureScanner(scannerDir, clones);
   const target = yield* materializeTarget(scanner, originUrl, targetRef);
 
-  const context: DerivationContext = { scanner, target, processScan, homeDir, nowMillis, windowSeconds };
+  const context: DerivationContext = { scanner, target, processScan, sessionCounts, homeDir, nowMillis, windowSeconds };
   const derivations = yield* Effect.forEach(stubs, (stub) => deriveCheckout(stub, context), { concurrency: 8 });
 
   const contestedPaths = buildContestedIndex(

--- a/packages/tooling/tool/cli/src/commands/Worktree/Worktree.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Worktree/Worktree.schemas.ts
@@ -156,7 +156,8 @@ export const parseWorktreePorcelain = (porcelain: string): ReadonlyArray<Worktre
  * **Details**
  *
  * Applied uniformly to the transcript-mtime and worktree-mtime probes. The
- * process-cwd probe is instantaneous and does not use a window.
+ * process-cwd and claude-session probes are instantaneous and do not use a
+ * window.
  *
  * **Example** (Read the liveness window)
  *
@@ -259,18 +260,32 @@ export type FleetLiveness = typeof FleetLiveness.Type;
 /**
  * The probe that produced a `live` liveness verdict.
  *
+ * **Details**
+ *
+ * `claude-session` is the session-registry probe: a registry entry under
+ * `~/.claude/sessions/` whose PID survived the `procStart` reuse guard and
+ * whose recorded working directory sits at or under the checkout. It carries
+ * no PID — the probe member is evidence of *how* liveness was measured, not a
+ * handle to the session.
+ *
  * **Example** (Read a probe member)
  *
  * ```ts
  * import { FleetLivenessProbe } from "@beep/repo-cli/commands/Worktree"
  *
  * console.log(FleetLivenessProbe.Enum["process-cwd"]) // "process-cwd"
+ * console.log(FleetLivenessProbe.Enum["claude-session"]) // "claude-session"
  * ```
  *
  * @category models
  * @since 0.0.0
  */
-export const FleetLivenessProbe = LiteralKit(["process-cwd", "transcript-mtime", "worktree-mtime"]).pipe(
+export const FleetLivenessProbe = LiteralKit([
+  "process-cwd",
+  "transcript-mtime",
+  "worktree-mtime",
+  "claude-session",
+]).pipe(
   $I.annoteSchema("FleetLivenessProbe", {
     description: "The probe that produced a live liveness verdict.",
   })
@@ -283,6 +298,51 @@ export const FleetLivenessProbe = LiteralKit(["process-cwd", "transcript-mtime",
  * @since 0.0.0
  */
 export type FleetLivenessProbe = typeof FleetLivenessProbe.Type;
+
+/**
+ * The fields the fleet liveness probe consumes from one on-disk Claude Code
+ * session-registry entry (`~/.claude/sessions/<pid>.json`).
+ *
+ * **Details**
+ *
+ * The registry entry carries many more fields; decoding tolerates and drops
+ * them. `procStart` is the PID-reuse guard: it must equal field 22
+ * (`starttime`) of `/proc/<pid>/stat`, or the entry is a stale file over a
+ * recycled PID and contributes nothing.
+ *
+ * **Gotchas**
+ *
+ * A registry entry proves a session *existed* with this PID and working
+ * directory — only the `/proc` starttime comparison upgrades that to "is
+ * still running". Never treat a decoded entry as liveness by itself.
+ *
+ * **Example** (Construct a registry entry)
+ *
+ * ```ts
+ * import { FleetSessionRegistryEntry } from "@beep/repo-cli/commands/Worktree"
+ *
+ * const entry = FleetSessionRegistryEntry.make({
+ *   pid: 244216,
+ *   procStart: "220635",
+ *   cwd: "/projects/beep-effect",
+ * })
+ * console.log(entry.procStart) // "220635"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class FleetSessionRegistryEntry extends S.Class<FleetSessionRegistryEntry>($I`FleetSessionRegistryEntry`)(
+  {
+    pid: S.Finite,
+    procStart: S.String,
+    cwd: S.String,
+  },
+  $I.annote("FleetSessionRegistryEntry", {
+    description:
+      "The pid, procStart reuse guard, and working directory the fleet liveness probe reads from one Claude Code session-registry entry.",
+  })
+) {}
 
 /**
  * One probe's reading during liveness classification.
@@ -333,7 +393,11 @@ export type FleetProbeReading = typeof FleetProbeReading.Type;
  * `processMatches` counts readable processes whose working directory sits
  * inside the checkout; `processScanComplete` is `false` when any process's
  * working directory was unreadable, because an unreadable process could be
- * inside this checkout.
+ * inside this checkout. `sessionMatches` counts session-registry entries that
+ * survived the `procStart` reuse guard and whose recorded working directory
+ * sits at or under the checkout — a positive-only probe, so `0` never
+ * contributes toward `dormant`: the registry covers Claude Code sessions
+ * only, never codex sessions, editors, or a human with a dirty tree.
  *
  * **Example** (Readings that leave liveness unknown)
  *
@@ -343,6 +407,7 @@ export type FleetProbeReading = typeof FleetProbeReading.Type;
  * const readings = FleetLivenessReadings.make({
  *   processMatches: 0,
  *   processScanComplete: false,
+ *   sessionMatches: 0,
  *   transcript: { _tag: "absent" },
  *   worktreeMtime: { _tag: "measured", ageSeconds: 86_400 },
  * })
@@ -356,6 +421,7 @@ export class FleetLivenessReadings extends S.Class<FleetLivenessReadings>($I`Fle
   {
     processMatches: S.Finite,
     processScanComplete: S.Boolean,
+    sessionMatches: S.Finite,
     transcript: FleetProbeReading,
     worktreeMtime: FleetProbeReading,
   },

--- a/packages/tooling/tool/cli/src/internal/cli/Json.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/Json.ts
@@ -6,7 +6,7 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { CauseTaggedError } from "@beep/schema";
-import { Effect, Result } from "effect";
+import { Context, Effect, Result } from "effect";
 import * as S from "effect/Schema";
 import * as jsonc from "jsonc-parser";
 
@@ -54,6 +54,47 @@ export const DEFAULT_JSON_FORMATTING_OPTIONS: jsonc.FormattingOptions = {
  * @since 0.0.0
  */
 export const DEFAULT_JSON_PRETTY_MAX_LENGTH = 500_000;
+
+/**
+ * Injectable sink for complete machine-readable command output.
+ *
+ * **Details**
+ *
+ * The default writes directly to stdout so payloads are not capped by Bun's
+ * platform Console. In-process callers can provide this reference with a
+ * capturing or silent writer without leaking output to the host process.
+ *
+ * **Example** (Capture command JSON without writing to stdout)
+ *
+ * ```ts
+ * import { CommandJsonOutput, printCommandJson } from "@beep/repo-cli/internal/cli/Json"
+ * import { Effect } from "effect"
+ *
+ * const chunks: Array<string> = []
+ * const program = printCommandJson({ ok: true }).pipe(
+ *   Effect.provideService(
+ *     CommandJsonOutput,
+ *     (text) => Effect.sync(() => {
+ *       chunks.push(text)
+ *     })
+ *   )
+ * )
+ *
+ * console.log(program)
+ * ```
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export const CommandJsonOutput: Context.Reference<(text: string) => Effect.Effect<void>> = Context.Reference(
+  $I`CommandJsonOutput`,
+  {
+    defaultValue: () => (text: string) =>
+      Effect.sync(() => {
+        process.stdout.write(text);
+      }),
+  }
+);
 
 /**
  * Failure raised when a command cannot encode a machine-readable JSON payload.
@@ -220,7 +261,6 @@ export const printCommandJson = Effect.fn("RepoCli.Json.printCommandJson")(funct
   value: unknown
 ): Effect.fn.Return<void, CliJsonError> {
   const encoded = yield* encodeCommandJson(value).pipe(CliJsonError.mapError("Failed to encode command JSON output."));
-  yield* Effect.sync(() => {
-    process.stdout.write(`${encoded}\n`);
-  });
+  const write = yield* CommandJsonOutput;
+  yield* write(`${encoded}\n`);
 });

--- a/packages/tooling/tool/cli/src/internal/cli/Json.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/Json.ts
@@ -6,7 +6,7 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { CauseTaggedError } from "@beep/schema";
-import { Console, Effect, Result } from "effect";
+import { Effect, Result } from "effect";
 import * as S from "effect/Schema";
 import * as jsonc from "jsonc-parser";
 
@@ -196,6 +196,13 @@ export const formatJsonValue = (value: unknown): string =>
 /**
  * Encode and print an arbitrary JSON-compatible command payload.
  *
+ * **Details**
+ *
+ * Writes directly to stdout at this process boundary rather than through
+ * `Console.log`. Bun's platform Console truncates one log entry at 64 KiB,
+ * which can turn a valid large command payload into invalid JSON; stdout
+ * preserves the complete encoded document.
+ *
  * **Example** (Print a machine-readable command result)
  *
  * ```ts
@@ -212,7 +219,8 @@ export const formatJsonValue = (value: unknown): string =>
 export const printCommandJson = Effect.fn("RepoCli.Json.printCommandJson")(function* (
   value: unknown
 ): Effect.fn.Return<void, CliJsonError> {
-  yield* Console.log(
-    yield* encodeCommandJson(value).pipe(CliJsonError.mapError("Failed to encode command JSON output."))
-  );
+  const encoded = yield* encodeCommandJson(value).pipe(CliJsonError.mapError("Failed to encode command JSON output."));
+  yield* Effect.sync(() => {
+    process.stdout.write(`${encoded}\n`);
+  });
 });

--- a/packages/tooling/tool/cli/test/cli-json-printer.test.ts
+++ b/packages/tooling/tool/cli/test/cli-json-printer.test.ts
@@ -59,6 +59,27 @@ describe("internal/cli/Json renderPrettyCommandJson", () => {
   });
 });
 
+describe("internal/cli/Json printCommandJson", () => {
+  it("emits payloads larger than 64 KiB intact across a process boundary", () => {
+    const payload = { value: "x".repeat(70_000) };
+    const moduleUrl = new URL("../src/internal/cli/Json.ts", import.meta.url).href;
+    const program = [
+      `import { printCommandJson } from ${JSON.stringify(moduleUrl)};`,
+      'import { Effect } from "effect";',
+      'await Effect.runPromise(printCommandJson({ value: "x".repeat(70_000) }));',
+    ].join("\n");
+    const result = Bun.spawnSync(["bun", "--eval", program], {
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const output = result.stdout.toString();
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.byteLength).toBeGreaterThan(65_536);
+    expect(output).toBe(`${JSON.stringify(payload)}\n`);
+  });
+});
+
 describe("internal/cli/Printer formatDurationSeconds", () => {
   it("renders two-decimal seconds (data-first)", () => {
     expect(formatDurationSeconds(1234, 2)).toBe("1.23s");

--- a/packages/tooling/tool/cli/test/cli-json-printer.test.ts
+++ b/packages/tooling/tool/cli/test/cli-json-printer.test.ts
@@ -1,9 +1,11 @@
 import {
+  CommandJsonOutput,
   DEFAULT_JSON_FORMATTING_OPTIONS,
   DEFAULT_JSON_PRETTY_MAX_LENGTH,
   formatDurationSeconds,
   logTaggedSummary,
   makeTaggedLogger,
+  printCommandJson,
   renderPrettyCommandJson,
 } from "@beep/repo-cli/test/Cli";
 import { describe, expect, it } from "@effect/vitest";
@@ -60,6 +62,23 @@ describe("internal/cli/Json renderPrettyCommandJson", () => {
 });
 
 describe("internal/cli/Json printCommandJson", () => {
+  it.effect(
+    "routes output through an injected writer",
+    Effect.fnUntraced(function* () {
+      const chunks: Array<string> = [];
+
+      yield* printCommandJson({ ok: true }).pipe(
+        Effect.provideService(CommandJsonOutput, (text) =>
+          Effect.sync(() => {
+            chunks.push(text);
+          })
+        )
+      );
+
+      expect(chunks).toEqual(['{"ok":true}\n']);
+    })
+  );
+
   it("emits payloads larger than 64 KiB intact across a process boundary", () => {
     const payload = { value: "x".repeat(70_000) };
     const moduleUrl = new URL("../src/internal/cli/Json.ts", import.meta.url).href;

--- a/packages/tooling/tool/cli/test/worktree-fleet-scan.test.ts
+++ b/packages/tooling/tool/cli/test/worktree-fleet-scan.test.ts
@@ -1,12 +1,19 @@
-import { FleetMirrorService, FleetMirrorServiceLive, FleetScanOptions } from "@beep/repo-cli/commands/Worktree";
-import { A, O } from "@beep/utils";
+import {
+  FleetMirrorService,
+  FleetMirrorServiceLive,
+  FleetScanOptions,
+  parseProcStatStartTime,
+} from "@beep/repo-cli/commands/Worktree";
+import { A, N, O, Str } from "@beep/utils";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, FileSystem, Layer, Path } from "effect";
+import * as S from "effect/Schema";
 import { ChildProcess } from "effect/unstable/process";
 import type { FleetCheckout, FleetSnapshot } from "@beep/repo-cli/commands/Worktree";
 
 const SCAN_TIMEOUT_MILLIS = 60_000;
+const encodeJson = S.encodeUnknownEffect(S.fromJsonString(S.Unknown));
 
 const README_BASE = "# fleet fixture\n\nshared line\n";
 const README_BETA = "# fleet fixture\n\nshared line (beta)\n";
@@ -67,8 +74,8 @@ const initScratchFleet = Effect.fn("FleetScanTest.initScratchFleet")(function* (
   const beta = path.join(fleetRoot, "beta");
 
   yield* fs.makeDirectory(fleetRoot, { recursive: true });
-  // An empty home keeps the transcript probe hermetic: it measures "absent",
-  // never the developer's real ~/.claude/projects tree.
+  // An empty home keeps the transcript and session-registry probes hermetic:
+  // they measure "absent", never the developer's real ~/.claude tree.
   yield* fs.makeDirectory(homeDir, { recursive: true });
   yield* runGit(tmpDir, ["init", "--bare", "--quiet", "--initial-branch=main", originPath]);
 
@@ -294,6 +301,90 @@ describe("fleet mirror scan", () => {
           // -uall expands the untracked directory, so the row counts the file.
           expect(checkoutAt(snapshot, fixture.alpha).dirtyCount).toBe(1);
           expect(checkoutAt(snapshot, fixture.beta).dirtyCount).toBe(1);
+        })
+      ),
+    SCAN_TIMEOUT_MILLIS
+  );
+
+  it.live(
+    "classifies live with claude-session evidence from a confirmed registry entry recorded in a subdirectory",
+    () =>
+      withScratchFleet((fixture) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+
+          // The test runner's own /proc identity makes the fixture entry pass
+          // the starttime reuse guard against a genuinely live process.
+          const stat = yield* fs.readFileString("/proc/self/stat");
+          const pid = O.getOrThrowWith(A.head(Str.split(stat, " ")), () => new Error("Failed to read the test pid."));
+          const numericPid = O.getOrThrowWith(N.parse(pid), () => new Error("Failed to parse the test pid."));
+          const procStart = O.getOrThrowWith(
+            parseProcStatStartTime(stat),
+            () => new Error("Failed to parse starttime from /proc/self/stat.")
+          );
+
+          const sessionsDir = path.join(fixture.homeDir, ".claude", "sessions");
+          yield* fs.makeDirectory(sessionsDir, { recursive: true });
+          // Real registry entries carry many more fields than the probe reads;
+          // the fixture keeps a representative sample to prove tolerant decode.
+          const registryEntry = yield* encodeJson({
+            pid: numericPid,
+            sessionId: "fixture-session",
+            cwd: path.join(fixture.beta, "notes"),
+            procStart,
+            version: "2.1.226",
+            kind: "interactive",
+            status: "busy",
+            messagingSocketPath: null,
+          });
+          yield* fs.writeFileString(path.join(sessionsDir, `${pid}.json`), registryEntry);
+
+          const snapshot = yield* scanFixture(fixture);
+
+          const betaRow = checkoutAt(snapshot, fixture.beta);
+          expect(betaRow.liveness).toBe("live");
+          // The recorded cwd is a subdirectory, so the at-or-under join credits beta.
+          expect(betaRow.livenessEvidence).toContain("claude-session");
+          expect(checkoutAt(snapshot, fixture.alpha).livenessEvidence).not.toContain("claude-session");
+        })
+      ),
+    SCAN_TIMEOUT_MILLIS
+  );
+
+  it.live(
+    "contributes nothing for recycled-PID, dead-PID, or malformed registry entries",
+    () =>
+      withScratchFleet((fixture) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+
+          const stat = yield* fs.readFileString("/proc/self/stat");
+          const pid = O.getOrThrowWith(A.head(Str.split(stat, " ")), () => new Error("Failed to read the test pid."));
+          const numericPid = O.getOrThrowWith(N.parse(pid), () => new Error("Failed to parse the test pid."));
+
+          const sessionsDir = path.join(fixture.homeDir, ".claude", "sessions");
+          yield* fs.makeDirectory(sessionsDir, { recursive: true });
+          // A stale file over a recycled PID: the process is alive, but its starttime differs.
+          const recycledEntry = yield* encodeJson({
+            pid: numericPid,
+            procStart: "1",
+            cwd: fixture.beta,
+          });
+          yield* fs.writeFileString(path.join(sessionsDir, `${pid}.json`), recycledEntry);
+          // A PID beyond pid_max, so /proc/<pid>/stat cannot exist.
+          const deadEntry = yield* encodeJson({ pid: 999999999, procStart: "1", cwd: fixture.beta });
+          yield* fs.writeFileString(path.join(sessionsDir, "999999999.json"), deadEntry);
+          // An entry that does not decode.
+          yield* fs.writeFileString(path.join(sessionsDir, "12345.json"), "not json");
+
+          const snapshot = yield* scanFixture(fixture);
+
+          expect(snapshot.coverage.checkoutsDiscovered).toBe(2);
+          for (const row of snapshot.checkouts) {
+            expect(row.livenessEvidence).not.toContain("claude-session");
+          }
         })
       ),
     SCAN_TIMEOUT_MILLIS

--- a/packages/tooling/tool/cli/test/worktree-fleet.test.ts
+++ b/packages/tooling/tool/cli/test/worktree-fleet.test.ts
@@ -1,27 +1,35 @@
 import {
   buildContestedIndex,
   classifyFleetLiveness,
+  contestedSwampingNotes,
   FLEET_LIVENESS_WINDOW_SECONDS,
+  FleetCheckout,
+  FleetContestedPath,
   FleetLivenessReadings,
   parseMergeTreeConflictNames,
+  parseProcStatStartTime,
   parseStatusPorcelainZ,
+  rankContestedPaths,
   transcriptProjectDirName,
 } from "@beep/repo-cli/commands/Worktree";
+import { A, O } from "@beep/utils";
 import { describe, expect, it } from "@effect/vitest";
 
 const FRESH_SECONDS = 30;
 const STALE_SECONDS = FLEET_LIVENESS_WINDOW_SECONDS * 2;
 
 /**
- * Complete negatives: a complete process scan with no match, an absent
- * transcript, and a measured worktree mtime older than the window. This is the
- * only shape that may classify as `dormant`, so every other case overrides one
- * field of it.
+ * Complete negatives: a complete process scan with no match, no confirmed
+ * registry session (which is silence, not a negative), an absent transcript,
+ * and a measured worktree mtime older than the window. This is the only shape
+ * that may classify as `dormant`, so every other case overrides one field of
+ * it.
  */
 const readings = (overrides: Partial<FleetLivenessReadings>): FleetLivenessReadings =>
   FleetLivenessReadings.make({
     processMatches: 0,
     processScanComplete: true,
+    sessionMatches: 0,
     transcript: { _tag: "absent" },
     worktreeMtime: { _tag: "measured", ageSeconds: STALE_SECONDS },
     ...overrides,
@@ -59,16 +67,24 @@ describe("classifyFleetLiveness", () => {
     );
   });
 
+  it("reports live from the claude-session probe alone", () => {
+    expect(classifyFleetLiveness(readings({ sessionMatches: 1 }))).toEqual({
+      status: "live",
+      evidence: ["claude-session"],
+    });
+  });
+
   it("records every positive probe in evidence order", () => {
     expect(
       classifyFleetLiveness(
         readings({
           processMatches: 2,
+          sessionMatches: 1,
           transcript: { _tag: "measured", ageSeconds: FRESH_SECONDS },
           worktreeMtime: { _tag: "measured", ageSeconds: FRESH_SECONDS },
         })
       )
-    ).toEqual({ status: "live", evidence: ["process-cwd", "transcript-mtime", "worktree-mtime"] });
+    ).toEqual({ status: "live", evidence: ["process-cwd", "transcript-mtime", "worktree-mtime", "claude-session"] });
   });
 
   it("reports unknown when the transcript probe failed, even with every other negative measured", () => {
@@ -195,5 +211,121 @@ describe("transcriptProjectDirName", () => {
   it("mangles separators, underscores, and dots into hyphens", () => {
     expect(transcriptProjectDirName("/a/b_c.d")).toBe("-a-b-c-d");
     expect(transcriptProjectDirName("/home/user/projects/beep_effect")).toBe("-home-user-projects-beep-effect");
+  });
+});
+
+/** Fields 3..21 then starttime at field 22, in the whitespace-joined form `/proc/<pid>/stat` uses after the comm. */
+const statTail = (startTime: string): string => A.join(["S", ...A.makeBy(18, () => "0"), startTime, "7"], " ");
+
+describe("parseProcStatStartTime", () => {
+  it("parses starttime after the last paren, so a comm with spaces and parens cannot shift fields", () => {
+    expect(O.getOrNull(parseProcStatStartTime(`244216 (tmux: server (1)) ${statTail("220635")}`))).toBe("220635");
+  });
+
+  it("parses a plain comm", () => {
+    expect(O.getOrNull(parseProcStatStartTime(`1 (init) ${statTail("4")}`))).toBe("4");
+  });
+
+  it("reads none from a line without a comm paren", () => {
+    expect(O.isNone(parseProcStatStartTime("garbage"))).toBe(true);
+  });
+
+  it("reads none when the tail is too short to carry field 22", () => {
+    expect(O.isNone(parseProcStatStartTime("1 (init) S 0 0"))).toBe(true);
+  });
+});
+
+/** A checkout row that only carries what the contested display consults: path, liveness, and dirty count. */
+const checkoutRow = (path: string, liveness: FleetCheckout["liveness"], dirtyCount: number | null): FleetCheckout =>
+  FleetCheckout.make({
+    path,
+    kind: "clone",
+    branch: null,
+    detached: null,
+    head: null,
+    dirtyCount,
+    mergeBase: null,
+    branchDiffCount: null,
+    liveness,
+    livenessEvidence: [],
+    conflict: "unknown",
+    conflictReason: "head-unknown",
+    conflictPaths: [],
+    policyMovement: "unknown",
+    policyReason: "head-unknown",
+    policyPaths: [],
+  });
+
+const contestedEntry = (path: string, checkouts: ReadonlyArray<string>): FleetContestedPath =>
+  FleetContestedPath.make({ path, checkouts });
+
+describe("rankContestedPaths", () => {
+  it("ranks rows with more live claimants first, then more claimants, then path", () => {
+    const rows = [
+      checkoutRow("/fleet/busy", "live", 2),
+      checkoutRow("/fleet/other", "live", 1),
+      checkoutRow("/fleet/idle", "dormant", 5_133),
+    ];
+    const ranked = rankContestedPaths(
+      [
+        contestedEntry("a.ts", ["/fleet/idle", "/fleet/unknown-elsewhere"]),
+        contestedEntry("b.ts", ["/fleet/busy", "/fleet/idle"]),
+        contestedEntry("c.ts", ["/fleet/busy", "/fleet/other"]),
+        contestedEntry("d.ts", ["/fleet/busy", "/fleet/idle", "/fleet/unknown-elsewhere"]),
+      ],
+      rows
+    );
+    // c: 2 live; b and d tie at 1 live, d has more claimants; a: 0 live.
+    expect(A.map(ranked, (entry) => entry.path)).toEqual(["c.ts", "d.ts", "b.ts", "a.ts"]);
+  });
+
+  it("keeps canonical path order when liveness distinguishes nothing", () => {
+    const ranked = rankContestedPaths(
+      [contestedEntry("b.ts", ["/fleet/x", "/fleet/y"]), contestedEntry("a.ts", ["/fleet/x", "/fleet/y"])],
+      []
+    );
+    expect(A.map(ranked, (entry) => entry.path)).toEqual(["a.ts", "b.ts"]);
+  });
+});
+
+describe("contestedSwampingNotes", () => {
+  // 25 rows: 21 claimed by the high-dirty checkout against rotating neighbors
+  // (each neighbor claims 7), 4 contested across live checkouts. Every
+  // claimant has a checkout row, as in a real snapshot.
+  const swampedContested = () =>
+    A.appendAll(
+      A.makeBy(21, (index) => contestedEntry(`dirty-${index}.ts`, ["/fleet/dirty", `/fleet/neighbor-${index % 3}`])),
+      A.makeBy(4, (index) => contestedEntry(`active-${index}.ts`, ["/fleet/busy", "/fleet/other"]))
+    );
+
+  const swampedRows = () => [
+    checkoutRow("/fleet/dirty", "live", 5_133),
+    checkoutRow("/fleet/neighbor-0", "dormant", 7),
+    checkoutRow("/fleet/neighbor-1", "dormant", 7),
+    checkoutRow("/fleet/neighbor-2", "dormant", 7),
+    checkoutRow("/fleet/busy", "live", 3),
+    checkoutRow("/fleet/other", "live", 2),
+  ];
+
+  it("flags only the checkout claiming more than half of an overflowing contested list, with its dirty count", () => {
+    expect(contestedSwampingNotes(swampedContested(), swampedRows())).toEqual([
+      "  note: /fleet/dirty claims 21/25 contested rows (dirty: 5133)",
+    ]);
+  });
+
+  it("stays silent when the contested list fits the render limit", () => {
+    const contested = A.makeBy(20, (index) =>
+      contestedEntry(`dirty-${index}.ts`, ["/fleet/dirty", `/fleet/neighbor-${index % 3}`])
+    );
+    expect(contestedSwampingNotes(contested, swampedRows())).toEqual([]);
+  });
+
+  it("stays silent about a checkout claiming exactly half", () => {
+    // 22 rows over rotating pairs: each of the four checkouts claims 11 — exactly half, never more.
+    const contested = A.makeBy(22, (index) =>
+      contestedEntry(`p-${index}.ts`, [`/fleet/spread-${index % 2}`, `/fleet/spread-${2 + (index % 2)}`])
+    );
+    const rows = A.makeBy(4, (index) => checkoutRow(`/fleet/spread-${index}`, "live", 9));
+    expect(contestedSwampingNotes(contested, rows)).toEqual([]);
   });
 });


### PR DESCRIPTION
## feat(worktree): harden fleet registry liveness

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_fleet-mirror-rung-1p5-registry-liveness-7021aca02787/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788952771&installation_model_id=424656&pr_number=642&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F642&signature=f01314aa0a54776edacdac5d8d76edc1abef13634f00dca5457bb9586c6c0da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->