### PR TITLE
fix(infra): roll back the CI fleet host IMDS DROP that starved the agent

### DIFF
--- a/.changeset/imds-block-rollback.md
+++ b/.changeset/imds-block-rollback.md
@@ -1,0 +1,9 @@
+---
+"@beep/infra": patch
+---
+
+Roll back the CI fleet controller's host IMDS `iptables` DROP: it keyed on the
+`ec2-user` uid, but the runner agent runs as that user, so the rule starved the
+agent at start-up and workers failed to register (caught by the Gate E probe
+before any cutover). The 64 GB instance types stay. The mitigation returns as a
+per-job `ACTIONS_RUNNER_HOOK_JOB_STARTED` hook, re-validated through Gate E.

--- a/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-endgame/research/OPPORTUNITIES.md
@@ -192,3 +192,31 @@
   regresses, the agent needed IMDS at runtime and the rule must move to a
   post-agent-start hook or a path-scoped local proxy. Do not flip the
   heavy-lane cutover until Gate E passes.
+
+## The host IMDS DROP starved the runner agent — deployed and rolled back same day
+
+- **Work:** P2 deploy (PR #660) — `pulumi up` of the 64 GB types + the CSF-003
+  host IMDS `iptables` OWNER-match DROP, then the Gate E probe.
+- **What happened:** the DROP keys on the `ec2-user` uid, but `runner_run_as`
+  is `ec2-user` too, so the *agent* is that uid. The shadow worker booted on a
+  64 GB `m7a.4xlarge`, fetched its SSM/JIT config as root (root IMDS still
+  worked), then `runner-start-failed with exit code 1` when the agent started
+  as `ec2-user`. It never registered; the Gate E job hung queued until the
+  instance self-terminated. Confirmed from `ec2:GetConsoleOutput`: iptables-nft
+  installed at boot, then the runner start failed as ec2-user.
+- **Recovery:** cancelled the stuck run, rolled back ONLY `userdata_post_install`
+  via a targeted `pulumi up` (kept the 64 GB types), and a plain shadow probe
+  confirmed the fleet registered and ran again.
+- **Why it wasn't caught earlier:** it is a runtime property — the code
+  compiles, tests pass, and the canonical github-aws-runners uid-DROP pattern
+  looks right on paper. Only a live boot on the shadow label exposes that the
+  agent shares the job uid. This is exactly why Gate E gates the deploy, and
+  why "job pickup still works" is its first criterion.
+- **Proposal / rework:** a boot-time firewall rule is the wrong shape when the
+  agent and jobs share a uid. Move the DROP to a per-job
+  `ACTIONS_RUNNER_HOOK_JOB_STARTED` hook (runs after the agent started the job,
+  before the job's steps, as the runner user via sudo), so agent start-up is
+  untouched while job steps are blocked. Re-validate through Gate E — including
+  the token-PUT probe and role-minimality enumeration — before any redeploy.
+  Until then, main must NOT carry an active `userdata_post_install` DROP, or a
+  redeploy re-breaks the fleet.

--- a/goals/codex-security-findings-2026-08-10/findings/CSF-003.md
+++ b/goals/codex-security-findings-2026-08-10/findings/CSF-003.md
@@ -13,20 +13,28 @@ organization-owned EC2 workers.
 
 ## Current-HEAD Validation
 
-Verdict: `defer-p2`. This PR adds the missing host IMDS credential-theft
-control: an `iptables` OWNER-match rule denies `ec2-user` access to IMDS while
-preserving the existing hop-limit-1 container defense.
+Verdict: `defer-p2`. The `iptables` OWNER-match IMDS DROP was deployed on
+2026-08-11 and ROLLED BACK the same day. Because the runner agent runs as the
+same `ec2-user` uid the rule targets, the DROP starved the agent at start-up:
+the worker booted on the 64 GB instance type, fetched its SSM/JIT config as
+root, then `runner-start-failed with exit code 1` when the agent tried to start
+as `ec2-user`, so it never registered and the job hung queued. The Gate E probe
+caught this before any heavy-lane cutover. Only the 64 GB instance-type change
+from this work remains live.
 
 ## Remediation
 
-The hardened one-job-one-VM controller is the structural remedy. The IMDS
-OWNER-match DROP is defense-in-depth only: the runner user keeps passwordless
-sudo for hosted parity, so root-capable job code can bypass any host firewall
-rule. The controls that actually bound credential theft are a minimal,
+A uid DROP cannot separate the runner agent from job steps when both share one
+uid, and a blanket DROP would sever the root config-time IMDS the runner needs
+for JIT registration — so a boot-time firewall rule is the wrong shape. The
+rework is a per-job `ACTIONS_RUNNER_HOOK_JOB_STARTED` hook that installs the
+DROP after the agent is running but before a job's steps execute, leaving agent
+start-up untouched. Even then the DROP is defense-in-depth only: the runner user
+keeps passwordless sudo and Docker access, so root-capable job code can bypass
+any host rule. The controls that actually bound credential theft are a minimal,
 permissions-boundary-capped instance-profile role and the ephemeral
-one-job-one-VM lifecycle. The finding remains open until the heavy-lane label
-cutover is live; merged mitigation code does not itself move pull-request jobs
-onto the fleet.
+one-job-one-VM lifecycle. The finding remains open until the reworked mitigation
+passes Gate E and the heavy-lane label cutover is live.
 
 ## Verification
 

--- a/infra/src/CiFleetController.ts
+++ b/infra/src/CiFleetController.ts
@@ -35,32 +35,10 @@ const githubAppWebhookSecretSsmParameterName = "/github-action-runners/app/githu
 const runnerInstanceTypes = ["r7a.2xlarge", "r7i.2xlarge", "r6i.2xlarge", "m7a.4xlarge"];
 const onDemandFailoverErrors = ["InsufficientInstanceCapacity", "InsufficientCapacityOnHost", "UnfulfillableCapacity"];
 
-// The IMDS block and the runner user are one decision: the OWNER-match rule
-// must key on the exact uid the jobs run as, so both the module's
-// `runner_run_as` and the drop rule below derive from this single constant. If
-// they diverged, jobs would keep IMDS access under the real runner uid.
+// The runner agent and every job step both run as this user, so the two cannot
+// be told apart by uid at agent-start time — the reason the post-install IMDS
+// DROP was rolled back (see the class prose and CSF-003).
 const runnerRunAs = "ec2-user";
-
-// Defense-in-depth, not containment: the runner user keeps passwordless sudo for
-// GitHub-hosted parity, so job code that escalates to root can still reach IMDS
-// or flush this rule. The PRIMARY control is therefore a minimal,
-// permissions-boundary-capped instance-profile role on an ephemeral
-// one-job-one-VM — a stolen credential is near-worthless and dies with the VM in
-// minutes. This OWNER-match DROP raises the bar for non-root job code as the
-// host-process complement to the hop-limit-1 container defense.
-const runnerImdsPostInstall = `#!/bin/sh
-set -eu
-
-command -v iptables >/dev/null 2>&1 || dnf install -y iptables-nft
-runner_uid="$(id -u ${runnerRunAs})"
-if iptables -C OUTPUT -m owner --uid-owner "$runner_uid" -d 169.254.169.254/32 -j DROP 2>/dev/null; then
-  rule_status="already present"
-else
-  iptables -I OUTPUT -m owner --uid-owner "$runner_uid" -d 169.254.169.254/32 -j DROP
-  rule_status="installed"
-fi
-logger -t beep-ci-imds "IPv4 IMDS OWNER drop rule $rule_status for ${runnerRunAs} uid $runner_uid"
-`;
 
 const awsArnPattern = /^arn:aws[a-z-]*:[a-z0-9-]+:[a-z0-9-]*:[0-9]*:.+$/u;
 const ssmParameterArnPattern = /^arn:aws[a-z-]*:ssm:[a-z0-9-]+:[0-9]*:parameter\/.+$/u;
@@ -279,20 +257,21 @@ type CiFleetControllerArgs = {
  *
  * **Gotchas**
  *
- * IMDS defense is layered, and the OWNER-match DROP is the weakest layer, not a
- * containment boundary: the runner user keeps passwordless sudo for hosted
- * parity AND can invoke Docker, so job code that escalates to root — directly
- * or through a privileged host-network container — can still reach IMDS or
- * flush the rule. A blanket DROP is not the answer either: it would sever the
- * root config-time IMDS access the runner needs to fetch its JIT registration,
- * killing the fleet. The controls that actually bound credential theft are a
- * minimal, permissions-boundary-capped instance-profile role and the ephemeral
- * one-job-one-VM lifecycle, which reduce a stolen credential to a near-worthless
- * value that dies with the VM. Hop limit 1 blocks unprivileged containers, the
- * DROP (keyed to `runnerRunAs`, never a divergent uid) blocks non-root host job
- * code, this IPv4-only fleet needs no IPv6 rule, and JIT config keeps no runner
- * registration token on the instance. The CSF-003 deploy gate (Gate E) must
- * therefore verify role minimality, not just that the DROP is present.
+ * The host IMDS credential-theft mitigation (CSF-003) is NOT wired here. A
+ * post-install `iptables` OWNER-match DROP on the `runnerRunAs` uid was deployed
+ * and rolled back the same day: because the runner agent itself runs as that
+ * uid, the DROP starved the agent at start-up and the worker failed to register
+ * (`runner-start-failed`), which the Gate E probe caught before any heavy-lane
+ * cutover. A uid DROP cannot separate the agent from job steps when both share
+ * one uid, and a blanket DROP would additionally sever the root config-time IMDS
+ * the runner needs for JIT registration. The rework is a per-job
+ * `ACTIONS_RUNNER_HOOK_JOB_STARTED` hook that installs the DROP after the agent
+ * is running but before a job's steps, re-validated through Gate E before
+ * redeploy. Until then the controls that bound credential theft are the layers
+ * that remain live: IMDSv2 with hop limit 1 (blocks unprivileged containers), a
+ * minimal permissions-boundary-capped instance-profile role, the ephemeral
+ * one-job-one-VM lifecycle, and JIT config that keeps no registration token on
+ * the instance.
  *
  * **Example** (Provision the shadow-label controller)
  *
@@ -475,7 +454,6 @@ export class CiFleetController extends pulumi.ComponentResource {
         runner_name_prefix: "beep-ci-",
         runner_os: "linux",
         runner_run_as: runnerRunAs,
-        userdata_post_install: runnerImdsPostInstall,
         runners_ebs_optimized: true,
         runners_lambda_zip: args.config.runnersLambdaZip,
         runners_maximum_count: 4,


### PR DESCRIPTION
The CSF-003 host IMDS mitigation deployed on 2026-08-11 and was rolled back the same day. The
post-install iptables OWNER-match rule keyed on the ec2-user uid, but `runner_run_as` is
ec2-user, so it starved the runner agent at start-up: the shadow worker booted on a 64 GB
instance, fetched its SSM/JIT config as root, then `runner-start-failed` when the agent started
as ec2-user, never registered, and left the job queued. The Gate E probe caught this before any
heavy-lane cutover.

This removes the `userdata_post_install` wiring so main matches the rolled-back live stack (a
redeploy can no longer re-break the fleet). The 64 GB instance types stay. The class prose,
CSF-003 verdict, and ledger record the rework: a per-job `ACTIONS_RUNNER_HOOK_JOB_STARTED` hook
that installs the DROP after the agent is running but before job steps, re-validated through
Gate E before any redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789050083&installation_model_id=424656&pr_number=665&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F665&signature=17f1d1d572549a4077c8cbba2097c0eee93ccaf79490808cefa7bd12712644a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->