### PR TITLE
docs(explorations): graduate holding-pen packets under reopen-on-trigger convention

### DIFF
--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -92,8 +92,10 @@ the goal (`goals/<slug>/research/SOURCES.md`), reproducing the source corpus for
 implementation and linking the exploration's ledger as primary, and register it
 in the goal manifest `researchReports[]` + `currentSourceOfTruth[]` with
 `provenance.exploration` wired to the exploration's `links.goals`; flip
-exploration status — `graduated`, or keep
-`active` if candidates remain.
+exploration status to `graduated` once every promised-now goal exists —
+gated/queued candidates do NOT hold the packet open; they stay in `MAP.md`
+as re-entry points, and a fired gate reopens the packet at `decompose`
+(ratified 2026-08-13; see `explorations/README.md` Graduation Contract).
 
 ## Guardrails
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -126,8 +126,10 @@ ratchets hold at zero — keep-green only, no new clicks past zero.
 - **Graph-&-ask** over the Postgres projection (per intake D6). A dedicated
   graph DB enters only if traversal benchmarks fail targets, behind the
   existing port. `docs/BEEPGRAPH_ARCHITECTURE.md` remains a proposal.
-- **Wave-1 exploration graduations** into freed lane slots:
-  [`uspto-patent-driver-depth`](../explorations/uspto-patent-driver-depth/),
+- **Wave-1 freed lane slots** (the `uspto-patent-driver-depth` graduation
+  already happened 2026-08-13): schedule its active goal packets
+  [`goals/uspto-prosecution-read`](../goals/uspto-prosecution-read/) and
+  [`goals/uspto-ptmnfee2-ingest`](../goals/uspto-ptmnfee2-ingest/), plus
   [`citation-grounding-hallucination-guard`](../explorations/citation-grounding-hallucination-guard/).
 - **`semantic-foundation` M2** (classification schemes) and **M3**
   (docketing and party roles).

--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -246,6 +246,7 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   [`routing.json`](./_gold-intake/routing.json) (219/219 routed, user-approved). Each packet:
   CAPTURE seeded from its nuggets, `RESEARCH.md` (external landscape · in-repo inventory ·
   constraints), codex gate-1 folded, `DECISIONS.md` pre-drafted.
+  **Graduate-now (Wave-1, user-confirmed):**
   [`mcp-auth-gated-registration`](./mcp-auth-gated-registration/README.md)
   (Q1–Q7 resolved; [`mcp-kit`](../goals/mcp-kit/README.md),
   [`uspto-mcp`](../goals/uspto-mcp/README.md), and

--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -214,26 +214,6 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   carries the arc). The thread-virtualization gate remains: secure beep-effect6
   editor-stack ownership and complete the pretext-driver handoff. Feeds
   [`docs/product/workspace-substrate.md`](../docs/product/workspace-substrate.md) §4–§5.
-- [`atlas-synthesis`](./atlas-synthesis/README.md) — grounding/context packet
-  (stage `research`): a maximal-fan-out synthesis of current repo state vs.
-  goals/vision, centered on a gap map
-  ([`synthesis/00-baseline-gap-map.md`](./atlas-synthesis/synthesis/00-baseline-gap-map.md)).
-  The **capability-inventory half of the grand-vision exercise** (renamed from
-  `baseline-synthesis`, 2026-06-17). First decomposition done (2026-06-17): graduated the
-  office-action wedge into two goal packets —
-  [`epistemic-claim-lifecycle-gate`](../goals/epistemic-claim-lifecycle-gate/README.md) (build
-  first) and [`law-practice-office-action-spike`](../goals/law-practice-office-action-spike/README.md).
-  More verticals (intake/drafting/contract review) follow once the loop turns once.
-- [`solo-firm-docketing`](./solo-firm-docketing/README.md) — how Tom's solo IP
-  practice deals with docketing (stage `graduate`, still active while gated
-  candidates remain). Graduated 2026-07-14 into
-  [`law-docketing-patent-spine`](../goals/law-docketing-patent-spine/README.md)
-  and [`law-docketing-reliability`](../goals/law-docketing-reliability/README.md),
-  with product orientation at
-  [`docs/product/solo-firm-docketing.md`](../docs/product/solo-firm-docketing.md).
-  Queued: CPI after the handroll-v1 trigger, trademark on a qualifying matter,
-  court on a qualifying matter plus licensed-engine shape, and foreign on a
-  qualifying matter plus licensed engine/source shape.
 - [`ip-attorney-time-tracking`](./ip-attorney-time-tracking/README.md) —
   capture/prebill overlay for Tom's solo IP practice (stage `graduate`, still
   active while gated candidates remain). Graduated 2026-07-14 into
@@ -244,15 +224,6 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   permission/sync/retention P0 and consent, PST on a demonstrated need,
   profitability after sufficient Slice 1 data, and LEDES/UTBMS on a client
   mandate with a concrete billing target.
-- [`local-first-voice`](./local-first-voice/README.md) — privilege-safe voice for
-  `apps/professional-desktop` (stage `graduate`, still active while follow-ons remain).
-  Graduated 2026-07-14 into
-  [`voice-composer-slice`](../goals/voice-composer-slice/README.md): local
-  push-to-talk Moonshine dictation plus manual, interruptible Kokoro read-aloud,
-  with the five-day Linux Tauri proof as fail-fast P0. Capture foundation and the
-  general inference worker are absorbed until a second consumer appears. Provider
-  ports, auto/streaming read-aloud, cloud transport, and voice-to-voice remain gated
-  follow-ons off the proven slice.
 - [`domain-layer-hardening`](./domain-layer-hardening/README.md) — systematic
   hardening of every product slice's domain/schema layer (entities, aggregates,
   value objects, typed errors) against a regret-minimization rubric + external
@@ -274,12 +245,7 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   provenance in [`_gold-intake/ROUTING.md`](./_gold-intake/ROUTING.md) /
   [`routing.json`](./_gold-intake/routing.json) (219/219 routed, user-approved). Each packet:
   CAPTURE seeded from its nuggets, `RESEARCH.md` (external landscape · in-repo inventory ·
-  constraints), codex gate-1 folded, `DECISIONS.md` pre-drafted. **Graduate-now (Wave-1,
-  user-confirmed):** [`uspto-patent-driver-depth`](./uspto-patent-driver-depth/README.md) (stage
-  `graduate`, still active for queued/parked lanes): graduated
-  [`uspto-prosecution-read`](../goals/uspto-prosecution-read/README.md) and
-  [`uspto-ptmnfee2-ingest`](../goals/uspto-ptmnfee2-ingest/README.md) on
-  2026-07-14,
+  constraints), codex gate-1 folded, `DECISIONS.md` pre-drafted.
   [`mcp-auth-gated-registration`](./mcp-auth-gated-registration/README.md)
   (Q1–Q7 resolved; [`mcp-kit`](../goals/mcp-kit/README.md),
   [`uspto-mcp`](../goals/uspto-mcp/README.md), and
@@ -298,11 +264,6 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   [`court-reporter-vocabulary`](../goals/court-reporter-vocabulary/README.md);
   `citation-ground-before-cite` remains queued, with MPEP patterns, hosted
   enrichment, matter-wall enforcement, and rich-text annotation gated.
-  [`effect-orchestration-patterns`](./effect-orchestration-patterns/README.md)
-  (stage `graduate`, still active for four demand-gated candidates): graduated
-  [`effect-v4-workflow-engine-spike`](../goals/effect-v4-workflow-engine-spike/README.md)
-  on 2026-07-14. Consumer-led reframe: Effect v4 workflow and promoted
-  `@beep/api-transport` supersede the original helper-bundle premise.
   **Queued (P2/P3, research-complete):**
   [`agent-memory-tiers-bitemporal-edges`](./agent-memory-tiers-bitemporal-edges/README.md)
   (stage `graduate`, still active for the retention lane): graduated
@@ -327,14 +288,6 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   (stage `graduate`, still active across two tracks): graduated
   [`ingestion-secret-scrub`](../goals/ingestion-secret-scrub/README.md) while five
   content-security/secret-governance candidates remain gated,
-  [`rag-retrieval-projection`](./rag-retrieval-projection/README.md) (stage
-  `graduate`, still active for four gated satellites): graduated
-  [`hybrid-retrieval-fusion-core`](../goals/hybrid-retrieval-fusion-core/README.md),
-  the single RRF-layer owner,
-  [`secure-document-download-proxy`](./secure-document-download-proxy/README.md)
-  (stage `graduate`, still active for three gated candidates): graduated
-  [`secure-document-delivery`](../goals/secure-document-delivery/README.md) on
-  2026-07-14,
   [`local-first-projection-sync`](./local-first-projection-sync/README.md) (stage
   `graduate`, still active for gated projector/topology candidates): graduated
   [`projection-dispatch-core`](../goals/projection-dispatch-core/README.md) on
@@ -370,8 +323,7 @@ The lego pieces already built. Authoritative inventories (link, never copy):
 
 ### Proposed
 
-- (none — `atlas-synthesis` is now an Active packet above; its capability-inventory
-  half is done and the outcome-decomposition half is its next stage.)
+- (none)
 
 ### Parked
 
@@ -405,6 +357,28 @@ The lego pieces already built. Authoritative inventories (link, never copy):
 
 ### Graduated
 
+- [`atlas-synthesis`](./atlas-synthesis/README.md) — graduated 2026-08-13 after
+  its two promised-now goals completed-retained; a future synthesis pass reopens
+  the packet at `decompose` or starts a fresh packet.
+- [`effect-orchestration-patterns`](./effect-orchestration-patterns/README.md) —
+  graduated 2026-08-13 with its workflow-engine spike scaffolded and four
+  demand-gated MAP re-entry points; a fired MAP gate reopens at `decompose`.
+- [`local-first-voice`](./local-first-voice/README.md) — graduated 2026-08-13
+  with the composer slice scaffolded and four gated voice re-entry points; a
+  fired MAP gate reopens at `decompose`.
+- [`rag-retrieval-projection`](./rag-retrieval-projection/README.md) — graduated
+  2026-08-13 with the fusion core scaffolded and four gate-proofed retrieval
+  satellites preserved; a fired MAP gate reopens at `decompose`.
+- [`secure-document-download-proxy`](./secure-document-download-proxy/README.md)
+  — graduated 2026-08-13 with secure document delivery scaffolded and three
+  gated integrations preserved; a fired MAP gate reopens at `decompose`.
+- [`solo-firm-docketing`](./solo-firm-docketing/README.md) — graduated
+  2026-08-13 with its patent spine and reliability goals scaffolded and four
+  queued lanes preserved; a fired MAP gate reopens at `decompose`.
+- [`uspto-patent-driver-depth`](./uspto-patent-driver-depth/README.md) —
+  graduated 2026-08-13 with its prosecution-read and `PTMNFEE2` goals scaffolded
+  and four provider/search lanes preserved; a fired MAP gate reopens at
+  `decompose`.
 - [`fleet-coordination`](./fleet-coordination/README.md) — graduated
   2026-08-10 into the retained
   [`fleet-mirror`](../goals/fleet-mirror/README.md) goal with no open design

--- a/explorations/README.md
+++ b/explorations/README.md
@@ -104,7 +104,7 @@ conversation — every stage, both voices, and what changes on disk — lives in
 | --- | --- |
 | `active` | Being worked; appears in the ATLAS active tree. |
 | `parked` | Deliberately shelved with a dated reason in `DECISIONS.md`; revisit later. |
-| `graduated` | Spawned its goal packet(s); packet remains as provenance. |
+| `graduated` | Spawned its promised-now goal packet(s); packet remains as provenance and reopens at `decompose` when a MAP gate fires. |
 | `killed` | Explicitly rejected. Gets a one-line epitaph in `ATLAS.md`. Killing an idea is a successful outcome, not a failure. |
 
 ## Manifest Schema
@@ -161,8 +161,10 @@ Mechanics, per approved candidate goal:
   constraints, `DECISIONS.md` entries seed the decision log.
 - Use back-links to the exploration packet, not copies.
 - Cross-link both manifests (`links.goals` here; provenance entry there).
-- Update `ATLAS.md` and flip the exploration status (`graduated`, or keep
-  `active` if more candidates remain).
+- Once all promised-now goals exist, update `ATLAS.md` and flip the exploration
+  status to `graduated`. Gated candidates remain in `MAP.md` as re-entry points;
+  when a gate fires, reopen the exploration at `decompose` rather than spawning
+  a goal directly.
 
 ## Conventions
 

--- a/explorations/atlas-synthesis/DECISIONS.md
+++ b/explorations/atlas-synthesis/DECISIONS.md
@@ -187,3 +187,14 @@ append-only hygiene (re-read each shared file before touching; skip + report on 
 **Rationale:** Avoids clobbering the assessment/goal-packet branches' edits to
 RESEARCH/DECISIONS/README/CAPTURE. Rejected: full integration now (clobber risk); standalone-only
 (doc not discoverable in the index).
+
+## 2026-08-13 — holding-pen graduation convention
+
+**Answer:** The two manifest questions are resolved by the completed-retained
+`epistemic-claim-lifecycle-gate` and `law-practice-office-action-spike` goals.
+Clear the frontier and graduate this packet. A future synthesis pass reopens
+the packet at `decompose` or opens a fresh exploration packet.
+
+**Rationale:** Promised-now work, not possible future decomposition, determines
+graduation. A future synthesis pass is a re-entry event rather than a reason to
+hold this packet open.

--- a/explorations/atlas-synthesis/DECISIONS.md
+++ b/explorations/atlas-synthesis/DECISIONS.md
@@ -190,6 +190,7 @@ RESEARCH/DECISIONS/README/CAPTURE. Rejected: full integration now (clobber risk)
 
 ## 2026-08-13 — holding-pen graduation convention
 
+**Question:** Does this packet stay `active` as a holding pen for its gated/queued MAP.md candidates, or does it graduate now that every promised-now goal exists?
 **Answer:** The two manifest questions are resolved by the completed-retained
 `epistemic-claim-lifecycle-gate` and `law-practice-office-action-spike` goals.
 Clear the frontier and graduate this packet. A future synthesis pass reopens
@@ -198,3 +199,5 @@ the packet at `decompose` or opens a fresh exploration packet.
 **Rationale:** Promised-now work, not possible future decomposition, determines
 graduation. A future synthesis pass is a re-entry event rather than a reason to
 hold this packet open.
+
+**Rejected:** keep-active holding pen (the prior convention — leaves terminal packets indistinguishable from in-flight work); flip-and-spawn (a fired gate spawns a goal directly from MAP.md — skips the operator's align/shape gates on the resumed scope; the ratified rule reopens the packet at `decompose` instead).

--- a/explorations/atlas-synthesis/README.md
+++ b/explorations/atlas-synthesis/README.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Stage: `research`
-Status: `active`
+Stage: `graduate`
+Status: `graduated`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -18,20 +18,8 @@ the outcome-decomposition half is the next stage.
 
 ## Next Open Question
 
-What direction should this baseline ground (the next instruction)? The three
-doctrine-hygiene calls the centerpiece teed up (`synthesis/00` §5) are now **done
-(2026-06-17)**: the `standards/memory-architecture/` standard was amended ("L3 = moat"
-retired), `effect-capability-kg` was **parked**, and this packet was **renamed**
-`baseline-synthesis → atlas-synthesis`. The product-shaped open question remains: which
-**first IP-law workflow** (office-action review / intake / drafting / contract review),
-and should `law-practice` graduate from domain-only to a full slice now? **Resolved (2026-06-17):** dad-tool-first
-(ambition ladder; rung-3 firm aggregation bracketed); migrate only the thin v3 slice
-(`EvidenceSpan`). The office-action wedge is chosen and **graduated into two goal packets** —
-[`goals/epistemic-claim-lifecycle-gate`](../../goals/epistemic-claim-lifecycle-gate/README.md)
-(the reusable boundary) and
-[`goals/law-practice-office-action-spike`](../../goals/law-practice-office-action-spike/README.md)
-(the IP-law vertical + loop). **Next:** build them — the epistemic boundary first, then the
-law-practice vertical that composes it.
+None. The two promised-now goals are completed-retained. A future synthesis
+pass reopens this packet at `decompose` or starts a fresh exploration packet.
 
 ## Read This First
 
@@ -44,6 +32,9 @@ law-practice vertical that composes it.
 
 ## Trail
 
+- 2026-08-13: **Holding-pen flip ratified** — the two promised-now goals are
+  completed-retained, so the packet is `graduated`. A future synthesis pass
+  reopens this packet at `decompose` or opens a fresh packet.
 - 2026-07-14: **Frontier re-drawn by the graduation campaign** — 16 exploration
   packets dispositioned in one run (~18 goals graduated, incl. the law-practice
   docketing/time/citation/doc-structure arc, the epistemic bitemporal core, the

--- a/explorations/atlas-synthesis/ops/manifest.json
+++ b/explorations/atlas-synthesis/ops/manifest.json
@@ -3,12 +3,9 @@
   "exploration": {
     "slug": "atlas-synthesis",
     "title": "Atlas Synthesis \u2014 Current State <-> Goals/Vision Grounding",
-    "status": "active",
-    "stage": "research",
-    "openQuestions": [
-      "Launch the two graduated goal packets: build goals/epistemic-claim-lifecycle-gate FIRST (the reusable boundary), then goals/law-practice-office-action-spike (the IP-law vertical + loop).",
-      "Continue the outcome-decomposition: the verticals/goals AFTER office-action review (intake, drafting, contract review) once the loop turns once."
-    ],
+    "status": "graduated",
+    "stage": "graduate",
+    "openQuestions": [],
     "links": {
       "goals": [
         "goals/epistemic-claim-lifecycle-gate",
@@ -25,6 +22,6 @@
       "supersededBy": null
     },
     "created": "2026-06-17",
-    "updated": "2026-07-14"
+    "updated": "2026-08-13"
   }
 }

--- a/explorations/effect-orchestration-patterns/DECISIONS.md
+++ b/explorations/effect-orchestration-patterns/DECISIONS.md
@@ -154,6 +154,7 @@ cross-reference, not a candidate graduated by this packet.
 
 ## 2026-08-13 — HOLDING-PEN CONVENTION — RATIFIED
 
+**Question:** Does this packet stay `active` as a holding pen for its gated/queued MAP.md candidates, or does it graduate now that every promised-now goal exists?
 **Answer:** Graduate the packet now that its promised-now goal exists. Keep
 `circuit-breaker-consumer-spike`, `degraded-fanout-promotion`,
 `provider-build-selector`, and `llm-retry-consolidation` in `MAP.md` as re-entry
@@ -162,3 +163,5 @@ spawn a goal directly.
 
 **Rationale:** Demand-gated candidates preserve future routing without holding
 a completed exploration open.
+
+**Rejected:** keep-active holding pen (the prior convention — leaves terminal packets indistinguishable from in-flight work); flip-and-spawn (a fired gate spawns a goal directly from MAP.md — skips the operator's align/shape gates on the resumed scope; the ratified rule reopens the packet at `decompose` instead).

--- a/explorations/effect-orchestration-patterns/DECISIONS.md
+++ b/explorations/effect-orchestration-patterns/DECISIONS.md
@@ -151,3 +151,14 @@ boundary.
 consumer and depends on evidence from `effect-v4-workflow-engine-spike`.
 `goals/uspto-prosecution-read` absorbs USPTO transport adoption; it is a
 cross-reference, not a candidate graduated by this packet.
+
+## 2026-08-13 — HOLDING-PEN CONVENTION — RATIFIED
+
+**Answer:** Graduate the packet now that its promised-now goal exists. Keep
+`circuit-breaker-consumer-spike`, `degraded-fanout-promotion`,
+`provider-build-selector`, and `llm-retry-consolidation` in `MAP.md` as re-entry
+points. A fired demand gate reopens this packet at `decompose`; it does not
+spawn a goal directly.
+
+**Rationale:** Demand-gated candidates preserve future routing without holding
+a completed exploration open.

--- a/explorations/effect-orchestration-patterns/README.md
+++ b/explorations/effect-orchestration-patterns/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 Stage: `graduate`
-Status: `active`
+Status: `graduated`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -22,11 +22,8 @@ remain in [`research/SOURCES.md`](./research/SOURCES.md) as provenance.
 
 ## Next Open Question
 
-The immediate spike has graduated. Resume only when one of four demand triggers
-fires: a measured failure survives limiter/retry/workflow/monitoring; a second
-fan-out consumer proves congruent semantics; a runtime must select compatible
-providers; or a second `ExecutionPlan` consumer proves matching LLM retry
-semantics. See [`MAP.md`](./MAP.md).
+None while graduated. The four demand-gated MAP candidates remain re-entry
+points; when one of their triggers fires, reopen this packet at `decompose`.
 
 ## Read This First
 
@@ -39,6 +36,9 @@ semantics. See [`MAP.md`](./MAP.md).
 
 ## Trail
 
+- 2026-08-13: holding-pen convention ratified; the packet flipped to
+  `graduated`. Its four demand-gated MAP candidates remain re-entry points, and
+  a fired gate reopens this packet at `decompose`.
 - 2026-07-14: BRIEF ratified as drafted; graduated only [`effect-v4-workflow-engine-spike`](../../goals/effect-v4-workflow-engine-spike/README.md); four candidates remain demand-gated and status stays active.
 - 2026-07-14: research refreshed against v4 workflow + api-transport; reframe ratified; 4 decisions + 4 gated deferrals.
 - 2026-06-29: research-complete — RESEARCH.md synthesized, codex gate-1 folded, DECISIONS pre-drafted.

--- a/explorations/effect-orchestration-patterns/ops/manifest.json
+++ b/explorations/effect-orchestration-patterns/ops/manifest.json
@@ -3,7 +3,7 @@
   "exploration": {
     "slug": "effect-orchestration-patterns",
     "title": "Effect Orchestration Patterns",
-    "status": "active",
+    "status": "graduated",
     "stage": "graduate",
     "openQuestions": [],
     "links": {
@@ -12,7 +12,7 @@
       "supersededBy": null
     },
     "created": "2026-06-29",
-    "updated": "2026-07-14",
+    "updated": "2026-08-13",
     "sources": ["research/SOURCES.md"]
   }
 }

--- a/explorations/local-first-voice/DECISIONS.md
+++ b/explorations/local-first-voice/DECISIONS.md
@@ -236,3 +236,13 @@ before P1—never silent scope growth.
 *unbounded tuning* (turns uncertainty reduction into implementation), and
 *threshold-by-threshold scope expansion* (hides a failed bet). The numbers measure
 the user-visible latency, privacy, teardown, and seam assumptions the slice depends on.
+
+## 2026-08-13 — holding-pen convention — RATIFIED
+
+**Answer:** Graduate the packet now that its promised-now goal exists. Keep
+`voice-provider-ports`, `voice-tts-playback`, `voice-cloud-transport`, and
+`voice-to-voice-session` in `MAP.md` as re-entry points. A fired gate reopens
+this packet at `decompose`; it does not spawn a goal directly.
+
+**Rationale:** Gated voice follow-ons preserve the path beyond the proven slice
+without holding the exploration open.

--- a/explorations/local-first-voice/DECISIONS.md
+++ b/explorations/local-first-voice/DECISIONS.md
@@ -239,6 +239,7 @@ the user-visible latency, privacy, teardown, and seam assumptions the slice depe
 
 ## 2026-08-13 — holding-pen convention — RATIFIED
 
+**Question:** Does this packet stay `active` as a holding pen for its gated/queued MAP.md candidates, or does it graduate now that every promised-now goal exists?
 **Answer:** Graduate the packet now that its promised-now goal exists. Keep
 `voice-provider-ports`, `voice-tts-playback`, `voice-cloud-transport`, and
 `voice-to-voice-session` in `MAP.md` as re-entry points. A fired gate reopens
@@ -246,3 +247,5 @@ this packet at `decompose`; it does not spawn a goal directly.
 
 **Rationale:** Gated voice follow-ons preserve the path beyond the proven slice
 without holding the exploration open.
+
+**Rejected:** keep-active holding pen (the prior convention — leaves terminal packets indistinguishable from in-flight work); flip-and-spawn (a fired gate spawns a goal directly from MAP.md — skips the operator's align/shape gates on the resumed scope; the ratified rule reopens the packet at `decompose` instead).

--- a/explorations/local-first-voice/README.md
+++ b/explorations/local-first-voice/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 Stage: `graduate`
-Status: `active`
+Status: `graduated`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -15,8 +15,8 @@ primitives with per-feature choice of local (Transformers.js) vs cloud models.
 
 ## Next Open Question
 
-run [`goals/voice-composer-slice`](../../goals/voice-composer-slice/README.md) P0
-spike (5-day cap) → proceed/reshape/stop
+None while graduated. The four gated follow-ons remain MAP re-entry points; a
+fired gate reopens this packet at `decompose`.
 
 ## Read This First
 
@@ -32,6 +32,9 @@ spike (5-day cap) → proceed/reshape/stop
 
 <Dated one-liners, newest first: what each session did and where it stopped.>
 
+- 2026-08-13: holding-pen convention ratified; the packet flipped to
+  `graduated`. The four gated voice follow-ons remain MAP re-entry points, and
+  a fired gate reopens this packet at `decompose`.
 - 2026-07-14: de-drifted BRIEF/MAP to the four locked ratifications, created the
   missing provenance ledger, and graduated `voice-composer-slice` with the bounded
   Linux Tauri spike as P0; exploration stays active for absorbed/gated follow-ons.

--- a/explorations/local-first-voice/ops/manifest.json
+++ b/explorations/local-first-voice/ops/manifest.json
@@ -3,7 +3,7 @@
   "exploration": {
     "slug": "local-first-voice",
     "title": "Local-First Voice & Microphone Capability",
-    "status": "active",
+    "status": "graduated",
     "stage": "graduate",
     "openQuestions": [],
     "links": {
@@ -12,7 +12,7 @@
       "supersededBy": null
     },
     "created": "2026-06-27",
-    "updated": "2026-07-14",
+    "updated": "2026-08-13",
     "sources": ["research/SOURCES.md"]
   }
 }

--- a/explorations/rag-retrieval-projection/DECISIONS.md
+++ b/explorations/rag-retrieval-projection/DECISIONS.md
@@ -167,6 +167,7 @@ whole fan-out into `local-first-projection-sync`; one omnibus goal.
 
 ## 2026-08-13 — HOLDING-PEN CONVENTION — RATIFIED
 
+**Question:** Does this packet stay `active` as a holding pen for its gated/queued MAP.md candidates, or does it graduate now that every promised-now goal exists?
 **Answer:** Graduate the packet now that its promised-now fusion goal exists.
 Keep `retrieval-vector-projection`, `retrieval-local-encoder`,
 `retrieval-evidence-dedup`, and `citation-graph-retrieval-channel` in `MAP.md`
@@ -175,3 +176,5 @@ gate reopens this packet at `decompose`; it does not spawn a goal directly.
 
 **Rationale:** Evidence-gated satellites remain discoverable and testable
 without holding the completed fusion exploration open.
+
+**Rejected:** keep-active holding pen (the prior convention — leaves terminal packets indistinguishable from in-flight work); flip-and-spawn (a fired gate spawns a goal directly from MAP.md — skips the operator's align/shape gates on the resumed scope; the ratified rule reopens the packet at `decompose` instead).

--- a/explorations/rag-retrieval-projection/DECISIONS.md
+++ b/explorations/rag-retrieval-projection/DECISIONS.md
@@ -164,3 +164,14 @@ whole fan-out into `local-first-projection-sync`; one omnibus goal.
 | Dedup policy authoring | Whether and how dedup graduates | Requires a clean-room product spec and representative corpus authored without the poisoned AGPL-derived note. |
 | BFS edge-availability spike | Whether citation BFS can ship against ODP | Requires proof that live ODP exposes sufficient citation edges through `@beep/uspto`. |
 | PGlite extension proof | Projection extension mechanism | Requires proof for `@electric-sql/pglite` 0.5.4, whose live exports contain no vector/textsearch subpaths. |
+
+## 2026-08-13 — HOLDING-PEN CONVENTION — RATIFIED
+
+**Answer:** Graduate the packet now that its promised-now fusion goal exists.
+Keep `retrieval-vector-projection`, `retrieval-local-encoder`,
+`retrieval-evidence-dedup`, and `citation-graph-retrieval-channel` in `MAP.md`
+as re-entry points, with their existing gate proofs as the triggers. A fired
+gate reopens this packet at `decompose`; it does not spawn a goal directly.
+
+**Rationale:** Evidence-gated satellites remain discoverable and testable
+without holding the completed fusion exploration open.

--- a/explorations/rag-retrieval-projection/README.md
+++ b/explorations/rag-retrieval-projection/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 Stage: `graduate`
-Status: `active`
+Status: `graduated`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -25,11 +25,8 @@ the unknown-license reimplement rule (lawyergpt), and the RRF single-owner manda
 
 ## Next Open Question
 
-Four implementation gates remain: PGlite 0.5.4 extension proof for
-`retrieval-vector-projection`, the runtime-adapter benchmark for
-`retrieval-local-encoder`, an independently authored clean-room policy for
-`retrieval-evidence-dedup`, and a live ODP edge-availability spike for
-`citation-graph-retrieval-channel`.
+None while graduated. The four gated satellites and their MAP gate proofs
+remain re-entry points; a fired gate reopens this packet at `decompose`.
 
 ## Read This First
 
@@ -42,6 +39,9 @@ Four implementation gates remain: PGlite 0.5.4 extension proof for
 
 ## Trail
 
+- 2026-08-13: holding-pen convention ratified; the packet flipped to
+  `graduated`. The four gated satellites and their MAP gate proofs remain
+  re-entry points, and a fired gate reopens this packet at `decompose`.
 - 2026-07-14: shape gate signed off; BRIEF ratified as drafted; graduated
   [`goals/hybrid-retrieval-fusion-core`](../../goals/hybrid-retrieval-fusion-core/README.md)
   as the sole RRF owner. Four gated satellites remain queued; no product prose

--- a/explorations/rag-retrieval-projection/ops/manifest.json
+++ b/explorations/rag-retrieval-projection/ops/manifest.json
@@ -3,7 +3,7 @@
   "exploration": {
     "slug": "rag-retrieval-projection",
     "title": "RAG Retrieval Projection Layer",
-    "status": "active",
+    "status": "graduated",
     "stage": "graduate",
     "openQuestions": [],
     "links": {
@@ -12,7 +12,7 @@
       "supersededBy": null
     },
     "created": "2026-06-29",
-    "updated": "2026-07-14",
+    "updated": "2026-08-13",
     "sources": ["research/SOURCES.md"]
   }
 }

--- a/explorations/secure-document-download-proxy/DECISIONS.md
+++ b/explorations/secure-document-download-proxy/DECISIONS.md
@@ -187,6 +187,7 @@ address enforcement.
 
 ## 2026-08-13 — Holding-pen convention — RATIFIED
 
+**Question:** Does this packet stay `active` as a holding pen for its gated/queued MAP.md candidates, or does it graduate now that every promised-now goal exists?
 **Answer:** Graduate the packet now that `secure-document-delivery` exists.
 Keep the Box-origin, viewer-integration, and additional-origins candidates in
 `MAP.md` as re-entry points. A fired gate reopens this packet at `decompose`;
@@ -194,3 +195,5 @@ it does not spawn a goal directly.
 
 **Rationale:** The three gated integrations preserve future routing without
 holding the completed delivery exploration open.
+
+**Rejected:** keep-active holding pen (the prior convention — leaves terminal packets indistinguishable from in-flight work); flip-and-spawn (a fired gate spawns a goal directly from MAP.md — skips the operator's align/shape gates on the resumed scope; the ratified rule reopens the packet at `decompose` instead).

--- a/explorations/secure-document-download-proxy/DECISIONS.md
+++ b/explorations/secure-document-download-proxy/DECISIONS.md
@@ -184,3 +184,13 @@ Keep acceptance fixture-backed. Live USPTO fetch proof remains blocked until
 the guarded-fetch DNS-rebinding/redirect harness from
 `explorations/ingestion-security-secret-governance` proves pinned connect-time
 address enforcement.
+
+## 2026-08-13 — Holding-pen convention — RATIFIED
+
+**Answer:** Graduate the packet now that `secure-document-delivery` exists.
+Keep the Box-origin, viewer-integration, and additional-origins candidates in
+`MAP.md` as re-entry points. A fired gate reopens this packet at `decompose`;
+it does not spawn a goal directly.
+
+**Rationale:** The three gated integrations preserve future routing without
+holding the completed delivery exploration open.

--- a/explorations/secure-document-download-proxy/MAP.md
+++ b/explorations/secure-document-download-proxy/MAP.md
@@ -9,8 +9,9 @@
 | GATED | `secure-document-viewer-integration` | Render delivered documents without weakening cache, session, revocation, or navigation rules. | Packaged-webview HTTP proof and a named product consumer. | Existing desktop UI is reusable; secure viewer/session integration is **NET-NEW**. |
 | GATED | `secure-document-additional-origins` | Add separately authorized docketing/documents/time-tracking origins through provider-owned drivers. | Two real consumer pulls and guarded-fetch harness for every live remote origin. | Drivers may be reused; every origin adapter and consumer policy remains **NET-NEW** until named. |
 
-The exploration stays `active` at stage `graduate` because the three gated
-candidates remain intentionally unscaffolded.
+The exploration is `graduated`; the three intentionally unscaffolded candidates
+remain re-entry points. A satisfied gate reopens this packet at `decompose`
+rather than spawning a goal directly.
 
 ## Cross-References and Ownership Fences
 

--- a/explorations/secure-document-download-proxy/README.md
+++ b/explorations/secure-document-download-proxy/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 Stage: `graduate`
-Status: `active`
+Status: `graduated`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -16,10 +16,9 @@ UUID-guarded resource route with an encrypted, auto-expiring opaque-link store.
 
 ## Next Open Question
 
-None. Eight alignment questions and the fan-out are ratified. Resume from the
-gated Box origin, viewer integration, or additional-origin candidate only when a
-named consumer pull satisfies its gate; implementation starts at
-[`goals/secure-document-delivery`](../../goals/secure-document-delivery/README.md).
+None while graduated. The gated Box origin, viewer integration, and
+additional-origin candidates remain MAP re-entry points; a fired gate reopens
+this packet at `decompose`.
 
 ## Read This First
 
@@ -40,6 +39,9 @@ in-repo `@beep/*` brick it composes. Derived from the gold-intake cluster
 
 ## Trail
 
+- 2026-08-13: holding-pen convention ratified; the packet flipped to
+  `graduated`. Its three gated MAP candidates remain re-entry points, and a
+  fired gate reopens this packet at `decompose`.
 - 2026-07-14: graduated `goals/secure-document-delivery`; exploration remains active for three gated candidates.
 - 2026-07-14: align closed in one round — Q1-Q8 and fan-out ratified; brief and map drafted.
 - 2026-06-29: research-complete — RESEARCH.md synthesized, codex gate-1 folded, DECISIONS pre-drafted.

--- a/explorations/secure-document-download-proxy/ops/manifest.json
+++ b/explorations/secure-document-download-proxy/ops/manifest.json
@@ -3,7 +3,7 @@
   "exploration": {
     "slug": "secure-document-download-proxy",
     "title": "Secure Document Download Proxy",
-    "status": "active",
+    "status": "graduated",
     "stage": "graduate",
     "openQuestions": [],
     "links": {
@@ -12,7 +12,7 @@
       "supersededBy": null
     },
     "created": "2026-06-29",
-    "updated": "2026-07-14",
+    "updated": "2026-08-13",
     "sources": ["research/SOURCES.md"]
   }
 }

--- a/explorations/solo-firm-docketing/DECISIONS.md
+++ b/explorations/solo-firm-docketing/DECISIONS.md
@@ -346,3 +346,13 @@ both directions: it forbids silent promotion today while preventing a future
 maintainer from reading "never" as a permanent product boundary the owners do
 not actually hold. *Rejected:* amending the doctrine now (nothing is earned
 yet); leaving the ambition unrecorded (it would resurface as creep).
+
+## 2026-08-13 — holding-pen graduation convention (RATIFIED)
+
+**Answer:** Graduate the packet now that the promised-now patent-spine and
+reliability goals exist. Keep the CPI, trademark, court-orders, and foreign
+candidates in `MAP.md` as re-entry points. A fired gate reopens this packet at
+`decompose`; it does not spawn a goal directly.
+
+**Rationale:** Matter-, access-, and license-gated lanes remain explicit
+without holding the completed patent-docketing exploration open.

--- a/explorations/solo-firm-docketing/DECISIONS.md
+++ b/explorations/solo-firm-docketing/DECISIONS.md
@@ -349,6 +349,7 @@ yet); leaving the ambition unrecorded (it would resurface as creep).
 
 ## 2026-08-13 — holding-pen graduation convention (RATIFIED)
 
+**Question:** Does this packet stay `active` as a holding pen for its gated/queued MAP.md candidates, or does it graduate now that every promised-now goal exists?
 **Answer:** Graduate the packet now that the promised-now patent-spine and
 reliability goals exist. Keep the CPI, trademark, court-orders, and foreign
 candidates in `MAP.md` as re-entry points. A fired gate reopens this packet at
@@ -356,3 +357,5 @@ candidates in `MAP.md` as re-entry points. A fired gate reopens this packet at
 
 **Rationale:** Matter-, access-, and license-gated lanes remain explicit
 without holding the completed patent-docketing exploration open.
+
+**Rejected:** keep-active holding pen (the prior convention — leaves terminal packets indistinguishable from in-flight work); flip-and-spawn (a fired gate spawns a goal directly from MAP.md — skips the operator's align/shape gates on the resumed scope; the ratified rule reopens the packet at `decompose` instead).

--- a/explorations/solo-firm-docketing/README.md
+++ b/explorations/solo-firm-docketing/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 Stage: `graduate`
-Status: `active`
+Status: `graduated`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -18,10 +18,8 @@ good API/MCP/SDK, or hybrid — reliable, agent-integratable, and developer-sane
 
 ## Next Open Question
 
-No blocking question remains. Four candidates stay queued behind their explicit
-gates: CPI access evaluation when handroll v1 lands; a qualifying US trademark
-matter; a qualifying court matter plus a separately shaped licensed rules
-engine; and a qualifying foreign matter plus its licensed engine/source shape.
+None while graduated. The four queued candidates remain MAP re-entry points; a
+fired gate reopens this packet at `decompose`.
 
 ## Read This First
 
@@ -50,6 +48,9 @@ engine; and a qualifying foreign matter plus its licensed engine/source shape.
 
 ## Trail
 
+- 2026-08-13: holding-pen convention ratified; the packet flipped to
+  `graduated`. Its four queued MAP candidates remain re-entry points, and a
+  fired gate reopens this packet at `decompose`.
 - 2026-07-14: shape signed off with the six-week appetite and paired
   acceptance; graduated [`law-docketing-patent-spine`](../../goals/law-docketing-patent-spine/README.md)
   plus [`law-docketing-reliability`](../../goals/law-docketing-reliability/README.md)

--- a/explorations/solo-firm-docketing/ops/manifest.json
+++ b/explorations/solo-firm-docketing/ops/manifest.json
@@ -3,7 +3,7 @@
   "exploration": {
     "slug": "solo-firm-docketing",
     "title": "Solo-Firm IP Docketing",
-    "status": "active",
+    "status": "graduated",
     "stage": "graduate",
     "openQuestions": [],
     "links": {
@@ -20,7 +20,7 @@
       "supersededBy": null
     },
     "created": "2026-06-18",
-    "updated": "2026-07-14",
+    "updated": "2026-08-13",
     "sources": ["research/SOURCES.md"]
   }
 }

--- a/explorations/uspto-patent-driver-depth/DECISIONS.md
+++ b/explorations/uspto-patent-driver-depth/DECISIONS.md
@@ -212,6 +212,7 @@ application-status, OA-event, document-code, and `PTMNFEE2`-event artifacts.
 
 ## 2026-08-13 — Holding-pen graduation convention — LOCKED
 
+**Question:** Does this packet stay `active` as a holding pen for its gated/queued MAP.md candidates, or does it graduate now that every promised-now goal exists?
 **Answer:** Graduate the packet now that its two promised-now goals exist. Keep
 `uspto-search-structured`, `epo-driver`,
 `google-patents-bigquery-driver`, and the SerpApi lane in `MAP.md` as re-entry
@@ -220,3 +221,5 @@ does not spawn a goal directly.
 
 **Rationale:** Spike-gated, consumer-pulled, and parked provider lanes preserve
 future routing without holding the official USPTO-depth exploration open.
+
+**Rejected:** keep-active holding pen (the prior convention — leaves terminal packets indistinguishable from in-flight work); flip-and-spawn (a fired gate spawns a goal directly from MAP.md — skips the operator's align/shape gates on the resumed scope; the ratified rule reopens the packet at `decompose` instead).

--- a/explorations/uspto-patent-driver-depth/DECISIONS.md
+++ b/explorations/uspto-patent-driver-depth/DECISIONS.md
@@ -209,3 +209,14 @@ the applications endpoint before admitting a public method.
 
 Prove one authoritative retrieval route and checksum stability for the generated
 application-status, OA-event, document-code, and `PTMNFEE2`-event artifacts.
+
+## 2026-08-13 — Holding-pen graduation convention — LOCKED
+
+**Answer:** Graduate the packet now that its two promised-now goals exist. Keep
+`uspto-search-structured`, `epo-driver`,
+`google-patents-bigquery-driver`, and the SerpApi lane in `MAP.md` as re-entry
+points. A fired spike or consumer gate reopens this packet at `decompose`; it
+does not spawn a goal directly.
+
+**Rationale:** Spike-gated, consumer-pulled, and parked provider lanes preserve
+future routing without holding the official USPTO-depth exploration open.

--- a/explorations/uspto-patent-driver-depth/README.md
+++ b/explorations/uspto-patent-driver-depth/README.md
@@ -18,7 +18,8 @@ keep legal interpretation and reliability orchestration in their owning goals.
 ## Next Open Question
 
 None while graduated. `uspto-search-structured`, EPO OPS, Google Patents
-BigQuery, and the SerpApi lane remain MAP re-entry points; a fired gate reopens
+BigQuery, the SerpApi lane, and the approval-gated `uspto-ppubs-experiment`
+remain MAP re-entry points; a fired gate reopens
 this packet at `decompose`.
 
 ## Sources & provenance

--- a/explorations/uspto-patent-driver-depth/README.md
+++ b/explorations/uspto-patent-driver-depth/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 Stage: `graduate`
-Status: `active`
+Status: `graduated`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -17,9 +17,9 @@ keep legal interpretation and reliability orchestration in their owning goals.
 
 ## Next Open Question
 
-**Queued gates:** `uspto-search-structured` waits for live applications-endpoint
-proof; EPO OPS and Google Patents BigQuery wait for named consumers; SerpApi and
-the ppubs experiment remain parked pending explicit pull/approval.
+None while graduated. `uspto-search-structured`, EPO OPS, Google Patents
+BigQuery, and the SerpApi lane remain MAP re-entry points; a fired gate reopens
+this packet at `decompose`.
 
 ## Sources & provenance
 
@@ -42,6 +42,9 @@ sources = port-with-attribution), the external research citations, and the
 
 ## Trail
 
+- 2026-08-13: holding-pen convention ratified; the packet flipped to
+  `graduated`. Its spike-gated and consumer-pulled MAP lanes remain re-entry
+  points, and a fired gate reopens this packet at `decompose`.
 - 2026-07-14: shape gate signed off as drafted; graduated
   [`goals/uspto-prosecution-read`](../../goals/uspto-prosecution-read/README.md)
   and

--- a/explorations/uspto-patent-driver-depth/ops/manifest.json
+++ b/explorations/uspto-patent-driver-depth/ops/manifest.json
@@ -3,7 +3,7 @@
   "exploration": {
     "slug": "uspto-patent-driver-depth",
     "title": "USPTO Patent Driver Depth",
-    "status": "active",
+    "status": "graduated",
     "stage": "graduate",
     "openQuestions": [],
     "links": {
@@ -12,7 +12,7 @@
       "supersededBy": null
     },
     "created": "2026-06-29",
-    "updated": "2026-07-14",
+    "updated": "2026-08-13",
     "sources": ["research/SOURCES.md"]
   }
 }


### PR DESCRIPTION
Operator-ratified 2026-08-13: gated/queued MAP.md candidates no longer hold an exploration packet open. When all promised-now goal packets exist the packet flips to graduated; gated candidates remain in MAP.md as re-entry points; a fired gate reopens the exploration at decompose.

Flips seven graduate-stage packets (atlas-synthesis, effect-orchestration-patterns, local-first-voice, rag-retrieval-projection, secure-document-download-proxy, solo-firm-docketing, uspto-patent-driver-depth), updates the graduation-contract wording in explorations/README.md, and syncs ATLAS.md. One commit per packet plus a convention/ATLAS commit.

Local yeet verify: all 21 lanes green on this exact tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789238559&installation_model_id=424656&pr_number=693&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F693&signature=ac96a2aa47b6d9e14d4a5e310c5a44eecef28f2b1eff0931855a2af438a62cf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->