### PR TITLE
feat(yeet): fail the monitor watch on the first red check

### DIFF
--- a/.changeset/yeet-monitor-fail-fast.md
+++ b/.changeset/yeet-monitor-fail-fast.md
@@ -1,0 +1,9 @@
+---
+"@beep/repo-cli": patch
+---
+
+Plan the yeet monitor check watch as `gh pr checks --watch --fail-fast`, so the first failed
+check ends the watch immediately instead of being withheld until the last pending lane
+finishes — this repo's lane tails run 20-30 minutes, so a T0 red previously reached the
+operator up to half an hour late. First A1 slice of goals/ship-velocity (research/c2 §1
+identified the missing flag); the registration backoff and rerun triage are unchanged.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorChecks.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorChecks.ts
@@ -98,7 +98,7 @@ export type YeetCheckRegistration = typeof YeetCheckRegistration.Type;
  *
  * const result = RepoStepRunResult.make({
  *   stepId: "monitor:02-pr-checks-watch",
- *   commandText: "gh pr checks --watch",
+ *   commandText: "gh pr checks --watch --fail-fast",
  *   exitCode: 1,
  *   output: "no checks reported on the 'feat/x' branch",
  * })

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
@@ -489,7 +489,11 @@ const monitorChecksStep = (context: RepoRunContext): RepoPlanStep =>
     label: "monitor:pr-checks:watch",
     phase: "monitor",
     command: "gh",
-    args: ["pr", "checks", "--watch"],
+    // `--fail-fast` makes the watch exit on the first failed check instead of
+    // holding a T0 red until the last pending lane ends — this repo's tails
+    // run 20-30 minutes, so without it the monitor's "exits on the first red"
+    // contract was prose, not behavior (ship-velocity A1, research/c2 §1).
+    args: ["pr", "checks", "--watch", "--fail-fast"],
     cwd: context.repoRoot,
     scope: "repo",
     mutability: "readonly",

--- a/packages/tooling/tool/cli/test/yeet-monitor-check-registration.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-monitor-check-registration.test.ts
@@ -28,7 +28,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 const watchResult = (exitCode: number, output: string): RepoStepRunResult =>
   RepoStepRunResult.make({
     stepId: "monitor:02-pr-checks-watch",
-    commandText: "gh pr checks --watch",
+    commandText: "gh pr checks --watch --fail-fast",
     exitCode,
     output,
   });
@@ -68,7 +68,7 @@ describe("yeetCheckRegistration", () => {
       yeetCheckRegistration(
         RepoStepRunResult.make({
           stepId: "monitor:02-pr-checks-watch",
-          commandText: "gh pr checks --watch",
+          commandText: "gh pr checks --watch --fail-fast",
           exitCode: 1,
         })
       )
@@ -232,7 +232,7 @@ const monitorSteps = (cwd: string): ReadonlyArray<RepoPlanStep> => [
     label: "monitor:pr-checks:watch",
     phase: "monitor",
     command: "gh",
-    args: ["pr", "checks", "--watch"],
+    args: ["pr", "checks", "--watch", "--fail-fast"],
     cwd,
     scope: "repo",
     mutability: "readonly",

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -544,7 +544,7 @@ describe("yeet planner", () => {
       "--json",
       "number,headRefName,state",
     ]);
-    expect(findStep(plan.steps, "monitor:pr-checks:watch").args).toEqual(["pr", "checks", "--watch"]);
+    expect(findStep(plan.steps, "monitor:pr-checks:watch").args).toEqual(["pr", "checks", "--watch", "--fail-fast"]);
   });
 
   it("builds status as local-only by default and adds remote PR reads on request", () => {


### PR DESCRIPTION
## feat(yeet): fail the monitor watch on the first red check

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_yeet-monitor-watch-stream-e180d4ffbda9/verdict.json

---

## Provenance

- Branch: <code>feat/yeet-monitor-watch-stream</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/yeet-monitor-watch-stream",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789559830&installation_model_id=424656&pr_number=749&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F749&signature=a6cbf6d9d76640b40124231109488f59de7df9cbb498a730fe805bbcd82ab46b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->