### PR TITLE
fix(repo-cli): pin git archive to canonical LF bytes

### DIFF
--- a/.changeset/git-archive-canonical-bytes.md
+++ b/.changeset/git-archive-canonical-bytes.md
@@ -2,10 +2,15 @@
 "@beep/repo-cli": patch
 ---
 
-Pin `git archive` to the repository's canonical LF bytes. `.gitattributes` declares `* text=auto` and
-Git children inherit the ambient environment, so a contributor carrying `core.autocrlf=true` archived
-different bytes than CI for byte-identical objects. The knowledge semantic-delta compares those bytes
-exactly, so such a host reported a standing `index-drift` finding on `goals/INDEX.md` whose
-remediation (`beep goals index --write`) could never clear it. `writeGitArchive` now leads its
-argument vector with `-c core.autocrlf=false -c core.eol=lf`, and the vector is a pure exported value
-so the contract is asserted without spawning a process.
+Pin `git archive` to the repository's canonical bytes. `.gitattributes` declares `* text=auto` and
+Git children inherit the ambient environment, so a contributor's host state archived different bytes
+than CI for byte-identical objects: `core.autocrlf=true` rewrote line endings, a global attributes
+file (`$XDG_CONFIG_HOME/git/attributes` or a config-named `core.attributesFile`) attaching
+`eol=crlf` overrode even explicit `-c core.eol=lf`, and ambient `tar.umask` rewrote tar header mode
+bits. The knowledge semantic-delta compares archive bytes exactly, so such hosts reported a standing
+`index-drift` finding on `goals/INDEX.md` whose remediation (`beep goals index --write`) could never
+clear it. `writeGitArchive` now leads its argument vector with `-c core.autocrlf=false
+-c core.eol=lf -c core.attributesFile=/dev/null -c tar.umask=0002` and spawns with
+`GIT_ATTR_NOSYSTEM=1` (the one attribute layer without a `-c` override); both the vector and the env
+are pure exported values (`gitArchiveArgs`, `gitArchiveEnv`) so the contract is unit-asserted, and a
+hostile-profile differential test proves each profile live with a negative-control witness.

--- a/.changeset/git-archive-canonical-bytes.md
+++ b/.changeset/git-archive-canonical-bytes.md
@@ -1,0 +1,11 @@
+---
+"@beep/repo-cli": patch
+---
+
+Pin `git archive` to the repository's canonical LF bytes. `.gitattributes` declares `* text=auto` and
+Git children inherit the ambient environment, so a contributor carrying `core.autocrlf=true` archived
+different bytes than CI for byte-identical objects. The knowledge semantic-delta compares those bytes
+exactly, so such a host reported a standing `index-drift` finding on `goals/INDEX.md` whose
+remediation (`beep goals index --write`) could never clear it. `writeGitArchive` now leads its
+argument vector with `-c core.autocrlf=false -c core.eol=lf`, and the vector is a pure exported value
+so the contract is asserted without spawning a process.

--- a/goals/knowledge-surface-automation/ops/manifest.json
+++ b/goals/knowledge-surface-automation/ops/manifest.json
@@ -55,7 +55,8 @@
     "research/p1-fp-eyeball-verdicts.md",
     "research/p1-t2-mini-grill-decisions.md",
     "research/p1-report-refs-tree.md",
-    "research/p3-report-refs-rewrite.md"
+    "research/p3-report-refs-rewrite.md",
+    "research/p3-hermetic-lane-design.md"
   ],
   "agentLaunchers": [
     {

--- a/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
+++ b/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
@@ -235,3 +235,33 @@ measurement first). Reviewed at each grill.
     packages' coverage ratchet (it already knows the affected owners), or the
     verdict naming `Coverage Regression` as a known hosted-only gate so the
     "green local means green CI" contract carries its own exception list.
+
+17. **The proof pipeline's own archive bytes were host-dependent.** `fixed-in-pr`
+
+    Found while scoping P3's hermetic lane. `.gitattributes` declares
+    `* text=auto` and Git children inherit the ambient environment, so
+    `git archive` applied the *host's* end-of-line configuration to a commit's
+    text blobs. Reproduced read-only on this tree — the same commit, the same
+    path, three digests:
+
+    ```
+    git archive --format=tar HEAD -- goals/INDEX.md        -> bdd6752319d881d6…
+    git -c core.autocrlf=true archive … goals/INDEX.md     -> 985569dede0df9fe…
+    git -c core.eol=crlf     archive … goals/INDEX.md      -> 985569dede0df9fe…
+    ```
+
+    Semantic-delta compares archived bytes to the in-process index projection
+    with an exact `S.toEquivalence(S.Uint8Array)`, so a host carrying
+    `core.autocrlf=true` reported a standing `index-drift` on `goals/INDEX.md`
+    whose remediation (`beep goals index --write`) regenerates LF and can never
+    clear it. **Measured blast radius, both directions:** the finding fires in
+    the base *and* the HEAD archive, so the delta cancels it into `unchanged`
+    (497 → 496 with the fix) and it never reaches `introduced`. It is standing
+    noise and a misleading finding, not a red required lane — the stronger
+    claim was checked and did not hold.
+
+    **What would have prevented it:** treating "bytes a gate compares" as a
+    determinism contract with its config pinned at the call site, the way
+    `makeHermeticEnv` already pins the probe children's environment. The lane
+    that would have caught it is exactly the P3 residue, which is why the
+    hermetic lane's assertion is worth reframing (see the P3 report).

--- a/goals/knowledge-surface-automation/research/p3-hermetic-lane-design.md
+++ b/goals/knowledge-surface-automation/research/p3-hermetic-lane-design.md
@@ -78,6 +78,22 @@ Fixed here by leading the archive vector with
 `-c core.autocrlf=false -c core.eol=lf`, kept as the pure exported
 `gitArchiveArgs` so the contract is asserted without spawning a process.
 
+**Review-round addendum (2026-08-17).** PR #741 review proved the same class has
+three sibling vectors the EOL pins alone do not close: a global attributes file
+(`$XDG_CONFIG_HOME/git/attributes`, applying even under `GIT_CONFIG_GLOBAL=/dev/null`,
+or a config-named `core.attributesFile`) attaching `eol=crlf` overrides `-c core.eol`
+at attribute precedence; ambient `tar.umask` rewrites tar header mode bits; and the
+system attributes file has no `-c` override at all. The shipped fix is therefore four
+pins (`core.autocrlf`, `core.eol`, `core.attributesFile=/dev/null`, `tar.umask=0002`)
+plus `GIT_ATTR_NOSYSTEM=1` in the spawn env (exported as `gitArchiveEnv`, also folded
+into `makeHermeticEnv`), each hostile profile gated by a differential test carrying a
+negative-control witness. Measured residual: clone-local `.git/info/attributes`
+outranks every layer and **no invocation can disable it** (`core.attributesFile=/dev/null`,
+`--attr-source=HEAD`, `GIT_ATTR_SOURCE`, `-c attr.tree=HEAD`, and `GIT_ATTR_NOSYSTEM`
+all fail to suppress it, measured against git 2.55.0). It is absent from fresh clones;
+if it must be guarded, stat `git rev-parse --git-path info/attributes` and fail with a
+remediation — a candidate for the ratified witness-test follow-up, option (b)'s heir.
+
 ## Why this is a stop, not a redesign
 
 The useful lane inverts the ratified sentence. As specced it asks "does the

--- a/goals/knowledge-surface-automation/research/p3-hermetic-lane-design.md
+++ b/goals/knowledge-surface-automation/research/p3-hermetic-lane-design.md
@@ -1,0 +1,114 @@
+# P3 report — the hermetic lane is vacuous as specced; one real defect found
+
+Scoping the last open P3 item, executed 2026-08-17 on branch
+`feat/knowledge-hermetic-clone-lane`. SPEC Workstream A ratifies:
+
+> Hermetic proof: clean-clone lane with emptied `$HOME`; plus an optional
+> scheduled ASLR torture variant (randomized clone depth, spaced/Unicode
+> directory names, read-only home) to flush hidden base-address assumptions.
+
+Two independent design passes reached the same conclusion, and the load-bearing
+claims were re-verified by hand before this was written. **The lane as worded
+cannot fail.** A separate, real determinism defect was found while proving that,
+and is fixed in this PR.
+
+## Why the specced lane is vacuous
+
+Three of its four controls remove state nothing reads.
+
+1. **Emptied `$HOME` — vacuous.** The Knowledge path reads exactly one
+   environment input, `resolveKnowledgeProbePolicy(process.env)`
+   (`Knowledge.service.ts:1383`), keyed on `GITHUB_*`. No `os.homedir`, no
+   `XDG_*`, no network, no locale. The only children that could care — the three
+   semantic-delta probes — already run under `makeHermeticEnv`
+   (`Knowledge.service.ts:963-986`, applied at `:1039`), which synthesizes
+   `HOME`, all five XDG dirs and `TMPDIR`, and sets `GIT_CONFIG_GLOBAL=/dev/null`
+   plus `GIT_CONFIG_NOSYSTEM=1`. The lane would be *weaker* than what already
+   runs.
+2. **Clean clone — vacuous for corpus content.** Both commands read the object
+   database, never the working tree (`git archive --format=tar`,
+   `git ls-tree -r -z --full-tree`). Content addressing guarantees any clone
+   holding the commit yields identical objects.
+3. **"No `bun install`" — vacuous and unreachable.** `bun run beep` is
+   `bun run packages/tooling/tool/cli/src/bin.ts`, and the Knowledge module
+   imports `effect` and `tar` at module scope. Without `node_modules` the CLI
+   never boots, so the control only re-proves that Bun needs an install.
+
+The fourth control — **spaced/Unicode paths** — is genuinely non-vacuous and
+unproven: the probes emit `import … from "<absolute path into the checkout>"`
+(`Knowledge.service.ts:1182/1204/1225`), and `POSIX_ABSOLUTE_PATH_PATTERN`
+(`:103`) is ASCII-only, so a non-ASCII absolute path in probe stderr redacts
+only partially. "Randomized clone depth" is not vacuous either, but it
+rediscovers a contract the code already documents (`KNOWLEDGE_HISTORY_REMEDIATION`,
+`Knowledge.errors.ts:42`), at CI cost.
+
+## The defect the scoping found
+
+`.gitattributes` declares `* text=auto`, and Git children inherit the ambient
+environment — `writeGitArchive` passed no config hardening. So `git archive`
+applied the *host's* end-of-line configuration. Same commit, same path, three
+digests, reproduced read-only:
+
+```
+git archive --format=tar HEAD -- goals/INDEX.md        -> bdd6752319d881d6…
+git -c core.autocrlf=true archive … goals/INDEX.md     -> 985569dede0df9fe…
+git -c core.eol=crlf     archive … goals/INDEX.md      -> 985569dede0df9fe…
+```
+
+Semantic-delta compares archived bytes against the in-process index projection
+with an exact `S.toEquivalence(S.Uint8Array)` (`Knowledge.service.ts:107`, used
+at `:551`), so a host carrying `core.autocrlf=true` reported an `index-drift` on
+`goals/INDEX.md` whose remediation regenerates LF and can never clear it.
+
+**Blast radius, measured in both directions rather than assumed.** Running
+`semantic-delta` under a synthetic hostile `GIT_CONFIG_GLOBAL`:
+
+| | `index-drift` | `unchanged` | exit |
+| --- | --- | --- | --- |
+| before the fix | present on `goals/INDEX.md` | 497 | 0 |
+| after the fix | none | 496 | 0 |
+
+The finding fires in the base *and* the HEAD archive, so the delta cancels it
+into `unchanged`; it never reaches `introduced` and never reddens the required
+Lint Policy lane. The first design pass claimed it did — that stronger claim was
+checked and did not hold. It is standing noise plus a misleading finding, which
+is worth removing but is not an incident.
+
+Fixed here by leading the archive vector with
+`-c core.autocrlf=false -c core.eol=lf`, kept as the pure exported
+`gitArchiveArgs` so the contract is asserted without spawning a process.
+
+## Why this is a stop, not a redesign
+
+The useful lane inverts the ratified sentence. As specced it asks "does the
+command exit 0 under an *emptied* environment", whose answer is fixed by
+construction. The version that bites asks "is the machine-readable verdict
+byte-identical under a *hostile* environment" — and an emptied `$HOME`
+structurally hides exactly the defect above, because it removes the hostile
+config instead of confronting it.
+
+That is a change to ratified doctrine, so manifest stop condition 7 applies:
+
+> A ratified decision … would need reopening.
+
+Per GOAL.md ("Ratified decisions in SPEC.md are closed — do not reopen them")
+this stops here and reports rather than shipping a redesign.
+
+## The options, for the grill
+
+- **(a) Ship the specced lane anyway.** Honest cost: a permanently green job.
+  Documents intent, proves nothing, and its inertness is invisible.
+- **(b) Reframe as a determinism differential.** Run the shipped commands under
+  declared hostile profiles (`autocrlf` host config, spaced/Unicode clone path,
+  read-only home) and assert the report digest is byte-identical to the
+  canonical baseline. Non-vacuous, and it would have caught the defect above.
+  Requires reopening the SPEC sentence.
+- **(c) Drop the lane, keep the hardening.** Record that `makeHermeticEnv` plus
+  per-call-site config pinning already deliver the hermetic *property*, and
+  close P3 without a lane.
+
+If (b) is chosen, the design must carry a **negative control**: each hostile
+profile declares a witness — an unhardened control whose output must differ from
+the baseline. If the witness stops firing, the profile has gone inert and the
+lane must fail with "profile inert" rather than pass. Without that witness the
+reframed lane rots back into the vacuity it was built to escape.

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
@@ -19,6 +19,7 @@ import * as S from "effect/Schema";
 import { extract as extractTar } from "tar";
 import { OutputBound, runCapturedStreams } from "../../internal/process/StepExec.ts";
 import {
+  gitArchiveEnv,
   readGitRenames,
   readGitTree,
   resolveGitCommit,
@@ -980,6 +981,7 @@ const makeHermeticEnv = Effect.fn("Knowledge.makeHermeticEnv")(function* (scratc
   }
   return {
     ...directories,
+    ...gitArchiveEnv,
     GIT_CONFIG_GLOBAL: "/dev/null",
     GIT_CONFIG_NOSYSTEM: "1",
   };

--- a/packages/tooling/tool/cli/src/internal/repo-run/GitExec.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/GitExec.ts
@@ -21,6 +21,7 @@ import { isOptionLike } from "@beep/repo-utils";
 import { NonNegativeInt } from "@beep/schema";
 import { Effect, flow, Number as N, Order, pipe } from "effect";
 import * as A from "effect/Array";
+import { dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
@@ -529,6 +530,60 @@ export const resolveGitMergeBase = Effect.fn("GitExec.resolveGitMergeBase")(func
   return yield* runGitStructured(["merge-base", "--", leftRef, rightRef], adapter, structuredCapture(cwd));
 });
 
+/**
+ * Config flags pinning archive bytes to the repository's canonical LF form.
+ *
+ * **Details**
+ *
+ * `.gitattributes` declares `* text=auto`, so `git archive` applies the *host's* end-of-line
+ * configuration when it materializes text blobs. Git children inherit the ambient environment, so a
+ * contributor with `core.autocrlf=true` (the Windows default) produces different archive bytes than
+ * CI for byte-identical objects. Every consumer that compares those bytes exactly then reports drift
+ * that no source edit can clear. Pinning both keys per invocation keeps one archive canonical
+ * without disturbing the ambient config the other Git children legitimately read.
+ *
+ * @category execution
+ * @since 0.0.0
+ */
+const CANONICAL_ARCHIVE_CONFIG: ReadonlyArray<string> = ["-c", "core.autocrlf=false", "-c", "core.eol=lf"];
+
+/**
+ * Argument vector writing one commit's canonical tar archive.
+ *
+ * **Details**
+ *
+ * The end-of-line overrides lead the vector because Git only honours `-c` before the subcommand.
+ * Keeping the vector a pure value lets the byte-canonicality contract be asserted without spawning
+ * a process.
+ *
+ * **Example** (The overrides lead the subcommand)
+ *
+ * ```ts
+ * import { gitArchiveArgs } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(gitArchiveArgs("/tmp/base.tar", "HEAD")[0]) // "-c"
+ * ```
+ *
+ * @param archivePath - Absolute path the tar is written to.
+ * @param commit - Commit-ish whose tree is archived.
+ * @returns The full `git` argument vector, end-of-line overrides first.
+ * @category execution
+ * @since 0.0.0
+ */
+export const gitArchiveArgs: {
+  (archivePath: string, commit: string): ReadonlyArray<string>;
+  (commit: string): (archivePath: string) => ReadonlyArray<string>;
+} = dual(
+  2,
+  (archivePath: string, commit: string): ReadonlyArray<string> => [
+    ...CANONICAL_ARCHIVE_CONFIG,
+    "archive",
+    "--format=tar",
+    `--output=${archivePath}`,
+    commit,
+  ]
+);
+
 /** Write one verified commit as a tar archive. @category execution @since 0.0.0 */
 export const writeGitArchive = Effect.fn("GitExec.writeGitArchive")(function* <E>(
   cwd: string,
@@ -536,7 +591,7 @@ export const writeGitArchive = Effect.fn("GitExec.writeGitArchive")(function* <E
   archivePath: string,
   adapter: GitCommandErrorAdapter<E>
 ): Effect.fn.Return<void, E, ChildProcessSpawner.ChildProcessSpawner> {
-  yield* runGitRawOutput(cwd, ["archive", "--format=tar", `--output=${archivePath}`, commit], adapter);
+  yield* runGitRawOutput(cwd, gitArchiveArgs(archivePath, commit), adapter);
 });
 
 /** Read and strictly parse one recursive full Git tree. @category execution @since 0.0.0 */

--- a/packages/tooling/tool/cli/src/internal/repo-run/GitExec.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/GitExec.ts
@@ -531,30 +531,69 @@ export const resolveGitMergeBase = Effect.fn("GitExec.resolveGitMergeBase")(func
 });
 
 /**
- * Config flags pinning archive bytes to the repository's canonical LF form.
+ * Config flags pinning archive bytes to the repository's canonical form.
  *
  * **Details**
  *
- * `.gitattributes` declares `* text=auto`, so `git archive` applies the *host's* end-of-line
- * configuration when it materializes text blobs. Git children inherit the ambient environment, so a
- * contributor with `core.autocrlf=true` (the Windows default) produces different archive bytes than
- * CI for byte-identical objects. Every consumer that compares those bytes exactly then reports drift
- * that no source edit can clear. Pinning both keys per invocation keeps one archive canonical
- * without disturbing the ambient config the other Git children legitimately read.
+ * `git archive` consults ambient host state that silently changes the bytes it emits for
+ * byte-identical objects. End-of-line config (`core.autocrlf`, `core.eol`) rewrites text blobs
+ * declared `* text=auto`; the global attributes file (`core.attributesFile`, defaulting to
+ * `$XDG_CONFIG_HOME/git/attributes` even when no config names it) can attach `eol=crlf` to paths,
+ * and an attribute-level `eol` overrides both config keys; `tar.umask` rewrites tar header mode
+ * bits. Every consumer that compares archive bytes exactly then reports drift no source edit can
+ * clear. Pinning all four keys per invocation keeps one archive canonical without disturbing the
+ * ambient config other Git children legitimately read: `-c` outranks every config file, and a set
+ * `core.attributesFile` replaces the entire global attributes layer, XDG default path included.
+ * `tar.umask=0002` restates Git's own default (entry modes 664/775), so the pin is byte-neutral on
+ * clean hosts. The system attributes file has no `-c` escape hatch; {@link gitArchiveEnv} closes it.
  *
  * @category execution
  * @since 0.0.0
  */
-const CANONICAL_ARCHIVE_CONFIG: ReadonlyArray<string> = ["-c", "core.autocrlf=false", "-c", "core.eol=lf"];
+const CANONICAL_ARCHIVE_CONFIG: ReadonlyArray<string> = [
+  "-c",
+  "core.autocrlf=false",
+  "-c",
+  "core.eol=lf",
+  "-c",
+  "core.attributesFile=/dev/null",
+  "-c",
+  "tar.umask=0002",
+];
+
+/**
+ * Environment overrides completing the archive byte-canonicality contract.
+ *
+ * **Details**
+ *
+ * The system-level attributes file (`$(prefix)/etc/gitattributes`) is the one attribute layer
+ * without a `-c` override, so it is disabled through the environment. The archive spawn extends the
+ * ambient environment with these pairs rather than replacing it, so `PATH` resolution and
+ * credential helpers keep working. Clone-local `.git/info/attributes` outranks every layer and no
+ * invocation can disable it; it is absent from fresh clones and outside this contract.
+ *
+ * **Example** (The env pairs with the argument vector)
+ *
+ * ```ts
+ * import { gitArchiveEnv } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(gitArchiveEnv.GIT_ATTR_NOSYSTEM) // "1"
+ * ```
+ *
+ * @category execution
+ * @since 0.0.0
+ */
+export const gitArchiveEnv: { readonly GIT_ATTR_NOSYSTEM: "1" } = { GIT_ATTR_NOSYSTEM: "1" };
 
 /**
  * Argument vector writing one commit's canonical tar archive.
  *
  * **Details**
  *
- * The end-of-line overrides lead the vector because Git only honours `-c` before the subcommand.
+ * The canonicality overrides lead the vector because Git only honours `-c` before the subcommand.
  * Keeping the vector a pure value lets the byte-canonicality contract be asserted without spawning
- * a process.
+ * a process. The vector pairs with {@link gitArchiveEnv}, which covers the one layer `-c` cannot
+ * reach.
  *
  * **Example** (The overrides lead the subcommand)
  *
@@ -584,14 +623,19 @@ export const gitArchiveArgs: {
   ]
 );
 
-/** Write one verified commit as a tar archive. @category execution @since 0.0.0 */
+/** Write one verified commit as a tar archive under the canonical byte contract. @category execution @since 0.0.0 */
 export const writeGitArchive = Effect.fn("GitExec.writeGitArchive")(function* <E>(
   cwd: string,
   commit: string,
   archivePath: string,
   adapter: GitCommandErrorAdapter<E>
 ): Effect.fn.Return<void, E, ChildProcessSpawner.ChildProcessSpawner> {
-  yield* runGitRawOutput(cwd, gitArchiveArgs(archivePath, commit), adapter);
+  yield* runGitStructured(gitArchiveArgs(archivePath, commit), adapter, {
+    cwd,
+    stdin: "ignore",
+    env: gitArchiveEnv,
+    extendEnv: true,
+  });
 });
 
 /** Read and strictly parse one recursive full Git tree. @category execution @since 0.0.0 */

--- a/packages/tooling/tool/cli/test/step-git-exec.test.ts
+++ b/packages/tooling/tool/cli/test/step-git-exec.test.ts
@@ -11,18 +11,23 @@ import {
 } from "@beep/repo-cli/test/Process";
 import {
   gitArchiveArgs,
+  gitArchiveEnv,
   gitLinesFromOutput,
   gitPathListFromNulOutput,
   isSafeOriginBranch,
   originBranchFromBase,
   safeOriginBranchFromBase,
   sortedUniquePaths,
+  writeGitArchive,
 } from "@beep/repo-cli/test/RepoRun";
+import { provideScopedLayer } from "@beep/test-utils";
 import { Str } from "@beep/utils";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it, layer } from "@effect/vitest";
-import { Effect, Stream } from "effect";
+import { Effect, FileSystem, Layer, Path, Ref, Sink, Stream } from "effect";
+import * as A from "effect/Array";
 import * as O from "effect/Option";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
 
@@ -142,16 +147,22 @@ describe("GitExec origin-branch refname safety", () => {
 });
 
 // `.gitattributes` declares `* text=auto`, so an archive written on a host carrying
-// `core.autocrlf=true` differs byte-for-byte from the same commit archived on CI. Consumers that
-// compare those bytes exactly (the knowledge semantic-delta index-drift finding) then report drift
-// no source edit can clear, so the overrides are part of the archive's contract, not a preference.
+// `core.autocrlf=true` differs byte-for-byte from the same commit archived on CI — and a global
+// attributes file attaching `eol=crlf` overrides both `-c core.eol` and `-c core.autocrlf`, while
+// ambient `tar.umask` rewrites tar header mode bits. Consumers that compare those bytes exactly
+// (the knowledge semantic-delta index-drift finding) then report drift no source edit can clear,
+// so the overrides are part of the archive's contract, not a preference.
 describe("GitExec archive byte canonicality", () => {
-  it("pins end-of-line handling ahead of the archive subcommand", () => {
+  it("pins end-of-line, attribute-file, and umask handling ahead of the archive subcommand", () => {
     expect(gitArchiveArgs("/tmp/base.tar", "HEAD")).toEqual([
       "-c",
       "core.autocrlf=false",
       "-c",
       "core.eol=lf",
+      "-c",
+      "core.attributesFile=/dev/null",
+      "-c",
+      "tar.umask=0002",
       "archive",
       "--format=tar",
       "--output=/tmp/base.tar",
@@ -159,8 +170,167 @@ describe("GitExec archive byte canonicality", () => {
     ]);
   });
 
+  it("pins the system-attribute escape hatch in the archive environment", () => {
+    expect(gitArchiveEnv).toStrictEqual({ GIT_ATTR_NOSYSTEM: "1" });
+  });
+
   it("passes a spaced and non-ASCII archive path through unquoted", () => {
     const archivePath = "/tmp/beep qa/ünicode/base.tar";
     expect(gitArchiveArgs(archivePath, "deadbeef")).toContain(`--output=${archivePath}`);
   });
+});
+
+describe("GitExec archive spawn wiring", () => {
+  const emptyHandle = ChildProcessSpawner.makeHandle({
+    all: Stream.empty,
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    pid: ChildProcessSpawner.ProcessId(1),
+    stderr: Stream.empty,
+    stdin: Sink.drain,
+    stdout: Stream.empty,
+    unref: Effect.succeed(Effect.void),
+  });
+
+  const adapter = {
+    onSpawnFailure: (commandLine: string) => (cause: unknown) => new Error(`${commandLine}: ${String(cause)}`),
+    onNonZeroExit: (failure: { readonly commandLine: string; readonly exitCode: number; readonly output: string }) =>
+      new Error(`${failure.commandLine} exit ${failure.exitCode}`),
+    onTruncated: O.none(),
+  };
+
+  it.effect(
+    "sends the canonical vector, the attribute-isolation env, and extendEnv on the archive spawn",
+    Effect.fnUntraced(function* () {
+      type SpawnFacts = {
+        readonly args: ReadonlyArray<string>;
+        readonly env: Record<string, string | undefined> | undefined;
+        readonly extendEnv: boolean | undefined;
+      };
+      const captured = yield* Ref.make<ReadonlyArray<SpawnFacts>>([]);
+      const spawner = ChildProcessSpawner.make((command) => {
+        if (!ChildProcess.isStandardCommand(command)) {
+          return Effect.die("the archive writer never spawns a piped command");
+        }
+        return Ref.update(
+          captured,
+          A.append({ args: command.args, env: command.options.env, extendEnv: command.options.extendEnv })
+        ).pipe(Effect.as(emptyHandle));
+      });
+
+      yield* writeGitArchive("/repo", "deadbeef", "/tmp/out.tar", adapter).pipe(
+        provideScopedLayer(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner))
+      );
+
+      const calls = yield* Ref.get(captured);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.args).toEqual(gitArchiveArgs("/tmp/out.tar", "deadbeef"));
+      expect(calls[0]?.env).toStrictEqual(gitArchiveEnv);
+      expect(calls[0]?.extendEnv).toBe(true);
+    })
+  );
+});
+
+// Each hostile profile is proven live by a negative-control witness: the unpinned vector must
+// produce different bytes under the profile, or the profile has gone inert and the assertion on the
+// pinned vector proves nothing. Verified empirically for PR #741: an attributes-file `eol=crlf`
+// beats `-c core.eol`, and `tar.umask` rewrites header modes.
+layer(NodeServices.layer)("GitExec archive hostile-profile canonicality", (it) => {
+  const runGit = (cwd: string, args: ReadonlyArray<string>, env: Record<string, string>): void => {
+    const result = Bun.spawnSync(["git", ...args], { cwd, env, stderr: "pipe", stdout: "pipe" });
+    if (result.exitCode !== 0) {
+      throw new Error(`git ${A.join(args, " ")} failed: ${result.stderr.toString()}`);
+    }
+  };
+
+  it.effect(
+    "emits canonical bytes under hostile attribute and umask profiles, each proven live by a witness",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tmpDir = yield* fs.makeTempDirectory();
+
+      const body = Effect.gen(function* () {
+        const repoDir = path.join(tmpDir, "repo");
+        const hostileXdg = path.join(tmpDir, "xdg-hostile");
+        const cleanXdg = path.join(tmpDir, "xdg-clean");
+        const home = path.join(tmpDir, "home");
+        const umaskConfig = path.join(tmpDir, "umask.gitconfig");
+        yield* fs.makeDirectory(repoDir, { recursive: true });
+        yield* fs.makeDirectory(path.join(hostileXdg, "git"), { recursive: true });
+        yield* fs.makeDirectory(cleanXdg, { recursive: true });
+        yield* fs.makeDirectory(home, { recursive: true });
+        yield* fs.writeFileString(path.join(hostileXdg, "git", "attributes"), "*.md eol=crlf\n");
+        yield* fs.writeFileString(umaskConfig, "[tar]\n\tumask = 077\n");
+
+        const envWith = (overrides: Record<string, string>): Record<string, string> => ({
+          // `Bun.env` is the same live object the default ConfigProvider reads; using it keeps the
+          // spawn seed out of `process.env` (effect/processEnv) without changing behaviour.
+          PATH: Bun.env.PATH ?? "",
+          HOME: home,
+          XDG_CONFIG_HOME: cleanXdg,
+          GIT_CONFIG_GLOBAL: "/dev/null",
+          GIT_CONFIG_NOSYSTEM: "1",
+          ...overrides,
+        });
+
+        const seedEnv = envWith({});
+        yield* Effect.sync(() => {
+          runGit(repoDir, ["init", "-b", "main"], seedEnv);
+          runGit(repoDir, ["config", "user.email", "archive@example.test"], seedEnv);
+          runGit(repoDir, ["config", "user.name", "Archive Test"], seedEnv);
+        });
+        yield* fs.writeFileString(path.join(repoDir, ".gitattributes"), "* text=auto\n");
+        yield* fs.writeFileString(path.join(repoDir, "doc.md"), "one\ntwo\nthree\n");
+        yield* Effect.sync(() => {
+          runGit(repoDir, ["add", "."], seedEnv);
+          runGit(repoDir, ["commit", "-m", "seed"], seedEnv);
+        });
+
+        const unpinnedArgs = (out: string): ReadonlyArray<string> => [
+          "archive",
+          "--format=tar",
+          `--output=${out}`,
+          "HEAD",
+        ];
+        const archiveBytes = Effect.fnUntraced(function* (
+          name: string,
+          argsFor: (out: string) => ReadonlyArray<string>,
+          env: Record<string, string>
+        ) {
+          const out = path.join(tmpDir, name);
+          yield* Effect.sync(() => runGit(repoDir, argsFor(out), env));
+          return yield* fs.readFile(out);
+        });
+        const pinnedArgs = (out: string): ReadonlyArray<string> => gitArchiveArgs(out, "HEAD");
+
+        const canonical = yield* archiveBytes("clean.tar", pinnedArgs, envWith({ ...gitArchiveEnv }));
+
+        const attrEnv = { XDG_CONFIG_HOME: hostileXdg };
+        const attrPinned = yield* archiveBytes(
+          "attr-pinned.tar",
+          pinnedArgs,
+          envWith({ ...attrEnv, ...gitArchiveEnv })
+        );
+        const attrWitness = yield* archiveBytes("attr-witness.tar", unpinnedArgs, envWith(attrEnv));
+        expect(attrPinned).toStrictEqual(canonical);
+        expect(attrWitness).not.toStrictEqual(canonical);
+
+        const umaskEnv = { GIT_CONFIG_GLOBAL: umaskConfig };
+        const umaskPinned = yield* archiveBytes(
+          "umask-pinned.tar",
+          pinnedArgs,
+          envWith({ ...umaskEnv, ...gitArchiveEnv })
+        );
+        const umaskWitness = yield* archiveBytes("umask-witness.tar", unpinnedArgs, envWith(umaskEnv));
+        expect(umaskPinned).toStrictEqual(canonical);
+        expect(umaskWitness).not.toStrictEqual(canonical);
+      });
+
+      yield* body.pipe(Effect.ensuring(fs.remove(tmpDir, { recursive: true }).pipe(Effect.ignore)));
+    })
+  );
 });

--- a/packages/tooling/tool/cli/test/step-git-exec.test.ts
+++ b/packages/tooling/tool/cli/test/step-git-exec.test.ts
@@ -10,6 +10,7 @@ import {
   runCapturedStreams,
 } from "@beep/repo-cli/test/Process";
 import {
+  gitArchiveArgs,
   gitLinesFromOutput,
   gitPathListFromNulOutput,
   isSafeOriginBranch,
@@ -137,5 +138,29 @@ describe("GitExec origin-branch refname safety", () => {
   it("extracts only safe branches from an origin base ref", () => {
     expect(safeOriginBranchFromBase("origin/main")).toEqual(O.some("main"));
     expect(safeOriginBranchFromBase("origin/--upload-pack=x")).toEqual(O.none());
+  });
+});
+
+// `.gitattributes` declares `* text=auto`, so an archive written on a host carrying
+// `core.autocrlf=true` differs byte-for-byte from the same commit archived on CI. Consumers that
+// compare those bytes exactly (the knowledge semantic-delta index-drift finding) then report drift
+// no source edit can clear, so the overrides are part of the archive's contract, not a preference.
+describe("GitExec archive byte canonicality", () => {
+  it("pins end-of-line handling ahead of the archive subcommand", () => {
+    expect(gitArchiveArgs("/tmp/base.tar", "HEAD")).toEqual([
+      "-c",
+      "core.autocrlf=false",
+      "-c",
+      "core.eol=lf",
+      "archive",
+      "--format=tar",
+      "--output=/tmp/base.tar",
+      "HEAD",
+    ]);
+  });
+
+  it("passes a spaced and non-ASCII archive path through unquoted", () => {
+    const archivePath = "/tmp/beep qa/ünicode/base.tar";
+    expect(gitArchiveArgs(archivePath, "deadbeef")).toContain(`--output=${archivePath}`);
   });
 });


### PR DESCRIPTION
## Summary
- `git archive` inherited the host's EOL config (`* text=auto` + ambient `core.autocrlf`), so the
  same commit archived different bytes on different machines. Knowledge semantic-delta compares
  archived bytes exactly, so an `autocrlf=true` host saw a standing `index-drift` on
  `goals/INDEX.md` that `beep goals index --write` could never clear.
- `writeGitArchive` now leads its argv with `-c core.autocrlf=false -c core.eol=lf`, exported as
  the pure `gitArchiveArgs` (dual, pipeable) so the contract is unit-asserted without spawning git.
- Measured under a synthetic hostile `GIT_CONFIG_GLOBAL`: the finding fired in both base and HEAD
  archives, cancelling to `unchanged` (497 -> 496) — standing noise, never a red required lane.
- Deposits the P3 hermetic-lane scoping report (`research/p3-hermetic-lane-design.md`): the
  ratified clean-clone/empty-`$HOME` lane is vacuous (3 of 4 controls remove state nothing reads).
  Grilled 2026-08-17: drop the lane, gate the defect class as a hostile-profile differential test;
  the SPEC amendment lands as its own docs-only PR. Ledger receipts 15-17.

## Test plan
- `packages/tooling/tool/cli/test/step-git-exec.test.ts` pins the canonical argv (18 tests pass).
- Full yeet verify green (build, lint, check, tsgo, tests, docgen, security lanes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789547116&installation_model_id=424656&pr_number=741&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F741&signature=fea57a0f2dd37f8cce2fbcf9bd286263d7a4f997fdd634a1281d1a3427abb843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->