### PR TITLE
feat(repo-cli): quarantine the ts2306 torn-read flake class in yeet monitor

### DIFF
--- a/.changeset/ts2306-flake-class.md
+++ b/.changeset/ts2306-flake-class.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-cli": patch
+---
+
+Add the ts2306-not-a-module torn-read fingerprint to the yeet monitor flake classes so the merge loop reruns it once per job per head SHA instead of reporting a code failure.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorLoop.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorLoop.ts
@@ -92,9 +92,14 @@ const mergeLoopPollInterval = Duration.seconds(30);
  * checker threads and tipping a near-ceiling package over the limit — it emits
  * `error TS2589` with no file location and never reproduces standalone.
  * `ci-timeout` is a heavy or property-based suite exceeding a runner limit that
- * it clears locally in seconds. The remaining three are shape classes shared
- * with the lane-timings collector and defined in `internal/github/JobShape`:
- * `setup-5xx`, `runner-loss`, and `install-failure`.
+ * it clears locally in seconds. `ts2306-not-a-module` is a torn cross-package
+ * read during concurrently scheduled builds — tsc resolves a sibling package's
+ * output mid-write and reports the source-mapped path as "not a module", with a
+ * cascade of downstream diagnostics; six occurrences across six runners all
+ * replayed green serially (main run 31968275700, PRs #720/#723, 2026-08-14/16).
+ * The remaining three are shape classes shared with the lane-timings collector
+ * and defined in `internal/github/JobShape`: `setup-5xx`, `runner-loss`, and
+ * `install-failure`.
  *
  * Anything outside this domain is a code failure by default. Widening it is a
  * decision, not a convenience: every member is a licence to spend a rerun.
@@ -113,6 +118,12 @@ const mergeLoopPollInterval = Duration.seconds(30);
  * SHA, after which the second occurrence reports `rerun-spent` and the operator
  * sees a real signal instead of a loop.
  *
+ * `ts2306-not-a-module` is admitted on the same population argument: a source
+ * file that genuinely exports nothing would match too, but it fails the rerun
+ * deterministically and surfaces as `rerun-spent`. The cascade that follows a
+ * torn read means the detector cannot demand "no other diagnostics" the way the
+ * TS2589 fingerprint does — the downstream errors are part of the signature.
+ *
  * **Example** (List the fingerprinted flake classes)
  *
  * ```ts
@@ -127,6 +138,7 @@ const mergeLoopPollInterval = Duration.seconds(30);
 export const YeetMonitorFlakeClass = LiteralKit([
   "ts2589-no-location",
   "ci-timeout",
+  "ts2306-not-a-module",
   "setup-5xx",
   "runner-loss",
   "install-failure",
@@ -186,6 +198,8 @@ const CI_TIMEOUT_PATTERNS: ReadonlyArray<RegExp> = [
   /timed out after \d+\s*(?:ms|s|m|seconds?|minutes?)/u,
 ];
 
+const TS2306_NOT_A_MODULE_PATTERN = /error TS2306: File '[^']+' is not a module/u;
+
 const stripGithubLogPrefix: (line: string) => string = flow(
   Str.replace(GITHUB_LOG_JOB_STEP_PREFIX_PATTERN, ""),
   Str.replace(GITHUB_LOG_TIMESTAMP_PATTERN, ""),
@@ -227,7 +241,11 @@ export const stripYeetMonitorLogDecoration = (log: string): string =>
  * The TS2589 arm delegates to the quality lane's
  * `detectNoLocationTs2589Flake`, so the strictness rules stay defined in one
  * place: every TS2589 line must be attributed to a Turbo task, no other TS
- * diagnostic may appear, and Turbo's `Failed:` footer must agree.
+ * diagnostic may appear, and Turbo's `Failed:` footer must agree. The TS2306
+ * arm matches the compiler's canonical "File '…' is not a module" line and
+ * deliberately tolerates surrounding diagnostics — a torn cross-package read
+ * cascades into hundreds of downstream errors, so their presence is part of
+ * the fingerprint, not a disqualifier.
  *
  * **Gotchas**
  *
@@ -254,8 +272,11 @@ export const detectYeetMonitorFlakeClass = (log: string): O.Option<YeetMonitorFl
   if (O.isSome(detectNoLocationTs2589Flake(normalized))) {
     return O.some(YeetMonitorFlakeClass.Enum["ts2589-no-location"]);
   }
-  return A.some(CI_TIMEOUT_PATTERNS, (pattern) => pattern.test(normalized))
-    ? O.some(YeetMonitorFlakeClass.Enum["ci-timeout"])
+  if (A.some(CI_TIMEOUT_PATTERNS, (pattern) => pattern.test(normalized))) {
+    return O.some(YeetMonitorFlakeClass.Enum["ci-timeout"]);
+  }
+  return TS2306_NOT_A_MODULE_PATTERN.test(normalized)
+    ? O.some(YeetMonitorFlakeClass.Enum["ts2306-not-a-module"])
     : O.none();
 };
 

--- a/packages/tooling/tool/cli/test/yeet-monitor-loop.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-monitor-loop.test.ts
@@ -61,6 +61,16 @@ const jobTimeoutLog = ghLog("Test Unit", "Complete job", [
 
 const cancelledSiblingLog = ghLog("Test Unit", "Run vitest", ["##[error]The operation was canceled."]);
 
+// Mirrors main Build job 95216658480 (2026-08-16): a torn cross-package read
+// under concurrent builds reports the source-mapped path as "not a module" and
+// cascades into downstream diagnostics; the cascade is part of the fingerprint.
+const ts2306TornReadLog = ghLog("Build", "Run bun run beep ci lane build", [
+  "##[error]../../foundation/modeling/schema/src/Cuid.ts(10,27): error TS2306: File '/opt/actions-runner/_work/beep-effect/beep-effect/packages/foundation/modeling/utils/src/DateTime.ts' is not a module.",
+  "##[error]../../foundation/modeling/schema/src/Cuid.ts(187,19): error TS377030: This has unknown in the requirements channel and unknown in the error channel which is not recommended.",
+  "##[error]command (/opt/actions-runner/_work/beep-effect/beep-effect/packages/ontology/config) /home/ec2-user/.bun/bin/bun run build exited (2)",
+  "Failed:    @beep/ontology-config#build",
+]);
+
 const failedJob = (databaseId: number, name: string, flakeClass: O.Option<YeetMonitorFlakeClass>) =>
   YeetMonitorFailedJob.make({ databaseId, name, flakeClass });
 
@@ -104,6 +114,10 @@ describe("yeet monitor flake fingerprints", () => {
     // A job cancelled because a sibling failed carries no timeout evidence;
     // classifying it would spend a rerun on a fail-fast side effect.
     expect(detectYeetMonitorFlakeClass(cancelledSiblingLog)).toStrictEqual(O.none());
+  });
+
+  it("recognizes the torn-read TS2306 signature despite its cascade", () => {
+    expect(detectYeetMonitorFlakeClass(ts2306TornReadLog)).toStrictEqual(O.some("ts2306-not-a-module"));
   });
 });
 
@@ -240,6 +254,7 @@ describe("yeet monitor job-shape fingerprints", () => {
     expect(YeetMonitorFlakeClass.Options).toStrictEqual([
       "ts2589-no-location",
       "ci-timeout",
+      "ts2306-not-a-module",
       "setup-5xx",
       "runner-loss",
       "install-failure",


### PR DESCRIPTION
## feat(repo-cli): quarantine the ts2306 torn-read flake class in yeet monitor

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_yeet-ts2306-flake-class-9ea413739b89/verdict.json

---

## Provenance

- Branch: <code>feat/yeet-ts2306-flake-class</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/yeet-ts2306-flake-class",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789505566&installation_model_id=424656&pr_number=726&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F726&signature=63dbb13495832cac05d91470df7388c8731b2a647d5dfbb9d1b0365286c3fb20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->