### PR TITLE
chore(ci): fetch blobless full-history checkouts in check.yml lanes

### DIFF
--- a/.changeset/ci-blobless-checkouts.md
+++ b/.changeset/ci-blobless-checkouts.md
@@ -1,0 +1,8 @@
+---
+{}
+---
+
+No release: full-history CI checkouts in check.yml now use `filter: blob:none`
+so lanes stop downloading ~1.4GB of historical pack data per job. The
+`secrets` (gitleaks-in-docker) lane keeps a full clone until the blobless
+posture is proven green elsewhere.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -147,6 +147,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: Fetch pull request base
@@ -396,6 +397,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: Fetch pull request base
@@ -567,6 +569,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: Setup monorepo CI
@@ -590,6 +593,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: Setup monorepo CI
@@ -639,6 +643,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: Setup monorepo CI
@@ -665,6 +670,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: Determine commit range
@@ -785,6 +791,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: OSV vulnerability scan
@@ -913,6 +920,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: false
 
       - name: Fetch pull request base


### PR DESCRIPTION
## What

Adds `filter: blob:none` to the eight `fetch-depth: 0` checkouts in check.yml (verify,
property-laws, knip, jsdoc-ratchet, build, commitlint, security, sast). The `secrets`
lane keeps a full clone for now.

## Why

The repository pack is ~1.4GB, and every full-history lane re-downloads it per job — a
dozen-plus times per PR run. History use in these lanes is name-only diffs
(`git diff --name-only base...HEAD`), commit-message reads (commitlint), and base-ref
config reads (`git show base:file`) — all tree/commit-metadata operations that a blobless
clone serves without fetching historical file contents. Checkout still materializes the
working tree for HEAD, so build/test behavior is unchanged.

## Why secrets is excluded

Gitleaks runs inside docker with `persist-credentials: false`; a scan over
`--log-opts base..HEAD` reads historical blobs, and an in-container lazy blob fetch has
no credentials to fetch with. That lane flips in a follow-up once the blobless posture
is proven green on these eight.

Full local yeet proof green (`chore_ci-blobless-checkouts-1109fd7f6188`, all lanes success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vDMsxcAXFJ3gQMt1FF42H

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789545958&installation_model_id=424656&pr_number=740&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F740&signature=81cae0b068ff88f39f6e3f62f83af567781164add376eafad13036173c1c3efb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->