### PR TITLE
fix(infra): escape HCL template sequences in fleet runner user-data

### DIFF
--- a/.changeset/csf-003-hcl-escape.md
+++ b/.changeset/csf-003-hcl-escape.md
@@ -1,0 +1,5 @@
+---
+"@beep/infra": patch
+---
+
+Escape bash `${...}` sequences in module-bound runner user-data so the fleet controller plans cleanly.

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -53,3 +53,28 @@ Record receipts at the moment friction happens; redact for the public repo.
   with registry integrity, frozen-install to verify, run both audit lanes.
   Advisory-feed failures mid-publish are recurring; the repair should be a
   one-command ritual, not lockfile surgery.
+
+## 2026-08-14 — merged P2 IMDS hook is undeployable: bash `${...}` parses as HCL in the bridge
+
+- What: answering "does anything need a deploy", ran `pulumi preview --stack
+  production --diff` on beep-ci-runners. The plan hard-fails on every
+  runner config's `userdata_post_install` (#708): the hook script's bash
+  expansions (`${runner_uid}`, `${runner_dir}`, `${hook_armed}`) reach the
+  terraform-module bridge's generated `pulumi.tf.json` unescaped, and
+  Terraform JSON syntax parses string values as templates — each `${...}`
+  becomes `Error: Invalid reference` ("a reference to a resource type must
+  be followed by at least one attribute access"), 10x, one per runner
+  config. The whole stack plan aborts, which also blocks the pending #700
+  CiTurboCache `integrationUri` updates (2 resources) from deploying.
+- Evidence: `pulumi preview` exit 1, `error: Preview failed: Plan failed`
+  after `~ 2 to update, 61 unchanged`; errors anchored on
+  `pulumi.tf.json` lines 144–168 `userdata_post_install` in
+  `module.ci-fleet-controller`. Source: `infra/src/CiFleetController.ts`
+  lines 81–106 (TS `\${...}` escapes produce literal bash `${...}`).
+- Prevention: escape Terraform-side as `$${...}` (TS template literal
+  `$\${...}`) so the rendered template hands bash `${...}` back; add a
+  test asserting module-bound userdata contains no unescaped `${` (the
+  #708 tests validated TS string content but never round-tripped through
+  an HCL template parse, so review + CI stayed green on an undeployable
+  artifact). Longer term: a plan/preview smoke lane for infra-touching PRs
+  would have caught this pre-merge.

--- a/infra/src/CiFleetController.ts
+++ b/infra/src/CiFleetController.ts
@@ -12,10 +12,11 @@
 
 import { $InfraId } from "@beep/identity/packages";
 import { SchemaUtils } from "@beep/schema";
-import { O } from "@beep/utils";
+import { O, Str } from "@beep/utils";
 import * as aws from "@pulumi/aws";
 import * as ghaRunners from "@pulumi/gharunners";
 import * as pulumi from "@pulumi/pulumi";
+import { flow } from "effect";
 import * as S from "effect/Schema";
 import { withPulumiConfigDecodeEffect } from "./internal/PulumiConfigSchema.ts";
 
@@ -109,7 +110,19 @@ BEEP_IMDS_DROP
 )
 `;
 
-const runnerPostInstall = runnerToolbeltPostInstall + imdsJobHookPostInstall;
+// The terraform-module bridge writes module inputs into `pulumi.tf.json`, and
+// Terraform's JSON syntax parses every string value as an HCL template: a
+// literal bash `${...}` (or `%{...}`) plans as an HCL reference and fails the
+// whole stack with "Invalid reference". `$${` / `%%{` render back to `${` /
+// `%{` in the instance's user-data, so the scripts run byte-identical. The
+// callback replacer is load-bearing: in a plain replacement string, `$$`
+// collapses to `$` and the escape silently becomes a no-op.
+const escapeHclTemplateSequences = flow(
+  Str.replaceAllWith(/\$\{/gu, () => "$${"),
+  Str.replaceAll("%{", "%%{")
+);
+
+const runnerPostInstall = escapeHclTemplateSequences(runnerToolbeltPostInstall + imdsJobHookPostInstall);
 
 const awsArnPattern = /^arn:aws[a-z-]*:[a-z0-9-]+:[a-z0-9-]*:[0-9]*:.+$/u;
 const ssmParameterArnPattern = /^arn:aws[a-z-]*:ssm:[a-z0-9-]+:[0-9]*:parameter\/.+$/u;

--- a/infra/test/CiFleetController.test.ts
+++ b/infra/test/CiFleetController.test.ts
@@ -2,7 +2,7 @@ import { CiFleetController, CiFleetControllerPulumiConfigValues, makeCiFleetCont
 import { O, Str } from "@beep/utils";
 import { assert, describe, expect, it } from "@effect/vitest";
 import * as pulumi from "@pulumi/pulumi";
-import { Effect, MutableHashMap, Result } from "effect";
+import { Effect, MutableHashMap, pipe, Result } from "effect";
 import * as S from "effect/Schema";
 
 const validConfigValues = {
@@ -202,15 +202,26 @@ describe("@beep/infra CiFleetController", () => {
       assert.isTrue(Str.includes("exec sudo /opt/beep/imds-job-started.sh")(postInstall));
       assert.isTrue(Str.includes("ec2-user ALL=(root) NOPASSWD: /opt/beep/imds-job-started.sh")(postInstall));
       assert.isTrue(
-        Str.includes('iptables -C OUTPUT -d 169.254.169.254/32 -m owner --uid-owner "${runner_uid}" -j DROP')(
+        Str.includes('iptables -C OUTPUT -d 169.254.169.254/32 -m owner --uid-owner "$${runner_uid}" -j DROP')(
           postInstall
         )
       );
       assert.isTrue(
-        Str.includes('|| iptables -A OUTPUT -d 169.254.169.254/32 -m owner --uid-owner "${runner_uid}" -j DROP')(
+        Str.includes('|| iptables -A OUTPUT -d 169.254.169.254/32 -m owner --uid-owner "$${runner_uid}" -j DROP')(
           postInstall
         )
       );
+      // Terraform parses `.tf.json` strings as HCL templates: the module-bound
+      // value may carry no unescaped `${`/`%{`, and rendering `$${` back to
+      // `${` must reproduce the original bash byte-identically.
+      expect(postInstall).not.toMatch(/(?<!\$)\$\{/u);
+      expect(postInstall).not.toMatch(/(?<!%)%\{/u);
+      const rendered = pipe(postInstall, Str.replaceAll("$${", "${"), Str.replaceAll("%%{", "%{"));
+      assert.isTrue(
+        Str.includes('iptables -C OUTPUT -d 169.254.169.254/32 -m owner --uid-owner "${runner_uid}" -j DROP')(rendered)
+      );
+      assert.isTrue(Str.includes('if [ -d "${runner_dir}" ]; then')(rendered));
+      assert.isTrue(Str.includes('if [ "${hook_armed}" = false ]; then')(rendered));
     })
   );
 });


### PR DESCRIPTION
## fix(infra): escape HCL template sequences in fleet runner user-data

The CSF-003 per-job IMDS hook script carries bash dollar-brace expansions
(runner_uid, runner_dir, hook_armed). The terraform-module bridge writes
userdata_post_install into pulumi.tf.json, where Terraform parses every
string value as an HCL template, so each expansion planned as an HCL
reference and failed the production stack plan with "Invalid reference".

Escape module-bound user-data at the composition boundary; Terraform
renders the escapes back so instance scripts run byte-identical. The
callback replacer is load-bearing: native replaceAll collapses a doubled
dollar in plain replacement strings, silently making the escape a no-op.

Proven live: pulumi preview --stack production plans clean (4 updates,
189 unchanged) and the decoded plan user-data carries the original bash.
Records the friction receipt in the ci-fleet-residue packet ledger.

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_imds-hook-hcl-escape-001fb73a96f7/verdict.json

---

## Provenance

- Branch: <code>fix/imds-hook-hcl-escape</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/imds-hook-hcl-escape",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789282205&installation_model_id=424656&pr_number=717&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F717&signature=f5ba061b1f87f9b80c78c8fc379778c61830816cba7e87216ebfb31ae497ff04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->