### PR TITLE
fix(infra): bake and self-heal the bunx symlink on runner images

### DIFF
--- a/.changeset/baked-ami-bunx.md
+++ b/.changeset/baked-ami-bunx.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-cli": patch
+---
+
+Create and prove the bunx symlink on baked runner images, and self-heal it in the CI baked fast path so `bunx turbo` spawns stop dying with ENOENT.

--- a/.github/actions/setup-monorepo-ci/action.yml
+++ b/.github/actions/setup-monorepo-ci/action.yml
@@ -50,6 +50,13 @@ runs:
             && [ "$baked_archive" = "$checkout_archive" ]; then
             hit=true
             echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+            # The release zip ships only the bun binary; images baked before
+            # the bake script created bunx (ami-07fb13d84a42d3584 and older)
+            # lack the symlink and every `bunx turbo` spawn dies with ENOENT.
+            if [ ! -e "$HOME/.bun/bin/bunx" ]; then
+              ln -s bun "$HOME/.bun/bin/bunx"
+              echo "baked runner repair: created missing bunx symlink"
+            fi
             echo "baked runner fast path: bun $baked_bun, lockfile $baked_lock, archive $baked_archive"
           else
             echo "baked runner stale (lock $baked_lock vs $checkout_lock, bun $baked_bun vs $checkout_bun, archive $baked_archive vs $checkout_archive); using full setup"

--- a/goals/ship-velocity/research/OPPORTUNITIES.md
+++ b/goals/ship-velocity/research/OPPORTUNITIES.md
@@ -36,3 +36,31 @@ session/machine ids.
   packages (@beep/ui, @beep/box, @beep/xai) in one run — the environmental native-compiler flake
   class, live receipt for the SPEC's TS2589 class-aware arbitration item; the verdict again
   surfaced the misattributed OSV hint alongside it.
+- `yeet status` on the metrics-baseline PR flagged `goals-doctor (baseline)` stale because
+  `goals/ship-velocity/PLAN.md` had a newer mtime than `goals/goals-doctor.baseline.jsonc`;
+  running the prescribed `beep goals doctor --write-baseline` produced zero content change —
+  the gate compares timestamps, not content, so any packet-doc edit forces a no-op regen step.
+  Prevention candidate: staleness gates on derived baselines should compare content hashes
+  (or the doctor's finding-key set) before prescribing a regen.
+- CORRECTED after an AWS-side audit (an earlier revision of this receipt called it a 2-day
+  fleet wedge — wrong): there was NO fleet outage 2026-08-14→16. It was ~5h of job-level flake
+  churn on 08-14 (Docgen silent-hang timeouts + genuine Coverage/TI reds → operator cancel
+  waves), then ~48h of ZERO workflow_job demand over the weekend (every webhook delivered 201,
+  every scale-up invocation succeeded, zero RunInstances because nothing was queued), with
+  stale cancelled/red check runs on PR pages reading as "queued for 2 days". Recovery was
+  plain operator re-runs on the unchanged old AMI. The real gap is observational: nothing
+  distinguishes "healthy scale-to-zero idle" from "starved", and stale PR check rows
+  masquerade as live state. Prevention: a queue-age probe (alarm only when a job is genuinely
+  queued beyond a bound — not when idle), and monitor `--summary` labeling check rows with
+  their run's age/attempt so a Friday red isn't read as a live Sunday hang. SPEC A1's watch
+  stream carries both.
+- Post-#718 baked-AMI activation broke every heavy lane in ~70s: the bake installs only the
+  `bun` binary from the release zip (`bun-linux-x64.zip` has no `bunx`; the official installer
+  creates that symlink, the bake never ran it), the setup action's baked fast path skips
+  oven-sh/setup-bun (which would have created it), and the CI CLI spawns `bunx turbo ...` →
+  ENOENT (main run 31968744160, all 5 heavy jobs; fleet-lane-probe 31969468654 caught it
+  within 2 minutes — the canary worked). The gap: the bake proved the `bun` binary but never
+  asserted the full spawn surface CI actually uses. Fixed by `ln -sfn bun .../bunx` +
+  `bunx --version` proof in the bake script and a self-heal in the fast path for
+  already-activated images. Pattern for A5/bake-style gates: verify the consumer's exact argv
+  surface, not the artifact's existence.

--- a/packages/tooling/tool/cli/src/commands/Runners/Runners.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Runners/Runners.service.ts
@@ -373,6 +373,9 @@ rm -rf /tmp/bun-linux-x64
 unzip -q /tmp/bun-linux-x64.zip -d /tmp/bun-linux-x64
 install -o ec2-user -g ec2-user -m 0755 \
   /tmp/bun-linux-x64/bun-linux-x64/bun /home/ec2-user/.bun/bin/bun
+ln -sfn bun /home/ec2-user/.bun/bin/bunx
+chown -h ec2-user:ec2-user /home/ec2-user/.bun/bin/bunx
+/home/ec2-user/.bun/bin/bunx --version
 rm -rf /tmp/bun-linux-x64 /tmp/bun-linux-x64.zip
 git clone --filter=blob:none ${BAKE_CLONE_URL} /tmp/beep-effect
 git -C /tmp/beep-effect checkout --detach ${inputs.gitRevision}

--- a/packages/tooling/tool/cli/test/runners-bake.test.ts
+++ b/packages/tooling/tool/cli/test/runners-bake.test.ts
@@ -672,6 +672,14 @@ describe("runner bake planning and argv", () => {
       script.indexOf("install -o ec2-user -g ec2-user -m 0755")
     );
     expect(script).not.toContain("bun.sh/install");
+    // The release zip ships only the bun binary; the bake must create the
+    // bunx symlink itself and prove it executes, or CI lanes spawning
+    // `bunx turbo` die with ENOENT on the baked image (main run 31968744160).
+    expect(script).toContain("ln -sfn bun /home/ec2-user/.bun/bin/bunx");
+    expect(script).toContain("/home/ec2-user/.bun/bin/bunx --version");
+    expect(script.indexOf("ln -sfn bun /home/ec2-user/.bun/bin/bunx")).toBeLessThan(
+      script.indexOf("git clone --filter=blob:none")
+    );
     expect(script).toContain("bun install --cwd /tmp/beep-effect --frozen-lockfile");
     expect(script).toContain("git -C /tmp/beep-effect checkout --detach 0123456789abcdef0123456789abcdef01234567");
     expect(script).toContain(`= "${digest}"`);


### PR DESCRIPTION
## fix(infra): bake and self-heal the bunx symlink on runner images

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_baked-ami-bunx-6b12933b8990/verdict.json

---

## Provenance

- Branch: <code>fix/baked-ami-bunx</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/baked-ami-bunx",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789503902&installation_model_id=424656&pr_number=725&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F725&signature=7912093d762401fcecfed095dbf8952d2ff32d16071085c635257fdf7a543275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->