### PR TITLE
ci(check): move Lint Policy and JSDoc Ratchet onto the EC2 fleet

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,7 +62,7 @@ jobs:
             install_typos: "true"
           - id: lint-policy
             name: Lint Policy
-            runner: ubuntu-24.04
+            runner: beep-ec2-heavy
             timeout_minutes: 50
             uses_turbo: "false"
             install_typos: "true"
@@ -519,7 +519,7 @@ jobs:
 
   jsdoc-ratchet:
     name: JSDoc Ratchet
-    runs-on: ubuntu-24.04
+    runs-on: beep-ec2-heavy
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
## ci(check): move Lint Policy and JSDoc Ratchet onto the EC2 fleet

Measured on PR 633's run: Lint Policy took 24.7 minutes and JSDoc Ratchet 9.6
on hosted ubuntu-24.04, while the fleet turned the heavier Check lane around
in 6.7. Both lanes install their full toolchain through setup-monorepo-ci and
Lint Policy already requests typos through the existing install flag, so the
move is a runner swap with no tooling changes.

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_heavy-lane-placement-479ad7cbc81e/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956420&installation_model_id=424656&pr_number=643&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F643&signature=c636320a25a150631da322d1df6c25b5a867e16c5a8375c9dda57c5add33749f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->