### PR TITLE
fix(repo-cli): redact non-ASCII absolute paths whole in knowledge probe diagnostics

### DIFF
--- a/.changeset/knowledge-unicode-redaction.md
+++ b/.changeset/knowledge-unicode-redaction.md
@@ -1,0 +1,11 @@
+---
+"@beep/repo-cli": patch
+---
+
+Redact non-ASCII absolute paths whole in knowledge probe diagnostics. The POSIX path pattern's
+segments were ASCII-only, so a path like `/home/üser/prójects/tökens.ts:3:7` in probe stderr was
+redacted only up to `/home`, leaking the non-ASCII tail with its line and column. Segments now admit
+Unicode letters, marks, and digits. The hostile-profile archive differential also gains the retired
+ASLR control's real half: the scratch checkout sits under a deep, spaced, non-ASCII path and
+archives land in a spaced output directory, so location-depth and quoting are exercised in the live
+spawn path (ratified in `goals/knowledge-surface-automation/research/p3-hermetic-lane-decisions.md`).

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
@@ -101,8 +101,10 @@ const ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/gu;
 const OTHER_ESCAPE_PATTERN = /\u001B[@-Z\\-_]/gu;
 const DISALLOWED_DIAGNOSTIC_CONTROL_PATTERN = /[\u0000-\u0009\u000B-\u001F\u007F-\u009F]/gu;
 const FORMAT_CHARACTER_PATTERN = /\p{Cf}/gu;
+// Segments admit Unicode letters, marks, and digits (not just ASCII) so a non-ASCII checkout path
+// in probe output is redacted whole instead of leaking its tail after the first non-ASCII segment.
 const POSIX_ABSOLUTE_PATH_PATTERN =
-  /(?<![A-Za-z0-9_.>:/-])\/[A-Za-z0-9._@+-]+(?:\/[A-Za-z0-9._@+-]+)*(?::\d+(?::\d+)?)?/gu;
+  /(?<![\p{L}\p{M}\p{N}_.>:/-])\/[\p{L}\p{M}\p{N}._@+-]+(?:\/[\p{L}\p{M}\p{N}._@+-]+)*(?::\d+(?::\d+)?)?/gu;
 const WINDOWS_ABSOLUTE_PATH_PATTERN = /[A-Za-z]:\\(?:[^\\\s"'`]+\\)*[^\\\s"'`]+(?::\d+(?::\d+)?)?/gu;
 const textEncoder = new TextEncoder();
 const bytesEquivalent = S.toEquivalence(S.Uint8Array);

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
@@ -101,10 +101,13 @@ const ANSI_ESCAPE_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/gu;
 const OTHER_ESCAPE_PATTERN = /\u001B[@-Z\\-_]/gu;
 const DISALLOWED_DIAGNOSTIC_CONTROL_PATTERN = /[\u0000-\u0009\u000B-\u001F\u007F-\u009F]/gu;
 const FORMAT_CHARACTER_PATTERN = /\p{Cf}/gu;
-// Segments admit Unicode letters, marks, and digits (not just ASCII) so a non-ASCII checkout path
-// in probe output is redacted whole instead of leaking its tail after the first non-ASCII segment.
-const POSIX_ABSOLUTE_PATH_PATTERN =
-  /(?<![\p{L}\p{M}\p{N}_.>:/-])\/[\p{L}\p{M}\p{N}._@+-]+(?:\/[\p{L}\p{M}\p{N}._@+-]+)*(?::\d+(?::\d+)?)?/gu;
+// Segments consume any non-delimiter character (mirroring WINDOWS_ABSOLUTE_PATH_PATTERN's negated
+// class) so a path with non-ASCII, emoji, or punctuation segments is redacted whole instead of
+// leaking its tail — a redactor must over-swallow, never under-swallow. Colon stays a delimiter so
+// the trailing `:line(:col)` suffix keeps matching; the lookbehind admits a path only at start,
+// after whitespace, or after quote/bracket/assignment openers, which blocks URL tails (`https://x`)
+// and word-adjacent slashes without enumerating every script's word characters.
+const POSIX_ABSOLUTE_PATH_PATTERN = /(?<![^\s"'`([{=,])\/[^\s/"'`:]+(?:\/[^\s/"'`:]+)*(?::\d+(?::\d+)?)?/gu;
 const WINDOWS_ABSOLUTE_PATH_PATTERN = /[A-Za-z]:\\(?:[^\\\s"'`]+\\)*[^\\\s"'`]+(?::\d+(?::\d+)?)?/gu;
 const textEncoder = new TextEncoder();
 const bytesEquivalent = S.toEquivalence(S.Uint8Array);

--- a/packages/tooling/tool/cli/test/knowledge-semantic-delta.test.ts
+++ b/packages/tooling/tool/cli/test/knowledge-semantic-delta.test.ts
@@ -1337,7 +1337,7 @@ describe("knowledge semantic-delta current-checkout probes", () => {
       Effect.gen(function* () {
         const harness = yield* makeProbeHarness(
           "unsafe stdout from /home/operator/private/stdout.ts",
-          "\u001B[31mSyntaxError\u001B[0m in /home/operator/private/stderr.ts\u0001\r\nsecond\rspoof at /secret and C:\\secret and /home/üser/prójects/tökens.ts:3:7 plus /données/été",
+          "\u001B[31mSyntaxError\u001B[0m in /home/operator/private/stderr.ts\u0001\r\nsecond\rspoof at /secret and C:\\secret and /home/üser/prójects/tökens.ts:3:7 plus /données/été near /var/💼client-secret/config.ts:3:7 (see https://example.com/keep-this-path)",
           1
         );
         const error = yield* Effect.flip(harness.oracle.probeCommands([["goals", "doctor"]]));
@@ -1352,14 +1352,19 @@ describe("knowledge semantic-delta current-checkout probes", () => {
         assert.notInclude(error.message, "/home/operator");
         assert.notInclude(error.message, "/secret");
         assert.notInclude(error.message, "C:\\secret");
-        // Non-ASCII segments must be swallowed by the same redaction, tail and line:col included —
-        // an ASCII-only pattern used to stop at `/home` and leak `üser/prójects/tökens.ts:3:7`.
+        // Non-ASCII, emoji, and punctuation segments must be swallowed by the same redaction, tail
+        // and line:col included — an enumerated segment class used to stop at the first character
+        // outside it and leak `üser/prójects/tökens.ts:3:7` or `💼client-secret/config.ts`.
         assert.notInclude(error.message, "üser");
         assert.notInclude(error.message, "prójects");
         assert.notInclude(error.message, "tökens");
         assert.notInclude(error.message, "3:7");
         assert.notInclude(error.message, "données");
         assert.notInclude(error.message, "été");
+        assert.notInclude(error.message, "💼");
+        assert.notInclude(error.message, "client-secret");
+        // URLs are not filesystem paths: the redaction must leave them legible.
+        assert.include(error.message, "https://example.com/keep-this-path");
         assert.include(error.message, "secondspoof");
         assert.notInclude(error.message, "\r");
         assert.notInclude(error.message, "\u001B");

--- a/packages/tooling/tool/cli/test/knowledge-semantic-delta.test.ts
+++ b/packages/tooling/tool/cli/test/knowledge-semantic-delta.test.ts
@@ -1337,7 +1337,7 @@ describe("knowledge semantic-delta current-checkout probes", () => {
       Effect.gen(function* () {
         const harness = yield* makeProbeHarness(
           "unsafe stdout from /home/operator/private/stdout.ts",
-          "\u001B[31mSyntaxError\u001B[0m in /home/operator/private/stderr.ts\u0001\r\nsecond\rspoof at /secret and C:\\secret",
+          "\u001B[31mSyntaxError\u001B[0m in /home/operator/private/stderr.ts\u0001\r\nsecond\rspoof at /secret and C:\\secret and /home/üser/prójects/tökens.ts:3:7 plus /données/été",
           1
         );
         const error = yield* Effect.flip(harness.oracle.probeCommands([["goals", "doctor"]]));
@@ -1352,6 +1352,14 @@ describe("knowledge semantic-delta current-checkout probes", () => {
         assert.notInclude(error.message, "/home/operator");
         assert.notInclude(error.message, "/secret");
         assert.notInclude(error.message, "C:\\secret");
+        // Non-ASCII segments must be swallowed by the same redaction, tail and line:col included —
+        // an ASCII-only pattern used to stop at `/home` and leak `üser/prójects/tökens.ts:3:7`.
+        assert.notInclude(error.message, "üser");
+        assert.notInclude(error.message, "prójects");
+        assert.notInclude(error.message, "tökens");
+        assert.notInclude(error.message, "3:7");
+        assert.notInclude(error.message, "données");
+        assert.notInclude(error.message, "été");
         assert.include(error.message, "secondspoof");
         assert.notInclude(error.message, "\r");
         assert.notInclude(error.message, "\u001B");

--- a/packages/tooling/tool/cli/test/step-git-exec.test.ts
+++ b/packages/tooling/tool/cli/test/step-git-exec.test.ts
@@ -254,12 +254,18 @@ layer(NodeServices.layer)("GitExec archive hostile-profile canonicality", (it) =
       const tmpDir = yield* fs.makeTempDirectory();
 
       const body = Effect.gen(function* () {
-        const repoDir = path.join(tmpDir, "repo");
+        // The checkout deliberately sits under a deep, spaced, non-ASCII path so the differential
+        // exercises location-depth behavior in the live spawn path (the retired ASLR control's real
+        // half — research/p3-hermetic-lane-decisions.md H2/H3), and archives land in a spaced
+        // output directory so `--output` quoting is exercised live rather than only as argv.
+        const repoDir = path.join(tmpDir, "nested depth", "ünïcode", "level-3", "repo");
+        const outDir = path.join(tmpDir, "out put ü");
         const hostileXdg = path.join(tmpDir, "xdg-hostile");
         const cleanXdg = path.join(tmpDir, "xdg-clean");
         const home = path.join(tmpDir, "home");
         const umaskConfig = path.join(tmpDir, "umask.gitconfig");
         yield* fs.makeDirectory(repoDir, { recursive: true });
+        yield* fs.makeDirectory(outDir, { recursive: true });
         yield* fs.makeDirectory(path.join(hostileXdg, "git"), { recursive: true });
         yield* fs.makeDirectory(cleanXdg, { recursive: true });
         yield* fs.makeDirectory(home, { recursive: true });
@@ -301,7 +307,7 @@ layer(NodeServices.layer)("GitExec archive hostile-profile canonicality", (it) =
           argsFor: (out: string) => ReadonlyArray<string>,
           env: Record<string, string>
         ) {
-          const out = path.join(tmpDir, name);
+          const out = path.join(outDir, name);
           yield* Effect.sync(() => runGit(repoDir, argsFor(out), env));
           return yield* fs.readFile(out);
         });


### PR DESCRIPTION
## fix(repo-cli): redact non-ASCII absolute paths whole in knowledge probe diagnostics

The POSIX path pattern admitted only ASCII segments, so a path like
/home/üser/prójects/tökens.ts:3:7 in probe stderr was redacted only up to /home,
leaking the non-ASCII tail with its line and column (and /données mangled into a
partial redaction). Segments now admit Unicode letters, marks, and digits, on
both sides of the lookbehind so word-adjacent slashes stay unredacted.

Also lands the retired ASLR control's real half per the ratified H2 correction:
the hostile-profile differential's scratch checkout now sits under a deep,
spaced, non-ASCII path and archives land in a spaced output directory, so
location-depth and --output quoting are exercised in the live spawn path
(goals/knowledge-surface-automation/research/p3-hermetic-lane-decisions.md).

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_knowledge-redaction-unicode-1df5fbc02773/verdict.json

---

## Provenance

- Branch: <code>fix/knowledge-redaction-unicode</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/knowledge-redaction-unicode",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789555718&installation_model_id=424656&pr_number=746&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F746&signature=997afa832ebb973d96322a177ea2b5432b97d720405b78a76761016ba106bd5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->