### PR TITLE
fix(build): drop stale tsconfig references outside the declared dep closure

### DIFF
--- a/.changeset/stale-tsconfig-references.md
+++ b/.changeset/stale-tsconfig-references.md
@@ -1,0 +1,8 @@
+---
+"@beep/epistemic-ui": patch
+"@beep/firecrawl": patch
+"@beep/ontology-ui": patch
+"@beep/shared-use-cases": patch
+---
+
+Drop tsconfig project references that point outside each package's declared dependency closure; an undeclared reference lets tsc -b span packages Turbo cannot order, which is the torn-read TS2306 race class.

--- a/packages/drivers/firecrawl/tsconfig.json
+++ b/packages/drivers/firecrawl/tsconfig.json
@@ -19,9 +19,6 @@
     },
     {
       "path": "../../tooling/test-kit/test-utils/tsconfig.json"
-    },
-    {
-      "path": "../../foundation/capability/observability/tsconfig.json"
     }
   ]
 }

--- a/packages/epistemic/ui/tsconfig.json
+++ b/packages/epistemic/ui/tsconfig.json
@@ -30,9 +30,6 @@
       "path": "../../foundation/modeling/provenance/tsconfig.json"
     },
     {
-      "path": "../config/tsconfig.json"
-    },
-    {
       "path": "../../foundation/modeling/utils/tsconfig.json"
     }
   ]

--- a/packages/ontology/ui/tsconfig.json
+++ b/packages/ontology/ui/tsconfig.json
@@ -25,12 +25,6 @@
     },
     {
       "path": "../use-cases/tsconfig.json"
-    },
-    {
-      "path": "../../foundation/modeling/lexical/tsconfig.json"
-    },
-    {
-      "path": "../../foundation/ui-system/editor/tsconfig.json"
     }
   ]
 }

--- a/packages/ontology/ui/tsconfig.test.json
+++ b/packages/ontology/ui/tsconfig.test.json
@@ -17,16 +17,10 @@
   },
   "references": [
     {
-      "path": "../../foundation/modeling/lexical/tsconfig.json"
-    },
-    {
       "path": "../../foundation/modeling/rdf/tsconfig.json"
     },
     {
       "path": "../../foundation/modeling/utils/tsconfig.json"
-    },
-    {
-      "path": "../../foundation/ui-system/editor/tsconfig.json"
     },
     {
       "path": "../../foundation/ui-system/ui/tsconfig.json"

--- a/packages/shared/use-cases/tsconfig.json
+++ b/packages/shared/use-cases/tsconfig.json
@@ -16,9 +16,6 @@
     },
     {
       "path": "../../tooling/test-kit/test-utils/tsconfig.json"
-    },
-    {
-      "path": "../domain/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
## fix(build): drop stale tsconfig references outside the declared dep closure

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_stale-tsconfig-references-ef59b62638a9/verdict.json

---

## Provenance

- Branch: <code>fix/stale-tsconfig-references</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/stale-tsconfig-references",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789506699&installation_model_id=424656&pr_number=728&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F728&signature=3ed4a0af9630a09b4e8198df8cc890e6b4ea64c34c17cb70b7725bc004b46b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->