### PR TITLE
fix(coverage): tune bounded shard workers

### DIFF
--- a/goals/ci-lane-economics/research/OPPORTUNITIES.md
+++ b/goals/ci-lane-economics/research/OPPORTUNITIES.md
@@ -184,6 +184,102 @@ evidence, what would have prevented it). Redact for the public repo.
   lane's aggregate concurrency budget and pass an explicit per-shard Vitest
   worker cap derived from host vCPUs divided by shard count.
 
+## 2026-08-13 — cold hosted prebuild flaked a second time
+
+- **Doing:** admitting the two-worker four-shard Coverage Regression candidate
+  on PR #698.
+- **Evidence:** run `31753283207`, job `94623544457`, failed after 1m26s when
+  the cold prebuild reported `thunk.ts is not a module` and missing exports
+  after five successful tasks. A clean detached worktree at exact merge ref
+  `c72c8e1ab3` then passed all 128 forced build tasks with zero cache hits in
+  1m03s. Targeted retry job `94625871718` passed the same prebuild.
+- **Would have prevented it:** make cold-build repeatability a first-class CI
+  probe and retry this known impossible-diagnostic signature once before
+  classifying it as a deterministic source failure.
+
+## 2026-08-13 — uniform two-worker cap preserved correctness but missed time
+
+- **Doing:** admitting the two-worker four-shard Coverage Regression candidate
+  on the existing eight-vCPU fleet runner.
+- **Evidence:** targeted retry job `94625871718` passed every test and compared
+  all 124 package summaries, but took 23m23s. Its cold prebuild took 3m38s and
+  the four shards took 15m32s, 16m58s, 17m26s, and 18m23s. The cap removed the
+  prior repo-cli timeouts but left insufficient CPU throughput for the charter.
+- **Would have prevented it:** a fleet-parity capacity model that includes the
+  cold prebuild and tests a small bounded worker-cap curve instead of treating
+  host-vCPU equality as the only safe candidate.
+
+## 2026-08-13 — uniform three-worker cap added contention without throughput
+
+- **Doing:** admitting the four-shard, three-worker Coverage Regression
+  candidate on PR #707.
+- **Evidence:** run `31759003628`, job `94641084512`, failed after 23m08s. The
+  cold prebuild took 3m30s; the three mixed shards passed in 16m05s, 16m32s,
+  and 17m16s, while the repo-cli shard failed after 18m16s when a bounded-work
+  assertion measured 1026.30ms against its 1000ms ceiling. There was no OOM or
+  runner shutdown. The repo-cli Vitest config disables file parallelism, so
+  raising `maxWorkers` could not shorten its 728.76 seconds of serial imports.
+- **Would have prevented it:** profile the long pole's Vitest configuration and
+  phase breakdown before raising a uniform worker cap; explicitly parallelize
+  the serial file-import boundary under a bounded coverage-only worker pool.
+
+## 2026-08-13 — root lint-fix did not accept file paths
+
+- **Doing:** formatting the focused Coverage Regression implementation files.
+- **Evidence:** `bun run lint:fix -- <two paths>` routed the paths to Turbo as
+  task names and exited with `Missing tasks in project`; no files were changed.
+- **Would have prevented it:** expose or document a canonical file-scoped
+  formatter entrypoint distinct from the root task-oriented lint-fix command.
+
+## 2026-08-13 — stale zero-cache flags became mutually exclusive
+
+- **Doing:** running the forced local full-path proof for the five-shard
+  coverage candidate.
+- **Evidence:** Turbo 2.10 rejected `--force --remote-only` before executing a
+  task because cache configuration cannot be combined with `force`; the prior
+  proof recipe had treated both as compatible zero-cache controls.
+- **Would have prevented it:** keep one canonical forced-execution recipe in
+  the packet or CLI and validate it against the pinned Turbo version.
+
+## 2026-08-13 — main advanced across an expensive local proof
+
+- **Doing:** proving and preparing the five-shard PR #707 revision for
+  publication.
+- **Evidence:** `origin/main` advanced from `ddc8a873b1` to `5ca003a342` while
+  the forced full coverage proof ran, including a concurrent edit to this
+  ledger. Rebasing therefore required additive conflict resolution and made
+  the successful old-base proof non-authoritative for the final head.
+- **Would have prevented it:** refresh and pin the intended merge base
+  immediately before expensive proof, and serialize writes to the active
+  packet ledger while an admission candidate is being closed out.
+
+## 2026-08-13 — main advanced again between verification and publish
+
+- **Doing:** publishing the fully verified five-shard PR #707 revision.
+- **Evidence:** Yeet reused the exact full proof but refused publication because
+  `origin/main` advanced from `5ca003a342` to `9c621da122` and overlapped the
+  coverage task test. The landed commit also edited all three active packet
+  evidence files, requiring another additive rebase and making the completed
+  proof non-authoritative for the final head.
+- **Would have prevented it:** serialize the final proof/publish window for an
+  active packet, or have the publisher pin and atomically lease-check the base
+  before starting the expensive proof.
+
+## 2026-08-13 — rebased cold prebuild hit transient TS2589
+
+- **Doing:** repeating the forced full-coverage proof after rebasing PR #707
+  onto the newly advanced main.
+- **Evidence:** the zero-cache prebuild stopped after nine seconds when
+  `@beep/box` reported `TS2589: Type instantiation is excessively deep and
+  possibly infinite`; an immediate focused `@beep/box` build passed in under
+  one second without a source change. A retry moved the same failure to
+  `@beep/xai` after 60 successful tasks; its immediate focused build also
+  passed. A process census showed a sibling checkout simultaneously running
+  many Vitest workers and a high-CPU tsgo check on the shared host.
+- **Would have prevented it:** retry this known transient compiler-depth
+  signature once at the failed package boundary before discarding an otherwise
+  admissible full-path proof.
+
 ## 2026-08-14 — wall-clock perf assertion still flakes under capped coverage shards
 
 - **Doing:** babysitting PR #695 (unrelated refactor) through the post-#698

--- a/goals/ci-lane-economics/research/coverage-sharding-design.md
+++ b/goals/ci-lane-economics/research/coverage-sharding-design.md
@@ -69,16 +69,39 @@ then ran for 24m10s and failed: its three mixed shards passed in
 15m30s-16m46s, while the `@beep/repo-cli` shard took 19m13s and produced ten
 5-second timeout failures plus one 1-second timing-bound failure. One Turbo
 task per shard did not bound the Vitest subprocesses, so four packages could
-still size worker pools from the same eight-vCPU host. The revised candidate
-preserves four weighted shards but caps each Vitest pool at two workers,
+still size worker pools from the same eight-vCPU host. The next candidate
+preserved four weighted shards but capped each Vitest pool at two workers,
 bounding aggregate test fan-out at the host's CPU count. A focused local
 coverage run under that cap passed all 90 `@beep/repo-cli` files and 1,492
 tests (five skipped) in 6m55s without the hosted timeout failures. The forced
 full local path then passed with remote cache disabled: the one-time prebuild
 took 23 seconds, the four shards completed 5, 32, 44, and 44 tasks in 8m32s,
-8m06s, 9m06s, and 9m40s, and the ratchet compared all 124 summaries. That is
-the candidate submitted for live fleet admission; local timing alone does not
-satisfy the hosted wall-time gate.
+8m06s, 9m06s, and 9m40s, and the ratchet compared all 124 summaries. Live
+retry job `94625871718` confirmed the correctness repair but rejected the
+timing shape: all 124 summaries passed, yet a 3m38s prebuild plus shards at
+15m32s, 16m58s, 17m26s, and 18m23s produced a 23m23s job. The next candidate
+raised the explicit cap to three workers per shard. Its forced full-path proof
+passed locally, but live PR #707 job `94641084512` rejected both correctness
+and timing after 23m08s: the 3m30s prebuild led into three green mixed shards
+at 16m05s-17m16s, while the repo-cli shard failed at 18m16s when CPU
+contention pushed a bounded-work assertion to 1026.30ms against 1000ms.
+
+The live phase breakdown exposed the missed boundary: repo-cli's Vitest config
+sets `fileParallelism: false`, so raising `maxWorkers` could not shorten its
+728.76 seconds of serial imports. A coverage-only override passed the complete
+local repo-cli suite without exclusions: three workers completed 90 files and
+1,514 tests (five skipped) in 141.26 seconds, and the safer two-worker probe
+completed them in 200.86 seconds with identical coverage. The next candidate
+therefore uses five stable weighted shards with `--fileParallelism=true` and
+`--maxWorkers=2`. It bounds aggregate test-process fan-out at 10 rather than
+the rejected three-worker candidate's 12, while the fifth shard reduces each
+non-repo-cli weight from about 800 to about 608 seconds. After `origin/main`
+advanced twice, a fresh forced local full-path proof passed on exact base
+`9c621da122` with remote cache unavailable. The prebuild completed 128/128 tasks
+in 2m36s; the five shards completed 1, 18, 35, 36, and 37 tasks in 3m45s, 5m19s,
+5m34s, 7m26s, and 6m55s; and the ratchet compared all 126 baseline packages.
+Every task was a cache miss, and there was no shutdown or OOM. Local timing
+still cannot satisfy the hosted wall-time gate.
 
 The live PR admission must prove all summaries, all regression tests, no runner
 shutdown/OOM, and complete job wall time below 20 minutes. Any source change

--- a/goals/ci-lane-economics/research/placement-decision.md
+++ b/goals/ci-lane-economics/research/placement-decision.md
@@ -31,7 +31,7 @@ required context.
 | Docgen | fleet | fleet | 13.4m | Retain; `uses_turbo: false`, so there is no cache-backed re-fit case. |
 | Codegen Drift | hosted | hosted | 3.3m | Retain. |
 | Repo Sanity | hosted | hosted | 4.1m | Retain. |
-| Coverage Regression | fleet | fleet | 29.5m | Keep one fleet placement. Use exact directly changed coverage owners on PRs with an explicit full fallback; prebuild once and run four stable weighted in-job shards with bounded Vitest workers for complete runs. |
+| Coverage Regression | fleet | fleet | 29.5m | Keep one fleet placement. Use exact directly changed coverage owners on PRs with an explicit full fallback; prebuild once and run five stable weighted in-job shards with coverage-only file parallelism and a two-worker Vitest cap for complete runs. |
 | Knip | hosted | hosted | 3.1m | Retain. |
 | Commitlint | hosted | hosted | 1.8m | Retain. |
 | Secret Scanning | hosted | hosted | 1.0m | Retain. |
@@ -80,17 +80,33 @@ pre-packet placement cannot raise the approved projection.
   in 24m10s. The three mixed shards passed in 15m30s-16m46s, but unbounded
   Vitest subprocess fan-out starved the sequential `@beep/repo-cli` shard: it
   took 19m13s and failed ten 5-second timeout tests plus one 1-second timing
-  assertion. The next candidate caps every shard's Vitest pool at two workers,
-  bounding aggregate test fan-out at the eight-vCPU runner's capacity.
-- Reject or roll back the worker-bounded four-shard admission if the existing
+  assertion. Capping every shard's Vitest pool at two workers repaired those
+  failures, but retry job `94625871718` then passed in 23m23s: its 3m38s
+  prebuild was followed by four green shards at 15m32s-18m23s. The next
+  candidate raised the cap to three workers per shard, but live job
+  `94641084512` failed after 23m08s. Three mixed shards passed in
+  16m05s-17m16s; the repo-cli shard failed at 18m16s when contention pushed a
+  bounded-work assertion over its ceiling. Its config disables file
+  parallelism, so the higher cap could not shorten 728.76 seconds of serial
+  imports. The next candidate uses five shards, explicitly enables file
+  parallelism on the full-coverage path, and restores the two-worker cap.
+- Reject or roll back the file-parallel five-shard admission if the existing
   32-GB fleet runner shuts down, exhausts memory, or the complete required job
   remains at or above 20 minutes. The design raises in-job package concurrency,
   not fleet job count.
-- The worker-bounded candidate passed its forced local full-path proof with
-  remote cache disabled: a 23-second prebuild, four green shards at 8m06s to
-  9m40s, and all 124 summaries accepted by the ratchet. This proves local
-  correctness and bounded execution; the live fleet run remains the admission
-  authority.
+- The two-worker candidate passed its forced local full-path proof but its live
+  retry proved correctness while rejecting timing. The three-worker revision
+  then passed a fresh forced local proof with remote cache disabled: all 128
+  prebuild tasks in 21.4 seconds, four green shards at 5m43s-6m32s, and all
+  124 summaries accepted by the ratchet. The three-worker candidate then failed
+  live. Coverage-only repo-cli probes established the new boundary: 90 files
+  and 1,514 tests passed at both three workers (141.26s) and two workers
+  (200.86s), with identical coverage and no exclusions. After `origin/main`
+  advanced twice, the rebased five-shard candidate passed a fresh forced local
+  full-path proof on exact base `9c621da122`: a zero-cache 128-task prebuild in
+  2m36s, five green zero-cache shards at 3m45s-7m26s, and all 126 baseline
+  packages accepted by the ratchet. The live fleet remains the timing and
+  admission authority.
 
 ## P2 live admission evidence
 
@@ -101,3 +117,6 @@ pre-packet placement cannot raise the approved projection.
 | `31727475076` / `94539333691` | `beep-ec2-heavy` | Passed after 28m23s | Accepted rollback head; Coverage itself ran 227 tasks with zero cache hits in 27m02s and compared all 124 packages. | Confirms correctness and the structural p95 breach; supplies the weights for the in-job shard admission. |
 | `31740786046` / `94583467537` | `beep-ec2-heavy` | Passed after 22m18s | Five-shard candidate compared all 124 packages without shutdown/OOM, but four mixed shards took 14m59s-15m54s and isolated `@beep/repo-cli` took 20m16s under five-way contention. | Reject the five-shard timing admission; exclude it from the accepted P3 population and test four shards at the fleet's accepted concurrency. |
 | `31748322804` / `94608048289` | `beep-ec2-heavy` | Failed after 24m10s | The prebuild took 3m32s and three shards passed in 15m30s-16m46s. The `@beep/repo-cli` shard took 19m13s and failed contention-sensitive timeouts because each co-resident Vitest process still sized itself from the whole host. | Reject the unbounded four-shard admission; exclude it from duration percentiles and admit the four-shard/two-worker candidate. |
+| `31753283207` / `94623544457` | `beep-ec2-heavy` | Failed after 1m26s | The cold prebuild emitted impossible missing-export diagnostics after five successful tasks. A clean detached build of the exact merge ref then passed 128/128 tasks with zero cache hits in 1m03s. | Attribute as a hosted cold-build flake, exclude from duration percentiles, and require a targeted retry. |
+| `31753283207` attempt 2 / `94625871718` | `beep-ec2-heavy` | Passed after 23m23s | The two-worker cap eliminated the contention-sensitive failures and compared all 124 packages. The 3m38s prebuild plus four green shards at 15m32s-18m23s still exceeded the charter. | Reject the uniform two-worker timing admission; exclude it from the accepted P3 population and admit the smallest bounded increase, three workers per shard. |
+| `31759003628` / `94641084512` | `beep-ec2-heavy` | Failed after 23m08s | The 3m30s prebuild led into three green shards at 16m05s-17m16s. The repo-cli shard failed after 18m16s when a bounded-work assertion measured 1026.30ms against 1000ms; no OOM or runner shutdown occurred. | Reject the uniform three-worker admission and exclude it from duration percentiles. Enable file parallelism only for full coverage, restore two workers, and use five weighted shards to reduce the mixed-shard long poles. |

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -110,13 +110,16 @@ const ROOT_TURBO_CONCURRENCY_ARG = "--concurrency=3";
 // tuning; the 16GB-survival value was 2.
 const CI_TURBO_CONCURRENCY_ARG = "--concurrency=4";
 const ROOT_COVERAGE_TURBO_CONCURRENCY_ARG = "--concurrency=3";
-// Match the fleet's accepted Turbo concurrency. Five concurrent Vitest
-// coverage processes made the isolated repo-cli long pole slower than the
-// 20-minute job charter on live fleet hardware.
-const COVERAGE_FULL_SHARD_COUNT = 4;
-// Each shard owns one Turbo task at a time, but Vitest otherwise sizes its
-// worker pool from the whole 8-vCPU host. Bound each pool so four shards cannot
-// oversubscribe the runner and starve repo-cli's intentionally sequential suite.
+// Five weighted shards reduce the non-repo-cli long poles while keeping the
+// work inside one fleet job. Two Vitest workers per shard bound aggregate
+// test-process fan-out at 10 instead of the unbounded pool's potential 40.
+const COVERAGE_FULL_SHARD_COUNT = 5;
+// repo-cli deliberately disables file parallelism for ordinary package runs,
+// but serial imports consumed 728.76 seconds in the rejected live coverage
+// candidate. Full coverage uses isolated Vitest workers, so enable file
+// parallelism only on this orchestrated path; a two-worker local probe passed
+// all 90 files in 200.86 seconds with identical coverage.
+const COVERAGE_FULL_VITEST_FILE_PARALLELISM_ARG = "--fileParallelism=true";
 const COVERAGE_FULL_VITEST_MAX_WORKERS_ARG = "--maxWorkers=2";
 const COVERAGE_WRITE_BASELINE_ARG = "--write-baseline";
 const DEFAULT_COVERAGE_FAST_CHECK_SEED = "20260708";
@@ -1330,6 +1333,7 @@ const coverageFullShardStep = (
         ...passthroughArgs,
         ...A.map(packageNames, (packageName) => `--filter=${packageName}`),
         "--",
+        COVERAGE_FULL_VITEST_FILE_PARALLELISM_ARG,
         COVERAGE_FULL_VITEST_MAX_WORKERS_ARG,
       ]
     ),

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -1633,6 +1633,7 @@ describe("quality task adapter", () => {
         "coverage:shard-2",
         "coverage:shard-3",
         "coverage:shard-4",
+        "coverage:shard-5",
       ]);
       expect(steps[0]?.args).toEqual([
         "turbo",
@@ -1650,7 +1651,7 @@ describe("quality task adapter", () => {
         expect(step.args).toContain("--force");
         expect(step.args).toContain("--remote-only");
         expect(step.args).toContain("--output-logs=errors-only");
-        expect(A.takeRight(step.args, 2)).toEqual(["--", "--maxWorkers=2"]);
+        expect(A.takeRight(step.args, 3)).toEqual(["--", "--fileParallelism=true", "--maxWorkers=2"]);
         expect(step.args).not.toContain("--concurrency=4");
         expect(step.args).not.toContain("9");
       }


### PR DESCRIPTION
## fix(coverage): tune bounded shard workers

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_coverage-shard-workers-9ceee6bce74e/verdict.json

---

## Provenance

- Branch: <code>fix/coverage-shard-workers</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/coverage-shard-workers",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789260969&installation_model_id=424656&pr_number=707&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F707&signature=0578061d3990b9fbcdc5435ce887ae11dd497f62da2b19f0620933d11a7384ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->