### PR TITLE
fix(yeet): restrict public provenance

### DIFF
--- a/.changeset/csf-007-public-provenance.md
+++ b/.changeset/csf-007-public-provenance.md
@@ -1,0 +1,6 @@
+---
+{}
+---
+
+No release: restrict Yeet pull-request provenance to a validated, escaped
+public projection without local paths or resumable session identity.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
@@ -61,7 +61,7 @@ const PrProvenancePath = S.String.check(
   })
 );
 
-const forbiddenGitBranchCharacter = /[\u0000-\u0020\u007f~^:?*[\]\\]/u;
+const forbiddenGitBranchCharacter = /[\u0000-\u0020\u007f~^:?*[\\]/u;
 
 /**
  * Git-valid branch name carried by local and public Yeet provenance.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts
@@ -9,7 +9,8 @@
  *
  * When multiple Claude sessions share one checkout, the newest recent
  * transcript wins. Modification time cannot honestly identify which concurrent
- * session invoked publish, so the footer may select the other live session.
+ * session invoked publish, so local resume detection may select the other live
+ * session. Session identity never enters the public footer.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -46,17 +47,73 @@ const $I = $RepoCliId.create("commands/Yeet/internal/Provenance");
 const recentClaudeSessionWindow = Duration.hours(6);
 const futureClaudeSessionSkew = Duration.minutes(1);
 const provenanceDetectionTimeout = Duration.seconds(2);
-/** Absolute or home-tokenized path safe to record in public PR provenance. */
+/** Absolute or home-tokenized path retained only for local resume detection. */
 const PrProvenancePath = S.String.check(
   S.isPattern(/^(?:\/|~(?:\/|$))/u, {
     identifier: "PrProvenancePath",
     title: "PR provenance path",
-    description: "An absolute or '~/'-prefixed filesystem path recorded in pull request provenance.",
+    description: "An absolute or '~/'-prefixed filesystem path retained for local resume detection.",
     message: "Expected an absolute path or a home-tokenized path starting with '~/'",
   })
 ).pipe(
   $I.annoteSchema("PrProvenancePath", {
-    description: "Absolute or home-tokenized clone or linked-worktree path recorded in pull request provenance.",
+    description: "Absolute or home-tokenized clone or linked-worktree path retained for local resume detection.",
+  })
+);
+
+const forbiddenGitBranchCharacter = /[\u0000-\u0020\u007f~^:?*[\]\\]/u;
+
+/**
+ * Git-valid branch name carried by local and public Yeet provenance.
+ *
+ * **Details**
+ *
+ * The refinement mirrors `git check-ref-format --branch`: it rejects option-like
+ * names, invalid path components, revision syntax, controls, whitespace, and
+ * Git's forbidden ref characters while retaining punctuation that is valid in
+ * a branch and must instead be escaped by each output context.
+ *
+ * **Example** (Validate a hostile but valid branch)
+ *
+ * ```ts
+ * import { PrProvenanceBranch } from "@beep/repo-cli/test/Yeet"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(PrProvenanceBranch)("feat/escaped`payload-->tail")) // true
+ * console.log(S.is(PrProvenanceBranch)("branch with spaces")) // false
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const PrProvenanceBranch = S.NonEmptyString.check(
+  S.makeFilter<string>(
+    (branch) =>
+      (!Str.startsWith("-")(branch) &&
+        branch !== "@" &&
+        O.isNone(Str.match(forbiddenGitBranchCharacter)(branch)) &&
+        !Str.includes("..")(branch) &&
+        !Str.includes("@{")(branch) &&
+        !Str.startsWith("/")(branch) &&
+        !Str.endsWith("/")(branch) &&
+        !Str.endsWith(".")(branch) &&
+        A.every(
+          Str.split("/")(branch),
+          (component) =>
+            Str.isNonEmpty(component) && !Str.startsWith(".")(component) && !Str.endsWith(".lock")(component)
+        )) || {
+        path: [],
+        issue: "Expected a valid Git branch name",
+      },
+    {
+      identifier: $I`PrProvenanceBranchCheck`,
+      title: "Git-valid provenance branch",
+      description: "A non-option Git branch name accepted by git check-ref-format --branch.",
+    }
+  )
+).pipe(
+  $I.annoteSchema("PrProvenanceBranch", {
+    description: "Git-valid branch name shared by local and public Yeet provenance.",
   })
 );
 
@@ -94,7 +151,7 @@ export const PrProvenanceHarness = LiteralKit(["claude-code", "codex", "unknown"
 export type PrProvenanceHarness = typeof PrProvenanceHarness.Type;
 
 /**
- * Clone, worktree, branch, and resumable harness identity for a Yeet PR.
+ * Local clone, worktree, branch, and resumable harness identity for Yeet.
  *
  * **Example** (Construct Codex provenance)
  *
@@ -116,14 +173,16 @@ export type PrProvenanceHarness = typeof PrProvenanceHarness.Type;
  * **Details**
  *
  * `clonePath` is the absolute or home-tokenized main clone path. `worktreePath`
- * is present only when publish runs from a linked worktree.
+ * is present only when publish runs from a linked worktree. Rendering projects
+ * this local model into {@link PublicPrProvenance}; paths and resumable identity
+ * never enter the pull request body.
  *
  * @category models
  * @since 0.0.0
  */
 export class PrProvenance extends S.Class<PrProvenance>($I`PrProvenance`)(
   {
-    branch: S.String,
+    branch: PrProvenanceBranch,
     clonePath: PrProvenancePath,
     harness: PrProvenanceHarness,
     resumeCommand: S.String,
@@ -131,7 +190,42 @@ export class PrProvenance extends S.Class<PrProvenance>($I`PrProvenance`)(
     worktreePath: S.OptionFromNullOr(PrProvenancePath),
   },
   $I.annote("PrProvenance", {
-    description: "Origin and paste-ready resume command recorded in a Yeet pull request body.",
+    description: "Local origin and paste-ready resume command detected for a Yeet publish invocation.",
+  })
+) {}
+
+/**
+ * Public projection of Yeet provenance safe to append to a pull request.
+ *
+ * **Details**
+ *
+ * Local clone paths, linked-worktree paths, resume commands, and AI session
+ * identifiers deliberately do not cross this boundary.
+ *
+ * **Example** (Construct public provenance)
+ *
+ * ```ts
+ * import { PublicPrProvenance } from "@beep/repo-cli/test/Yeet"
+ *
+ * const provenance = PublicPrProvenance.make({
+ *   schemaVersion: 1,
+ *   branch: "feat/example",
+ *   harness: "codex",
+ * })
+ * console.log(provenance.branch)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class PublicPrProvenance extends S.Class<PublicPrProvenance>($I`PublicPrProvenance`)(
+  {
+    schemaVersion: S.Literal(1),
+    branch: PrProvenanceBranch,
+    harness: PrProvenanceHarness,
+  },
+  $I.annote("PublicPrProvenance", {
+    description: "Public, non-resumable provenance appended to a Yeet pull request body.",
   })
 ) {}
 
@@ -167,7 +261,7 @@ export const mungeClaudeProjectPath = repoPathToClaudeProjectName;
  * ```
  *
  * @param home - Absolute home directory supplied by the runtime configuration.
- * @param path - Filesystem path to make safe for public provenance.
+ * @param path - Filesystem path to normalize for local resume output.
  * @returns The home-tokenized path, or the original path when it is outside home.
  * @category formatting
  * @since 0.0.0
@@ -318,7 +412,21 @@ export const resumeCommandFor: {
   })
 );
 
-const encodePrProvenanceJson = S.encodeUnknownResult(S.fromJsonString(PrProvenance));
+const encodePublicPrProvenanceJson = S.encodeUnknownResult(S.fromJsonString(PublicPrProvenance));
+
+const escapeHtmlText = (value: string): string =>
+  pipe(
+    value,
+    Str.replaceAll("&", "&amp;"),
+    Str.replaceAll("<", "&lt;"),
+    Str.replaceAll(">", "&gt;"),
+    Str.replaceAll("`", "&#96;"),
+    Str.replaceAll("\r", "&#13;"),
+    Str.replaceAll("\n", "&#10;")
+  );
+
+const escapeHtmlCommentJson = (value: string): string =>
+  pipe(value, Str.replaceAll("&", "\\u0026"), Str.replaceAll("<", "\\u003c"), Str.replaceAll(">", "\\u003e"));
 
 /**
  * Render provenance as the trailing Markdown section of a pull request body.
@@ -346,25 +454,26 @@ const encodePrProvenanceJson = S.encodeUnknownResult(S.fromJsonString(PrProvenan
  * @since 0.0.0
  */
 export const renderPrProvenance = (provenance: PrProvenance): string => {
-  const worktreeLine = pipe(
-    provenance.worktreePath,
-    O.map((worktreePath) => `- Worktree: \`${worktreePath}\`\n`),
-    O.getOrElse(() => "")
+  const publicProvenance = PublicPrProvenance.make({
+    schemaVersion: 1,
+    branch: provenance.branch,
+    harness: provenance.harness,
+  });
+  const encoded = pipe(
+    publicProvenance,
+    encodePublicPrProvenanceJson,
+    Result.getOrThrow,
+    renderPrettyCommandJson,
+    Str.trimEnd,
+    escapeHtmlCommentJson
   );
-  const encoded = pipe(provenance, encodePrProvenanceJson, Result.getOrThrow, renderPrettyCommandJson, Str.trimEnd);
+  const visibleBranch = escapeHtmlText(provenance.branch);
   return `---
 
 ## Provenance
 
-- Clone: \`${provenance.clonePath}\`
-${worktreeLine}- Branch: \`${provenance.branch}\`
+- Branch: <code>${visibleBranch}</code>
 - Harness: \`${provenance.harness}\`
-
-Resume this session:
-
-\`\`\`sh
-${provenance.resumeCommand}
-\`\`\`
 
 <!-- yeet-provenance
 ${encoded}

--- a/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
@@ -4,19 +4,22 @@ import {
   findRecentClaudeSession,
   mungeClaudeProjectPath,
   PrProvenance,
+  PrProvenanceBranch,
+  PublicPrProvenance,
   renderPrProvenance,
   resumeCommandFor,
   tokenizeHomePath,
 } from "@beep/repo-cli/test/Yeet";
-import { provideScopedLayer } from "@beep/test-utils";
+import { fcRuns, provideScopedLayer } from "@beep/test-utils";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
-import { describe, expect, it } from "@effect/vitest";
-import { ConfigProvider, Duration, Effect, FileSystem, Layer, Path, pipe } from "effect";
+import { assert, describe, expect, it } from "@effect/vitest";
+import { ConfigProvider, Duration, Effect, FileSystem, Layer, Path, pipe, Result } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
+import { FastCheck as fc } from "effect/testing";
 
 const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
 
@@ -30,6 +33,47 @@ const withTempDirectory = <Result, Error, Requirements>(
   ).pipe(provideScopedLayer(PlatformLayer));
 
 describe("Yeet PR provenance", () => {
+  it("round-trips schema-derived public provenance values", () => {
+    const encode = S.encodeResult(PublicPrProvenance);
+    const decode = S.decodeResult(PublicPrProvenance);
+
+    fc.assert(
+      fc.property(S.toArbitrary(PublicPrProvenance)(fc), (value) => {
+        const encoded = encode(value);
+        if (Result.isFailure(encoded)) {
+          return assert.fail("Expected schema-derived public provenance to encode");
+        }
+        const decoded = decode(encoded.success);
+        if (Result.isFailure(decoded)) {
+          return assert.fail("Expected encoded public provenance to decode");
+        }
+        assert.deepStrictEqual(decoded.success, value);
+      }),
+      fcRuns(32)
+    );
+  });
+
+  it("accepts Git-valid hostile branches and rejects invalid ref names", () => {
+    const isBranch = S.is(PrProvenanceBranch);
+
+    expect(isBranch("feat/evil`payload-->still-branch")).toBe(true);
+    for (const invalid of [
+      "",
+      "-option",
+      "branch with spaces",
+      "feature\\windows",
+      "feature//double",
+      "feature/../escape",
+      "feature/.hidden",
+      "feature/locked.lock",
+      "feature/trailing.",
+      "feature/@{upstream}",
+      "@",
+    ]) {
+      expect(isBranch(invalid), invalid).toBe(false);
+    }
+  });
+
   it("delegates Claude project naming to the canonical slash converter", () => {
     expect(mungeClaudeProjectPath("/home/operator/beep.effect\\.claude/worktrees/end.game")).toBe(
       "-home-operator-beep.effect-.claude-worktrees-end.game"
@@ -181,7 +225,7 @@ describe("Yeet PR provenance", () => {
     );
   });
 
-  it.effect("tokenizes detected paths in both human and machine provenance", () =>
+  it.effect("keeps detected resume details local and omits them from public provenance", () =>
     Effect.gen(function* () {
       const clonePath = "/home/operator/YeeBois/projects/beep-effect3";
       const checkoutPath = `${clonePath}/.claude/worktrees/footer-redact`;
@@ -193,16 +237,19 @@ describe("Yeet PR provenance", () => {
       );
       const footer = renderPrProvenance(provenance);
 
-      expect(provenance.clonePath).toBe("~/YeeBois/projects/beep-effect3");
-      expect(provenance.worktreePath).toStrictEqual(
+      assert.strictEqual(provenance.clonePath, "~/YeeBois/projects/beep-effect3");
+      assert.deepStrictEqual(
+        provenance.worktreePath,
         O.some("~/YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact")
       );
-      expect(provenance.resumeCommand).toBe(
+      assert.strictEqual(
+        provenance.resumeCommand,
         "cd ~/'YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact' &&\n  codex resume 'thread-123'"
       );
-      expect(footer).not.toContain("/home/operator");
-      expect(footer).toContain("- Clone: `~/YeeBois/projects/beep-effect3`");
-      expect(footer).toContain("- Worktree: `~/YeeBois/projects/beep-effect3/.claude/worktrees/footer-redact`");
+      assert.isFalse(Str.includes("/home/operator")(footer));
+      assert.isFalse(Str.includes("~/YeeBois/projects/beep-effect3")(footer));
+      assert.isFalse(Str.includes("thread-123")(footer));
+      assert.isFalse(Str.includes("codex resume")(footer));
 
       const encoded = pipe(
         footer,
@@ -211,7 +258,14 @@ describe("Yeet PR provenance", () => {
         O.flatMap((tail) => pipe(tail, Str.split("\n-->"), A.head)),
         O.getOrThrow
       );
-      expect(yield* S.decodeEffect(S.fromJsonString(PrProvenance))(encoded)).toStrictEqual(provenance);
+      assert.deepStrictEqual(
+        yield* S.decodeEffect(S.fromJsonString(PublicPrProvenance))(encoded),
+        PublicPrProvenance.make({
+          schemaVersion: 1,
+          branch: "fix/yeet-footer-redact-home",
+          harness: "codex",
+        })
+      );
     }).pipe(
       Effect.provideService(
         ConfigProvider.ConfigProvider,
@@ -232,9 +286,15 @@ describe("Yeet PR provenance", () => {
         "fix/yeet-footer-redact-home"
       );
 
-      expect(provenance.clonePath).toBe(clonePath);
-      expect(provenance.worktreePath).toStrictEqual(O.some(checkoutPath));
-      expect(provenance.resumeCommand).toBe(`cd '${checkoutPath}' &&\n  codex resume 'thread-123'`);
+      assert.strictEqual(provenance.clonePath, clonePath);
+      assert.deepStrictEqual(provenance.worktreePath, O.some(checkoutPath));
+      assert.strictEqual(provenance.resumeCommand, `cd '${checkoutPath}' &&\n  codex resume 'thread-123'`);
+
+      const footer = renderPrProvenance(provenance);
+      assert.isFalse(Str.includes(clonePath)(footer));
+      assert.isFalse(Str.includes(checkoutPath)(footer));
+      assert.isFalse(Str.includes("thread-123")(footer));
+      assert.isFalse(Str.includes("codex resume")(footer));
     }).pipe(
       Effect.provideService(
         ConfigProvider.ConfigProvider,
@@ -244,7 +304,7 @@ describe("Yeet PR provenance", () => {
     )
   );
 
-  it.effect("renders human and schema-decodable machine provenance twins", () =>
+  it.effect("renders public human and machine provenance without resumable identity", () =>
     Effect.gen(function* () {
       const provenance = PrProvenance.make({
         branch: "feat/yeet-pr-provenance",
@@ -256,12 +316,12 @@ describe("Yeet PR provenance", () => {
       });
       const footer = renderPrProvenance(provenance);
 
-      expect(footer).toContain("---\n\n## Provenance");
-      expect(footer).toContain("- Clone: `~/workspace/beep-effect`");
-      expect(footer).toContain("- Worktree: `~/workspace/beep-effect/.claude/worktrees/endgame`");
-      expect(footer).toContain("- Branch: `feat/yeet-pr-provenance`");
-      expect(footer).toContain("- Harness: `claude-code`");
-      expect(footer).toContain("```sh\ncd ~/'workspace/beep-effect' &&\n  claude --resume 'session-123'\n```");
+      assert.isTrue(Str.includes("---\n\n## Provenance")(footer));
+      assert.isTrue(Str.includes("- Branch: <code>feat/yeet-pr-provenance</code>")(footer));
+      assert.isTrue(Str.includes("- Harness: `claude-code`")(footer));
+      assert.isFalse(Str.includes("~/workspace/beep-effect")(footer));
+      assert.isFalse(Str.includes("session-123")(footer));
+      assert.isFalse(Str.includes("claude --resume")(footer));
 
       const encoded = pipe(
         footer,
@@ -270,13 +330,51 @@ describe("Yeet PR provenance", () => {
         O.flatMap((tail) => pipe(tail, Str.split("\n-->"), A.head)),
         O.getOrThrow
       );
-      expect(yield* S.decodeEffect(S.fromJsonString(PrProvenance))(encoded)).toStrictEqual(provenance);
-      expect(
+      assert.deepStrictEqual(
+        yield* S.decodeEffect(S.fromJsonString(PublicPrProvenance))(encoded),
+        PublicPrProvenance.make({
+          schemaVersion: 1,
+          branch: "feat/yeet-pr-provenance",
+          harness: "claude-code",
+        })
+      );
+      assert.isTrue(
         pipe(
           Str.split("\n")(footer),
           A.every((line) => Str.length(line) < 100)
         )
-      ).toBe(true);
+      );
+    })
+  );
+
+  it.effect("escapes Git-valid branch names in both public framing contexts", () =>
+    Effect.gen(function* () {
+      const branch = "feat/evil`payload-->still-branch";
+      const footer = renderPrProvenance(
+        PrProvenance.make({
+          branch,
+          clonePath: "/repo",
+          harness: "unknown",
+          resumeCommand: "cd '/repo' &&\n  claude --resume",
+          sessionId: O.none(),
+          worktreePath: O.none(),
+        })
+      );
+      const encoded = pipe(
+        footer,
+        Str.split("<!-- yeet-provenance\n"),
+        A.get(1),
+        O.flatMap((tail) => pipe(tail, Str.split("\n-->"), A.head)),
+        O.getOrThrow
+      );
+
+      assert.isTrue(Str.includes("<code>feat/evil&#96;payload--&gt;still-branch</code>")(footer));
+      assert.strictEqual(A.length(Str.split("-->")(footer)), 2);
+      assert.isTrue(Str.includes("\\u003e")(encoded));
+      assert.deepStrictEqual(
+        yield* S.decodeEffect(S.fromJsonString(PublicPrProvenance))(encoded),
+        PublicPrProvenance.make({ schemaVersion: 1, branch, harness: "unknown" })
+      );
     })
   );
 });

--- a/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts
@@ -57,10 +57,12 @@ describe("Yeet PR provenance", () => {
     const isBranch = S.is(PrProvenanceBranch);
 
     expect(isBranch("feat/evil`payload-->still-branch")).toBe(true);
+    expect(isBranch("feat/a]b")).toBe(true);
     for (const invalid of [
       "",
       "-option",
       "branch with spaces",
+      "feat/a[b",
       "feature\\windows",
       "feature//double",
       "feature/../escape",


### PR DESCRIPTION
## Summary

- project local Yeet provenance into a non-resumable public schema
- omit clone paths, worktree paths, resume commands, and session identifiers
- validate Git branch names and escape Markdown and HTML-comment output

Closes finding CSF-007.

## Verification

- `bun run beep yeet verify`
- focused provenance test: 15 passed
