### PR TITLE
feat(yeet): stream typed PR state transitions with yeet monitor --watch

### DIFF
--- a/.changeset/yeet-monitor-watch-stream.md
+++ b/.changeset/yeet-monitor-watch-stream.md
@@ -1,0 +1,12 @@
+---
+"@beep/repo-cli": minor
+---
+
+Add `yeet monitor --watch`: a typed transition stream for the current branch's pull request.
+Each poll collects one snapshot (head, PR state, mergeability, classified check outcomes, review
+thread resolution) and a pure differ emits one `yeet-watch/v1` NDJSON row per state transition —
+check moved, thread opened or resolved, mergeability changed, head superseded — ending with a
+`watch-ended` row whose failure census drives the exit code. Raw GitHub bucket and state
+vocabulary is totalized into a closed outcome domain at the boundary, and transition detection
+keys on typed snapshot diffs, never log-line matching. First half of ship-velocity A1; failure
+capsules and remediation dispatch build on this stream.

--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -139,6 +139,15 @@ bun run beep yeet monitor
 bun run beep yeet monitor --until-merged
 ```
 
+- Stream one NDJSON row per PR state transition (typed `yeet-watch/v1` rows:
+  check transitions, thread open/resolve, mergeability, head supersession)
+  until the PR settles; exits non-zero on a red wave, a closed PR, or a poll
+  error:
+
+```bash
+bun run beep yeet monitor --watch
+```
+
 - Reset the clone after a merge (prune refs, fast-forward `main`, delete the
   merged branch locally and remotely, reinstall when `bun.lock` moved, end on
   `main`). Inspect the plan before running it:

--- a/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
@@ -16,7 +16,13 @@ import {
 } from "./internal/FallowFeedback.ts";
 import { runYeet } from "./internal/Handler.ts";
 import { DEFAULT_YEET_PACKET_DIR, YeetProofTier } from "./internal/Planner.ts";
-import { runYeetMerge, runYeetMergeLoop, runYeetReplyPass, runYeetSweep } from "./internal/Porcelain.ts";
+import {
+  runYeetMerge,
+  runYeetMergeLoop,
+  runYeetReplyPass,
+  runYeetSweep,
+  runYeetWatchLoop,
+} from "./internal/Porcelain.ts";
 import { YeetRunOptions } from "./Yeet.schemas.ts";
 import type { YeetRunMode } from "./internal/Planner.ts";
 
@@ -245,10 +251,17 @@ const publishFlags = {
   summary: summaryFlag,
 } as const;
 
+const watchFlag = Flag.boolean("watch").pipe(
+  Flag.withDescription(
+    "Stream one NDJSON row per PR state transition until the PR settles, instead of the blocking check watch"
+  )
+);
+
 const monitorFlags = {
   ...sharedFlags,
   summary: summaryFlag,
   untilMerged: untilMergedFlag,
+  watch: watchFlag,
 } as const;
 
 const porcelainFlags = {
@@ -366,8 +379,12 @@ const yeetPublishCommand = Command.make("publish", publishFlags, (options) => ru
   Command.withDescription("Commit reviewed staged changes, prove the commit, then push")
 );
 
-const yeetMonitorCommand = Command.make("monitor", monitorFlags, ({ untilMerged, ...options }) =>
-  untilMerged && !options.plan ? runYeetMergeLoop(options) : runYeetMode("monitor", options)
+const yeetMonitorCommand = Command.make("monitor", monitorFlags, ({ untilMerged, watch, ...options }) =>
+  untilMerged && !options.plan
+    ? runYeetMergeLoop(options)
+    : watch && !options.plan
+      ? runYeetWatchLoop(options)
+      : runYeetMode("monitor", options)
 ).pipe(Command.withDescription("Monitor hosted PR checks for the current branch"));
 
 const yeetSweepCommand = Command.make("sweep", sweepFlags, (options) => runYeetSweep(options)).pipe(

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorChecks.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorChecks.ts
@@ -38,10 +38,30 @@ import type { RepoStepRunResult } from "../../../internal/repo-run/index.ts";
 
 const $I = $RepoCliId.create("commands/Yeet/internal/MonitorChecks");
 
-// `gh pr checks` prints "no checks reported on the '<branch>' branch", and
-// "no required checks reported on ..." under `--required`. Both mean the same
-// thing to a freshly pushed head: nothing has registered yet.
-const NO_CHECKS_REPORTED = /no (?:required )?checks reported/iu;
+/**
+ * Matches `gh pr checks`' empty-registration error text.
+ *
+ * **Details**
+ *
+ * `gh pr checks` prints "no checks reported on the '<branch>' branch", and
+ * "no required checks reported on ..." under `--required`. Both mean the same
+ * thing to a freshly pushed head: nothing has registered yet. This is the ONLY
+ * non-zero checks exit that may be read as an empty rollup — any other failure
+ * (authentication, rate limit, network) is a poll error, and treating it as
+ * empty converts an outage into a green completion.
+ *
+ * **Example** (Match the registration message)
+ *
+ * ```ts
+ * import { NO_CHECKS_REPORTED } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(NO_CHECKS_REPORTED.test("no checks reported on the 'feat/x' branch")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const NO_CHECKS_REPORTED = /no (?:required )?checks reported/iu;
 
 /**
  * Whether a check watch found checks to watch.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts
@@ -34,6 +34,7 @@ import { runYeetMonitorUntilMerged } from "./MonitorLoop.ts";
 import { renderYeetReplyFailureVerdict, replyReportPathForContext, runYeetReply } from "./Reply.ts";
 import { SweepPlanJson, SweepReportJson } from "./Sweep.schemas.ts";
 import { executeSweep, overrideSweepBranch, planSweep, renderSweepReport } from "./Sweep.ts";
+import { runYeetWatchStream, yeetWatchExitFailure } from "./WatchMode.ts";
 import type { FileSystem, Path } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { CliReportedExit } from "../../../internal/cli/ExitCodeError.ts";
@@ -289,4 +290,62 @@ export const runYeetMergeLoop = Effect.fn("Yeet.runMergeLoopCommand")(function* 
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
   return yield* runYeetMonitorUntilMerged(yield* hydrateYeetReadOnlyContext(options), {});
+});
+
+/**
+ * Default poll interval for `yeet monitor --watch`, matching the GitHub CLI's
+ * own check-watch cadence.
+ *
+ * **Example** (Read the interval)
+ *
+ * ```ts
+ * import { YEET_WATCH_INTERVAL_MILLIS } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_WATCH_INTERVAL_MILLIS) // 10000
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_WATCH_INTERVAL_MILLIS = 10_000;
+
+/**
+ * Stream the current branch PR's state transitions until it settles.
+ *
+ * **Details**
+ *
+ * This is `yeet monitor --watch`: one NDJSON row per transition on stdout,
+ * ending when the PR merges, closes, or every check is terminal. The exit code
+ * is the backpressure contract — a red wave, a closed PR, or a poll error
+ * exits non-zero so a supervising session treats the stream's end as a signal,
+ * not a shrug.
+ *
+ * **Example** (Build the watch-loop runner effect)
+ *
+ * ```ts
+ * import { runYeetWatchLoop } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(runYeetWatchLoop)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Parsed `yeet monitor` flag values.
+ * @returns Nothing on a green settle; a reported non-zero exit otherwise.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetWatchLoop = Effect.fn("Yeet.runWatchLoopCommand")(function* (
+  options: YeetPorcelainOptions
+): Effect.fn.Return<
+  void,
+  YeetCommandError | CliReportedExit,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const context = yield* hydrateYeetReadOnlyContext(options);
+  const ended = yield* runYeetWatchStream(context, { intervalMillis: YEET_WATCH_INTERVAL_MILLIS });
+  if (yeetWatchExitFailure(ended)) {
+    yield* Console.error(`yeet watch ended ${ended.reason} with ${ended.failing} failing check(s).`);
+    return yield* failWithReportedExit(`yeet watch ended ${ended.reason} with ${ended.failing} failing check(s).`);
+  }
 });

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
@@ -34,6 +34,7 @@ import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import { runRepoCommandCapture } from "../../../internal/repo-run/index.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
+import { NO_CHECKS_REPORTED } from "./MonitorChecks.ts";
 import {
   classifyYeetCheckOutcome,
   countYeetWatchFailures,
@@ -118,9 +119,13 @@ const watchThreadsQuery =
  * downstream speaks {@link YeetWatchSnapshot}.
  *
  * A PR with zero checks yet is returned as-is; the caller decides whether that
- * ends the watch. `gh pr checks` exits non-zero for "no checks reported",
- * which this collector treats as an empty rollup rather than a failure — the
- * registration story belongs to the caller's backoff, not to every poll.
+ * ends the watch. Only `gh pr checks`' "no checks reported" exit reads as an
+ * empty rollup — that is GitHub's registration gap, and the registration story
+ * belongs to the caller's backoff. Every other non-zero read (authentication,
+ * rate limit, network) fails the collection: an outage that decoded to an
+ * empty rollup would end the watch as a green `all-terminal`, and a thread
+ * read that decayed to an empty set would make the next good poll re-report
+ * every existing thread as newly opened.
  *
  * **Example** (Build the collector effect)
  *
@@ -170,6 +175,12 @@ export const collectYeetWatchSnapshot = Effect.fn("Yeet.collectYeetWatchSnapshot
     ["pr", "checks", "--json", "name,state,bucket"],
     context.repoRoot
   ).pipe(Effect.mapError(YeetCommandError.new("Failed to read PR checks for yeet watch.")));
+  if (checksResult.exitCode !== 0 && !NO_CHECKS_REPORTED.test(checksResult.output)) {
+    return yield* YeetCommandError.make({
+      message: `yeet watch could not read PR checks: ${checksResult.output}`,
+      exitCode: 1,
+    });
+  }
   const checkRows =
     checksResult.exitCode === 0
       ? yield* decodeCheckRows(checksResult.output).pipe(
@@ -182,13 +193,16 @@ export const collectYeetWatchSnapshot = Effect.fn("Yeet.collectYeetWatchSnapshot
     ["api", "graphql", "-f", `query=${watchThreadsQuery}`, "-F", `id=${view.id}`],
     context.repoRoot
   ).pipe(Effect.mapError(YeetCommandError.new("Failed to read PR review threads for yeet watch.")));
-  const threadNodes =
-    threadsResult.exitCode === 0
-      ? yield* decodeThreadsDocument(threadsResult.output).pipe(
-          Effect.map((document) => document.data.node?.reviewThreads.nodes ?? A.empty<WatchThreadNode>()),
-          Effect.mapError(YeetCommandError.new("Failed to decode PR review threads JSON for yeet watch."))
-        )
-      : A.empty<WatchThreadNode>();
+  if (threadsResult.exitCode !== 0) {
+    return yield* YeetCommandError.make({
+      message: `yeet watch could not read PR review threads: ${threadsResult.output}`,
+      exitCode: 1,
+    });
+  }
+  const threadNodes = yield* decodeThreadsDocument(threadsResult.output).pipe(
+    Effect.map((document) => document.data.node?.reviewThreads.nodes ?? A.empty<WatchThreadNode>()),
+    Effect.mapError(YeetCommandError.new("Failed to decode PR review threads JSON for yeet watch."))
+  );
 
   return YeetWatchSnapshot.make({
     checks: A.map(checkRows, (row) =>
@@ -231,6 +245,12 @@ const emitWatchEvent = (event: YeetWatchEvent): Effect.Effect<void, YeetCommandE
  * supersedes the prior wave" reads in stream form. The consumer that dispatches
  * remediation keys its dedup on `headSha`, so superseded-wave rows cannot leak
  * into the new wave's session.
+ *
+ * A failed poll after the stream has started does not escape as an untyped
+ * error: the stream ends with a `watch-ended` row whose reason is
+ * `poll-error`, carrying the last good snapshot's failure census, so a
+ * consumer never sees a truncated stream. Only the *initial* collection fails
+ * hard — there is nothing to truncate before `watch-started`.
  *
  * **Example** (Build the stream effect)
  *
@@ -285,7 +305,23 @@ export const runYeetWatchStream = Effect.fn("Yeet.runYeetWatchStream")(function*
     }
 
     yield* Effect.sleep(Duration.millis(config.intervalMillis));
-    const next = yield* collectYeetWatchSnapshot(context);
+    const polled = yield* collectYeetWatchSnapshot(context).pipe(
+      Effect.map(O.some),
+      Effect.catch((error) =>
+        Console.error(`[yeet] watch poll failed: ${error.message}`).pipe(Effect.as(O.none<YeetWatchSnapshot>()))
+      )
+    );
+    if (O.isNone(polled)) {
+      const ended = YeetWatchEnded.make({
+        at: yield* isoNow,
+        failing: countYeetWatchFailures(current),
+        headSha: current.headSha,
+        reason: "poll-error",
+      });
+      yield* emitWatchEvent(ended);
+      return ended;
+    }
+    const next = polled.value;
     const events = diffYeetWatchSnapshots(YeetWatchDiffInput.make({ at: yield* isoNow, next, prev: current }));
     yield* Effect.forEach(events, emitWatchEvent, { discard: true });
     current = next;

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
@@ -1,0 +1,315 @@
+/**
+ * The `yeet monitor --watch` transition-stream mode.
+ *
+ * **Details**
+ *
+ * This is the runtime half of the watch redesign (ship-velocity A1):
+ * {@link collectYeetWatchSnapshot} reads one typed snapshot of the pull
+ * request, and {@link runYeetWatchStream} polls, diffs consecutive snapshots
+ * through the pure `WatchStream` differ, and emits one NDJSON row per
+ * transition on stdout. Prose for the operator goes to stderr, so stdout stays
+ * a machine surface a consumer can pipe line-by-line into a decoder.
+ *
+ * The collector's schemas are deliberately minimal — the watch needs the head,
+ * the PR state, mergeability, check names with raw bucket/state strings, and
+ * thread resolution. Yeet status owns the richer shapes; duplicating its deep
+ * private class chain here would couple the two surfaces for fields the watch
+ * never reads.
+ *
+ * **Gotchas**
+ *
+ * The stream reports transitions, not summaries: a consumer that wants "is it
+ * green now" folds the rows or asks `yeet status --remote`. And the poll clock
+ * is injectable because the tests drive the loop with zero delays — wall-clock
+ * sleeps in tests are how suites time out under TestClock.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { Console, DateTime, Duration, Effect } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { runRepoCommandCapture } from "../../../internal/repo-run/index.ts";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import {
+  classifyYeetCheckOutcome,
+  countYeetWatchFailures,
+  diffYeetWatchSnapshots,
+  renderYeetWatchEventLine,
+  YeetCheckSignal,
+  YeetWatchCheck,
+  YeetWatchDiffInput,
+  YeetWatchEnded,
+  YeetWatchEndReason,
+  YeetWatchSnapshot,
+  YeetWatchStarted,
+  YeetWatchThread,
+  yeetWatchEndReason,
+} from "./WatchStream.ts";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
+import type { YeetWatchEvent } from "./WatchStream.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/WatchMode");
+
+class WatchPullRequestView extends S.Class<WatchPullRequestView>($I`WatchPullRequestView`)(
+  {
+    headRefOid: S.NonEmptyString,
+    id: S.NonEmptyString,
+    mergeable: S.NullOr(S.String),
+    state: S.String,
+  },
+  $I.annote("WatchPullRequestView", {
+    description: "The minimal gh pr view payload the watch stream reads.",
+  })
+) {}
+
+class WatchCheckRow extends S.Class<WatchCheckRow>($I`WatchCheckRow`)(
+  {
+    bucket: S.String,
+    name: S.String,
+    state: S.String,
+  },
+  $I.annote("WatchCheckRow", {
+    description: "One raw gh pr checks row: name plus unclassified bucket and state strings.",
+  })
+) {}
+
+class WatchThreadNode extends S.Class<WatchThreadNode>($I`WatchThreadNode`)(
+  {
+    id: S.NonEmptyString,
+    isResolved: S.Boolean,
+  },
+  $I.annote("WatchThreadNode", { description: "One review thread's identity and resolution state." })
+) {}
+
+class WatchThreadsDocument extends S.Class<WatchThreadsDocument>($I`WatchThreadsDocument`)(
+  {
+    data: S.Struct({
+      node: S.NullOr(
+        S.Struct({
+          reviewThreads: S.Struct({ nodes: S.Array(WatchThreadNode) }),
+        })
+      ),
+    }),
+  },
+  $I.annote("WatchThreadsDocument", { description: "The GraphQL document shape of the watch's thread query." })
+) {}
+
+const decodePullRequestView = S.decodeUnknownEffect(S.fromJsonString(WatchPullRequestView));
+const decodeCheckRows = S.decodeUnknownEffect(S.fromJsonString(S.Array(WatchCheckRow)));
+const decodeThreadsDocument = S.decodeUnknownEffect(S.fromJsonString(WatchThreadsDocument));
+
+const watchThreadsQuery =
+  "query($id:ID!){node(id:$id){... on PullRequest{reviewThreads(first:100){nodes{id isResolved}}}}}";
+
+/**
+ * Collect one typed snapshot of the current branch's pull request.
+ *
+ * **Details**
+ *
+ * Three reads, same argv surfaces yeet status uses: `gh pr view` for identity
+ * and mergeability, `gh pr checks --json name,state,bucket` for the rollup,
+ * and one GraphQL thread query for resolution states. Raw bucket/state strings
+ * classify into the closed outcome domain at this boundary, so everything
+ * downstream speaks {@link YeetWatchSnapshot}.
+ *
+ * A PR with zero checks yet is returned as-is; the caller decides whether that
+ * ends the watch. `gh pr checks` exits non-zero for "no checks reported",
+ * which this collector treats as an empty rollup rather than a failure — the
+ * registration story belongs to the caller's backoff, not to every poll.
+ *
+ * **Example** (Build the collector effect)
+ *
+ * ```ts
+ * import { collectYeetWatchSnapshot, RepoRunContext } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const context = RepoRunContext.make({
+ *   base: "origin/main",
+ *   branch: "feature/watch",
+ *   cwd: ".",
+ *   head: "HEAD",
+ *   originalArgv: [],
+ *   packetDir: ".beep/yeet",
+ *   repoRoot: ".",
+ *   turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] }
+ * })
+ *
+ * console.log(Effect.isEffect(collectYeetWatchSnapshot(context))) // true
+ * ```
+ *
+ * @param context - Repo context naming the checkout to read from.
+ * @returns The snapshot this poll observed.
+ * @category services
+ * @since 0.0.0
+ */
+export const collectYeetWatchSnapshot = Effect.fn("Yeet.collectYeetWatchSnapshot")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<YeetWatchSnapshot, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const viewResult = yield* runRepoCommandCapture(
+    "gh",
+    ["pr", "view", "--json", "id,state,mergeable,headRefOid"],
+    context.repoRoot
+  ).pipe(Effect.mapError(YeetCommandError.new("Failed to read the pull request for yeet watch.")));
+  if (viewResult.exitCode !== 0) {
+    return yield* YeetCommandError.make({
+      message: "yeet monitor --watch requires an open pull request for the current branch.",
+      exitCode: 1,
+    });
+  }
+  const view = yield* decodePullRequestView(viewResult.output).pipe(
+    Effect.mapError(YeetCommandError.new("Failed to decode gh pr view JSON for yeet watch."))
+  );
+
+  const checksResult = yield* runRepoCommandCapture(
+    "gh",
+    ["pr", "checks", "--json", "name,state,bucket"],
+    context.repoRoot
+  ).pipe(Effect.mapError(YeetCommandError.new("Failed to read PR checks for yeet watch.")));
+  const checkRows =
+    checksResult.exitCode === 0
+      ? yield* decodeCheckRows(checksResult.output).pipe(
+          Effect.mapError(YeetCommandError.new("Failed to decode gh pr checks JSON for yeet watch."))
+        )
+      : A.empty<WatchCheckRow>();
+
+  const threadsResult = yield* runRepoCommandCapture(
+    "gh",
+    ["api", "graphql", "-f", `query=${watchThreadsQuery}`, "-F", `id=${view.id}`],
+    context.repoRoot
+  ).pipe(Effect.mapError(YeetCommandError.new("Failed to read PR review threads for yeet watch.")));
+  const threadNodes =
+    threadsResult.exitCode === 0
+      ? yield* decodeThreadsDocument(threadsResult.output).pipe(
+          Effect.map((document) => document.data.node?.reviewThreads.nodes ?? A.empty<WatchThreadNode>()),
+          Effect.mapError(YeetCommandError.new("Failed to decode PR review threads JSON for yeet watch."))
+        )
+      : A.empty<WatchThreadNode>();
+
+  return YeetWatchSnapshot.make({
+    checks: A.map(checkRows, (row) =>
+      YeetWatchCheck.make({
+        name: row.name,
+        outcome: classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: row.bucket, state: row.state })),
+      })
+    ),
+    headSha: view.headRefOid,
+    mergeable: view.mergeable ?? "UNKNOWN",
+    state: view.state,
+    threads: A.map(threadNodes, (node) => YeetWatchThread.make({ id: node.id, isResolved: node.isResolved })),
+  });
+});
+
+const isoNow = DateTime.now.pipe(Effect.map(DateTime.formatIso));
+
+const emitWatchEvent = (event: YeetWatchEvent): Effect.Effect<void, YeetCommandError> =>
+  renderYeetWatchEventLine(event).pipe(
+    Effect.mapError(YeetCommandError.new("Failed to encode a yeet watch event row.")),
+    Effect.flatMap(Console.log)
+  );
+
+/**
+ * Poll the pull request and stream one NDJSON row per state transition.
+ *
+ * **Details**
+ *
+ * The loop collects a snapshot, emits `watch-started`, then polls on the given
+ * interval: each poll's snapshot diffs against the previous one and every
+ * derived event is emitted in order. The stream ends when the snapshot is
+ * terminal — merged, closed, or no check pending — with a final `watch-ended`
+ * row carrying the failure census, which is also the returned count so the
+ * command can exit non-zero on a red wave.
+ *
+ * **Gotchas**
+ *
+ * A head change does not end the stream: the new wave's transitions simply
+ * start diffing against the post-change baseline, which is how "a new push
+ * supersedes the prior wave" reads in stream form. The consumer that dispatches
+ * remediation keys its dedup on `headSha`, so superseded-wave rows cannot leak
+ * into the new wave's session.
+ *
+ * **Example** (Build the stream effect)
+ *
+ * ```ts
+ * import { RepoRunContext, runYeetWatchStream } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const context = RepoRunContext.make({
+ *   base: "origin/main",
+ *   branch: "feature/watch",
+ *   cwd: ".",
+ *   head: "HEAD",
+ *   originalArgv: [],
+ *   packetDir: ".beep/yeet",
+ *   repoRoot: ".",
+ *   turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] }
+ * })
+ *
+ * console.log(Effect.isEffect(runYeetWatchStream(context, { intervalMillis: 10_000 }))) // true
+ * ```
+ *
+ * @param context - Repo context naming the checkout to watch from.
+ * @param config - Poll interval in milliseconds.
+ * @returns The final `watch-ended` row: the end reason plus the failure census.
+ * @category services
+ * @since 0.0.0
+ */
+export const runYeetWatchStream = Effect.fn("Yeet.runYeetWatchStream")(function* (
+  context: RepoRunContext,
+  config: { readonly intervalMillis: number }
+): Effect.fn.Return<YeetWatchEnded, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  let current = yield* collectYeetWatchSnapshot(context);
+  yield* emitWatchEvent(
+    YeetWatchStarted.make({
+      at: yield* isoNow,
+      checks: A.length(current.checks),
+      headSha: current.headSha,
+    })
+  );
+
+  while (true) {
+    const end = yeetWatchEndReason(current);
+    if (O.isSome(end)) {
+      const ended = YeetWatchEnded.make({
+        at: yield* isoNow,
+        failing: countYeetWatchFailures(current),
+        headSha: current.headSha,
+        reason: end.value,
+      });
+      yield* emitWatchEvent(ended);
+      return ended;
+    }
+
+    yield* Effect.sleep(Duration.millis(config.intervalMillis));
+    const next = yield* collectYeetWatchSnapshot(context);
+    const events = diffYeetWatchSnapshots(YeetWatchDiffInput.make({ at: yield* isoNow, next, prev: current }));
+    yield* Effect.forEach(events, emitWatchEvent, { discard: true });
+    current = next;
+  }
+});
+
+/**
+ * End reasons that exit `yeet monitor --watch` with a failure code even when
+ * no check failed.
+ *
+ * **Example** (A closed PR is a failed watch)
+ *
+ * ```ts
+ * import { yeetWatchExitFailure } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(yeetWatchExitFailure({ failing: 0, reason: "pr-closed" })) // true
+ * ```
+ *
+ * @param ended - The end reason and the final failure census.
+ * @returns Whether the command should exit non-zero.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const yeetWatchExitFailure = (ended: Pick<YeetWatchEnded, "failing" | "reason">): boolean =>
+  ended.failing > 0 ||
+  YeetWatchEndReason.is["pr-closed"](ended.reason) ||
+  YeetWatchEndReason.is["poll-error"](ended.reason);

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchStream.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchStream.ts
@@ -32,9 +32,8 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit } from "@beep/schema";
-import { Effect } from "effect";
+import { Effect, HashMap } from "effect";
 import * as A from "effect/Array";
-import * as HashMap from "effect/HashMap";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchStream.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchStream.ts
@@ -1,0 +1,661 @@
+/**
+ * Typed transition stream for Yeet monitor watch sessions.
+ *
+ * **Details**
+ *
+ * The watch redesign (ship-velocity A1) replaces "read the checks page again
+ * and re-print everything" with a stream of state *transitions*: each poll
+ * collects one {@link YeetWatchSnapshot}, and {@link diffYeetWatchSnapshots}
+ * derives the {@link YeetWatchEvent} rows that describe exactly what changed.
+ * Consumers — the operator's terminal, the A2 inbox, the remediation
+ * dispatcher — read one NDJSON row per transition instead of scraping output.
+ *
+ * The module is deliberately split along a boundary/domain seam. GitHub's
+ * check `bucket` vocabulary is open-ended in practice (`fail`, `failing`,
+ * `cancel`, `cancelled`, `error`, `timed_out`, ...), so snapshots keep the raw
+ * strings at the boundary and {@link classifyYeetCheckOutcome} totalizes them
+ * into the closed {@link YeetCheckOutcome} domain that events speak. A bucket
+ * GitHub invents tomorrow degrades to a conservative classification instead of
+ * a decode failure that kills the watch.
+ *
+ * **Gotchas**
+ *
+ * Transition detection keys on typed snapshot diffs, never on log-line
+ * matching: this repo's own proof logs contain realistic failure prose as
+ * fixture output (`yeet monitor failed.` inside a green run), so any consumer
+ * that greps rendered text will find failures that never happened. The differ
+ * is pure precisely so the whole transition matrix is testable without GitHub.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import { Effect } from "effect";
+import * as A from "effect/Array";
+import * as HashMap from "effect/HashMap";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/WatchStream");
+
+/**
+ * Schema version stamped on every emitted watch row.
+ *
+ * **Example** (Read the version)
+ *
+ * ```ts
+ * import { YEET_WATCH_SCHEMA_VERSION } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_WATCH_SCHEMA_VERSION) // "yeet-watch/v1"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_WATCH_SCHEMA_VERSION = "yeet-watch/v1";
+
+/**
+ * Closed outcome domain a check occupies from the watch's point of view.
+ *
+ * **Details**
+ *
+ * This is the internal vocabulary events speak. The boundary keeps GitHub's
+ * raw `bucket`/`state` strings; {@link classifyYeetCheckOutcome} maps them
+ * here totally, so downstream code matches on four cases instead of an
+ * open-ended string set.
+ *
+ * **Example** (Check an outcome)
+ *
+ * ```ts
+ * import { YeetCheckOutcome } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetCheckOutcome.is.fail("fail")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetCheckOutcome = LiteralKit(["pending", "pass", "fail", "skip"]).pipe(
+  $I.annoteSchema("YeetCheckOutcome", {
+    title: "Yeet Check Outcome",
+    description: "Closed classification of one PR check's state within a watch snapshot.",
+  })
+);
+
+/**
+ * Closed outcome domain a check occupies from the watch's point of view.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetCheckOutcome = typeof YeetCheckOutcome.Type;
+
+// The contains-lists mirror yeet status's classifiers (Status.ts), which have
+// watched these strings in the field since the monitor existed. Order matters:
+// failure evidence wins over pending evidence, because a cancelled-while-queued
+// check reports both.
+const FAILING_BUCKETS: ReadonlyArray<string> = ["fail", "failing", "cancel", "cancelled", "error", "timed_out"];
+const FAILING_STATES: ReadonlyArray<string> = ["failure", "cancelled", "error", "timed_out"];
+const PENDING_BUCKETS: ReadonlyArray<string> = ["pending", "running", "queued", "waiting"];
+const PENDING_STATES: ReadonlyArray<string> = ["pending", "in_progress", "queued", "waiting"];
+const SKIP_BUCKETS: ReadonlyArray<string> = ["skipping", "skipped", "neutral"];
+
+/**
+ * One check's raw classification evidence as GitHub reports it.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetCheckSignal extends S.Class<YeetCheckSignal>($I`YeetCheckSignal`)(
+  {
+    bucket: S.String,
+    state: S.String,
+  },
+  $I.annote("YeetCheckSignal", {
+    description: "Raw bucket and state strings for one check, as gh pr checks --json reports them.",
+  })
+) {}
+
+/**
+ * Totalize one raw check payload into the closed outcome domain.
+ *
+ * **Details**
+ *
+ * Classification is deliberately conservative for vocabulary GitHub has not
+ * shown us yet: anything that carries neither failure, pending, nor skip
+ * evidence classifies as `pass` only when its state says so, and otherwise
+ * falls back to `pending` — the one outcome the watch will revisit rather
+ * than conclude on.
+ *
+ * **Example** (Classify a cancelled check)
+ *
+ * ```ts
+ * import { classifyYeetCheckOutcome, YeetCheckSignal } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: "cancel", state: "CANCELLED" }))) // "fail"
+ * ```
+ *
+ * @param check - Raw `bucket` and `state` strings as `gh pr checks --json` reports them.
+ * @returns The closed outcome the watch acts on.
+ * @category mapping
+ * @since 0.0.0
+ */
+export const classifyYeetCheckOutcome = (check: YeetCheckSignal): YeetCheckOutcome => {
+  const bucket = Str.toLowerCase(check.bucket);
+  const state = Str.toLowerCase(check.state);
+  if (A.contains(FAILING_BUCKETS, bucket) || A.contains(FAILING_STATES, state)) {
+    return YeetCheckOutcome.Enum.fail;
+  }
+  if (A.contains(PENDING_BUCKETS, bucket) || A.contains(PENDING_STATES, state)) {
+    return YeetCheckOutcome.Enum.pending;
+  }
+  if (A.contains(SKIP_BUCKETS, bucket) || state === "skipped") {
+    return YeetCheckOutcome.Enum.skip;
+  }
+  if (bucket === "pass" || state === "success") {
+    return YeetCheckOutcome.Enum.pass;
+  }
+  return YeetCheckOutcome.Enum.pending;
+};
+
+/**
+ * One check within a watch snapshot: its name and classified outcome.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetWatchCheck extends S.Class<YeetWatchCheck>($I`YeetWatchCheck`)(
+  {
+    name: S.NonEmptyString,
+    outcome: YeetCheckOutcome,
+  },
+  $I.annote("YeetWatchCheck", {
+    description: "One PR check's name and classified outcome within a watch snapshot.",
+  })
+) {}
+
+/**
+ * One review thread within a watch snapshot: its identity and resolution.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetWatchThread extends S.Class<YeetWatchThread>($I`YeetWatchThread`)(
+  {
+    id: S.NonEmptyString,
+    isResolved: S.Boolean,
+  },
+  $I.annote("YeetWatchThread", {
+    description: "One PR review thread's identity and resolution state within a watch snapshot.",
+  })
+) {}
+
+/**
+ * Everything one watch poll observed about the pull request.
+ *
+ * **Details**
+ *
+ * The snapshot is the unit of comparison: the poller collects one per tick and
+ * the differ derives events from consecutive pairs. `mergeable` and `state`
+ * stay raw strings for the same reason buckets do — GitHub's vocabulary there
+ * (`MERGEABLE`/`CONFLICTING`/`UNKNOWN`, `OPEN`/`MERGED`/`CLOSED`) is an
+ * interoperability surface, not this module's domain.
+ *
+ * **Example** (Construct an empty snapshot)
+ *
+ * ```ts
+ * import { YeetWatchSnapshot } from "@beep/repo-cli/test/Yeet"
+ *
+ * const snapshot = YeetWatchSnapshot.make({
+ *   checks: [],
+ *   headSha: "abc123",
+ *   mergeable: "MERGEABLE",
+ *   state: "OPEN",
+ *   threads: []
+ * })
+ *
+ * console.log(snapshot.headSha) // "abc123"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetWatchSnapshot extends S.Class<YeetWatchSnapshot>($I`YeetWatchSnapshot`)(
+  {
+    checks: S.Array(YeetWatchCheck),
+    headSha: S.NonEmptyString,
+    mergeable: S.String,
+    state: S.String,
+    threads: S.Array(YeetWatchThread),
+  },
+  $I.annote("YeetWatchSnapshot", {
+    description: "Everything one yeet watch poll observed about the pull request.",
+  })
+) {}
+
+/**
+ * The watch began: the first snapshot's identity, before any transition.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetWatchStarted extends S.Class<YeetWatchStarted>($I`YeetWatchStarted`)(
+  {
+    kind: S.tag("watch-started"),
+    schemaVersion: S.Literal(YEET_WATCH_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_WATCH_SCHEMA_VERSION))
+    ),
+    at: S.String,
+    headSha: S.NonEmptyString,
+    checks: S.Finite,
+  },
+  $I.annote("YeetWatchStarted", {
+    description: "First row of a watch stream: the head under watch and how many checks it carries.",
+  })
+) {}
+
+/**
+ * One check moved between outcomes.
+ *
+ * **Details**
+ *
+ * `from` is absent for a check's first observation — a lane that registers
+ * mid-watch arrives as a transition from nothing rather than being silently
+ * folded into the baseline.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetCheckTransition extends S.Class<YeetCheckTransition>($I`YeetCheckTransition`)(
+  {
+    kind: S.tag("check-transition"),
+    schemaVersion: S.Literal(YEET_WATCH_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_WATCH_SCHEMA_VERSION))
+    ),
+    at: S.String,
+    headSha: S.NonEmptyString,
+    name: S.NonEmptyString,
+    from: S.NullOr(YeetCheckOutcome),
+    to: YeetCheckOutcome,
+  },
+  $I.annote("YeetCheckTransition", {
+    description: "One PR check moved between classified outcomes (from null = first observation).",
+  })
+) {}
+
+/**
+ * A review thread appeared or changed resolution state.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetThreadTransition extends S.Class<YeetThreadTransition>($I`YeetThreadTransition`)(
+  {
+    kind: S.tag("thread-transition"),
+    schemaVersion: S.Literal(YEET_WATCH_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_WATCH_SCHEMA_VERSION))
+    ),
+    at: S.String,
+    headSha: S.NonEmptyString,
+    threadId: S.NonEmptyString,
+    to: LiteralKit(["opened", "resolved", "unresolved"]),
+  },
+  $I.annote("YeetThreadTransition", {
+    description: "A review thread appeared (opened), was resolved, or was re-opened (unresolved).",
+  })
+) {}
+
+/**
+ * The PR's mergeability answer changed.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMergeabilityChanged extends S.Class<YeetMergeabilityChanged>($I`YeetMergeabilityChanged`)(
+  {
+    kind: S.tag("mergeability-changed"),
+    schemaVersion: S.Literal(YEET_WATCH_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_WATCH_SCHEMA_VERSION))
+    ),
+    at: S.String,
+    headSha: S.NonEmptyString,
+    from: S.String,
+    to: S.String,
+  },
+  $I.annote("YeetMergeabilityChanged", {
+    description: "GitHub's mergeability answer for the PR changed between polls.",
+  })
+) {}
+
+/**
+ * The PR's head moved: a new push supersedes the watched wave.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetHeadChanged extends S.Class<YeetHeadChanged>($I`YeetHeadChanged`)(
+  {
+    kind: S.tag("head-changed"),
+    schemaVersion: S.Literal(YEET_WATCH_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_WATCH_SCHEMA_VERSION))
+    ),
+    at: S.String,
+    from: S.NonEmptyString,
+    to: S.NonEmptyString,
+  },
+  $I.annote("YeetHeadChanged", {
+    description: "The PR head moved to a new SHA; transitions before it belong to a superseded wave.",
+  })
+) {}
+
+/**
+ * Reasons a watch stream ends.
+ *
+ * **Example** (Check a reason)
+ *
+ * ```ts
+ * import { YeetWatchEndReason } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetWatchEndReason.is["all-terminal"]("all-terminal")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetWatchEndReason = LiteralKit(["all-terminal", "pr-merged", "pr-closed", "poll-error"]).pipe(
+  $I.annoteSchema("YeetWatchEndReason", {
+    title: "Yeet Watch End Reason",
+    description: "Why a yeet watch stream ended.",
+  })
+);
+
+/**
+ * Reasons a watch stream ends.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetWatchEndReason = typeof YeetWatchEndReason.Type;
+
+/**
+ * The watch ended, with the reason and the final failure census.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetWatchEnded extends S.Class<YeetWatchEnded>($I`YeetWatchEnded`)(
+  {
+    kind: S.tag("watch-ended"),
+    schemaVersion: S.Literal(YEET_WATCH_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_WATCH_SCHEMA_VERSION))
+    ),
+    at: S.String,
+    headSha: S.NonEmptyString,
+    reason: YeetWatchEndReason,
+    failing: S.Finite,
+  },
+  $I.annote("YeetWatchEnded", {
+    description: "Last row of a watch stream: why it ended and how many checks were failing.",
+  })
+) {}
+
+/**
+ * One row of the watch stream.
+ *
+ * **Details**
+ *
+ * Every member carries `schemaVersion`, `at`, and a discriminating `kind`, so
+ * a consumer can decode line-by-line without context and route on `kind` with
+ * an exhaustive match.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetWatchEvent = S.Union([
+  YeetWatchStarted,
+  YeetCheckTransition,
+  YeetThreadTransition,
+  YeetMergeabilityChanged,
+  YeetHeadChanged,
+  YeetWatchEnded,
+]).pipe(
+  $I.annoteSchema("YeetWatchEvent", {
+    title: "Yeet Watch Event",
+    description: "One typed row of the yeet monitor watch transition stream.",
+  })
+);
+
+/**
+ * One row of the watch stream.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetWatchEvent = typeof YeetWatchEvent.Type;
+
+const encodeWatchEvent = S.encodeUnknownEffect(S.fromJsonString(YeetWatchEvent));
+
+/**
+ * Render one watch event as its NDJSON line.
+ *
+ * **Details**
+ *
+ * The stream contract is one JSON document per line on stdout; human-facing
+ * prose belongs on stderr. Encoding goes through the schema so the emitted
+ * shape is exactly the declared one — a consumer can decode any line with
+ * {@link YeetWatchEvent} and an out-of-date consumer can key on
+ * `schemaVersion`.
+ *
+ * **Example** (Render a head change)
+ *
+ * ```ts
+ * import { renderYeetWatchEventLine, YeetHeadChanged } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const line = renderYeetWatchEventLine(YeetHeadChanged.make({ at: "2026-08-17T00:00:00Z", from: "aaa", to: "bbb" }))
+ *
+ * console.log(Effect.isEffect(line)) // true
+ * ```
+ *
+ * @param event - The event to render.
+ * @returns The event as a single-line JSON string.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetWatchEventLine = (event: YeetWatchEvent): Effect.Effect<string, S.SchemaError> =>
+  encodeWatchEvent(event);
+
+const checkOutcomes = (snapshot: YeetWatchSnapshot): HashMap.HashMap<string, YeetCheckOutcome> =>
+  HashMap.fromIterable(A.map(snapshot.checks, (check) => [check.name, check.outcome] as const));
+
+const threadStates = (snapshot: YeetWatchSnapshot): HashMap.HashMap<string, boolean> =>
+  HashMap.fromIterable(A.map(snapshot.threads, (thread) => [thread.id, thread.isResolved] as const));
+
+/**
+ * The differ's input: two consecutive snapshots plus the row timestamp.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetWatchDiffInput extends S.Class<YeetWatchDiffInput>($I`YeetWatchDiffInput`)(
+  {
+    at: S.String,
+    next: YeetWatchSnapshot,
+    prev: YeetWatchSnapshot,
+  },
+  $I.annote("YeetWatchDiffInput", {
+    description: "Two consecutive watch snapshots plus the timestamp stamped on derived events.",
+  })
+) {}
+
+/**
+ * Derive the transition events between two consecutive snapshots.
+ *
+ * **Details**
+ *
+ * The differ is pure and total: given the previous and next snapshots plus the
+ * row timestamp, it returns every event the change implies, in a stable order
+ * (head movement first, then check transitions in the next snapshot's check
+ * order, then thread transitions, then mergeability). When the head moved, the
+ * check and thread diffs are suppressed — those transitions belong to the new
+ * wave's own baseline, and emitting them against the old wave would attribute
+ * a fresh push's pending checks to the superseded head.
+ *
+ * **Gotchas**
+ *
+ * A check that disappears from the rollup (GitHub dropped it, a workflow was
+ * renamed) emits nothing: the stream reports observed states, not absence.
+ * The consumer that cares about disappearance is the terminal-condition
+ * evaluator, which reads the whole snapshot anyway.
+ *
+ * **Example** (One check goes red)
+ *
+ * ```ts
+ * import { diffYeetWatchSnapshots, YeetWatchCheck, YeetWatchSnapshot } from "@beep/repo-cli/test/Yeet"
+ *
+ * const prev = YeetWatchSnapshot.make({
+ *   checks: [YeetWatchCheck.make({ name: "Check", outcome: "pending" })],
+ *   headSha: "abc",
+ *   mergeable: "MERGEABLE",
+ *   state: "OPEN",
+ *   threads: []
+ * })
+ * const next = YeetWatchSnapshot.make({
+ *   checks: [YeetWatchCheck.make({ name: "Check", outcome: "fail" })],
+ *   headSha: "abc",
+ *   mergeable: "MERGEABLE",
+ *   state: "OPEN",
+ *   threads: []
+ * })
+ *
+ * console.log(diffYeetWatchSnapshots(YeetWatchDiffInput.make({ at: "2026-08-17T00:00:00Z", next, prev })).length) // 1
+ * ```
+ *
+ * @param input - The previous and next snapshots plus the timestamp stamped on
+ * every derived event.
+ * @returns The events describing what changed, possibly empty.
+ * @category mapping
+ * @since 0.0.0
+ */
+export const diffYeetWatchSnapshots = (input: YeetWatchDiffInput): ReadonlyArray<YeetWatchEvent> => {
+  const { at, next, prev } = input;
+  if (prev.headSha !== next.headSha) {
+    return [YeetHeadChanged.make({ at, from: prev.headSha, to: next.headSha })];
+  }
+
+  const previousChecks = checkOutcomes(prev);
+  // A.flatMap over A.filterMap: v4 filterMap takes a Result-returning Filter,
+  // and an Option-returning callback compiles while silently yielding [].
+  const checkEvents = A.flatMap(next.checks, (check): ReadonlyArray<YeetWatchEvent> => {
+    const before = HashMap.get(previousChecks, check.name);
+    return O.isSome(before) && before.value === check.outcome
+      ? A.empty()
+      : [
+          YeetCheckTransition.make({
+            at,
+            headSha: next.headSha,
+            name: check.name,
+            from: O.getOrNull(before),
+            to: check.outcome,
+          }),
+        ];
+  });
+
+  const previousThreads = threadStates(prev);
+  const threadEvents = A.flatMap(next.threads, (thread): ReadonlyArray<YeetWatchEvent> => {
+    const before = HashMap.get(previousThreads, thread.id);
+    const to = O.match(before, {
+      onNone: () => (thread.isResolved ? O.none<"opened" | "resolved" | "unresolved">() : O.some("opened" as const)),
+      onSome: (wasResolved) =>
+        wasResolved === thread.isResolved
+          ? O.none<"opened" | "resolved" | "unresolved">()
+          : O.some(thread.isResolved ? ("resolved" as const) : ("unresolved" as const)),
+    });
+    return O.match(to, {
+      onNone: () => A.empty<YeetWatchEvent>(),
+      onSome: (state) => [YeetThreadTransition.make({ at, headSha: next.headSha, threadId: thread.id, to: state })],
+    });
+  });
+
+  const mergeabilityEvents: ReadonlyArray<YeetWatchEvent> =
+    prev.mergeable === next.mergeable
+      ? A.empty()
+      : [YeetMergeabilityChanged.make({ at, headSha: next.headSha, from: prev.mergeable, to: next.mergeable })];
+
+  return A.appendAll(A.appendAll(checkEvents, threadEvents), mergeabilityEvents);
+};
+
+/**
+ * Decide whether a snapshot ends the watch, and why.
+ *
+ * **Details**
+ *
+ * A closed or merged PR ends the watch regardless of check state. Otherwise
+ * the watch ends when no check is pending — including the degenerate zero-
+ * check snapshot, which the registration backoff upstream is responsible for
+ * not handing to the stream in the first place.
+ *
+ * **Example** (A merged PR ends the watch)
+ *
+ * ```ts
+ * import { yeetWatchEndReason, YeetWatchSnapshot } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const snapshot = YeetWatchSnapshot.make({
+ *   checks: [],
+ *   headSha: "abc",
+ *   mergeable: "UNKNOWN",
+ *   state: "MERGED",
+ *   threads: []
+ * })
+ *
+ * console.log(O.getOrNull(yeetWatchEndReason(snapshot))) // "pr-merged"
+ * ```
+ *
+ * @param snapshot - The snapshot to evaluate.
+ * @returns The end reason, or none while the watch should continue.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const yeetWatchEndReason = (snapshot: YeetWatchSnapshot): O.Option<YeetWatchEndReason> => {
+  const state = Str.toUpperCase(snapshot.state);
+  if (state === "MERGED") {
+    return O.some(YeetWatchEndReason.Enum["pr-merged"]);
+  }
+  if (state === "CLOSED") {
+    return O.some(YeetWatchEndReason.Enum["pr-closed"]);
+  }
+  return A.some(snapshot.checks, (check) => YeetCheckOutcome.is.pending(check.outcome))
+    ? O.none()
+    : O.some(YeetWatchEndReason.Enum["all-terminal"]);
+};
+
+/**
+ * Count the failing checks in a snapshot.
+ *
+ * **Example** (Count a red snapshot)
+ *
+ * ```ts
+ * import { countYeetWatchFailures, YeetWatchCheck, YeetWatchSnapshot } from "@beep/repo-cli/test/Yeet"
+ *
+ * const snapshot = YeetWatchSnapshot.make({
+ *   checks: [YeetWatchCheck.make({ name: "Check", outcome: "fail" })],
+ *   headSha: "abc",
+ *   mergeable: "MERGEABLE",
+ *   state: "OPEN",
+ *   threads: []
+ * })
+ *
+ * console.log(countYeetWatchFailures(snapshot)) // 1
+ * ```
+ *
+ * @param snapshot - The snapshot to count within.
+ * @returns How many checks classify as `fail`.
+ * @category getters
+ * @since 0.0.0
+ */
+export const countYeetWatchFailures = (snapshot: YeetWatchSnapshot): number =>
+  A.length(A.filter(snapshot.checks, (check) => YeetCheckOutcome.is.fail(check.outcome)));

--- a/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
@@ -53,6 +53,8 @@ export * from "../commands/Yeet/internal/Sweep.schemas.ts";
 export * from "../commands/Yeet/internal/Sweep.ts";
 export * from "../commands/Yeet/internal/TurboQuery.ts";
 export * from "../commands/Yeet/internal/Verdict.ts";
+export * from "../commands/Yeet/internal/WatchMode.ts";
+export * from "../commands/Yeet/internal/WatchStream.ts";
 export * from "../commands/Yeet/Yeet.render.ts";
 export * from "../commands/Yeet/Yeet.schemas.ts";
 export { GhActor } from "../internal/github/GhSchema.ts";

--- a/packages/tooling/tool/cli/test/yeet-watch-mode.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-watch-mode.test.ts
@@ -159,11 +159,14 @@ describe("collectYeetWatchSnapshot", () => {
       )
     )
   );
-  it.effect("degrades a failed thread read to an empty thread set", () =>
+  // An outage that decoded to an empty thread set would make the next good
+  // poll re-report every existing thread as newly opened (#751 review P1).
+  it.effect("fails a poll whose thread read fails, instead of faking emptiness", () =>
     Effect.gen(function* () {
-      const snapshot = yield* collectYeetWatchSnapshot(context);
+      const failure = yield* Effect.flip(collectYeetWatchSnapshot(context));
 
-      expect(snapshot.threads).toEqual([]);
+      expect(failure).toBeInstanceOf(YeetCommandError);
+      expect(failure.message).toContain("could not read PR review threads");
     }).pipe(
       provideScopedLayer(
         scriptedSpawnerLayer([
@@ -171,6 +174,27 @@ describe("collectYeetWatchSnapshot", () => {
             view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
             checks: { exitCode: 0, output: checksJson([]) },
             threads: { exitCode: 1, output: "gh: API rate limit exceeded" },
+          },
+        ])
+      )
+    )
+  );
+
+  // Only gh's registration message buys an empty rollup; any other checks
+  // failure ending the watch as green `all-terminal` was #751's first P1.
+  it.effect("fails a poll whose checks read fails for a non-registration reason", () =>
+    Effect.gen(function* () {
+      const failure = yield* Effect.flip(collectYeetWatchSnapshot(context));
+
+      expect(failure).toBeInstanceOf(YeetCommandError);
+      expect(failure.message).toContain("could not read PR checks");
+    }).pipe(
+      provideScopedLayer(
+        scriptedSpawnerLayer([
+          {
+            view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+            checks: { exitCode: 1, output: "gh: API rate limit exceeded" },
+            threads: { exitCode: 0, output: threadsJson([]) },
           },
         ])
       )
@@ -233,6 +257,38 @@ describe("runYeetWatchStream", () => {
             {
               view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
               checks: { exitCode: 0, output: checksJson([{ bucket: "fail", name: "Coverage", state: "FAILURE" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+
+  it.live("converts a failed later poll into a typed poll-error ending", () =>
+    Effect.gen(function* () {
+      const ended = yield* runYeetWatchStream(context, { intervalMillis: 0 });
+
+      expect(ended.reason).toBe("poll-error");
+      expect(ended.failing).toBe(0);
+      const lines = A.map(yield* TestConsole.logLines, String);
+      const events = yield* Effect.forEach(lines, (line) => decodeLine(line));
+      expect(A.map(events, (event) => event.kind)).toEqual(["watch-started", "watch-ended"]);
+      const errors = A.map(yield* TestConsole.errorLines, String);
+      expect(A.some(errors, (line) => Str.includes("watch poll failed")(line))).toBe(true);
+    }).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          scriptedSpawnerLayer([
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "pending", name: "Coverage", state: "QUEUED" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 1, output: "gh: API rate limit exceeded" },
               threads: { exitCode: 0, output: threadsJson([]) },
             },
           ])

--- a/packages/tooling/tool/cli/test/yeet-watch-mode.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-watch-mode.test.ts
@@ -1,0 +1,264 @@
+import {
+  collectYeetWatchSnapshot,
+  RepoRunContext,
+  runYeetWatchStream,
+  YeetCommandError,
+  YeetWatchEvent,
+  yeetWatchExitFailure,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Ref, Sink, Stream } from "effect";
+import * as A from "effect/Array";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import * as TestConsole from "effect/testing/TestConsole";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+const context = RepoRunContext.make({
+  base: "origin/main",
+  branch: "feature/watch",
+  cwd: ".",
+  head: "HEAD",
+  originalArgv: [],
+  packetDir: ".beep/yeet",
+  repoRoot: ".",
+  turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+});
+
+const encoder = new TextEncoder();
+
+const stubHandle = (exitCode: number, output: string) =>
+  ChildProcessSpawner.makeHandle({
+    all: Stream.make(encoder.encode(output)),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    pid: ChildProcessSpawner.ProcessId(1),
+    stderr: Stream.empty,
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(output)),
+    unref: Effect.succeed(Effect.void),
+  });
+
+/** The three answers one snapshot collection reads, in spawn order. */
+interface PollScript {
+  readonly checks: { readonly exitCode: number; readonly output: string };
+  readonly threads: { readonly exitCode: number; readonly output: string };
+  readonly view: { readonly exitCode: number; readonly output: string };
+}
+
+const viewJson = (state: string, headSha: string): string =>
+  JSON.stringify({ headRefOid: headSha, id: "PR_watch", mergeable: "MERGEABLE", state });
+
+const checksJson = (rows: ReadonlyArray<{ readonly name: string; readonly bucket: string; readonly state: string }>) =>
+  JSON.stringify(rows);
+
+const threadsJson = (nodes: ReadonlyArray<{ readonly id: string; readonly isResolved: boolean }>) =>
+  JSON.stringify({ data: { node: { reviewThreads: { nodes } } } });
+
+// One scripted answer set per poll; `gh api graphql` — the last read of each
+// collection — advances the cursor to the next poll's script.
+const scriptedSpawnerLayer = (scripts: ReadonlyArray<PollScript>) =>
+  Layer.effect(
+    ChildProcessSpawner.ChildProcessSpawner,
+    Effect.gen(function* () {
+      const cursor = yield* Ref.make(0);
+      return ChildProcessSpawner.make((command) => {
+        if (!ChildProcess.isStandardCommand(command)) {
+          return Effect.die("the watch never spawns a piped command");
+        }
+        const line = A.join([command.command, ...command.args], " ");
+        return Effect.gen(function* () {
+          const index = Math.min(yield* Ref.get(cursor), A.length(scripts) - 1);
+          const script = scripts[index] as PollScript;
+          if (Str.includes("pr view")(line)) {
+            return stubHandle(script.view.exitCode, script.view.output);
+          }
+          if (Str.includes("pr checks")(line)) {
+            return stubHandle(script.checks.exitCode, script.checks.output);
+          }
+          yield* Ref.update(cursor, (value) => value + 1);
+          return stubHandle(script.threads.exitCode, script.threads.output);
+        });
+      });
+    })
+  );
+
+const greenScript = (headSha: string): PollScript => ({
+  view: { exitCode: 0, output: viewJson("OPEN", headSha) },
+  checks: { exitCode: 0, output: checksJson([{ bucket: "pass", name: "Check", state: "SUCCESS" }]) },
+  threads: { exitCode: 0, output: threadsJson([]) },
+});
+
+describe("collectYeetWatchSnapshot", () => {
+  it.effect("decodes and classifies one full snapshot", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* collectYeetWatchSnapshot(context);
+
+      expect(snapshot.headSha).toBe("aaa111");
+      expect(snapshot.state).toBe("OPEN");
+      expect(A.map(snapshot.checks, (check) => check.outcome)).toEqual(["pending", "fail"]);
+      expect(A.map(snapshot.threads, (thread) => thread.isResolved)).toEqual([false]);
+    }).pipe(
+      provideScopedLayer(
+        scriptedSpawnerLayer([
+          {
+            view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+            checks: {
+              exitCode: 0,
+              output: checksJson([
+                { bucket: "pending", name: "Coverage", state: "IN_PROGRESS" },
+                { bucket: "fail", name: "Lint", state: "FAILURE" },
+              ]),
+            },
+            threads: { exitCode: 0, output: threadsJson([{ id: "T1", isResolved: false }]) },
+          },
+        ])
+      )
+    )
+  );
+
+  it.effect("fails loudly when no pull request exists for the branch", () =>
+    Effect.gen(function* () {
+      const failure = yield* Effect.flip(collectYeetWatchSnapshot(context));
+
+      expect(failure).toBeInstanceOf(YeetCommandError);
+      expect(failure.message).toContain("requires an open pull request");
+    }).pipe(
+      provideScopedLayer(
+        scriptedSpawnerLayer([
+          {
+            view: { exitCode: 1, output: "no pull requests found" },
+            checks: { exitCode: 0, output: "[]" },
+            threads: { exitCode: 0, output: threadsJson([]) },
+          },
+        ])
+      )
+    )
+  );
+
+  // "no checks reported" is gh's registration gap, not a poll failure — the
+  // snapshot carries an empty rollup and the caller's policy decides.
+  it.effect("reads a failed checks read as an empty rollup", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* collectYeetWatchSnapshot(context);
+
+      expect(snapshot.checks).toEqual([]);
+    }).pipe(
+      provideScopedLayer(
+        scriptedSpawnerLayer([
+          {
+            view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+            checks: { exitCode: 1, output: "no checks reported on the 'feature/watch' branch" },
+            threads: { exitCode: 0, output: threadsJson([]) },
+          },
+        ])
+      )
+    )
+  );
+  it.effect("degrades a failed thread read to an empty thread set", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* collectYeetWatchSnapshot(context);
+
+      expect(snapshot.threads).toEqual([]);
+    }).pipe(
+      provideScopedLayer(
+        scriptedSpawnerLayer([
+          {
+            view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+            checks: { exitCode: 0, output: checksJson([]) },
+            threads: { exitCode: 1, output: "gh: API rate limit exceeded" },
+          },
+        ])
+      )
+    )
+  );
+
+  // GraphQL answers `node: null` for an id the token cannot see; a null
+  // mergeable is GitHub still computing it. Neither may kill a poll.
+  it.effect("reads a null GraphQL node and a null mergeable as empty and UNKNOWN", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* collectYeetWatchSnapshot(context);
+
+      expect(snapshot.threads).toEqual([]);
+      expect(snapshot.mergeable).toBe("UNKNOWN");
+    }).pipe(
+      provideScopedLayer(
+        scriptedSpawnerLayer([
+          {
+            view: {
+              exitCode: 0,
+              output: JSON.stringify({ headRefOid: "aaa111", id: "PR_watch", mergeable: null, state: "OPEN" }),
+            },
+            checks: { exitCode: 0, output: checksJson([]) },
+            threads: { exitCode: 0, output: JSON.stringify({ data: { node: null } }) },
+          },
+        ])
+      )
+    )
+  );
+});
+
+describe("runYeetWatchStream", () => {
+  const decodeLine = S.decodeUnknownEffect(S.fromJsonString(YeetWatchEvent));
+
+  // it.live: the loop sleeps between polls, and under the TestClock a real
+  // sleep parks forever (A7's receipt). Zero interval keeps it instant.
+  it.live("streams started, transitions, and ended rows as decodable NDJSON", () =>
+    Effect.gen(function* () {
+      const ended = yield* runYeetWatchStream(context, { intervalMillis: 0 });
+
+      expect(ended.reason).toBe("all-terminal");
+      expect(ended.failing).toBe(1);
+
+      const lines = A.map(yield* TestConsole.logLines, String);
+      const events = yield* Effect.forEach(lines, (line) => decodeLine(line));
+      expect(A.map(events, (event) => event.kind)).toEqual(["watch-started", "check-transition", "watch-ended"]);
+      const transition = events[1] as Extract<YeetWatchEvent, { readonly kind: "check-transition" }>;
+      expect(transition.from).toBe("pending");
+      expect(transition.to).toBe("fail");
+    }).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          scriptedSpawnerLayer([
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "pending", name: "Coverage", state: "QUEUED" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "fail", name: "Coverage", state: "FAILURE" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+
+  it.live("ends immediately when the first snapshot is already terminal", () =>
+    Effect.gen(function* () {
+      const ended = yield* runYeetWatchStream(context, { intervalMillis: 0 });
+
+      expect(ended.reason).toBe("all-terminal");
+      expect(ended.failing).toBe(0);
+      const lines = A.map(yield* TestConsole.logLines, String);
+      expect(A.length(lines)).toBe(2);
+    }).pipe(provideScopedLayer(Layer.mergeAll(TestConsole.layer, scriptedSpawnerLayer([greenScript("aaa111")]))))
+  );
+});
+
+describe("yeetWatchExitFailure", () => {
+  it("fails on any red, on a closed PR, and on a poll error; passes a green settle and a merge", () => {
+    expect(yeetWatchExitFailure({ failing: 2, reason: "all-terminal" })).toBe(true);
+    expect(yeetWatchExitFailure({ failing: 0, reason: "pr-closed" })).toBe(true);
+    expect(yeetWatchExitFailure({ failing: 0, reason: "poll-error" })).toBe(true);
+    expect(yeetWatchExitFailure({ failing: 0, reason: "all-terminal" })).toBe(false);
+    expect(yeetWatchExitFailure({ failing: 0, reason: "pr-merged" })).toBe(false);
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet-watch-stream.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-watch-stream.test.ts
@@ -1,0 +1,220 @@
+import {
+  classifyYeetCheckOutcome,
+  countYeetWatchFailures,
+  diffYeetWatchSnapshots,
+  renderYeetWatchEventLine,
+  YEET_WATCH_SCHEMA_VERSION,
+  YeetCheckSignal,
+  YeetWatchCheck,
+  YeetWatchDiffInput,
+  YeetWatchEnded,
+  YeetWatchEvent,
+  YeetWatchSnapshot,
+  YeetWatchStarted,
+  YeetWatchThread,
+  yeetWatchEndReason,
+} from "@beep/repo-cli/test/Yeet";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import type { YeetCheckTransition, YeetHeadChanged } from "@beep/repo-cli/test/Yeet";
+
+const AT = "2026-08-17T00:00:00Z";
+
+const snapshot = (overrides: Partial<Parameters<typeof YeetWatchSnapshot.make>[0]> = {}): YeetWatchSnapshot =>
+  YeetWatchSnapshot.make({
+    checks: [],
+    headSha: "aaa111",
+    mergeable: "MERGEABLE",
+    state: "OPEN",
+    threads: [],
+    ...overrides,
+  });
+
+const check = (name: string, outcome: "pending" | "pass" | "fail" | "skip"): YeetWatchCheck =>
+  YeetWatchCheck.make({ name, outcome });
+
+const thread = (id: string, isResolved: boolean): YeetWatchThread => YeetWatchThread.make({ id, isResolved });
+
+describe("classifyYeetCheckOutcome", () => {
+  it("classifies every failing bucket and failing state as fail", () => {
+    for (const bucket of ["fail", "failing", "cancel", "cancelled", "error", "timed_out"]) {
+      expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket, state: "COMPLETED" }))).toBe("fail");
+    }
+    for (const state of ["FAILURE", "CANCELLED", "ERROR", "TIMED_OUT"]) {
+      expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: "unknown-bucket", state }))).toBe("fail");
+    }
+  });
+
+  it("classifies pending buckets and states as pending", () => {
+    for (const bucket of ["pending", "running", "queued", "waiting"]) {
+      expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket, state: "" }))).toBe("pending");
+    }
+    expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: "novel", state: "IN_PROGRESS" }))).toBe("pending");
+  });
+
+  it("classifies skip vocabulary as skip", () => {
+    for (const bucket of ["skipping", "skipped", "neutral"]) {
+      expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket, state: "" }))).toBe("skip");
+    }
+    expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: "novel", state: "SKIPPED" }))).toBe("skip");
+  });
+
+  it("classifies pass only on positive evidence", () => {
+    expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: "pass", state: "" }))).toBe("pass");
+    expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: "novel", state: "SUCCESS" }))).toBe("pass");
+  });
+
+  // The conservative fallback: vocabulary GitHub has not shown us degrades to
+  // the one outcome the watch revisits, never to a conclusion.
+  it("classifies unknown vocabulary as pending", () => {
+    expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: "brand-new-bucket", state: "BRAND_NEW" }))).toBe(
+      "pending"
+    );
+  });
+
+  it("lets failure evidence win over pending evidence", () => {
+    expect(classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: "cancel", state: "QUEUED" }))).toBe("fail");
+  });
+});
+
+describe("diffYeetWatchSnapshots", () => {
+  const diff = (input: { at: string; next: YeetWatchSnapshot; prev: YeetWatchSnapshot }) =>
+    diffYeetWatchSnapshots(YeetWatchDiffInput.make(input));
+
+  it("emits nothing when nothing changed", () => {
+    const same = snapshot({ checks: [check("Check", "pending")], threads: [thread("T1", false)] });
+    expect(diff({ at: AT, next: same, prev: same })).toEqual([]);
+  });
+
+  it("emits one transition when a check goes red, carrying the prior outcome", () => {
+    const events = diff({
+      at: AT,
+      next: snapshot({ checks: [check("Coverage", "fail")] }),
+      prev: snapshot({ checks: [check("Coverage", "pending")] }),
+    });
+    expect(A.length(events)).toBe(1);
+    const event = events[0] as YeetCheckTransition;
+    expect(event.kind).toBe("check-transition");
+    expect(event.from).toBe("pending");
+    expect(event.to).toBe("fail");
+    expect(event.name).toBe("Coverage");
+    expect(event.headSha).toBe("aaa111");
+  });
+
+  it("reports a first observation as a transition from nothing", () => {
+    const events = diff({
+      at: AT,
+      next: snapshot({ checks: [check("Late Lane", "pending")] }),
+      prev: snapshot(),
+    });
+    expect(A.length(events)).toBe(1);
+    expect((events[0] as YeetCheckTransition).from).toBeNull();
+  });
+
+  it("suppresses check and thread diffs when the head moved", () => {
+    const events = diff({
+      at: AT,
+      next: snapshot({ checks: [check("Check", "pending")], headSha: "bbb222", threads: [thread("T1", false)] }),
+      prev: snapshot({ checks: [check("Check", "fail")] }),
+    });
+    expect(A.length(events)).toBe(1);
+    const event = events[0] as YeetHeadChanged;
+    expect(event.kind).toBe("head-changed");
+    expect(event.from).toBe("aaa111");
+    expect(event.to).toBe("bbb222");
+  });
+
+  it("reports thread lifecycle transitions: opened, resolved, unresolved", () => {
+    const opened = diff({ at: AT, next: snapshot({ threads: [thread("T1", false)] }), prev: snapshot() });
+    expect(A.map(opened, (event) => (event as { readonly to: string }).to)).toEqual(["opened"]);
+
+    const resolved = diff({
+      at: AT,
+      next: snapshot({ threads: [thread("T1", true)] }),
+      prev: snapshot({ threads: [thread("T1", false)] }),
+    });
+    expect(A.map(resolved, (event) => (event as { readonly to: string }).to)).toEqual(["resolved"]);
+
+    const reopened = diff({
+      at: AT,
+      next: snapshot({ threads: [thread("T1", false)] }),
+      prev: snapshot({ threads: [thread("T1", true)] }),
+    });
+    expect(A.map(reopened, (event) => (event as { readonly to: string }).to)).toEqual(["unresolved"]);
+  });
+
+  it("does not report a thread that arrives already resolved", () => {
+    const events = diff({ at: AT, next: snapshot({ threads: [thread("T1", true)] }), prev: snapshot() });
+    expect(events).toEqual([]);
+  });
+
+  it("reports a mergeability change after check and thread events", () => {
+    const events = diff({
+      at: AT,
+      next: snapshot({ checks: [check("Check", "pass")], mergeable: "CONFLICTING" }),
+      prev: snapshot({ checks: [check("Check", "pending")] }),
+    });
+    expect(A.map(events, (event) => event.kind)).toEqual(["check-transition", "mergeability-changed"]);
+  });
+});
+
+describe("yeetWatchEndReason", () => {
+  it("ends on a merged PR regardless of checks", () => {
+    const reason = yeetWatchEndReason(snapshot({ checks: [check("Check", "pending")], state: "MERGED" }));
+    expect(O.getOrNull(reason)).toBe("pr-merged");
+  });
+
+  it("ends on a closed PR", () => {
+    expect(O.getOrNull(yeetWatchEndReason(snapshot({ state: "CLOSED" })))).toBe("pr-closed");
+  });
+
+  it("continues while any check is pending", () => {
+    const reason = yeetWatchEndReason(snapshot({ checks: [check("A", "pass"), check("B", "pending")] }));
+    expect(O.isNone(reason)).toBe(true);
+  });
+
+  it("ends all-terminal when no check is pending", () => {
+    const reason = yeetWatchEndReason(snapshot({ checks: [check("A", "pass"), check("B", "fail")] }));
+    expect(O.getOrNull(reason)).toBe("all-terminal");
+  });
+});
+
+describe("countYeetWatchFailures", () => {
+  it("counts only failing checks", () => {
+    const counted = countYeetWatchFailures(
+      snapshot({ checks: [check("A", "fail"), check("B", "pass"), check("C", "fail"), check("D", "skip")] })
+    );
+    expect(counted).toBe(2);
+  });
+});
+
+describe("renderYeetWatchEventLine", () => {
+  const decodeLine = S.decodeUnknownEffect(S.fromJsonString(YeetWatchEvent));
+
+  it.effect("renders one single-line JSON document that round-trips through the schema", () =>
+    Effect.gen(function* () {
+      const started = YeetWatchStarted.make({ at: AT, checks: 3, headSha: "aaa111" });
+      const line = yield* renderYeetWatchEventLine(started);
+
+      expect(Str.includes("\n")(line)).toBe(false);
+      const decoded = yield* decodeLine(line);
+      expect(decoded.kind).toBe("watch-started");
+      expect(decoded.schemaVersion).toBe(YEET_WATCH_SCHEMA_VERSION);
+    })
+  );
+
+  it.effect("stamps the schema version on every event without callers passing it", () =>
+    Effect.gen(function* () {
+      const ended = YeetWatchEnded.make({ at: AT, failing: 1, headSha: "aaa111", reason: "all-terminal" });
+      const line = yield* renderYeetWatchEventLine(ended);
+      const decoded = yield* decodeLine(line);
+
+      expect(decoded.kind).toBe("watch-ended");
+      expect(decoded.schemaVersion).toBe(YEET_WATCH_SCHEMA_VERSION);
+    })
+  );
+});


### PR DESCRIPTION
## feat(yeet): stream typed PR state transitions with yeet monitor --watch

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_yeet-watch-event-stream-da6df673cc44/verdict.json

---

## Provenance

- Branch: <code>feat/yeet-watch-event-stream</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/yeet-watch-event-stream",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789565478&installation_model_id=424656&pr_number=751&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F751&signature=fa632d7a68d3ed3deaff92d2496e95c43ac80325b4cd048cd97401dd984ce204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->