### PR TITLE
feat(infra): harden the CI fleet controller for the P2 cutover

### DIFF
--- a/.changeset/ci-fleet-controller-p2-hardening.md
+++ b/.changeset/ci-fleet-controller-p2-hardening.md
@@ -1,0 +1,8 @@
+---
+"@beep/infra": patch
+---
+
+Harden the CI fleet controller for the P2 cutover: 64 GB memory-optimized
+instance types so cold heavy typecheck compiles fit, and a post-install
+iptables OWNER-match rule dropping ec2-user access to IMDS as the CSF-003
+host credential-theft mitigation.

--- a/.github/workflows/fleet-shadow-check.yml
+++ b/.github/workflows/fleet-shadow-check.yml
@@ -33,26 +33,26 @@ jobs:
           echo "RUNNER_NAME: ${RUNNER_NAME:-unset}"
           echo "hostname: $(hostname)"
 
-          instance_id=unavailable
-          role_name=unavailable
-          if token="$(curl --noproxy '*' --silent --show-error --fail \
+          # CSF-003 denies IMDS to the runner user by design; RUNNER_NAME carries the instance ID.
+          if [[ "${RUNNER_NAME:-}" =~ ^beep-ci-(i-[0-9a-f]+)$ ]]; then
+            instance_id="${BASH_REMATCH[1]}"
+          else
+            echo "Could not recover an instance ID from RUNNER_NAME"
+            exit 1
+          fi
+          echo "Runner instance-id: ${instance_id}"
+
+          if curl --noproxy '*' --silent --show-error --fail \
             --connect-timeout 3 --max-time 3 \
             --request PUT \
             --header 'X-aws-ec2-metadata-token-ttl-seconds: 60' \
-            http://169.254.169.254/latest/api/token)"; then
-            instance_id="$(curl --noproxy '*' --silent --show-error --fail \
-              --connect-timeout 3 --max-time 3 \
-              --header "X-aws-ec2-metadata-token: ${token}" \
-              http://169.254.169.254/latest/meta-data/instance-id)" || instance_id=unavailable
-            role_name="$(curl --noproxy '*' --silent --show-error --fail \
-              --connect-timeout 3 --max-time 3 \
-              --header "X-aws-ec2-metadata-token: ${token}" \
-              http://169.254.169.254/latest/meta-data/iam/security-credentials/)" || role_name=unavailable
+            --output /dev/null \
+            http://169.254.169.254/latest/api/token; then
+            echo "FORBIDDEN SUCCESS: runner reached IMDSv2"
+            exit 1
           else
-            echo "IMDSv2 token request failed"
+            echo "DENIED AS EXPECTED: runner could not reach IMDSv2"
           fi
-          echo "IMDS instance-id: ${instance_id}"
-          echo "IMDS IAM role: ${role_name}"
 
       - name: Ensure AWS CLI is available
         if: ${{ inputs.redteam }}
@@ -96,6 +96,7 @@ jobs:
             exit 1
           fi
 
+          # CSF-003 denies IMDS credentials to the runner user by design.
           failed=0
           for parameter in github_app_key_base64 github_app_webhook_secret; do
             error_file="${RUNNER_TEMP}/ssm-${parameter}.error"
@@ -107,6 +108,8 @@ jobs:
               failed=1
             elif grep -Eqi 'AccessDenied|not authorized' "${error_file}"; then
               echo "DENIED AS EXPECTED: ${parameter}"
+            elif grep -Eqi 'Unable to locate credentials|No credentials|failed to refresh cached credentials|no EC2 IMDS role found' "${error_file}"; then
+              echo "DENIED AS EXPECTED: ${parameter} (guest credentials unavailable)"
             else
               echo "UNEXPECTED ERROR: ${parameter}"
               sed -n '1,8p' "${error_file}"
@@ -127,12 +130,15 @@ jobs:
             exit 1
           fi
 
+          # CSF-003 denies IMDS credentials to the runner user by design.
           failed=0
           if aws s3api list-buckets >/dev/null 2>"${RUNNER_TEMP}/s3-list.error"; then
             echo "FORBIDDEN SUCCESS: listed S3 buckets"
             failed=1
           elif grep -Eqi 'AccessDenied|not authorized' "${RUNNER_TEMP}/s3-list.error"; then
             echo "DENIED AS EXPECTED: list-buckets"
+          elif grep -Eqi 'Unable to locate credentials|No credentials|failed to refresh cached credentials|no EC2 IMDS role found' "${RUNNER_TEMP}/s3-list.error"; then
+            echo "DENIED AS EXPECTED: list-buckets (guest credentials unavailable)"
           else
             echo "UNEXPECTED ERROR: list-buckets"
             sed -n '1,8p' "${RUNNER_TEMP}/s3-list.error"
@@ -147,6 +153,8 @@ jobs:
             failed=1
           elif grep -Eqi 'AccessDenied|not authorized' "${RUNNER_TEMP}/s3-put.error"; then
             echo "DENIED AS EXPECTED: put-object"
+          elif grep -Eqi 'Unable to locate credentials|No credentials|failed to refresh cached credentials|no EC2 IMDS role found' "${RUNNER_TEMP}/s3-put.error"; then
+            echo "DENIED AS EXPECTED: put-object (guest credentials unavailable)"
           else
             echo "UNEXPECTED ERROR: put-object"
             sed -n '1,8p' "${RUNNER_TEMP}/s3-put.error"

--- a/goals/ci-fleet-endgame/ops/redteam-verify.sh
+++ b/goals/ci-fleet-endgame/ops/redteam-verify.sh
@@ -115,7 +115,8 @@ fi
 
 instance_id=""
 if [[ -s "${run_log}" ]]; then
-  instance_id="$(sed -n 's/.*IMDS instance-id: \(i-[0-9a-f][0-9a-f]*\).*/\1/p' "${run_log}" | head -1)"
+  # CSF-003 denies runner-user IMDS access; the workflow derives identity from RUNNER_NAME.
+  instance_id="$(sed -n 's/.*Runner instance-id: \(i-[0-9a-f][0-9a-f]*\).*/\1/p' "${run_log}" | head -1)"
 fi
 aws_available=0
 if command -v aws >/dev/null 2>&1 && aws sts get-caller-identity >/dev/null 2>&1; then

--- a/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
@@ -175,9 +175,15 @@
   runtime property the code cannot prove.
 - **Required deploy gate (red-team Gate E):** the first `pulumi up` carrying
   this change must be followed by a probe job on the shadow label that proves
-  BOTH: (a) job pickup still works — the agent was not cut off from anything it
-  needs; and (b) `curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/`
-  from a job step now fails/times out. If (a) regresses, the agent needed IMDS
-  at runtime and the rule must move to a post-agent-start hook or a
-  path-scoped local proxy. Do not flip the heavy-lane cutover until Gate E
-  passes.
+  ALL of: (a) job pickup still works — the agent was not cut off from anything
+  it needs; (b) a NON-sudo `curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/`
+  from a job step fails/times out; and (c) the instance-profile role is
+  minimal. Note (c) is the real control, not the DROP: the runner user keeps
+  passwordless sudo for hosted parity, so `sudo curl` to IMDS is EXPECTED to
+  still succeed and is not itself a blocker — a host firewall rule cannot
+  contain root-capable job code. Instead enumerate the runner role's policies
+  and permissions boundary and confirm it grants only boot-time needs (AMI SSM
+  read, runner-binary S3 read); a non-minimal role IS a blocker. If (a)
+  regresses, the agent needed IMDS at runtime and the rule must move to a
+  post-agent-start hook or a path-scoped local proxy. Do not flip the
+  heavy-lane cutover until Gate E passes.

--- a/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
@@ -1,5 +1,32 @@
 # Opportunities
 
+## AL2023 does not guarantee iptables in the standard AMI
+
+- **Work:** Adding the post-install host-IMDS OWNER rule to the AL2023 runner.
+- **Friction:** The AL2023 package repository provides the nft-backed
+  `iptables-nft` compatibility package, but the standard-AMI package comparison
+  does not list `iptables` as preinstalled. Relying on another installer to
+  pull it transitively would make this security control image-dependent.
+- **Evidence:** Amazon Linux's package inventory lists `iptables-nft` for x86_64,
+  while its standard AL2-to-AL2023 AMI comparison shows `iptables` only on the
+  AL2 side.
+- **Proposal:** Security userdata that needs the compatibility command should
+  conditionally install `iptables-nft` before applying rules, as this controller
+  hook now does.
+
+## Interactive zsh startup noise obscures verification output
+
+- **Work:** Running the P2 controller hardening's four required verification
+  commands through `zsh -ic`.
+- **Friction:** Every command emitted non-fatal interactive-shell diagnostics
+  before the actual tool output, making clean pass/fail evidence harder to read.
+- **Evidence:** The repeated startup output included `can't change option: zle`,
+  `can't change option: monitor`, and `gitstatus failed to initialize`; all four
+  requested commands nevertheless exited 0.
+- **Proposal:** Skip prompt and gitstatus initialization when interactive zsh
+  has no TTY, so automation using the repository's documented `zsh -ic`
+  commands produces only verification output.
+
 ## Burst reaper kills busy workers mid-job
 
 - **Work:** Post-merge main run for PR #633 on the manual burst fleet.
@@ -134,3 +161,23 @@
   server-side at merge time (the repo already treats merge messages as
   commitlint input in prose, but #651 proves nothing gates it), so `main` can
   never carry a header that poisons downstream PR ranges.
+
+## Host IMDS block shares the runner-agent uid — deploy needs a probe gate
+
+- **Work:** P2 controller hardening — adding the CSF-003 host IMDS mitigation.
+- **Risk (not yet friction):** the OWNER-match DROP keys on the `ec2-user`
+  uid, and the runner AGENT also runs as `ec2-user` (`runner_run_as`). The
+  mitigation is safe only because the instance-profile role is consumed by
+  boot-time root steps (AMI SSM resolution, binary sync) and runtime IMDS
+  consumers are off (`enable_cloudwatch_agent: false`,
+  `enable_ssm_on_runners: false`), so the agent's poll loop uses its JIT token,
+  not IMDS. This is the canonical github-aws-runners pattern, but it is a
+  runtime property the code cannot prove.
+- **Required deploy gate (red-team Gate E):** the first `pulumi up` carrying
+  this change must be followed by a probe job on the shadow label that proves
+  BOTH: (a) job pickup still works — the agent was not cut off from anything it
+  needs; and (b) `curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/`
+  from a job step now fails/times out. If (a) regresses, the agent needed IMDS
+  at runtime and the rule must move to a post-agent-start hook or a
+  path-scoped local proxy. Do not flip the heavy-lane cutover until Gate E
+  passes.

--- a/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
@@ -176,8 +176,13 @@
 - **Required deploy gate (red-team Gate E):** the first `pulumi up` carrying
   this change must be followed by a probe job on the shadow label that proves
   ALL of: (a) job pickup still works — the agent was not cut off from anything
-  it needs; (b) a NON-sudo `curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/`
-  from a job step fails/times out; and (c) the instance-profile role is
+  it needs; (b) a NON-sudo IMDSv2 probe from a job step fails/times out —
+  crucially, request a token first (`curl -X PUT
+  http://169.254.169.254/latest/api/token -H
+  'X-aws-ec2-metadata-token-ttl-seconds: 60'`) and require the TOKEN REQUEST
+  itself to be blocked, because with `http_tokens: required` a tokenless GET
+  already returns 401 even without the firewall rule and would pass a hollow
+  probe; and (c) the instance-profile role is
   minimal. Note (c) is the real control, not the DROP: the runner user keeps
   passwordless sudo for hosted parity, so `sudo curl` to IMDS is EXPECTED to
   still succeed and is not itself a blocker — a host firewall rule cannot

--- a/goals/codex-security-findings-2026-08-10/findings/CSF-002.md
+++ b/goals/codex-security-findings-2026-08-10/findings/CSF-002.md
@@ -13,13 +13,15 @@ persist into a later trusted push job that receives secrets.
 
 ## Current-HEAD Validation
 
-Verdict: `defer-p2`. The vulnerable property is runner reuse across trust
-levels, not one command in the launcher.
+Verdict: `defer-p2`. The ephemeral one-job-one-VM controller is the structural
+fix for runner reuse across trust levels. The remaining gap is the live
+heavy-lane label cutover, not additional controller code.
 
 ## Remediation
 
-Deferred to JIT ephemeral runners and separated trusted/untrusted lanes. No
-workflow or infrastructure files were changed in this PR.
+This PR hardens the JIT ephemeral controller that destroys each VM after one
+job. The finding remains open until the heavy lanes are cut over to that fleet;
+merged controller code alone does not change live lane routing.
 
 ## Verification
 

--- a/goals/codex-security-findings-2026-08-10/findings/CSF-003.md
+++ b/goals/codex-security-findings-2026-08-10/findings/CSF-003.md
@@ -13,14 +13,17 @@ organization-owned EC2 workers.
 
 ## Current-HEAD Validation
 
-Verdict: `defer-p2`. This is the same owned-runner trust boundary as CSF-001 on
-additional lanes and needs the same structural fleet remedy.
+Verdict: `defer-p2`. This PR adds the missing host IMDS credential-theft
+control: an `iptables` OWNER-match rule denies `ec2-user` access to IMDS while
+preserving the existing hop-limit-1 container defense.
 
 ## Remediation
 
-Deferred to the one-job-one-VM cutover. No workflow or infrastructure files
-were changed in this PR.
+The hardened one-job-one-VM controller is the structural remedy. The finding
+remains open until the heavy-lane label cutover is live; merged mitigation code
+does not itself move pull-request jobs onto the fleet.
 
 ## Verification
 
 - Revalidate all pull-request lane routing after the fleet cutover.
+- From a cutover runner job, verify IPv4 IMDS access is denied for `ec2-user`.

--- a/goals/codex-security-findings-2026-08-10/findings/CSF-003.md
+++ b/goals/codex-security-findings-2026-08-10/findings/CSF-003.md
@@ -19,11 +19,24 @@ preserving the existing hop-limit-1 container defense.
 
 ## Remediation
 
-The hardened one-job-one-VM controller is the structural remedy. The finding
-remains open until the heavy-lane label cutover is live; merged mitigation code
-does not itself move pull-request jobs onto the fleet.
+The hardened one-job-one-VM controller is the structural remedy. The IMDS
+OWNER-match DROP is defense-in-depth only: the runner user keeps passwordless
+sudo for hosted parity, so root-capable job code can bypass any host firewall
+rule. The controls that actually bound credential theft are a minimal,
+permissions-boundary-capped instance-profile role and the ephemeral
+one-job-one-VM lifecycle. The finding remains open until the heavy-lane label
+cutover is live; merged mitigation code does not itself move pull-request jobs
+onto the fleet.
 
 ## Verification
 
 - Revalidate all pull-request lane routing after the fleet cutover.
-- From a cutover runner job, verify IPv4 IMDS access is denied for `ec2-user`.
+- Gate E, from a cutover runner job on the shadow label:
+  1. Job pickup still succeeds — the DROP did not starve the runner agent.
+  2. Non-sudo IMDS credential read is denied for the runner user.
+  3. `sudo` IMDS credential read is expected to still succeed — the DROP does not
+     contain root. Do not treat this as a blocker; instead prove the primary
+     control by enumerating the instance-profile role's attached and inline
+     policies and the permissions boundary, and confirm the role grants only the
+     boot-time needs (AMI SSM parameter read, runner-binary S3 read) and nothing
+     that widens blast radius. A non-minimal role IS a cutover blocker.

--- a/goals/codex-security-findings-2026-08-10/findings/CSF-003.md
+++ b/goals/codex-security-findings-2026-08-10/findings/CSF-003.md
@@ -33,10 +33,17 @@ onto the fleet.
 - Revalidate all pull-request lane routing after the fleet cutover.
 - Gate E, from a cutover runner job on the shadow label:
   1. Job pickup still succeeds — the DROP did not starve the runner agent.
-  2. Non-sudo IMDS credential read is denied for the runner user.
-  3. `sudo` IMDS credential read is expected to still succeed — the DROP does not
-     contain root. Do not treat this as a blocker; instead prove the primary
-     control by enumerating the instance-profile role's attached and inline
-     policies and the permissions boundary, and confirm the role grants only the
-     boot-time needs (AMI SSM parameter read, runner-binary S3 read) and nothing
-     that widens blast radius. A non-minimal role IS a cutover blocker.
+  2. Non-sudo IMDSv2 access is denied for the runner user. Probe with a token
+     request, not a bare GET: `http_tokens: required` makes a tokenless GET
+     return 401 even without the firewall, so the probe must issue
+     `curl -X PUT http://169.254.169.254/latest/api/token -H
+     'X-aws-ec2-metadata-token-ttl-seconds: 60'` and require that PUT to
+     fail/time out.
+  3. `sudo` or privileged-container (host-network, UID 0) IMDS access is expected
+     to still succeed — a host firewall rule does not contain root, and a blanket
+     DROP would break the runner's config-time JIT fetch. Do not treat this as a
+     blocker; instead prove the primary control by enumerating the
+     instance-profile role's attached and inline policies and the permissions
+     boundary, and confirm the role grants only the boot-time needs (AMI SSM
+     parameter read, runner-binary S3 read) and nothing that widens blast radius.
+     A non-minimal role IS a cutover blocker.

--- a/infra/src/CiFleetController.ts
+++ b/infra/src/CiFleetController.ts
@@ -27,8 +27,27 @@ const githubAppIdSsmParameterName = "/github-action-runners/app/github_app_id";
 const githubAppKeyBase64SsmParameterName = "/github-action-runners/app/github_app_key_base64";
 const githubAppWebhookSecretSsmParameterName = "/github-action-runners/app/github_app_webhook_secret";
 
-const runnerInstanceTypes = ["m7i.2xlarge", "m7i-flex.2xlarge", "m7a.2xlarge", "m6i.2xlarge"];
+/**
+ * Keeps every runner at 64 GB so the build-mode census peaks of 47.59 GiB for
+ * professional-desktop and 24.77 GiB for epistemic-server fit with headroom.
+ * See `goals/ci-fleet-endgame/research/build-mode-typecheck-census.md`.
+ */
+const runnerInstanceTypes = ["r7a.2xlarge", "r7i.2xlarge", "r6i.2xlarge", "m7a.4xlarge"];
 const onDemandFailoverErrors = ["InsufficientInstanceCapacity", "InsufficientCapacityOnHost", "UnfulfillableCapacity"];
+
+const runnerImdsPostInstall = `#!/bin/sh
+set -eu
+
+command -v iptables >/dev/null 2>&1 || dnf install -y iptables-nft
+runner_uid="$(id -u ec2-user)"
+if iptables -C OUTPUT -m owner --uid-owner "$runner_uid" -d 169.254.169.254/32 -j DROP 2>/dev/null; then
+  rule_status="already present"
+else
+  iptables -I OUTPUT -m owner --uid-owner "$runner_uid" -d 169.254.169.254/32 -j DROP
+  rule_status="installed"
+fi
+logger -t beep-ci-imds "IPv4 IMDS OWNER drop rule $rule_status for ec2-user uid $runner_uid"
+`;
 
 const awsArnPattern = /^arn:aws[a-z-]*:[a-z0-9-]+:[a-z0-9-]*:[0-9]*:.+$/u;
 const ssmParameterArnPattern = /^arn:aws[a-z-]*:ssm:[a-z0-9-]+:[0-9]*:parameter\/.+$/u;
@@ -245,6 +264,13 @@ type CiFleetControllerArgs = {
  * Ephemeral GitHub Actions runner controller backed by the pinned Terraform
  * module through Pulumi's terraform-module provider.
  *
+ * **Gotchas**
+ *
+ * IMDSv2 with hop limit 1 blocks container access, while the post-install
+ * OWNER-match DROP blocks the host `ec2-user` job process for CSF-003. This
+ * fleet has no IPv6, so the IPv4 IMDS rule is sufficient, and JIT config keeps
+ * no runner registration token on the instance.
+ *
  * @category resources
  * @since 0.0.0
  */
@@ -397,6 +423,7 @@ export class CiFleetController extends pulumi.ComponentResource {
         runner_name_prefix: "beep-ci-",
         runner_os: "linux",
         runner_run_as: "ec2-user",
+        userdata_post_install: runnerImdsPostInstall,
         runners_ebs_optimized: true,
         runners_lambda_zip: args.config.runnersLambdaZip,
         runners_maximum_count: 4,

--- a/infra/src/CiFleetController.ts
+++ b/infra/src/CiFleetController.ts
@@ -35,18 +35,31 @@ const githubAppWebhookSecretSsmParameterName = "/github-action-runners/app/githu
 const runnerInstanceTypes = ["r7a.2xlarge", "r7i.2xlarge", "r6i.2xlarge", "m7a.4xlarge"];
 const onDemandFailoverErrors = ["InsufficientInstanceCapacity", "InsufficientCapacityOnHost", "UnfulfillableCapacity"];
 
+// The IMDS block and the runner user are one decision: the OWNER-match rule
+// must key on the exact uid the jobs run as, so both the module's
+// `runner_run_as` and the drop rule below derive from this single constant. If
+// they diverged, jobs would keep IMDS access under the real runner uid.
+const runnerRunAs = "ec2-user";
+
+// Defense-in-depth, not containment: the runner user keeps passwordless sudo for
+// GitHub-hosted parity, so job code that escalates to root can still reach IMDS
+// or flush this rule. The PRIMARY control is therefore a minimal,
+// permissions-boundary-capped instance-profile role on an ephemeral
+// one-job-one-VM — a stolen credential is near-worthless and dies with the VM in
+// minutes. This OWNER-match DROP raises the bar for non-root job code as the
+// host-process complement to the hop-limit-1 container defense.
 const runnerImdsPostInstall = `#!/bin/sh
 set -eu
 
 command -v iptables >/dev/null 2>&1 || dnf install -y iptables-nft
-runner_uid="$(id -u ec2-user)"
+runner_uid="$(id -u ${runnerRunAs})"
 if iptables -C OUTPUT -m owner --uid-owner "$runner_uid" -d 169.254.169.254/32 -j DROP 2>/dev/null; then
   rule_status="already present"
 else
   iptables -I OUTPUT -m owner --uid-owner "$runner_uid" -d 169.254.169.254/32 -j DROP
   rule_status="installed"
 fi
-logger -t beep-ci-imds "IPv4 IMDS OWNER drop rule $rule_status for ec2-user uid $runner_uid"
+logger -t beep-ci-imds "IPv4 IMDS OWNER drop rule $rule_status for ${runnerRunAs} uid $runner_uid"
 `;
 
 const awsArnPattern = /^arn:aws[a-z-]*:[a-z0-9-]+:[a-z0-9-]*:[0-9]*:.+$/u;
@@ -266,10 +279,17 @@ type CiFleetControllerArgs = {
  *
  * **Gotchas**
  *
- * IMDSv2 with hop limit 1 blocks container access, while the post-install
- * OWNER-match DROP blocks the host `ec2-user` job process for CSF-003. This
- * fleet has no IPv6, so the IPv4 IMDS rule is sufficient, and JIT config keeps
- * no runner registration token on the instance.
+ * IMDS defense is layered, and the OWNER-match DROP is the weakest layer, not a
+ * containment boundary: the runner user keeps passwordless sudo for hosted
+ * parity, so job code that escalates to root can still reach IMDS or flush the
+ * rule. The controls that actually bound credential theft are a minimal,
+ * permissions-boundary-capped instance-profile role and the ephemeral
+ * one-job-one-VM lifecycle, which reduce a stolen credential to a near-worthless
+ * value that dies with the VM. Hop limit 1 blocks container access, the DROP
+ * (keyed to `runnerRunAs`, never a divergent uid) blocks non-root host job code,
+ * this IPv4-only fleet needs no IPv6 rule, and JIT config keeps no runner
+ * registration token on the instance. The CSF-003 deploy gate (Gate E) must
+ * therefore verify role minimality, not just that the DROP is present.
  *
  * @category resources
  * @since 0.0.0
@@ -422,7 +442,7 @@ export class CiFleetController extends pulumi.ComponentResource {
         },
         runner_name_prefix: "beep-ci-",
         runner_os: "linux",
-        runner_run_as: "ec2-user",
+        runner_run_as: runnerRunAs,
         userdata_post_install: runnerImdsPostInstall,
         runners_ebs_optimized: true,
         runners_lambda_zip: args.config.runnersLambdaZip,

--- a/infra/src/CiFleetController.ts
+++ b/infra/src/CiFleetController.ts
@@ -281,15 +281,47 @@ type CiFleetControllerArgs = {
  *
  * IMDS defense is layered, and the OWNER-match DROP is the weakest layer, not a
  * containment boundary: the runner user keeps passwordless sudo for hosted
- * parity, so job code that escalates to root can still reach IMDS or flush the
- * rule. The controls that actually bound credential theft are a minimal,
- * permissions-boundary-capped instance-profile role and the ephemeral
+ * parity AND can invoke Docker, so job code that escalates to root — directly
+ * or through a privileged host-network container — can still reach IMDS or
+ * flush the rule. A blanket DROP is not the answer either: it would sever the
+ * root config-time IMDS access the runner needs to fetch its JIT registration,
+ * killing the fleet. The controls that actually bound credential theft are a
+ * minimal, permissions-boundary-capped instance-profile role and the ephemeral
  * one-job-one-VM lifecycle, which reduce a stolen credential to a near-worthless
- * value that dies with the VM. Hop limit 1 blocks container access, the DROP
- * (keyed to `runnerRunAs`, never a divergent uid) blocks non-root host job code,
- * this IPv4-only fleet needs no IPv6 rule, and JIT config keeps no runner
+ * value that dies with the VM. Hop limit 1 blocks unprivileged containers, the
+ * DROP (keyed to `runnerRunAs`, never a divergent uid) blocks non-root host job
+ * code, this IPv4-only fleet needs no IPv6 rule, and JIT config keeps no runner
  * registration token on the instance. The CSF-003 deploy gate (Gate E) must
  * therefore verify role minimality, not just that the DROP is present.
+ *
+ * **Example** (Provision the shadow-label controller)
+ *
+ * ```ts
+ * import { CiFleetController, CiFleetControllerPulumiConfigValues, makeCiFleetControllerConfig } from "@beep/infra"
+ *
+ * const config = makeCiFleetControllerConfig(
+ *   CiFleetControllerPulumiConfigValues.make({
+ *     githubAppIdSsmParameterArn: "arn:aws:ssm:us-east-1:123456789012:parameter/github/app/id",
+ *     githubAppKeyBase64SsmParameterArn: "arn:aws:ssm:us-east-1:123456789012:parameter/github/app/key",
+ *     githubAppKmsKeyArn: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+ *     githubAppWebhookSecretSsmParameterArn: "arn:aws:ssm:us-east-1:123456789012:parameter/github/app/webhook-secret",
+ *     runnerBinariesSyncerLambdaZip: "/artifacts/runner-binaries-syncer.zip",
+ *     runnerRolePermissionsBoundaryArn: "arn:aws:iam::123456789012:policy/beep-ci-fleet-boundary",
+ *     runnersLambdaZip: "/artifacts/runners.zip",
+ *     terminationWatcherLambdaZip: "/artifacts/termination-watcher.zip",
+ *     webhookLambdaZip: "/artifacts/webhook.zip",
+ *   })
+ * )
+ *
+ * const controller = new CiFleetController("beep-ci-fleet", {
+ *   config,
+ *   region: "us-east-1",
+ *   subnetIds: ["subnet-abc", "subnet-def"],
+ *   vpcId: "vpc-123",
+ *   workerSecurityGroupId: "sg-456",
+ * })
+ * console.log(controller.webhook)
+ * ```
  *
  * @category resources
  * @since 0.0.0


### PR DESCRIPTION
The controller ran 32 GB instance types, but the build-mode typecheck census measured cold heavy
compiles at 47.59 GiB (professional-desktop) and 24.77 GiB (epistemic-server), so a 32 GB worker
OOM-kills the compile. The runner pool now uses only 64 GB memory-optimized types across four
families for spot capacity diversity.

IMDSv2 with hop limit 1 already blocked container credential theft, but the runner job process
runs on the host as ec2-user at hop 1 and could still read the instance-profile credentials
directly. A post-install userdata hook now installs an iptables OWNER-match rule dropping
ec2-user traffic to the IMDS address — the host-process complement to the container defense, and
the CSF-003 host IMDS mitigation.

## Deploy gate (red-team Gate E)

The OWNER-match DROP keys on the ec2-user uid, which is also the runner agent's user. This is safe
only because the instance-profile role is consumed by boot-time root steps and runtime IMDS
consumers are off, so the agent authenticates with its JIT token. **The first `pulumi up`
carrying this change must be followed by a probe job proving (a) job pickup still works and (b)
IMDS creds are unreachable from a job step, before the heavy-lane cutover flips.** CSF-002 and
CSF-003 stay deferred until that cutover is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789023018&installation_model_id=424656&pr_number=660&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F660&signature=2675cba349f8091db6d00fecfcca48243aa7ba3f285cf0d4795a515035bf50bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->