### PR TITLE
ci(check): consume the deployed asymmetric Turbo remote cache

### DIFF
--- a/.changeset/quiet-caches-flow.md
+++ b/.changeset/quiet-caches-flow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Wire CI to the deployed asymmetric Turbo remote cache without releasing packages.

--- a/.changeset/quiet-caches-flow.md
+++ b/.changeset/quiet-caches-flow.md
@@ -1,4 +1,5 @@
 ---
+{}
 ---
 
 Wire CI to the deployed asymmetric Turbo remote cache without releasing packages.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -118,10 +118,10 @@ jobs:
     env:
       # PRs receive the repository read token; main pushes receive the
       # turbo-cache-write environment's trusted write token.
-      TURBO_API: ${{ vars.TURBO_API || '' }}
+      TURBO_API: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && vars.TURBO_API || '' }}
       TURBO_TOKEN: ${{ vars.TURBO_API && secrets.TURBO_TOKEN || '' }}
-      TURBO_TEAM: ${{ vars.TURBO_API && vars.TURBO_TEAM || '' }}
-      TURBO_CACHE: ${{ vars.TURBO_API && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
+      TURBO_TEAM: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && vars.TURBO_TEAM || '' }}
+      TURBO_CACHE: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
       DATABASE_URL: ${{ github.event_name == 'push' && secrets.DATABASE_URL || '' }}
       DATABASE_URL_UNPOOLED: ${{ github.event_name == 'push' && secrets.DATABASE_URL_UNPOOLED || '' }}
       EMAIL_RESEND_API_KEY: ${{ github.event_name == 'push' && secrets.EMAIL_RESEND_API_KEY || '' }}
@@ -332,10 +332,10 @@ jobs:
     permissions:
       contents: read
     env:
-      TURBO_API: ${{ vars.TURBO_API || '' }}
+      TURBO_API: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && vars.TURBO_API || '' }}
       TURBO_TOKEN: ${{ vars.TURBO_API && secrets.TURBO_TOKEN || '' }}
-      TURBO_TEAM: ${{ vars.TURBO_API && vars.TURBO_TEAM || '' }}
-      TURBO_CACHE: ${{ vars.TURBO_API && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
+      TURBO_TEAM: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && vars.TURBO_TEAM || '' }}
+      TURBO_CACHE: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -442,10 +442,10 @@ jobs:
         id: fallow
         shell: bash
         env:
-          TURBO_API: ${{ vars.TURBO_API || '' }}
+          TURBO_API: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && vars.TURBO_API || '' }}
           TURBO_TOKEN: ${{ vars.TURBO_API && secrets.TURBO_TOKEN || '' }}
-          TURBO_TEAM: ${{ vars.TURBO_API && vars.TURBO_TEAM || '' }}
-          TURBO_CACHE: ${{ vars.TURBO_API && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
+          TURBO_TEAM: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && vars.TURBO_TEAM || '' }}
+          TURBO_CACHE: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
         run: |
           # Lane body (blocking audit/dead-code, advisory sweep, status.md
           # accounting, envelope existence) lives in the beep CLI; envelope
@@ -567,10 +567,10 @@ jobs:
     permissions:
       contents: read
     env:
-      TURBO_API: ${{ vars.TURBO_API || '' }}
+      TURBO_API: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && vars.TURBO_API || '' }}
       TURBO_TOKEN: ${{ vars.TURBO_API && secrets.TURBO_TOKEN || '' }}
-      TURBO_TEAM: ${{ vars.TURBO_API && vars.TURBO_TEAM || '' }}
-      TURBO_CACHE: ${{ vars.TURBO_API && 'local:rw,remote:rw' || 'local:rw' }}
+      TURBO_TEAM: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && vars.TURBO_TEAM || '' }}
+      TURBO_CACHE: ${{ vars.TURBO_API && secrets.TURBO_TOKEN && 'local:rw,remote:rw' || 'local:rw' }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
       EMAIL_RESEND_API_KEY: ${{ secrets.EMAIL_RESEND_API_KEY }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,6 +48,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
+    environment: ${{ github.event_name == 'push' && 'turbo-cache-write' || null }}
     permissions:
       contents: read
     strategy:
@@ -115,12 +116,12 @@ jobs:
             uses_turbo: "false"
             install_typos: "false"
     env:
-      # Verification runs PR-controlled code. Keep every secret-backed value on
-      # trusted push events only; PR lanes use local cache and fixture/default
-      # app configuration.
-      TURBO_TOKEN: ${{ github.event_name == 'push' && secrets.TURBO_TOKEN || '' }}
-      TURBO_TEAM: ${{ github.event_name == 'push' && (vars.TURBO_TEAM || secrets.TURBO_TEAM) || '' }}
-      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || '' }}
+      # PRs receive the repository read token; main pushes receive the
+      # turbo-cache-write environment's trusted write token.
+      TURBO_API: ${{ vars.TURBO_API || '' }}
+      TURBO_TOKEN: ${{ vars.TURBO_API && secrets.TURBO_TOKEN || '' }}
+      TURBO_TEAM: ${{ vars.TURBO_API && vars.TURBO_TEAM || '' }}
+      TURBO_CACHE: ${{ vars.TURBO_API && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
       DATABASE_URL: ${{ github.event_name == 'push' && secrets.DATABASE_URL || '' }}
       DATABASE_URL_UNPOOLED: ${{ github.event_name == 'push' && secrets.DATABASE_URL_UNPOOLED || '' }}
       EMAIL_RESEND_API_KEY: ${{ github.event_name == 'push' && secrets.EMAIL_RESEND_API_KEY || '' }}
@@ -327,14 +328,14 @@ jobs:
     name: Property Laws
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    environment: ${{ github.event_name == 'push' && 'turbo-cache-write' || null }}
     permissions:
       contents: read
     env:
-      # Same secret posture as the verify matrix: PR-controlled code gets no
-      # repository secrets and uses local Turbo cache only.
-      TURBO_TOKEN: ${{ github.event_name == 'push' && secrets.TURBO_TOKEN || '' }}
-      TURBO_TEAM: ${{ github.event_name == 'push' && (vars.TURBO_TEAM || secrets.TURBO_TEAM) || '' }}
-      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || '' }}
+      TURBO_API: ${{ vars.TURBO_API || '' }}
+      TURBO_TOKEN: ${{ vars.TURBO_API && secrets.TURBO_TOKEN || '' }}
+      TURBO_TEAM: ${{ vars.TURBO_API && vars.TURBO_TEAM || '' }}
+      TURBO_CACHE: ${{ vars.TURBO_API && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -376,6 +377,7 @@ jobs:
     name: Fallow Advisory Envelopes
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    environment: ${{ github.event_name == 'push' && 'turbo-cache-write' || null }}
     permissions:
       contents: read
     steps:
@@ -440,11 +442,10 @@ jobs:
         id: fallow
         shell: bash
         env:
-          # Fallow runs PR-controlled `bun run beep` code; keep repository
-          # secrets on push only and use local cache for pull requests.
-          TURBO_TOKEN: ${{ github.event_name == 'push' && secrets.TURBO_TOKEN || '' }}
-          TURBO_TEAM: ${{ github.event_name == 'push' && (vars.TURBO_TEAM || secrets.TURBO_TEAM) || '' }}
-          TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || '' }}
+          TURBO_API: ${{ vars.TURBO_API || '' }}
+          TURBO_TOKEN: ${{ vars.TURBO_API && secrets.TURBO_TOKEN || '' }}
+          TURBO_TEAM: ${{ vars.TURBO_API && vars.TURBO_TEAM || '' }}
+          TURBO_CACHE: ${{ vars.TURBO_API && (github.event_name == 'push' && 'local:rw,remote:rw' || 'local:rw,remote:r') || 'local:rw' }}
         run: |
           # Lane body (blocking audit/dead-code, advisory sweep, status.md
           # accounting, envelope existence) lives in the beep CLI; envelope
@@ -562,11 +563,14 @@ jobs:
     if: github.event_name == 'push'
     runs-on: beep-ec2-heavy
     timeout-minutes: 40
+    environment: turbo-cache-write
     permissions:
       contents: read
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM || secrets.TURBO_TEAM }}
+      TURBO_API: ${{ vars.TURBO_API || '' }}
+      TURBO_TOKEN: ${{ vars.TURBO_API && secrets.TURBO_TOKEN || '' }}
+      TURBO_TEAM: ${{ vars.TURBO_API && vars.TURBO_TEAM || '' }}
+      TURBO_CACHE: ${{ vars.TURBO_API && 'local:rw,remote:rw' || 'local:rw' }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
       EMAIL_RESEND_API_KEY: ${{ secrets.EMAIL_RESEND_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -383,7 +383,7 @@
     "create-package": "bun run beep create-package",
     "deps:update": "bunx syncpack update --target=latest --dependency-types=catalog",
     "dev": "bunx turbo run dev",
-    "docgen": "bunx turbo run docgen --cache=local:rw --concurrency=3 && bun run docs:aggregate",
+    "docgen": "bunx turbo run docgen --concurrency=3 && bun run docs:aggregate",
     "docgen:affected": "bun run docgen:local -- --parallel=3",
     "docgen:local": "bun run beep docgen local",
     "docs:aggregate": "beep-cli docgen aggregate",


### PR DESCRIPTION
## Summary

Second half of the P3 cache activation ([#673](https://github.com/beep-effect/beep-effect/pull/673) deployed the API): `check.yml` now consumes the live asymmetric Turbo remote cache.

- **PR lanes**: repository read token, `TURBO_CACHE: local:rw,remote:r` — consume, never write. Fork PRs hold no secrets, so they degrade to local-only by construction (the signed no-fork-reads decision).
- **Push lanes** (verify matrix, Property Laws, Fallow, full Docgen): declare the `turbo-cache-write` GitHub environment (deployment branch policy: `main` only), so the same `secrets.TURBO_TOKEN` name resolves to the trusted write token, with `remote:rw`.
- **Degradation guard**: every block gates on `vars.TURBO_API` — a repo/fork without the variable falls back to exactly the pre-PR local-cache behavior.
- Root `docgen` script drops its hard-coded `--cache=local:rw` so the environment controls cache mode (local runs without `TURBO_*` env are unchanged).

Environment idiom: `environment: ${{ github.event_name == 'push' && 'turbo-cache-write' || null }}` — `null` per GitHub's expression-literals doc (an empty-string name is not documented as no-environment); same pattern as Playwright's workflows. The `push` trigger is `main`-only, so the environment's branch policy can never fail a legitimate run.

Defense in depth: even a misconfigured job holding the read token cannot poison the cache — the deployed authorizer 403s read-token `PUT`s server-side (probe evidence in #673).

## Acceptance

- Local `yeet verify` fully green on this tree (all lanes).
- After merge: first `main` push seeds the cache (S3 object count rises); the next PR wave shows `Remote caching enabled` + cache hits in turbo logs. I'll attach both as follow-up evidence on this PR.

GitHub-side prerequisites already live: `TURBO_API`/`TURBO_TEAM` variables, repo read-token secret, `turbo-cache-write` environment with the write token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789196905&installation_model_id=424656&pr_number=674&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F674&signature=78a298d5fd8cf27dbf08a038cc3b3fb2489c278ac070ec2a3d3b558b16e521f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->