### PR TITLE
fix(repo-cli): redact the operator home directory from the PR provenance footer

### DIFF
--- a/.changeset/yeet-footer-redact-home.md
+++ b/.changeset/yeet-footer-redact-home.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-cli": patch
+---
+
+The footer now tokenizes the operator home directory as `~` so public PRs do not leak the username or workstation layout.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
@@ -45,16 +45,17 @@ const $I = $RepoCliId.create("commands/Yeet/internal/Provenance");
 const recentClaudeSessionWindow = Duration.hours(6);
 const futureClaudeSessionSkew = Duration.minutes(1);
 const provenanceDetectionTimeout = Duration.seconds(2);
-const PrProvenanceAbsolutePath = S.String.check(
-  S.isPattern(/^\//u, {
-    identifier: "PrProvenanceAbsolutePath",
-    title: "PR provenance absolute path",
-    description: "An absolute filesystem path recorded in pull request provenance.",
-    message: "Expected an absolute path starting with '/'",
+/** Absolute or home-tokenized path safe to record in public PR provenance. */
+const PrProvenancePath = S.String.check(
+  S.isPattern(/^(?:\/|~(?:\/|$))/u, {
+    identifier: "PrProvenancePath",
+    title: "PR provenance path",
+    description: "An absolute or '~/'-prefixed filesystem path recorded in pull request provenance.",
+    message: "Expected an absolute path or a home-tokenized path starting with '~/'",
   })
 ).pipe(
-  $I.annoteSchema("PrProvenanceAbsolutePath", {
-    description: "Absolute clone or linked-worktree path recorded in pull request provenance.",
+  $I.annoteSchema("PrProvenancePath", {
+    description: "Absolute or home-tokenized clone or linked-worktree path recorded in pull request provenance.",
   })
 );
 
@@ -102,9 +103,9 @@ export type PrProvenanceHarness = typeof PrProvenanceHarness.Type;
  *
  * const provenance = PrProvenance.make({
  *   branch: "feat/example",
- *   clonePath: "/home/user/beep-effect",
+ *   clonePath: "~/beep-effect",
  *   harness: "codex",
- *   resumeCommand: "cd '/home/user/beep-effect' &&\n  codex resume --last",
+ *   resumeCommand: "cd ~/'beep-effect' &&\n  codex resume --last",
  *   sessionId: O.none(),
  *   worktreePath: O.none(),
  * })
@@ -113,8 +114,8 @@ export type PrProvenanceHarness = typeof PrProvenanceHarness.Type;
  *
  * **Details**
  *
- * `clonePath` is the absolute main clone path. `worktreePath` is present only
- * when publish runs from a linked worktree.
+ * `clonePath` is the absolute or home-tokenized main clone path. `worktreePath`
+ * is present only when publish runs from a linked worktree.
  *
  * @category models
  * @since 0.0.0
@@ -122,11 +123,11 @@ export type PrProvenanceHarness = typeof PrProvenanceHarness.Type;
 export class PrProvenance extends S.Class<PrProvenance>($I`PrProvenance`)(
   {
     branch: S.String,
-    clonePath: PrProvenanceAbsolutePath,
+    clonePath: PrProvenancePath,
     harness: PrProvenanceHarness,
     resumeCommand: S.String,
     sessionId: S.OptionFromNullOr(S.String),
-    worktreePath: S.OptionFromNullOr(PrProvenanceAbsolutePath),
+    worktreePath: S.OptionFromNullOr(PrProvenancePath),
   },
   $I.annote("PrProvenance", {
     description: "Origin and paste-ready resume command recorded in a Yeet pull request body.",
@@ -151,6 +152,42 @@ export class PrProvenance extends S.Class<PrProvenance>($I`PrProvenance`)(
  * @since 0.0.0
  */
 export const mungeClaudeProjectPath = repoPathToClaudeProjectName;
+
+/**
+ * Replace a path's leading home-directory segment with `~`.
+ *
+ * **Example** (Tokenize a checkout path)
+ *
+ * ```ts
+ * import { tokenizeHomePath } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(tokenizeHomePath("/home/user", "/home/user/src/repo"))
+ * // ~/src/repo
+ * ```
+ *
+ * @param home - Absolute home directory supplied by the runtime configuration.
+ * @param path - Filesystem path to make safe for public provenance.
+ * @returns The home-tokenized path, or the original path when it is outside home.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const tokenizeHomePath = (home: string, path: string): string => {
+  const normalizedHome = Str.replace(/\/+$/u, "")(home);
+  if (Str.isEmpty(normalizedHome)) {
+    return path;
+  }
+  if (path === normalizedHome) {
+    return "~";
+  }
+  return Str.startsWith(`${normalizedHome}/`)(path) ? `~/${Str.slice(Str.length(normalizedHome) + 1)(path)}` : path;
+};
+
+const tokenizeConfiguredHomePath = (home: O.Option<string>, path: string): string =>
+  pipe(
+    home,
+    O.map((homePath) => tokenizeHomePath(homePath, path)),
+    O.getOrElse(() => path)
+  );
 
 const sessionOrder = Order.mapInput(
   Order.Number,
@@ -231,6 +268,13 @@ export const findRecentClaudeSession = Effect.fn("PrProvenance.findRecentClaudeS
   );
 });
 
+const shellQuoteDirectory = (directory: string): string => {
+  if (directory === "~") {
+    return directory;
+  }
+  return Str.startsWith("~/")(directory) ? `~/${shellQuote(Str.slice(2)(directory))}` : shellQuote(directory);
+};
+
 /**
  * Build the paste-ready command for a detected harness.
  *
@@ -258,16 +302,16 @@ export const resumeCommandFor = (
   PrProvenanceHarness.$match(harness, {
     "claude-code": () =>
       O.match(sessionId, {
-        onNone: () => `cd ${shellQuote(directory)} &&\n  claude --resume`,
-        onSome: (id) => `cd ${shellQuote(directory)} &&\n  claude --resume ${shellQuote(id)}`,
+        onNone: () => `cd ${shellQuoteDirectory(directory)} &&\n  claude --resume`,
+        onSome: (id) => `cd ${shellQuoteDirectory(directory)} &&\n  claude --resume ${shellQuote(id)}`,
       }),
     codex: () =>
-      `cd ${shellQuote(directory)} &&\n  ${pipe(
+      `cd ${shellQuoteDirectory(directory)} &&\n  ${pipe(
         sessionId,
         O.map((id) => `codex resume ${shellQuote(id)}`),
         O.getOrElse(() => "codex resume --last")
       )}`,
-    unknown: () => `cd ${shellQuote(directory)} &&\n  claude --resume`,
+    unknown: () => `cd ${shellQuoteDirectory(directory)} &&\n  claude --resume`,
   });
 
 const encodePrProvenanceJson = S.encodeUnknownResult(S.fromJsonString(PrProvenance));
@@ -357,6 +401,7 @@ export class PrProvenanceService extends Context.Service<PrProvenanceService, Pr
 type PrProvenanceRequirements = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner;
 
 const makeUnknownProvenance = (
+  home: O.Option<string>,
   clonePath: string,
   checkoutPath: string,
   worktreePath: O.Option<string>,
@@ -364,11 +409,11 @@ const makeUnknownProvenance = (
 ): PrProvenance =>
   PrProvenance.make({
     branch,
-    clonePath,
+    clonePath: tokenizeConfiguredHomePath(home, clonePath),
     harness: "unknown",
-    resumeCommand: resumeCommandFor("unknown", checkoutPath, O.none()),
+    resumeCommand: resumeCommandFor("unknown", tokenizeConfiguredHomePath(home, checkoutPath), O.none()),
     sessionId: O.none(),
-    worktreePath,
+    worktreePath: O.map(worktreePath, (value) => tokenizeConfiguredHomePath(home, value)),
   });
 
 /**
@@ -433,19 +478,22 @@ export const detectPrProvenanceFromPaths = Effect.fn("PrProvenance.detectFromPat
   branch: string
 ) {
   const path = yield* Path.Path;
+  const home = yield* Config.option(Config.string("HOME")).pipe(Effect.orElseSucceed(O.none<string>));
+  const publicPath = (value: string): string => tokenizeConfiguredHomePath(home, value);
+  const publicClonePath = publicPath(clonePath);
+  const publicWorktreePath = O.map(worktreePath, publicPath);
   const [isCodex, codexThreadId] = yield* detectCodexEnvironment();
   if (isCodex) {
     return PrProvenance.make({
       branch,
-      clonePath,
+      clonePath: publicClonePath,
       harness: "codex",
-      resumeCommand: resumeCommandFor("codex", checkoutPath, codexThreadId),
+      resumeCommand: resumeCommandFor("codex", publicPath(checkoutPath), codexThreadId),
       sessionId: codexThreadId,
-      worktreePath,
+      worktreePath: publicWorktreePath,
     });
   }
 
-  const home = yield* Config.option(Config.string("HOME"));
   const nowMillis = yield* Clock.currentTimeMillis;
   const claudeSession = yield* pipe(
     home,
@@ -459,37 +507,38 @@ export const detectPrProvenanceFromPaths = Effect.fn("PrProvenance.detectFromPat
     const [launchPath, sessionId] = claudeSession.value;
     return PrProvenance.make({
       branch,
-      clonePath,
+      clonePath: publicClonePath,
       harness: "claude-code",
-      resumeCommand: resumeCommandFor("claude-code", launchPath, O.some(sessionId)),
+      resumeCommand: resumeCommandFor("claude-code", publicPath(launchPath), O.some(sessionId)),
       sessionId: O.some(sessionId),
-      worktreePath,
+      worktreePath: publicWorktreePath,
     });
   }
 
   return PrProvenance.make({
     branch,
-    clonePath,
+    clonePath: publicClonePath,
     harness: "unknown",
-    resumeCommand: resumeCommandFor("unknown", checkoutPath, O.none()),
+    resumeCommand: resumeCommandFor("unknown", publicPath(checkoutPath), O.none()),
     sessionId: O.none(),
-    worktreePath,
+    worktreePath: publicWorktreePath,
   });
 });
 
 const makePrProvenanceService = Effect.fn("PrProvenanceService.make")(function* () {
   const path = yield* Path.Path;
   const runtimeContext = yield* Effect.context<PrProvenanceRequirements>();
+  const home = yield* Config.option(Config.string("HOME")).pipe(Effect.orElseSucceed(O.none<string>));
   return PrProvenanceService.of({
     detect: Effect.fn("PrProvenanceService.detect")((cwd, branch) => {
       const checkoutFallback = path.resolve(cwd);
-      const gitFallback = makeUnknownProvenance(checkoutFallback, checkoutFallback, O.none(), branch);
+      const gitFallback = makeUnknownProvenance(home, checkoutFallback, checkoutFallback, O.none(), branch);
       return detectGitPaths(cwd).pipe(
         Effect.provide(runtimeContext),
         Effect.matchCauseEffect({
           onFailure: () => Effect.succeed(gitFallback),
           onSuccess: ([clonePath, checkoutPath, worktreePath]) => {
-            const fallback = makeUnknownProvenance(clonePath, checkoutPath, worktreePath, branch);
+            const fallback = makeUnknownProvenance(home, clonePath, checkoutPath, worktreePath, branch);
             return detectPrProvenanceFromPaths(clonePath, checkoutPath, worktreePath, branch).pipe(
               Effect.provide(runtimeContext),
               Effect.catchCause(() => Effect.succeed(fallback)),

--- a/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
@@ -6,6 +6,7 @@ import {
   PrProvenance,
   renderPrProvenance,
   resumeCommandFor,
+  tokenizeHomePath,
 } from "@beep/repo-cli/test/Yeet";
 import { provideScopedLayer } from "@beep/test-utils";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
@@ -33,6 +34,14 @@ describe("Yeet PR provenance", () => {
     expect(mungeClaudeProjectPath("/home/operator/beep.effect\\.claude/worktrees/end.game")).toBe(
       "-home-operator-beep.effect-.claude-worktrees-end.game"
     );
+  });
+
+  it("tokenizes only paths at or below the configured home directory", () => {
+    expect(tokenizeHomePath("/home/operator", "/home/operator/YeeBois/beep-effect")).toBe("~/YeeBois/beep-effect");
+    expect(tokenizeHomePath("/home/operator", "/home/operator-other/beep-effect")).toBe(
+      "/home/operator-other/beep-effect"
+    );
+    expect(tokenizeHomePath("/home/operator", "/workspace/beep-effect")).toBe("/workspace/beep-effect");
   });
 
   it.effect("detects split Codex markers and reads CODEX_THREAD_ID by its exact environment key", () =>
@@ -71,6 +80,8 @@ describe("Yeet PR provenance", () => {
         );
 
         expect(provenance.harness).toBe("codex");
+        expect(provenance.clonePath).toBe(clonePath);
+        expect(provenance.worktreePath).toStrictEqual(O.some(checkoutPath));
         expect(provenance.sessionId).toStrictEqual(O.some("thread-123"));
         expect(provenance.resumeCommand).toBe(
           "cd '/workspace/beep-effect/.claude/worktrees/endgame' &&\n  codex resume 'thread-123'"
@@ -164,24 +175,93 @@ describe("Yeet PR provenance", () => {
     );
   });
 
+  it("leaves the tilde expandable while quoting the home-relative remainder", () => {
+    expect(resumeCommandFor("codex", "~/YeeBois/a && b", O.some("thread-123"))).toBe(
+      "cd ~/'YeeBois/a && b' &&\n  codex resume 'thread-123'"
+    );
+  });
+
+  it.effect("tokenizes detected paths in both human and machine provenance", () =>
+    Effect.gen(function* () {
+      const clonePath = "/home/operator/YeeBois/projects/beep-effect3";
+      const checkoutPath = `${clonePath}/.claude/worktrees/footer-redact`;
+      const provenance = yield* detectPrProvenanceFromPaths(
+        clonePath,
+        checkoutPath,
+        O.some(checkoutPath),
+        "fix/yeet-footer-redact-home"
+      );
+      const footer = renderPrProvenance(provenance);
+
+      expect(provenance.clonePath).toBe("~/YeeBois/projects/beep-effect3");
+      expect(provenance.worktreePath).toStrictEqual(
+        O.some("~/YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact")
+      );
+      expect(provenance.resumeCommand).toBe(
+        "cd ~/'YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact' &&\n  codex resume 'thread-123'"
+      );
+      expect(footer).not.toContain("/home/operator");
+      expect(footer).toContain("- Clone: `~/YeeBois/projects/beep-effect3`");
+      expect(footer).toContain("- Worktree: `~/YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact`");
+
+      const encoded = pipe(
+        footer,
+        Str.split("<!-- yeet-provenance\n"),
+        A.get(1),
+        O.flatMap((tail) => pipe(tail, Str.split("\n-->"), A.head)),
+        O.getOrThrow
+      );
+      expect(yield* S.decodeUnknownEffect(S.fromJsonString(PrProvenance))(encoded)).toStrictEqual(provenance);
+    }).pipe(
+      Effect.provideService(
+        ConfigProvider.ConfigProvider,
+        ConfigProvider.fromEnv({ env: { CODEX_THREAD_ID: "thread-123", HOME: "/home/operator" } })
+      ),
+      provideScopedLayer(PlatformLayer)
+    )
+  );
+
+  it.effect("keeps absolute paths when HOME is unset", () =>
+    Effect.gen(function* () {
+      const clonePath = "/home/operator/YeeBois/projects/beep-effect3";
+      const checkoutPath = `${clonePath}/.claude/worktrees/footer-redact`;
+      const provenance = yield* detectPrProvenanceFromPaths(
+        clonePath,
+        checkoutPath,
+        O.some(checkoutPath),
+        "fix/yeet-footer-redact-home"
+      );
+
+      expect(provenance.clonePath).toBe(clonePath);
+      expect(provenance.worktreePath).toStrictEqual(O.some(checkoutPath));
+      expect(provenance.resumeCommand).toBe(`cd '${checkoutPath}' &&\n  codex resume 'thread-123'`);
+    }).pipe(
+      Effect.provideService(
+        ConfigProvider.ConfigProvider,
+        ConfigProvider.fromEnv({ env: { CODEX_THREAD_ID: "thread-123" } })
+      ),
+      provideScopedLayer(PlatformLayer)
+    )
+  );
+
   it.effect("renders human and schema-decodable machine provenance twins", () =>
     Effect.gen(function* () {
       const provenance = PrProvenance.make({
         branch: "feat/yeet-pr-provenance",
-        clonePath: "/workspace/beep-effect",
+        clonePath: "~/workspace/beep-effect",
         harness: "claude-code",
-        resumeCommand: resumeCommandFor("claude-code", "/workspace/beep-effect", O.some("session-123")),
+        resumeCommand: resumeCommandFor("claude-code", "~/workspace/beep-effect", O.some("session-123")),
         sessionId: O.some("session-123"),
-        worktreePath: O.some("/workspace/beep-effect/.claude/worktrees/endgame"),
+        worktreePath: O.some("~/workspace/beep-effect/.claude/worktrees/endgame"),
       });
       const footer = renderPrProvenance(provenance);
 
       expect(footer).toContain("---\n\n## Provenance");
-      expect(footer).toContain("- Clone: `/workspace/beep-effect`");
-      expect(footer).toContain("- Worktree: `/workspace/beep-effect/.claude/worktrees/endgame`");
+      expect(footer).toContain("- Clone: `~/workspace/beep-effect`");
+      expect(footer).toContain("- Worktree: `~/workspace/beep-effect/.claude/worktrees/endgame`");
       expect(footer).toContain("- Branch: `feat/yeet-pr-provenance`");
       expect(footer).toContain("- Harness: `claude-code`");
-      expect(footer).toContain("```sh\ncd '/workspace/beep-effect' &&\n  claude --resume 'session-123'\n```");
+      expect(footer).toContain("```sh\ncd ~/'workspace/beep-effect' &&\n  claude --resume 'session-123'\n```");
 
       const encoded = pipe(
         footer,


### PR DESCRIPTION
## fix(repo-cli): redact the operator home directory from the PR provenance footer

Every Yeet-published PR body carried absolute local paths: the clone, the
worktree, and the resume command's cd target. This repository is public, so
those paths leaked the operator username and workstation layout on real PRs.

The footer now tokenizes the home directory as ~ in the human lines, the
machine-readable twin, and the resume command, so a public PR no longer
publishes the username. The resume command emits the tilde outside the shell
quotes so it still expands when pasted, while the remaining path stays quoted.
Paths outside home and an unset HOME fall back to the absolute form so the
resume bookmark never breaks.

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_yeet-footer-redact-home-59a095a02fba/verdict.json

---

## Provenance

- Clone: `~/YeeBois/projects/beep-effect3`
- Worktree: `~/YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact`
- Branch: `fix/yeet-footer-redact-home`
- Harness: `codex`

Resume this session:

```sh
cd ~/'YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact' &&
  codex resume --last
```

<!-- yeet-provenance
{
  "branch": "fix/yeet-footer-redact-home",
  "clonePath": "~/YeeBois/projects/beep-effect3",
  "harness": "codex",
  "resumeCommand": "cd ~/'YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact' &&\n  codex resume --last",
  "sessionId": null,
  "worktreePath": "~/YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788968828&installation_model_id=424656&pr_number=650&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F650&signature=fd197118a3a0e1cdbfc0ed2fba26af7d34b116e8ab3019e8a20bfa1c63087550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->