### PR TITLE
chore(security): admit Effect RC squash gitleaks fingerprints

### DIFF
--- a/.changeset/gitleaks-effect-rc108-fingerprints.md
+++ b/.changeset/gitleaks-effect-rc108-fingerprints.md
@@ -1,0 +1,6 @@
+---
+{}
+---
+
+No release: admit the Effect 4.0.0-rc.108 subtree squash Gitleaks fingerprints
+so the RC catalog PR can pass hosted Secret Scanning.

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -92,3 +92,14 @@ cb5d50cf0a7e6ca0cf7b31be33f2ed931b36e92e:packages/effect/src/Config.ts:generic-a
 # False positive in the immutable Effect subtree squash used by the
 # 4.0.0-beta.105 refresh. Same Config.redacted JSDoc sample at line 1484.
 ceebcebce7e0ffff8dd377f524e05c9ceafde756:packages/effect/src/Config.ts:generic-api-key:1484
+
+# False positives in the immutable Effect subtree re-add used by the
+# 4.0.0-rc.108 refresh (`7d11d177cf`, content from 08a3c74133). Same upstream
+# JSDoc/fixture tokens as the beta.105 allowlist: Config.redacted `API_KEY`,
+# HTTPAPI curl header, EventLog identity fixture, and the NodeHttpServer
+# Sec-WebSocket-Key sample. Paths are subtree-relative because `git subtree
+# pull --squash` records upstream-relative paths.
+7d11d177cfcc0f5ff00f3c90428238fd4c490ef6:packages/effect/src/Config.ts:generic-api-key:1484
+7d11d177cfcc0f5ff00f3c90428238fd4c490ef6:packages/effect/HTTPAPI.md:curl-auth-header:1039
+7d11d177cfcc0f5ff00f3c90428238fd4c490ef6:packages/effect/test/unstable/eventlog/EventLogIdentityDerivation.test.ts:generic-api-key:6
+7d11d177cfcc0f5ff00f3c90428238fd4c490ef6:packages/platform/node/test/NodeHttpServer.test.ts:generic-api-key:853


### PR DESCRIPTION
## Summary

Config-only. Admit the four Effect subtree squash fingerprints from
`7d11d177cf` (Config.redacted `API_KEY`, HTTPAPI curl header, EventLog
identity fixture, NodeHttpServer `Sec-WebSocket-Key`).

Hosted Secret Scanning on PRs uses `main`'s `.gitleaksignore`, so PR #670
(Effect `4.0.0-rc.108`) cannot pass that lane until this merges.

## Test plan

- [x] Local `gitleaks` over `origin/main..effect-ontology-experiment` is clean
      once these fingerprints are present
- [ ] Hosted Secret Scanning on this PR (should stay green; no new squash)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789187978&installation_model_id=424656&pr_number=671&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F671&signature=4ac2e57a558f7ffbf07adeb32c081d59f2f31df92e1328fc7d659222f15ec487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->