### PR TITLE
feat(yeet): dispatch failure capsules from the watch stream

### DIFF
--- a/.changeset/yeet-watch-failure-capsules.md
+++ b/.changeset/yeet-watch-failure-capsules.md
@@ -1,0 +1,15 @@
+---
+"@beep/repo-cli": minor
+---
+
+`yeet monitor --watch` now dispatches remediation for every observed red: a failure capsule
+derived from the failing check's own record (lane, job link, workflow, raw bucket/state) is
+appended to `<checkout>/.beep/inbox/failures.ndjson` (`yeet-inbox/v1`, the row shape the A2 hook
+adapters will consume), and a persisted wave record (`.beep/inbox/dispatch.json`,
+`yeet-dispatch/v1`) counts one repair session per head — the first red starts it, later reds
+queue with headSha+lane dedup, a re-run red is dropped as a duplicate, and a new push supersedes
+the wave before the new baseline's reds are seeded. The watch also now polls through gh's
+post-push "no checks reported" registration gap for a bounded number of ticks instead of ending
+green while a push's checks are still registering, and wave freshness is keyed on
+(prNumber, headSha) so a stale record from a dead PR on the same branch tip cannot swallow a new
+PR's session start.

--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -142,7 +142,12 @@ bun run beep yeet monitor --until-merged
 - Stream one NDJSON row per PR state transition (typed `yeet-watch/v1` rows:
   check transitions, thread open/resolve, mergeability, head supersession)
   until the PR settles; exits non-zero on a red wave, a closed PR, or a poll
-  error:
+  error. Every observed red also appends a failure capsule — derived from the
+  failing check's own record — to `<checkout>/.beep/inbox/failures.ndjson`
+  (`yeet-inbox/v1`) and advances the wave record at
+  `.beep/inbox/dispatch.json` (`yeet-dispatch/v1`): first red for a head opens
+  the repair session, later reds queue with headSha+lane dedup, a new push
+  supersedes the wave:
 
 ```bash
 bun run beep yeet monitor --watch

--- a/goals/ship-velocity/PLAN.md
+++ b/goals/ship-velocity/PLAN.md
@@ -46,7 +46,17 @@ the C5 metric correction and the new C7 item below.
 
 ## P2 — Backpressure engine
 
-- A1 `yeet monitor --watch` transition stream + failure capsules + remediation dispatch.
+- ~~A1 `yeet monitor --watch` transition stream + failure capsules + remediation dispatch.~~
+  Done 2026-08-17 across three PRs: #749 (`gh pr checks --watch --fail-fast` in the publish
+  monitor), #751 (typed `yeet-watch/v1` NDJSON transition stream), and the capsule/dispatch PR
+  (failure capsules derived from the failing check's own record into
+  `.beep/inbox/failures.ndjson` — `yeet-inbox/v1`, the row shape A2's adapters consume — plus
+  the `yeet-dispatch/v1` wave record: first red for a head opens the repair session, later reds
+  queue with headSha+lane dedup, re-run reds drop as duplicates, a push supersedes the wave).
+  Acceptance holds: capsules land on the observing poll tick (≤ one 10s interval, inside the
+  15s p95), and three reds on one head produce one session record with three queued capsules.
+  Live session attach/spawn is deliberately not part of A1: attaching consumes the inbox via
+  A2's hook adapters, and spawn-when-owner-busy needs A4's leases.
 - A2 hook-mutex + ACK inbox (Claude deny / Codex inject / Grok tail adapters).
 - A3 can't-leave-the-scene (Stop-hook veto + yeet poison-pill + waives).
 - A5 package-scoped gates (skill instructions + script gap fill + create-package templates).

--- a/goals/ship-velocity/research/OPPORTUNITIES.md
+++ b/goals/ship-velocity/research/OPPORTUNITIES.md
@@ -464,3 +464,21 @@ is itself the fourth receipt below; the batching is the symptom, not the practic
   mechanism and needs the mechanism check — who is in the process group, and when the reap can
   actually run — not just the plausible fact that X exists. Both confident misattributions this
   week burned exactly this way.
+
+## 2026-08-17 — A1 PR-2: the registration gap the sibling surface had already solved
+
+- Pre-publish adversarial review of the capsule/dispatch PR confirmed a P1 inherited from the
+  merged watch-stream PR (#751): a zero-check OPEN snapshot ends the watch as a green
+  `all-terminal` with exit 0. `gh pr checks` answers "no checks reported" for seconds after any
+  push, so a watch started (or a push landing mid-watch) inside that window reported a green
+  settle while the wave's checks were about to run — and PR-2's dispatch would additionally
+  retire the superseded wave record on that same tick. The classic monitor had this exact law
+  already (A7: "zero-checks-yet ≠ terminal-empty", `YEET_CHECK_REGISTRATION_BACKOFF`, ~95s of
+  patience), and the stream PR's own docstring *claimed* an upstream registration backoff that
+  did not exist on its path. Fixed in PR-2 with a bounded in-loop patience (10 consecutive
+  zero-check polls at the 10s interval) mirroring the monitor's budget.
+- Prevention, two shapes: (1) when a new surface replaces an old one, its guard inventory must be
+  diffed against the old surface's laws — the registration backoff was a named constant one file
+  away; (2) a docstring that assigns a responsibility "upstream" is a claim about a mechanism and
+  needs the same mechanism check as an exoneration — name the call site that implements it or
+  implement it where the claim lives.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Inbox.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Inbox.ts
@@ -167,6 +167,32 @@ export class YeetFailureCapsule extends S.Class<YeetFailureCapsule>($I`YeetFailu
  * when the transition was observed — the watch stamps both from the same poll
  * tick.
  *
+ * **Example** (Build a row)
+ *
+ * ```ts
+ * import { YeetCheckFailedRow, YeetFailureCapsule, yeetInboxRowId } from "@beep/repo-cli/test/Yeet"
+ *
+ * const capsule = YeetFailureCapsule.make({
+ *   bucket: "fail",
+ *   headSha: "abc123",
+ *   lane: "Check / Coverage",
+ *   link: null,
+ *   observedAt: "2026-08-17T00:00:00Z",
+ *   prNumber: 754,
+ *   state: "FAILURE",
+ *   workflow: null
+ * })
+ * const row = YeetCheckFailedRow.make({
+ *   capsule,
+ *   checkout: "/repo",
+ *   id: yeetInboxRowId(capsule),
+ *   severity: "P0",
+ *   ts: "2026-08-17T00:00:00Z"
+ * })
+ *
+ * console.log(row.kind) // "check-failed"
+ * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -227,6 +253,13 @@ export type YeetInboxRow = typeof YeetInboxRow.Type;
  * segment. It doubles as the ack receipt filename under `.beep/inbox/acks/`,
  * which is why it must never carry observation-time entropy.
  *
+ * **Gotchas**
+ *
+ * Two checks that share a display name on one head share an identity — that
+ * is the dedup contract (headSha + lane), not an accident. The capsule keeps
+ * the first observed record's link and raw signal; a repair session works the
+ * lane by name and sees every same-named job on the PR checks page anyway.
+ *
  * **Example** (Same failure, same id)
  *
  * ```ts
@@ -253,6 +286,20 @@ export const yeetInboxRowId = (capsule: Pick<YeetFailureCapsule, "headSha" | "la
 
 /**
  * The inbox file layout under one checkout.
+ *
+ * **Example** (Build the layout)
+ *
+ * ```ts
+ * import { YeetInboxPaths } from "@beep/repo-cli/test/Yeet"
+ *
+ * const paths = YeetInboxPaths.make({
+ *   acksDir: "/repo/.beep/inbox/acks",
+ *   dir: "/repo/.beep/inbox",
+ *   failuresPath: "/repo/.beep/inbox/failures.ndjson"
+ * })
+ *
+ * console.log(paths.failuresPath) // "/repo/.beep/inbox/failures.ndjson"
+ * ```
  *
  * @category models
  * @since 0.0.0

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Inbox.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Inbox.ts
@@ -1,0 +1,451 @@
+/**
+ * The checkout inbox: typed failure rows for the backpressure engine.
+ *
+ * **Details**
+ *
+ * This module is the durable contract between the writers that observe
+ * failures (the `yeet monitor --watch` stream today; local lane runners and
+ * collision detectors later) and the harness adapters that consume them
+ * (ship-velocity A2: Claude hook deny/inject, Codex tool-boundary splice, Grok
+ * tail). Writers append one self-describing NDJSON row per failure to
+ * `<checkout>/.beep/inbox/failures.ndjson`; consumers acknowledge a row by
+ * writing a receipt file at `<checkout>/.beep/inbox/acks/<id>`. The hot path on
+ * the consumer side is stat+read of these git-ignored local files only —
+ * GitHub never enters a hook.
+ *
+ * A failure capsule is derived from the failing check's *own* record — its
+ * name, its job link, its workflow, its raw bucket/state strings — never from a
+ * classifier pass over composite output. Misattributed repair hints from
+ * composite-log scraping are a repeat-offender failure class in this repo's
+ * ledger; the capsule shape makes the attribution structural.
+ *
+ * **Gotchas**
+ *
+ * Row ids are deterministic over (prNumber, headSha, lane), which is what
+ * makes dedup and the ack protocol work across watch restarts: re-observing
+ * the same red re-derives the same id, so an existing receipt keeps covering
+ * it and a dispatcher can drop it as already queued. Do not add
+ * observation-time entropy to the id.
+ *
+ * Rows are immutable first-observation evidence and the file is append-only,
+ * so it accumulates rows from superseded waves and dead PRs. Liveness is not
+ * a row property: a consumer decides it by joining the row's
+ * `capsule.headSha`/`capsule.prNumber` against the wave record the dispatcher
+ * maintains at `.beep/inbox/dispatch.json` — rows whose identity does not
+ * match the current wave belong to a superseded push and must not gate
+ * anything.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { createHash } from "node:crypto";
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import { Effect, FileSystem, Path } from "effect";
+import * as S from "effect/Schema";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import { safeArtifactName } from "./ArtifactPaths.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Inbox");
+
+/**
+ * Schema version stamped on every inbox row.
+ *
+ * **Example** (Read the version)
+ *
+ * ```ts
+ * import { YEET_INBOX_SCHEMA_VERSION } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_INBOX_SCHEMA_VERSION) // "yeet-inbox/v1"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_INBOX_SCHEMA_VERSION = "yeet-inbox/v1";
+
+/**
+ * Severity tiers the harness adapters gate their enforcement on.
+ *
+ * **Details**
+ *
+ * The A2 enforcement ladder: `P0` (required check red, sibling collision)
+ * denies the next tool; `P1` (review thread) injects context only; `P2` (base
+ * drift) surfaces at session start. The watch writer stamps every hosted check
+ * red `P0` today — the required-versus-optional split that would demote an
+ * optional lane's red is A6's deliverable, and until it lands a red is treated
+ * as merge-blocking.
+ *
+ * **Example** (Check a severity)
+ *
+ * ```ts
+ * import { YeetInboxSeverity } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetInboxSeverity.is.P0("P0")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetInboxSeverity = LiteralKit(["P0", "P1", "P2"]).pipe(
+  $I.annoteSchema("YeetInboxSeverity", {
+    title: "Yeet Inbox Severity",
+    description: "Enforcement tier of one inbox row: P0 denies, P1 injects, P2 surfaces at session start.",
+  })
+);
+
+/**
+ * Severity tiers the harness adapters gate their enforcement on.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetInboxSeverity = typeof YeetInboxSeverity.Type;
+
+/**
+ * One hosted check failure, described by the failing check's own record.
+ *
+ * **Details**
+ *
+ * Everything here comes from the failing check's `gh pr checks` row and the
+ * watched PR's identity — nothing is inferred from logs. `lane` is the check's
+ * display name (the dedup key half alongside `headSha`), `link` points at the
+ * failing job run itself, and the raw `bucket`/`state` strings are preserved
+ * because they distinguish a content failure from an infrastructure one: a
+ * `CANCELLED` state on this repo's burst workers usually means a TTL reap, and
+ * a repair session that knows that starts with a rerun instead of a bisect.
+ *
+ * **Example** (Build a capsule)
+ *
+ * ```ts
+ * import { YeetFailureCapsule } from "@beep/repo-cli/test/Yeet"
+ *
+ * const capsule = YeetFailureCapsule.make({
+ *   bucket: "fail",
+ *   headSha: "abc123",
+ *   lane: "Check / Coverage",
+ *   link: "https://github.com/o/r/actions/runs/1/job/2",
+ *   observedAt: "2026-08-17T00:00:00Z",
+ *   prNumber: 751,
+ *   state: "FAILURE",
+ *   workflow: "Check"
+ * })
+ *
+ * console.log(capsule.lane) // "Check / Coverage"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetFailureCapsule extends S.Class<YeetFailureCapsule>($I`YeetFailureCapsule`)(
+  {
+    bucket: S.String,
+    headSha: S.NonEmptyString,
+    lane: S.NonEmptyString,
+    link: S.NullOr(S.String),
+    observedAt: S.String,
+    prNumber: S.Finite,
+    state: S.String,
+    workflow: S.NullOr(S.String),
+  },
+  $I.annote("YeetFailureCapsule", {
+    description: "One hosted check failure, derived from the failing check's own gh record.",
+  })
+) {}
+
+/**
+ * One `check-failed` inbox row: a failure capsule plus routing metadata.
+ *
+ * **Details**
+ *
+ * `id` is deterministic over the capsule's (prNumber, headSha, lane) via
+ * {@link yeetInboxRowId}; `checkout` names the repository root the failure
+ * belongs to, so a machine-wide consumer can route rows written into a shared
+ * location; `ts` is when the row was appended, while `capsule.observedAt` is
+ * when the transition was observed — the watch stamps both from the same poll
+ * tick.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetCheckFailedRow extends S.Class<YeetCheckFailedRow>($I`YeetCheckFailedRow`)(
+  {
+    kind: S.tag("check-failed"),
+    schemaVersion: S.Literal(YEET_INBOX_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_INBOX_SCHEMA_VERSION))
+    ),
+    id: S.NonEmptyString,
+    severity: YeetInboxSeverity,
+    checkout: S.NonEmptyString,
+    ts: S.String,
+    capsule: YeetFailureCapsule,
+  },
+  $I.annote("YeetCheckFailedRow", {
+    description: "One check-failed inbox row: the failure capsule plus id, severity, checkout, and timestamp.",
+  })
+) {}
+
+/**
+ * One row of the checkout inbox.
+ *
+ * **Details**
+ *
+ * Every member carries `schemaVersion`, a discriminating `kind`, a
+ * deterministic `id`, and a `severity`, so a consumer can decode line-by-line
+ * without context and gate enforcement on the tier. `check-failed` is the only
+ * member today; A2's additional writers (sibling collision, review thread,
+ * base drift) extend the union without a version bump.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetInboxRow = S.Union([YeetCheckFailedRow]).pipe(
+  $I.annoteSchema("YeetInboxRow", {
+    title: "Yeet Inbox Row",
+    description: "One typed NDJSON row of the checkout failure inbox.",
+  })
+);
+
+/**
+ * One row of the checkout inbox.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetInboxRow = typeof YeetInboxRow.Type;
+
+/**
+ * Derive the deterministic inbox row id for one failure.
+ *
+ * **Details**
+ *
+ * The id is the dedup key (headSha + lane, scoped by PR) rendered path-safe:
+ * a sanitized lane segment for the operator's eyes plus a short digest for
+ * uniqueness, because two distinct lane names can sanitize to the same
+ * segment. It doubles as the ack receipt filename under `.beep/inbox/acks/`,
+ * which is why it must never carry observation-time entropy.
+ *
+ * **Example** (Same failure, same id)
+ *
+ * ```ts
+ * import { yeetInboxRowId } from "@beep/repo-cli/test/Yeet"
+ *
+ * const a = yeetInboxRowId({ headSha: "abc123", lane: "Check / Coverage", prNumber: 751 })
+ * const b = yeetInboxRowId({ headSha: "abc123", lane: "Check / Coverage", prNumber: 751 })
+ *
+ * console.log(a === b) // true
+ * ```
+ *
+ * @param capsule - The failure's PR number, head SHA, and lane name.
+ * @returns A path-safe id, stable across observations of the same failure.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const yeetInboxRowId = (capsule: Pick<YeetFailureCapsule, "headSha" | "lane" | "prNumber">): string => {
+  const digest = createHash("sha256")
+    .update(`${capsule.prNumber}:${capsule.headSha}:${capsule.lane}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `${safeArtifactName(capsule.lane)}-${digest}`;
+};
+
+/**
+ * The inbox file layout under one checkout.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetInboxPaths extends S.Class<YeetInboxPaths>($I`YeetInboxPaths`)(
+  {
+    acksDir: S.NonEmptyString,
+    dir: S.NonEmptyString,
+    failuresPath: S.NonEmptyString,
+  },
+  $I.annote("YeetInboxPaths", {
+    description: "Resolved inbox locations for one checkout: the inbox dir, the failures file, and the acks dir.",
+  })
+) {}
+
+/**
+ * Resolve the inbox layout for one checkout.
+ *
+ * **Example** (Build the resolution effect)
+ *
+ * ```ts
+ * import { yeetInboxPaths } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(yeetInboxPaths("/repo"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout the inbox belongs to.
+ * @returns The resolved inbox layout.
+ * @category services
+ * @since 0.0.0
+ */
+export const yeetInboxPaths = Effect.fn("Yeet.yeetInboxPaths")(function* (
+  repoRoot: string
+): Effect.fn.Return<YeetInboxPaths, never, Path.Path> {
+  const path = yield* Path.Path;
+  const dir = path.join(repoRoot, ".beep", "inbox");
+  return YeetInboxPaths.make({
+    acksDir: path.join(dir, "acks"),
+    dir,
+    failuresPath: path.join(dir, "failures.ndjson"),
+  });
+});
+
+/**
+ * Resolve the ack receipt path for one inbox row.
+ *
+ * **Details**
+ *
+ * The receipt file's existence is the acknowledgment: A2's consumers write it
+ * with the fix SHA, a wontfix reason, or a thread URL, and until it exists the
+ * harness keeps re-presenting the row. The writer side never creates it.
+ *
+ * **Example** (Build the resolution effect)
+ *
+ * ```ts
+ * import { yeetInboxAckPath } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(yeetInboxAckPath("/repo", "lane-abc"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout the inbox belongs to.
+ * @param id - The inbox row id the receipt acknowledges.
+ * @returns The receipt file path for that row.
+ * @category services
+ * @since 0.0.0
+ */
+export const yeetInboxAckPath = Effect.fn("Yeet.yeetInboxAckPath")(function* (
+  repoRoot: string,
+  id: string
+): Effect.fn.Return<string, never, Path.Path> {
+  const paths = yield* yeetInboxPaths(repoRoot);
+  const path = yield* Path.Path;
+  return path.join(paths.acksDir, id);
+});
+
+/**
+ * JSON string codec for one inbox row.
+ *
+ * **Details**
+ *
+ * The writer side encodes through it; consumers (A2's hook adapters, tests)
+ * get the matching `decode`/`decodeOption` without re-deriving the codec, so
+ * both directions provably speak the same shape.
+ *
+ * **Example** (Decode a row line)
+ *
+ * ```ts
+ * import { YeetInboxRowJson } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * console.log(O.isNone(YeetInboxRowJson.decodeOption("not json"))) // true
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const YeetInboxRowJson = JsonStringCodec(YeetInboxRow);
+
+/**
+ * Render one inbox row as its NDJSON line.
+ *
+ * **Example** (Build the render effect)
+ *
+ * ```ts
+ * import { renderYeetInboxRowLine, YeetCheckFailedRow, YeetFailureCapsule } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const row = YeetCheckFailedRow.make({
+ *   capsule: YeetFailureCapsule.make({
+ *     bucket: "fail",
+ *     headSha: "abc123",
+ *     lane: "Check",
+ *     link: null,
+ *     observedAt: "2026-08-17T00:00:00Z",
+ *     prNumber: 751,
+ *     state: "FAILURE",
+ *     workflow: null
+ *   }),
+ *   checkout: "/repo",
+ *   id: "check-abc",
+ *   severity: "P0",
+ *   ts: "2026-08-17T00:00:00Z"
+ * })
+ *
+ * console.log(Effect.isEffect(renderYeetInboxRowLine(row))) // true
+ * ```
+ *
+ * @param row - The row to render.
+ * @returns The row as a single-line JSON string.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetInboxRowLine = (row: YeetInboxRow): Effect.Effect<string, S.SchemaError> =>
+  YeetInboxRowJson.encode(row);
+
+/**
+ * Append one row to a checkout's failure inbox.
+ *
+ * **Details**
+ *
+ * Creates the inbox directory on first use and appends exactly one NDJSON
+ * line. Appends are the only mutation the writer side performs — rows are
+ * immutable once written, and acknowledgment happens through receipt files,
+ * so concurrent writers interleave whole lines rather than contending on a
+ * shared document.
+ *
+ * **Example** (Build the append effect)
+ *
+ * ```ts
+ * import { appendYeetInboxRow, YeetCheckFailedRow, YeetFailureCapsule } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const row = YeetCheckFailedRow.make({
+ *   capsule: YeetFailureCapsule.make({
+ *     bucket: "fail",
+ *     headSha: "abc123",
+ *     lane: "Check",
+ *     link: null,
+ *     observedAt: "2026-08-17T00:00:00Z",
+ *     prNumber: 751,
+ *     state: "FAILURE",
+ *     workflow: null
+ *   }),
+ *   checkout: "/repo",
+ *   id: "check-abc",
+ *   severity: "P0",
+ *   ts: "2026-08-17T00:00:00Z"
+ * })
+ *
+ * console.log(Effect.isEffect(appendYeetInboxRow("/repo", row))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout whose inbox receives the row.
+ * @param row - The row to append.
+ * @returns Nothing on success.
+ * @category services
+ * @since 0.0.0
+ */
+export const appendYeetInboxRow = Effect.fn("Yeet.appendYeetInboxRow")(function* (
+  repoRoot: string,
+  row: YeetInboxRow
+): Effect.fn.Return<void, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const paths = yield* yeetInboxPaths(repoRoot);
+  const line = yield* renderYeetInboxRowLine(row).pipe(
+    Effect.mapError(YeetCommandError.new("Failed to encode an inbox row."))
+  );
+  yield* fs
+    .makeDirectory(paths.dir, { recursive: true })
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to create the inbox directory "${paths.dir}".`)));
+  yield* fs
+    .writeFileString(paths.failuresPath, `${line}\n`, { flag: "a" })
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to append to the failure inbox "${paths.failuresPath}".`)));
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Remediation.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Remediation.ts
@@ -1,0 +1,665 @@
+/**
+ * Remediation dispatch for the `yeet monitor --watch` backpressure engine.
+ *
+ * **Details**
+ *
+ * This is the policy half of ship-velocity A1: every hosted check red the
+ * watch observes becomes one inbox capsule, and the *wave record* decides what
+ * that capsule means — the first red for a head opens the wave's repair
+ * session, subsequent reds for the same head queue onto it, and a new push
+ * supersedes the whole wave. The policy is a pure total function over the
+ * persisted {@link YeetRemediationWave}; the effectful wrapper only loads
+ * state, appends the inbox row, persists, and announces.
+ *
+ * The wave record at `.beep/inbox/dispatch.json` is the countable "repair
+ * session" unit: one wave, one session, N queued capsules. Attaching a live
+ * harness to that session is deliberately not this module's job — A2's hook
+ * adapters consume the inbox rows, and A4's lease machinery decides where a
+ * session runs when the owning checkout is busy.
+ *
+ * **Gotchas**
+ *
+ * Dispatch failures never escape to the watch loop: a capsule that cannot be
+ * appended is reported loudly on stderr and *not* recorded in the wave, so the
+ * next observation of the same red retries the append instead of believing the
+ * capsule was delivered. The A7 posture applies — a side-channel failure must
+ * not cancel check watching.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import { Console, Effect, FileSystem, Match, Path } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as P from "effect/Predicate";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
+import {
+  appendYeetInboxRow,
+  YeetCheckFailedRow,
+  YeetFailureCapsule,
+  YeetInboxSeverity,
+  yeetInboxPaths,
+  yeetInboxRowId,
+} from "./Inbox.ts";
+import { writeTextFile } from "./IssueArtifacts.ts";
+import type { YeetWatchCheck, YeetWatchSnapshot } from "./WatchStream.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Remediation");
+
+/**
+ * Schema version stamped on the persisted wave record.
+ *
+ * **Example** (Read the version)
+ *
+ * ```ts
+ * import { YEET_DISPATCH_SCHEMA_VERSION } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_DISPATCH_SCHEMA_VERSION) // "yeet-dispatch/v1"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_DISPATCH_SCHEMA_VERSION = "yeet-dispatch/v1";
+
+/**
+ * The remediation wave for one PR head: the repair session and its queue.
+ *
+ * **Details**
+ *
+ * `sessionStartedAt` is null between a head change and that head's first red —
+ * the push opens a fresh, empty wave, and only a red opens the session.
+ * `capsuleIds` holds the queued inbox row ids in arrival order; because row
+ * ids are deterministic over (prNumber, headSha, lane), membership here is
+ * exactly the "dedup by headSha+lane" the dispatch contract requires.
+ *
+ * **Example** (Build a wave)
+ *
+ * ```ts
+ * import { YeetRemediationWave } from "@beep/repo-cli/test/Yeet"
+ *
+ * const wave = YeetRemediationWave.make({
+ *   capsuleIds: ["coverage-abc"],
+ *   headSha: "abc123",
+ *   prNumber: 751,
+ *   sessionStartedAt: "2026-08-17T00:00:00Z",
+ *   updatedAt: "2026-08-17T00:00:00Z"
+ * })
+ *
+ * console.log(wave.capsuleIds.length) // 1
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetRemediationWave extends S.Class<YeetRemediationWave>($I`YeetRemediationWave`)(
+  {
+    schemaVersion: S.Literal(YEET_DISPATCH_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_DISPATCH_SCHEMA_VERSION))
+    ),
+    capsuleIds: S.Array(S.String),
+    headSha: S.NonEmptyString,
+    prNumber: S.Finite,
+    sessionStartedAt: S.NullOr(S.String),
+    updatedAt: S.String,
+  },
+  $I.annote("YeetRemediationWave", {
+    description: "The remediation wave for one PR head: session start, queued capsule ids, and freshness.",
+  })
+) {}
+
+/**
+ * JSON string codec for the persisted wave record.
+ *
+ * **Example** (Reject garbage)
+ *
+ * ```ts
+ * import { YeetRemediationWaveJson } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * console.log(O.isNone(YeetRemediationWaveJson.decodeOption("not json"))) // true
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const YeetRemediationWaveJson = JsonStringCodec(YeetRemediationWave);
+
+/**
+ * What the dispatch policy decided about one observed red.
+ *
+ * **Example** (Check a decision)
+ *
+ * ```ts
+ * import { YeetDispatchDecision } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetDispatchDecision.is["start-session"]("start-session")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetDispatchDecision = LiteralKit(["start-session", "queue", "duplicate"]).pipe(
+  $I.annoteSchema("YeetDispatchDecision", {
+    title: "Yeet Dispatch Decision",
+    description: "Whether an observed red opened the wave's repair session, queued onto it, or was already queued.",
+  })
+);
+
+/**
+ * What the dispatch policy decided about one observed red.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetDispatchDecision = typeof YeetDispatchDecision.Type;
+
+/**
+ * The dispatch policy's input: one observed red plus the persisted wave.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetRemediationInput extends S.Class<YeetRemediationInput>($I`YeetRemediationInput`)(
+  {
+    at: S.String,
+    capsuleId: S.NonEmptyString,
+    headSha: S.NonEmptyString,
+    prNumber: S.Finite,
+    wave: S.NullOr(YeetRemediationWave),
+  },
+  $I.annote("YeetRemediationInput", {
+    description: "One observed red (capsule id, head, PR) plus the persisted wave record, or null for none.",
+  })
+) {}
+
+/**
+ * The dispatch policy's output: the decision and the wave to persist.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetRemediationOutcome extends S.Class<YeetRemediationOutcome>($I`YeetRemediationOutcome`)(
+  {
+    decision: YeetDispatchDecision,
+    wave: YeetRemediationWave,
+  },
+  $I.annote("YeetRemediationOutcome", {
+    description: "The dispatch decision plus the wave record reflecting it.",
+  })
+) {}
+
+/**
+ * Decide what one observed red means for the current remediation wave.
+ *
+ * **Details**
+ *
+ * The policy is total over four cases: no wave (or a wave for another head)
+ * starts a fresh session for this head; a capsule id already in the wave's
+ * queue is a duplicate — the same lane re-observed red on the same head, for
+ * example after a job re-run — and changes nothing; a wave whose session has
+ * not started yet (a push opened it empty) starts the session now; anything
+ * else queues onto the running session. The first two SPEC sentences fall out
+ * directly: first red for a head starts a repair session, subsequent reds for
+ * the same head append to that session's queue.
+ *
+ * **Example** (First red starts the session)
+ *
+ * ```ts
+ * import { decideYeetRemediation, YeetRemediationInput } from "@beep/repo-cli/test/Yeet"
+ *
+ * const outcome = decideYeetRemediation(YeetRemediationInput.make({
+ *   at: "2026-08-17T00:00:00Z",
+ *   capsuleId: "coverage-abc",
+ *   headSha: "abc123",
+ *   prNumber: 751,
+ *   wave: null
+ * }))
+ *
+ * console.log(outcome.decision) // "start-session"
+ * ```
+ *
+ * @param input - The observed red and the persisted wave.
+ * @returns The decision plus the wave record to persist.
+ * @category mapping
+ * @since 0.0.0
+ */
+export const decideYeetRemediation = (input: YeetRemediationInput): YeetRemediationOutcome => {
+  const wave = input.wave;
+  // Freshness is (prNumber, headSha): a branch tip re-opened as a new PR
+  // shares the head with the dead PR's wave, and treating that stale record
+  // as current would swallow the new PR's start-session signal.
+  if (P.isNull(wave) || wave.headSha !== input.headSha || wave.prNumber !== input.prNumber) {
+    return YeetRemediationOutcome.make({
+      decision: YeetDispatchDecision.Enum["start-session"],
+      wave: YeetRemediationWave.make({
+        capsuleIds: [input.capsuleId],
+        headSha: input.headSha,
+        prNumber: input.prNumber,
+        sessionStartedAt: input.at,
+        updatedAt: input.at,
+      }),
+    });
+  }
+  if (A.contains(wave.capsuleIds, input.capsuleId)) {
+    return YeetRemediationOutcome.make({ decision: YeetDispatchDecision.Enum.duplicate, wave });
+  }
+  const queued = A.append(wave.capsuleIds, input.capsuleId);
+  return P.isNull(wave.sessionStartedAt)
+    ? YeetRemediationOutcome.make({
+        decision: YeetDispatchDecision.Enum["start-session"],
+        wave: YeetRemediationWave.make({
+          capsuleIds: queued,
+          headSha: wave.headSha,
+          prNumber: wave.prNumber,
+          sessionStartedAt: input.at,
+          updatedAt: input.at,
+        }),
+      })
+    : YeetRemediationOutcome.make({
+        decision: YeetDispatchDecision.Enum.queue,
+        wave: YeetRemediationWave.make({
+          capsuleIds: queued,
+          headSha: wave.headSha,
+          prNumber: wave.prNumber,
+          sessionStartedAt: wave.sessionStartedAt,
+          updatedAt: input.at,
+        }),
+      });
+};
+
+/**
+ * The supersession input: the observed head plus the persisted wave.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetWaveSupersedeInput extends S.Class<YeetWaveSupersedeInput>($I`YeetWaveSupersedeInput`)(
+  {
+    at: S.String,
+    headSha: S.NonEmptyString,
+    prNumber: S.Finite,
+    wave: S.NullOr(YeetRemediationWave),
+  },
+  $I.annote("YeetWaveSupersedeInput", {
+    description: "The newly observed head (after a push) plus the persisted wave record, or null for none.",
+  })
+) {}
+
+/**
+ * Supersede the wave after a push: a new head opens a fresh, empty wave.
+ *
+ * **Details**
+ *
+ * "A new push supersedes the prior wave" in record form: the fresh wave has no
+ * session and no queue, and the old head's capsules can no longer leak into
+ * the new wave because membership is keyed on the new head's ids. A wave
+ * already on the observed head passes through unchanged, so calling this on
+ * every observation is safe.
+ *
+ * **Example** (A push resets the wave)
+ *
+ * ```ts
+ * import { supersedeYeetRemediationWave, YeetWaveSupersedeInput } from "@beep/repo-cli/test/Yeet"
+ *
+ * const wave = supersedeYeetRemediationWave(YeetWaveSupersedeInput.make({
+ *   at: "2026-08-17T00:00:00Z",
+ *   headSha: "bbb222",
+ *   prNumber: 751,
+ *   wave: null
+ * }))
+ *
+ * console.log(wave.capsuleIds.length) // 0
+ * ```
+ *
+ * @param input - The newly observed head and the persisted wave.
+ * @returns The wave record for the observed head.
+ * @category mapping
+ * @since 0.0.0
+ */
+export const supersedeYeetRemediationWave = (input: YeetWaveSupersedeInput): YeetRemediationWave => {
+  const wave = input.wave;
+  return P.isNotNull(wave) && wave.headSha === input.headSha && wave.prNumber === input.prNumber
+    ? wave
+    : YeetRemediationWave.make({
+        capsuleIds: [],
+        headSha: input.headSha,
+        prNumber: input.prNumber,
+        sessionStartedAt: null,
+        updatedAt: input.at,
+      });
+};
+
+/**
+ * Resolve the persisted wave record's path for one checkout.
+ *
+ * **Example** (Build the resolution effect)
+ *
+ * ```ts
+ * import { yeetDispatchStatePath } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(yeetDispatchStatePath("/repo"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout the wave record belongs to.
+ * @returns The wave record's file path.
+ * @category services
+ * @since 0.0.0
+ */
+export const yeetDispatchStatePath = Effect.fn("Yeet.yeetDispatchStatePath")(function* (
+  repoRoot: string
+): Effect.fn.Return<string, never, Path.Path> {
+  const paths = yield* yeetInboxPaths(repoRoot);
+  const path = yield* Path.Path;
+  return path.join(paths.dir, "dispatch.json");
+});
+
+/**
+ * Read the persisted wave record for one checkout.
+ *
+ * **Details**
+ *
+ * Every way the read can go wrong — no record yet, an unreadable file, an
+ * older schema version — yields `None`, which the dispatcher reads as "no
+ * wave". The record is a dedup optimisation over deterministic row ids, so a
+ * lost record degrades to re-announcing, never to a lost capsule.
+ *
+ * **Example** (Build the read effect)
+ *
+ * ```ts
+ * import { loadYeetRemediationWave } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(loadYeetRemediationWave("/repo"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout the wave record belongs to.
+ * @returns The persisted wave, or `None` when there is no usable one.
+ * @category services
+ * @since 0.0.0
+ */
+export const loadYeetRemediationWave = Effect.fn("Yeet.loadYeetRemediationWave")(function* (
+  repoRoot: string
+): Effect.fn.Return<O.Option<YeetRemediationWave>, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const statePath = yield* yeetDispatchStatePath(repoRoot);
+  const text = yield* Effect.option(fs.readFileString(statePath));
+  return O.flatMap(text, YeetRemediationWaveJson.decodeOption);
+});
+
+/**
+ * Warn that the wave record could not be persisted, naming the consequence.
+ *
+ * **Example** (Render the warning)
+ *
+ * ```ts
+ * import { renderYeetDispatchStateWarning } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(renderYeetDispatchStateWarning("disk is full"))
+ * ```
+ *
+ * @param reason - Why the write failed.
+ * @returns The operator warning line.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetDispatchStateWarning = (reason: string): string =>
+  `[yeet] could not persist the remediation wave record (${reason}); reds may be re-announced, but capsule ids are deterministic so inbox consumers still dedup safely.`;
+
+const writeRemediationWave = Effect.fn("Yeet.writeRemediationWave")(function* (
+  repoRoot: string,
+  wave: YeetRemediationWave
+) {
+  const statePath = yield* yeetDispatchStatePath(repoRoot);
+  const json = yield* YeetRemediationWaveJson.encode(wave);
+  yield* writeTextFile(statePath, `${json}\n`);
+});
+
+// Persisting is best effort by the same argument as the comment cursor: the
+// record is a dedup optimisation, and failing the watch over it would cost the
+// whole check stream.
+const persistYeetRemediationWave = (
+  repoRoot: string,
+  wave: YeetRemediationWave
+): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+  writeRemediationWave(repoRoot, wave).pipe(
+    Effect.catch((error) => Console.error(renderYeetDispatchStateWarning(error.message)))
+  );
+
+/**
+ * The rendering input for one dispatch announcement: decision plus row.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetDispatchReport extends S.Class<YeetDispatchReport>($I`YeetDispatchReport`)(
+  {
+    outcome: YeetRemediationOutcome,
+    row: YeetCheckFailedRow,
+  },
+  $I.annote("YeetDispatchReport", {
+    description: "One dispatch outcome plus the inbox row it concerns, for operator announcement.",
+  })
+) {}
+
+/**
+ * Render the operator announcement for one dispatch outcome.
+ *
+ * **Example** (Announce a session start)
+ *
+ * ```ts
+ * import {
+ *   renderYeetDispatchLine,
+ *   YeetCheckFailedRow,
+ *   YeetDispatchReport,
+ *   YeetFailureCapsule,
+ *   YeetRemediationOutcome,
+ *   YeetRemediationWave
+ * } from "@beep/repo-cli/test/Yeet"
+ *
+ * const row = YeetCheckFailedRow.make({
+ *   capsule: YeetFailureCapsule.make({
+ *     bucket: "fail",
+ *     headSha: "abc123def",
+ *     lane: "Check",
+ *     link: null,
+ *     observedAt: "2026-08-17T00:00:00Z",
+ *     prNumber: 751,
+ *     state: "FAILURE",
+ *     workflow: null
+ *   }),
+ *   checkout: "/repo",
+ *   id: "check-abc",
+ *   severity: "P0",
+ *   ts: "2026-08-17T00:00:00Z"
+ * })
+ * const outcome = YeetRemediationOutcome.make({
+ *   decision: "start-session",
+ *   wave: YeetRemediationWave.make({
+ *     capsuleIds: ["check-abc"],
+ *     headSha: "abc123def",
+ *     prNumber: 751,
+ *     sessionStartedAt: "2026-08-17T00:00:00Z",
+ *     updatedAt: "2026-08-17T00:00:00Z"
+ *   })
+ * })
+ *
+ * console.log(renderYeetDispatchLine(YeetDispatchReport.make({ outcome, row })).includes("repair session opened")) // true
+ * ```
+ *
+ * @param report - The dispatch outcome and the inbox row it concerns.
+ * @returns The stderr announcement line.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetDispatchLine = (report: YeetDispatchReport): string => {
+  const lane = report.row.capsule.lane;
+  const head = Str.slice(0, 7)(report.row.capsule.headSha);
+  const count = A.length(report.outcome.wave.capsuleIds);
+  return Match.value(report.outcome.decision).pipe(
+    Match.when(
+      "start-session",
+      () =>
+        `[yeet] first red on "${lane}" (head ${head}) — repair session opened; capsule ${report.row.id} queued in .beep/inbox/failures.ndjson`
+    ),
+    Match.when(
+      "queue",
+      () =>
+        `[yeet] red on "${lane}" — capsule ${report.row.id} queued to the head ${head} repair session (${count} capsules)`
+    ),
+    Match.when("duplicate", () => `[yeet] red on "${lane}" already queued for head ${head}`),
+    Match.exhaustive
+  );
+};
+
+/**
+ * Dispatch one observed check failure: capsule, inbox row, wave, announcement.
+ *
+ * **Details**
+ *
+ * The capsule derives from the failing check's own snapshot record — name,
+ * link, workflow, raw bucket/state — plus the watched PR's identity, and the
+ * row id is deterministic over (prNumber, headSha, lane). A `duplicate`
+ * decision performs no writes at all. Otherwise the inbox append happens
+ * *before* the wave persist, and an append failure skips the persist: the
+ * wave must never claim a capsule the inbox does not hold, because the next
+ * observation of the same red is the retry.
+ *
+ * Nothing here fails the caller: every failure path degrades to a loud stderr
+ * line, keeping the A7 posture that a side-channel failure must not cancel
+ * check watching.
+ *
+ * **Example** (Build the dispatch effect)
+ *
+ * ```ts
+ * import { dispatchYeetCheckFailure, YeetWatchCheck, YeetWatchSnapshot } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const check = YeetWatchCheck.make({ name: "Check", outcome: "fail" })
+ * const snapshot = YeetWatchSnapshot.make({
+ *   checks: [check],
+ *   headSha: "abc123",
+ *   mergeable: "MERGEABLE",
+ *   prNumber: 751,
+ *   state: "OPEN",
+ *   threads: []
+ * })
+ *
+ * console.log(Effect.isEffect(dispatchYeetCheckFailure("/repo", snapshot, check, "2026-08-17T00:00:00Z"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout whose inbox and wave record receive the failure.
+ * @param snapshot - The snapshot the failure was observed in.
+ * @param check - The failing check's record itself — never a name to re-resolve,
+ * because a rollup can legitimately carry two same-named checks.
+ * @param at - The observation timestamp stamped on the capsule and row.
+ * @returns Nothing; every failure path degrades to a stderr line.
+ * @category services
+ * @since 0.0.0
+ */
+export const dispatchYeetCheckFailure = Effect.fn("Yeet.dispatchYeetCheckFailure")(function* (
+  repoRoot: string,
+  snapshot: YeetWatchSnapshot,
+  check: YeetWatchCheck,
+  at: string
+): Effect.fn.Return<void, never, FileSystem.FileSystem | Path.Path> {
+  const capsule = YeetFailureCapsule.make({
+    bucket: check.signal.bucket,
+    headSha: snapshot.headSha,
+    lane: check.name,
+    link: check.link,
+    observedAt: at,
+    prNumber: snapshot.prNumber,
+    state: check.signal.state,
+    workflow: check.workflow,
+  });
+  const row = YeetCheckFailedRow.make({
+    capsule,
+    checkout: repoRoot,
+    id: yeetInboxRowId(capsule),
+    severity: YeetInboxSeverity.Enum.P0,
+    ts: at,
+  });
+  const wave = yield* loadYeetRemediationWave(repoRoot);
+  const outcome = decideYeetRemediation(
+    YeetRemediationInput.make({
+      at,
+      capsuleId: row.id,
+      headSha: snapshot.headSha,
+      prNumber: snapshot.prNumber,
+      wave: O.getOrNull(wave),
+    })
+  );
+  if (YeetDispatchDecision.is.duplicate(outcome.decision)) {
+    return;
+  }
+  const delivered = yield* appendYeetInboxRow(repoRoot, row).pipe(
+    Effect.as(O.some(row)),
+    Effect.catch((error) =>
+      Console.error(
+        `[yeet] failed to deliver capsule ${row.id} for "${capsule.lane}" to the inbox (${error.message}); the red is NOT queued and will retry on the next observation.`
+      ).pipe(Effect.as(O.none<YeetCheckFailedRow>()))
+    )
+  );
+  if (O.isNone(delivered)) {
+    return;
+  }
+  yield* persistYeetRemediationWave(repoRoot, outcome.wave);
+  yield* Console.error(renderYeetDispatchLine(YeetDispatchReport.make({ outcome, row })));
+});
+
+/**
+ * Supersede the persisted wave after the watch observed a head change.
+ *
+ * **Details**
+ *
+ * Loads the record, applies {@link supersedeYeetRemediationWave}, persists the
+ * fresh wave, and announces when an in-flight session was actually superseded.
+ * Safe to call when no record exists — the push still pins the new head so the
+ * first red after it starts cleanly.
+ *
+ * **Example** (Build the supersession effect)
+ *
+ * ```ts
+ * import { supersedeYeetDispatchState } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(supersedeYeetDispatchState("/repo", "bbb222", 751, "2026-08-17T00:00:00Z"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout whose wave record is superseded.
+ * @param headSha - The newly observed head.
+ * @param prNumber - The watched pull request.
+ * @param at - The observation timestamp.
+ * @returns Nothing; persistence failures degrade to a stderr line.
+ * @category services
+ * @since 0.0.0
+ */
+export const supersedeYeetDispatchState = Effect.fn("Yeet.supersedeYeetDispatchState")(function* (
+  repoRoot: string,
+  headSha: string,
+  prNumber: number,
+  at: string
+): Effect.fn.Return<void, never, FileSystem.FileSystem | Path.Path> {
+  const previous = yield* loadYeetRemediationWave(repoRoot);
+  const wave = supersedeYeetRemediationWave(
+    YeetWaveSupersedeInput.make({ at, headSha, prNumber, wave: O.getOrNull(previous) })
+  );
+  yield* persistYeetRemediationWave(repoRoot, wave);
+  const superseded = O.filter(
+    previous,
+    (before) =>
+      (before.headSha !== headSha || before.prNumber !== prNumber) && A.isReadonlyArrayNonEmpty(before.capsuleIds)
+  );
+  if (O.isSome(superseded)) {
+    yield* Console.error(
+      `[yeet] head moved to ${Str.slice(0, 7)(headSha)}; the ${A.length(superseded.value.capsuleIds)}-capsule wave for ${Str.slice(0, 7)(superseded.value.headSha)} is superseded.`
+    );
+  }
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Remediation.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Remediation.ts
@@ -25,6 +25,14 @@
  * capsule was delivered. The A7 posture applies — a side-channel failure must
  * not cancel check watching.
  *
+ * The wave record is last-writer-wins by design, not a lock: two concurrent
+ * watches on one checkout can interleave load/persist and clobber each
+ * other's record. The failure modes that leaves are bounded — a re-announced
+ * red or a same-id row re-appended, never a lost capsule (the inbox is
+ * append-only and ids are deterministic, so consumers dedup by id), and a
+ * stale-head record self-heals on the next tick's supersede-and-converge.
+ * Single-writer discipline for the checkout is A2's hook-mutex deliverable.
+ *
  * @packageDocumentation
  * @since 0.0.0
  */
@@ -162,6 +170,22 @@ export type YeetDispatchDecision = typeof YeetDispatchDecision.Type;
 /**
  * The dispatch policy's input: one observed red plus the persisted wave.
  *
+ * **Example** (Build a first-red input)
+ *
+ * ```ts
+ * import { YeetRemediationInput } from "@beep/repo-cli/test/Yeet"
+ *
+ * const input = YeetRemediationInput.make({
+ *   at: "2026-08-17T00:00:00Z",
+ *   capsuleId: "coverage-abc",
+ *   headSha: "abc123",
+ *   prNumber: 754,
+ *   wave: null
+ * })
+ *
+ * console.log(input.wave) // null
+ * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -180,6 +204,25 @@ export class YeetRemediationInput extends S.Class<YeetRemediationInput>($I`YeetR
 
 /**
  * The dispatch policy's output: the decision and the wave to persist.
+ *
+ * **Example** (Build an outcome)
+ *
+ * ```ts
+ * import { YeetRemediationOutcome, YeetRemediationWave } from "@beep/repo-cli/test/Yeet"
+ *
+ * const outcome = YeetRemediationOutcome.make({
+ *   decision: "start-session",
+ *   wave: YeetRemediationWave.make({
+ *     capsuleIds: ["coverage-abc"],
+ *     headSha: "abc123",
+ *     prNumber: 754,
+ *     sessionStartedAt: "2026-08-17T00:00:00Z",
+ *     updatedAt: "2026-08-17T00:00:00Z"
+ *   })
+ * })
+ *
+ * console.log(outcome.decision) // "start-session"
+ * ```
  *
  * @category models
  * @since 0.0.0
@@ -275,6 +318,21 @@ export const decideYeetRemediation = (input: YeetRemediationInput): YeetRemediat
 
 /**
  * The supersession input: the observed head plus the persisted wave.
+ *
+ * **Example** (Build a supersession input)
+ *
+ * ```ts
+ * import { YeetWaveSupersedeInput } from "@beep/repo-cli/test/Yeet"
+ *
+ * const input = YeetWaveSupersedeInput.make({
+ *   at: "2026-08-17T00:00:00Z",
+ *   headSha: "bbb222",
+ *   prNumber: 754,
+ *   wave: null
+ * })
+ *
+ * console.log(input.headSha) // "bbb222"
+ * ```
  *
  * @category models
  * @since 0.0.0
@@ -434,6 +492,51 @@ const persistYeetRemediationWave = (
 
 /**
  * The rendering input for one dispatch announcement: decision plus row.
+ *
+ * **Example** (Build a report)
+ *
+ * ```ts
+ * import {
+ *   YeetCheckFailedRow,
+ *   YeetDispatchReport,
+ *   YeetFailureCapsule,
+ *   YeetRemediationOutcome,
+ *   YeetRemediationWave,
+ *   yeetInboxRowId
+ * } from "@beep/repo-cli/test/Yeet"
+ *
+ * const capsule = YeetFailureCapsule.make({
+ *   bucket: "fail",
+ *   headSha: "abc123",
+ *   lane: "Check",
+ *   link: null,
+ *   observedAt: "2026-08-17T00:00:00Z",
+ *   prNumber: 754,
+ *   state: "FAILURE",
+ *   workflow: null
+ * })
+ * const report = YeetDispatchReport.make({
+ *   outcome: YeetRemediationOutcome.make({
+ *     decision: "start-session",
+ *     wave: YeetRemediationWave.make({
+ *       capsuleIds: [yeetInboxRowId(capsule)],
+ *       headSha: "abc123",
+ *       prNumber: 754,
+ *       sessionStartedAt: "2026-08-17T00:00:00Z",
+ *       updatedAt: "2026-08-17T00:00:00Z"
+ *     })
+ *   }),
+ *   row: YeetCheckFailedRow.make({
+ *     capsule,
+ *     checkout: "/repo",
+ *     id: yeetInboxRowId(capsule),
+ *     severity: "P0",
+ *     ts: "2026-08-17T00:00:00Z"
+ *   })
+ * })
+ *
+ * console.log(report.outcome.decision) // "start-session"
+ * ```
  *
  * @category models
  * @since 0.0.0

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
@@ -330,12 +330,15 @@ const advanceYeetWatchTick = Effect.fn("Yeet.advanceYeetWatchTick")(function* (
   const observedAt = yield* isoNow;
   const events = diffYeetWatchSnapshots(YeetWatchDiffInput.make({ at: observedAt, next, prev }));
   yield* Effect.forEach(events, emitWatchEvent, { discard: true });
-  if (next.headSha !== prev.headSha) {
+  const headChanged = next.headSha !== prev.headSha;
+  if (headChanged) {
     yield* supersedeYeetDispatchState(context.repoRoot, next.headSha, next.prNumber, observedAt);
   }
   yield* convergeYeetWatchDispatch(context, next, observedAt);
+  // The registration window belongs to a head: a new push starts its own
+  // patience budget rather than inheriting whatever the superseded head spent.
   return O.some({
-    emptyPolls: A.isReadonlyArrayEmpty(next.checks) ? emptyPolls + 1 : 0,
+    emptyPolls: A.isReadonlyArrayEmpty(next.checks) ? (headChanged ? 1 : emptyPolls + 1) : 0,
     snapshot: next,
   });
 });

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
@@ -10,6 +10,14 @@
  * transition on stdout. Prose for the operator goes to stderr, so stdout stays
  * a machine surface a consumer can pipe line-by-line into a decoder.
  *
+ * The stream is also the backpressure writer: after every poll the inbox is
+ * *converged* to the snapshot — each failing check dispatches through
+ * `Remediation` on the tick that observed it, appending a failure capsule and
+ * advancing the wave record, with deterministic capsule ids making the
+ * convergence idempotent. A head change supersedes the wave before the new
+ * push's snapshot converges, and a zero-check snapshot inside the
+ * registration window is polled through rather than believed.
+ *
  * The collector's schemas are deliberately minimal — the watch needs the head,
  * the PR state, mergeability, check names with raw bucket/state strings, and
  * thread resolution. Yeet status owns the richer shapes; duplicating its deep
@@ -31,15 +39,19 @@ import { $RepoCliId } from "@beep/identity/packages";
 import { Console, DateTime, Duration, Effect } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
+import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { runRepoCommandCapture } from "../../../internal/repo-run/index.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
 import { NO_CHECKS_REPORTED } from "./MonitorChecks.ts";
+import { dispatchYeetCheckFailure, supersedeYeetDispatchState } from "./Remediation.ts";
 import {
   classifyYeetCheckOutcome,
   countYeetWatchFailures,
   diffYeetWatchSnapshots,
   renderYeetWatchEventLine,
+  YeetCheckOutcome,
   YeetCheckSignal,
   YeetWatchCheck,
   YeetWatchDiffInput,
@@ -50,6 +62,7 @@ import {
   YeetWatchThread,
   yeetWatchEndReason,
 } from "./WatchStream.ts";
+import type { FileSystem, Path } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
 import type { YeetWatchEvent } from "./WatchStream.ts";
@@ -61,6 +74,7 @@ class WatchPullRequestView extends S.Class<WatchPullRequestView>($I`WatchPullReq
     headRefOid: S.NonEmptyString,
     id: S.NonEmptyString,
     mergeable: S.NullOr(S.String),
+    number: S.Finite,
     state: S.String,
   },
   $I.annote("WatchPullRequestView", {
@@ -71,11 +85,13 @@ class WatchPullRequestView extends S.Class<WatchPullRequestView>($I`WatchPullReq
 class WatchCheckRow extends S.Class<WatchCheckRow>($I`WatchCheckRow`)(
   {
     bucket: S.String,
+    link: S.NullOr(S.String),
     name: S.String,
     state: S.String,
+    workflow: S.NullOr(S.String),
   },
   $I.annote("WatchCheckRow", {
-    description: "One raw gh pr checks row: name plus unclassified bucket and state strings.",
+    description: "One raw gh pr checks row: name, unclassified bucket/state strings, job link, and workflow.",
   })
 ) {}
 
@@ -107,16 +123,23 @@ const decodeThreadsDocument = S.decodeUnknownEffect(S.fromJsonString(WatchThread
 const watchThreadsQuery =
   "query($id:ID!){node(id:$id){... on PullRequest{reviewThreads(first:100){nodes{id isResolved}}}}}";
 
+// gh renders an absent link or workflow as "" in some check sources (plain
+// commit statuses); the domain speaks null for "the record has no such field".
+const presentOrNull = (value: string | null): string | null =>
+  P.isNotNull(value) && Str.isNonEmpty(value) ? value : null;
+
 /**
  * Collect one typed snapshot of the current branch's pull request.
  *
  * **Details**
  *
  * Three reads, same argv surfaces yeet status uses: `gh pr view` for identity
- * and mergeability, `gh pr checks --json name,state,bucket` for the rollup,
- * and one GraphQL thread query for resolution states. Raw bucket/state strings
- * classify into the closed outcome domain at this boundary, so everything
- * downstream speaks {@link YeetWatchSnapshot}.
+ * and mergeability, `gh pr checks --json name,state,bucket,link,workflow` for
+ * the rollup, and one GraphQL thread query for resolution states. Raw
+ * bucket/state strings classify into the closed outcome domain at this
+ * boundary, and each check keeps its own record fields (link, workflow, raw
+ * signal) so a failure capsule can derive from the failing check's record, so
+ * everything downstream speaks {@link YeetWatchSnapshot}.
  *
  * A PR with zero checks yet is returned as-is; the caller decides whether that
  * ends the watch. Only `gh pr checks`' "no checks reported" exit reads as an
@@ -157,7 +180,7 @@ export const collectYeetWatchSnapshot = Effect.fn("Yeet.collectYeetWatchSnapshot
 ): Effect.fn.Return<YeetWatchSnapshot, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
   const viewResult = yield* runRepoCommandCapture(
     "gh",
-    ["pr", "view", "--json", "id,state,mergeable,headRefOid"],
+    ["pr", "view", "--json", "id,number,state,mergeable,headRefOid"],
     context.repoRoot
   ).pipe(Effect.mapError(YeetCommandError.new("Failed to read the pull request for yeet watch.")));
   if (viewResult.exitCode !== 0) {
@@ -172,7 +195,7 @@ export const collectYeetWatchSnapshot = Effect.fn("Yeet.collectYeetWatchSnapshot
 
   const checksResult = yield* runRepoCommandCapture(
     "gh",
-    ["pr", "checks", "--json", "name,state,bucket"],
+    ["pr", "checks", "--json", "name,state,bucket,link,workflow"],
     context.repoRoot
   ).pipe(Effect.mapError(YeetCommandError.new("Failed to read PR checks for yeet watch.")));
   if (checksResult.exitCode !== 0 && !NO_CHECKS_REPORTED.test(checksResult.output)) {
@@ -205,14 +228,19 @@ export const collectYeetWatchSnapshot = Effect.fn("Yeet.collectYeetWatchSnapshot
   );
 
   return YeetWatchSnapshot.make({
-    checks: A.map(checkRows, (row) =>
-      YeetWatchCheck.make({
+    checks: A.map(checkRows, (row) => {
+      const signal = YeetCheckSignal.make({ bucket: row.bucket, state: row.state });
+      return YeetWatchCheck.make({
         name: row.name,
-        outcome: classifyYeetCheckOutcome(YeetCheckSignal.make({ bucket: row.bucket, state: row.state })),
-      })
-    ),
+        outcome: classifyYeetCheckOutcome(signal),
+        link: presentOrNull(row.link),
+        signal,
+        workflow: presentOrNull(row.workflow),
+      });
+    }),
     headSha: view.headRefOid,
     mergeable: view.mergeable ?? "UNKNOWN",
+    prNumber: view.number,
     state: view.state,
     threads: A.map(threadNodes, (node) => YeetWatchThread.make({ id: node.id, isResolved: node.isResolved })),
   });
@@ -226,25 +254,55 @@ const emitWatchEvent = (event: YeetWatchEvent): Effect.Effect<void, YeetCommandE
     Effect.flatMap(Console.log)
   );
 
+// Converge the inbox to the snapshot: dispatch every check it reports
+// failing, passing each failing check's own record — never a name to
+// re-resolve, because a rollup can carry two same-named checks. Row ids are
+// deterministic and the wave record drops known ids as duplicates, so running
+// this on every tick is idempotent — which is also the retry path for a
+// capsule whose append failed while its red stayed steady.
+const convergeYeetWatchDispatch = (
+  context: RepoRunContext,
+  snapshot: YeetWatchSnapshot,
+  at: string
+): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.forEach(
+    A.filter(snapshot.checks, (check) => YeetCheckOutcome.is.fail(check.outcome)),
+    (check) => dispatchYeetCheckFailure(context.repoRoot, snapshot, check, at),
+    { discard: true }
+  );
+
+// How many consecutive zero-check polls the watch sits through before it
+// believes an empty rollup. GitHub registers a push's checks a few seconds
+// after gh starts answering "no checks reported"; ending the watch on that
+// window would report a green settle for a wave whose checks never ran. Ten
+// polls at the 10s interval ≈ the ~95s patience the classic monitor's
+// registration backoff (MonitorChecks) grants the same gap.
+const YEET_WATCH_REGISTRATION_PATIENCE = 10;
+
 /**
  * Poll the pull request and stream one NDJSON row per state transition.
  *
  * **Details**
  *
  * The loop collects a snapshot, emits `watch-started`, then polls on the given
- * interval: each poll's snapshot diffs against the previous one and every
- * derived event is emitted in order. The stream ends when the snapshot is
- * terminal — merged, closed, or no check pending — with a final `watch-ended`
- * row carrying the failure census, which is also the returned count so the
- * command can exit non-zero on a red wave.
+ * interval: each poll's snapshot diffs against the previous one, every derived
+ * event is emitted in order, and the inbox converges to the snapshot's failing
+ * set on the same tick. The stream ends when the snapshot is terminal —
+ * merged, closed, or no check pending — with a final `watch-ended` row
+ * carrying the failure census, which is also the returned count so the
+ * command can exit non-zero on a red wave. One exception: a zero-check OPEN
+ * snapshot within {@link collectYeetWatchSnapshot}'s registration gap is
+ * polled through for a bounded number of ticks instead of ending the watch as
+ * a green `all-terminal` while the push's checks are still registering.
  *
  * **Gotchas**
  *
  * A head change does not end the stream: the new wave's transitions simply
  * start diffing against the post-change baseline, which is how "a new push
- * supersedes the prior wave" reads in stream form. The consumer that dispatches
- * remediation keys its dedup on `headSha`, so superseded-wave rows cannot leak
- * into the new wave's session.
+ * supersedes the prior wave" reads in stream form. A head change also
+ * supersedes the persisted wave record before the new snapshot converges, and
+ * because capsule ids are keyed on `(prNumber, headSha)`, superseded-wave
+ * rows cannot leak into the new wave's session.
  *
  * A failed poll after the stream has started does not escape as an untyped
  * error: the stream ends with a `watch-ended` row whose reason is
@@ -281,19 +339,40 @@ const emitWatchEvent = (event: YeetWatchEvent): Effect.Effect<void, YeetCommandE
 export const runYeetWatchStream = Effect.fn("Yeet.runYeetWatchStream")(function* (
   context: RepoRunContext,
   config: { readonly intervalMillis: number }
-): Effect.fn.Return<YeetWatchEnded, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+): Effect.fn.Return<
+  YeetWatchEnded,
+  YeetCommandError,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> {
   let current = yield* collectYeetWatchSnapshot(context);
+  const startedAt = yield* isoNow;
   yield* emitWatchEvent(
     YeetWatchStarted.make({
-      at: yield* isoNow,
+      at: startedAt,
       checks: A.length(current.checks),
       headSha: current.headSha,
     })
   );
+  // Converge the wave record before seeding: a stale record left by a prior
+  // push (or a dead PR on the same branch tip) must not capture this wave's
+  // first red as a mere queue entry. Both calls are idempotent when nothing
+  // changed.
+  yield* supersedeYeetDispatchState(context.repoRoot, current.headSha, current.prNumber, startedAt);
+  yield* convergeYeetWatchDispatch(context, current, startedAt);
+  let emptyPolls = A.isReadonlyArrayEmpty(current.checks) ? 1 : 0;
 
   while (true) {
     const end = yeetWatchEndReason(current);
-    if (O.isSome(end)) {
+    // A zero-check OPEN snapshot inside the registration window is not a
+    // verdict: gh answers "no checks reported" for seconds after a push, and
+    // believing it would end the watch green while the wave's checks are
+    // about to run. Merged/closed endings pass through regardless.
+    const awaitingRegistration =
+      O.isSome(end) &&
+      YeetWatchEndReason.is["all-terminal"](end.value) &&
+      A.isReadonlyArrayEmpty(current.checks) &&
+      emptyPolls <= YEET_WATCH_REGISTRATION_PATIENCE;
+    if (O.isSome(end) && !awaitingRegistration) {
       const ended = YeetWatchEnded.make({
         at: yield* isoNow,
         failing: countYeetWatchFailures(current),
@@ -302,6 +381,11 @@ export const runYeetWatchStream = Effect.fn("Yeet.runYeetWatchStream")(function*
       });
       yield* emitWatchEvent(ended);
       return ended;
+    }
+    if (awaitingRegistration) {
+      yield* Console.error(
+        `[yeet] no checks registered for head ${Str.slice(0, 7)(current.headSha)} yet (${emptyPolls}/${YEET_WATCH_REGISTRATION_PATIENCE}); continuing to poll.`
+      );
     }
 
     yield* Effect.sleep(Duration.millis(config.intervalMillis));
@@ -322,8 +406,14 @@ export const runYeetWatchStream = Effect.fn("Yeet.runYeetWatchStream")(function*
       return ended;
     }
     const next = polled.value;
-    const events = diffYeetWatchSnapshots(YeetWatchDiffInput.make({ at: yield* isoNow, next, prev: current }));
+    const observedAt = yield* isoNow;
+    const events = diffYeetWatchSnapshots(YeetWatchDiffInput.make({ at: observedAt, next, prev: current }));
     yield* Effect.forEach(events, emitWatchEvent, { discard: true });
+    if (next.headSha !== current.headSha) {
+      yield* supersedeYeetDispatchState(context.repoRoot, next.headSha, next.prNumber, observedAt);
+    }
+    yield* convergeYeetWatchDispatch(context, next, observedAt);
+    emptyPolls = A.isReadonlyArrayEmpty(next.checks) ? emptyPolls + 1 : 0;
     current = next;
   }
 });

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchMode.ts
@@ -279,6 +279,67 @@ const convergeYeetWatchDispatch = (
 // registration backoff (MonitorChecks) grants the same gap.
 const YEET_WATCH_REGISTRATION_PATIENCE = 10;
 
+// Emit the terminal row and hand it back as the stream's return value.
+const emitWatchEnded = Effect.fn("Yeet.emitWatchEnded")(function* (
+  snapshot: YeetWatchSnapshot,
+  reason: YeetWatchEndReason
+) {
+  const ended = YeetWatchEnded.make({
+    at: yield* isoNow,
+    failing: countYeetWatchFailures(snapshot),
+    headSha: snapshot.headSha,
+    reason,
+  });
+  yield* emitWatchEvent(ended);
+  return ended;
+});
+
+// A zero-check OPEN snapshot inside the registration window is not a verdict:
+// gh answers "no checks reported" for seconds after a push, and believing it
+// would end the watch green while the wave's checks are about to run.
+// Merged/closed endings pass through regardless.
+const watchTickEnd = (snapshot: YeetWatchSnapshot, emptyPolls: number): O.Option<YeetWatchEndReason> =>
+  O.filter(
+    yeetWatchEndReason(snapshot),
+    (reason) =>
+      !(
+        YeetWatchEndReason.is["all-terminal"](reason) &&
+        A.isReadonlyArrayEmpty(snapshot.checks) &&
+        emptyPolls <= YEET_WATCH_REGISTRATION_PATIENCE
+      )
+  );
+
+// One post-sleep tick: poll, emit the diff, supersede on a head change, and
+// converge the inbox. `None` means the poll itself failed and the stream must
+// end as a typed poll-error.
+const advanceYeetWatchTick = Effect.fn("Yeet.advanceYeetWatchTick")(function* (
+  context: RepoRunContext,
+  prev: YeetWatchSnapshot,
+  emptyPolls: number
+) {
+  const polled = yield* collectYeetWatchSnapshot(context).pipe(
+    Effect.map(O.some),
+    Effect.catch((error) =>
+      Console.error(`[yeet] watch poll failed: ${error.message}`).pipe(Effect.as(O.none<YeetWatchSnapshot>()))
+    )
+  );
+  if (O.isNone(polled)) {
+    return O.none<{ readonly emptyPolls: number; readonly snapshot: YeetWatchSnapshot }>();
+  }
+  const next = polled.value;
+  const observedAt = yield* isoNow;
+  const events = diffYeetWatchSnapshots(YeetWatchDiffInput.make({ at: observedAt, next, prev }));
+  yield* Effect.forEach(events, emitWatchEvent, { discard: true });
+  if (next.headSha !== prev.headSha) {
+    yield* supersedeYeetDispatchState(context.repoRoot, next.headSha, next.prNumber, observedAt);
+  }
+  yield* convergeYeetWatchDispatch(context, next, observedAt);
+  return O.some({
+    emptyPolls: A.isReadonlyArrayEmpty(next.checks) ? emptyPolls + 1 : 0,
+    snapshot: next,
+  });
+});
+
 /**
  * Poll the pull request and stream one NDJSON row per state transition.
  *
@@ -362,59 +423,22 @@ export const runYeetWatchStream = Effect.fn("Yeet.runYeetWatchStream")(function*
   let emptyPolls = A.isReadonlyArrayEmpty(current.checks) ? 1 : 0;
 
   while (true) {
-    const end = yeetWatchEndReason(current);
-    // A zero-check OPEN snapshot inside the registration window is not a
-    // verdict: gh answers "no checks reported" for seconds after a push, and
-    // believing it would end the watch green while the wave's checks are
-    // about to run. Merged/closed endings pass through regardless.
-    const awaitingRegistration =
-      O.isSome(end) &&
-      YeetWatchEndReason.is["all-terminal"](end.value) &&
-      A.isReadonlyArrayEmpty(current.checks) &&
-      emptyPolls <= YEET_WATCH_REGISTRATION_PATIENCE;
-    if (O.isSome(end) && !awaitingRegistration) {
-      const ended = YeetWatchEnded.make({
-        at: yield* isoNow,
-        failing: countYeetWatchFailures(current),
-        headSha: current.headSha,
-        reason: end.value,
-      });
-      yield* emitWatchEvent(ended);
-      return ended;
+    const end = watchTickEnd(current, emptyPolls);
+    if (O.isSome(end)) {
+      return yield* emitWatchEnded(current, end.value);
     }
-    if (awaitingRegistration) {
+    if (A.isReadonlyArrayEmpty(current.checks)) {
       yield* Console.error(
         `[yeet] no checks registered for head ${Str.slice(0, 7)(current.headSha)} yet (${emptyPolls}/${YEET_WATCH_REGISTRATION_PATIENCE}); continuing to poll.`
       );
     }
-
     yield* Effect.sleep(Duration.millis(config.intervalMillis));
-    const polled = yield* collectYeetWatchSnapshot(context).pipe(
-      Effect.map(O.some),
-      Effect.catch((error) =>
-        Console.error(`[yeet] watch poll failed: ${error.message}`).pipe(Effect.as(O.none<YeetWatchSnapshot>()))
-      )
-    );
-    if (O.isNone(polled)) {
-      const ended = YeetWatchEnded.make({
-        at: yield* isoNow,
-        failing: countYeetWatchFailures(current),
-        headSha: current.headSha,
-        reason: "poll-error",
-      });
-      yield* emitWatchEvent(ended);
-      return ended;
+    const advanced = yield* advanceYeetWatchTick(context, current, emptyPolls);
+    if (O.isNone(advanced)) {
+      return yield* emitWatchEnded(current, YeetWatchEndReason.Enum["poll-error"]);
     }
-    const next = polled.value;
-    const observedAt = yield* isoNow;
-    const events = diffYeetWatchSnapshots(YeetWatchDiffInput.make({ at: observedAt, next, prev: current }));
-    yield* Effect.forEach(events, emitWatchEvent, { discard: true });
-    if (next.headSha !== current.headSha) {
-      yield* supersedeYeetDispatchState(context.repoRoot, next.headSha, next.prNumber, observedAt);
-    }
-    yield* convergeYeetWatchDispatch(context, next, observedAt);
-    emptyPolls = A.isReadonlyArrayEmpty(next.checks) ? emptyPolls + 1 : 0;
-    current = next;
+    current = advanced.value.snapshot;
+    emptyPolls = advanced.value.emptyPolls;
   }
 });
 

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchStream.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchStream.ts
@@ -161,7 +161,15 @@ export const classifyYeetCheckOutcome = (check: YeetCheckSignal): YeetCheckOutco
 };
 
 /**
- * One check within a watch snapshot: its name and classified outcome.
+ * One check within a watch snapshot: its classified outcome plus its record.
+ *
+ * **Details**
+ *
+ * `link`, `workflow`, and the raw `signal` are the check's own record as
+ * `gh pr checks` reported it, preserved so a failure capsule derives from the
+ * failing check's record instead of a classifier pass over composite output.
+ * They default (null link/workflow, empty signal) so synthetic snapshots in
+ * differ tests stay terse; the collector always fills them from the live row.
  *
  * @category models
  * @since 0.0.0
@@ -170,9 +178,14 @@ export class YeetWatchCheck extends S.Class<YeetWatchCheck>($I`YeetWatchCheck`)(
   {
     name: S.NonEmptyString,
     outcome: YeetCheckOutcome,
+    link: S.NullOr(S.String).pipe(S.withConstructorDefault(Effect.succeed(null))),
+    signal: YeetCheckSignal.pipe(
+      S.withConstructorDefault(Effect.succeed(YeetCheckSignal.make({ bucket: "", state: "" })))
+    ),
+    workflow: S.NullOr(S.String).pipe(S.withConstructorDefault(Effect.succeed(null))),
   },
   $I.annote("YeetWatchCheck", {
-    description: "One PR check's name and classified outcome within a watch snapshot.",
+    description: "One PR check's name, classified outcome, and raw record within a watch snapshot.",
   })
 ) {}
 
@@ -212,6 +225,7 @@ export class YeetWatchThread extends S.Class<YeetWatchThread>($I`YeetWatchThread
  *   checks: [],
  *   headSha: "abc123",
  *   mergeable: "MERGEABLE",
+ *   prNumber: 751,
  *   state: "OPEN",
  *   threads: []
  * })
@@ -227,6 +241,7 @@ export class YeetWatchSnapshot extends S.Class<YeetWatchSnapshot>($I`YeetWatchSn
     checks: S.Array(YeetWatchCheck),
     headSha: S.NonEmptyString,
     mergeable: S.String,
+    prNumber: S.Finite,
     state: S.String,
     threads: S.Array(YeetWatchThread),
   },
@@ -519,6 +534,7 @@ export class YeetWatchDiffInput extends S.Class<YeetWatchDiffInput>($I`YeetWatch
  *   checks: [YeetWatchCheck.make({ name: "Check", outcome: "pending" })],
  *   headSha: "abc",
  *   mergeable: "MERGEABLE",
+ *   prNumber: 751,
  *   state: "OPEN",
  *   threads: []
  * })
@@ -526,6 +542,7 @@ export class YeetWatchDiffInput extends S.Class<YeetWatchDiffInput>($I`YeetWatch
  *   checks: [YeetWatchCheck.make({ name: "Check", outcome: "fail" })],
  *   headSha: "abc",
  *   mergeable: "MERGEABLE",
+ *   prNumber: 751,
  *   state: "OPEN",
  *   threads: []
  * })
@@ -594,8 +611,10 @@ export const diffYeetWatchSnapshots = (input: YeetWatchDiffInput): ReadonlyArray
  *
  * A closed or merged PR ends the watch regardless of check state. Otherwise
  * the watch ends when no check is pending — including the degenerate zero-
- * check snapshot, which the registration backoff upstream is responsible for
- * not handing to the stream in the first place.
+ * check snapshot. The evaluator itself is deliberately memoryless about the
+ * registration gap: the watch loop owns the bounded patience that keeps a
+ * zero-check answer from being believed while a push's checks are still
+ * registering.
  *
  * **Example** (A merged PR ends the watch)
  *
@@ -607,6 +626,7 @@ export const diffYeetWatchSnapshots = (input: YeetWatchDiffInput): ReadonlyArray
  *   checks: [],
  *   headSha: "abc",
  *   mergeable: "UNKNOWN",
+ *   prNumber: 751,
  *   state: "MERGED",
  *   threads: []
  * })
@@ -644,6 +664,7 @@ export const yeetWatchEndReason = (snapshot: YeetWatchSnapshot): O.Option<YeetWa
  *   checks: [YeetWatchCheck.make({ name: "Check", outcome: "fail" })],
  *   headSha: "abc",
  *   mergeable: "MERGEABLE",
+ *   prNumber: 751,
  *   state: "OPEN",
  *   threads: []
  * })

--- a/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
@@ -31,6 +31,7 @@ export {
 } from "../commands/Yeet/internal/GitExec.ts";
 export * from "../commands/Yeet/internal/Guards.ts";
 export * from "../commands/Yeet/internal/Handler.ts";
+export * from "../commands/Yeet/internal/Inbox.ts";
 export * from "../commands/Yeet/internal/IssueArtifacts.ts";
 export * from "../commands/Yeet/internal/IssueClassification.ts";
 export * from "../commands/Yeet/internal/IssueParser.ts";
@@ -47,6 +48,7 @@ export * from "../commands/Yeet/internal/Provenance.ts";
 export * from "../commands/Yeet/internal/PublishScope.ts";
 export * from "../commands/Yeet/internal/PullRequest.ts";
 export * from "../commands/Yeet/internal/QualityIssueIndex.ts";
+export * from "../commands/Yeet/internal/Remediation.ts";
 export * from "../commands/Yeet/internal/Reply.schemas.ts";
 export * from "../commands/Yeet/internal/Reply.ts";
 export * from "../commands/Yeet/internal/Sweep.schemas.ts";

--- a/packages/tooling/tool/cli/test/yeet-inbox.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-inbox.test.ts
@@ -1,0 +1,159 @@
+import {
+  appendYeetInboxRow,
+  renderYeetInboxRowLine,
+  YEET_INBOX_SCHEMA_VERSION,
+  YeetCheckFailedRow,
+  YeetFailureCapsule,
+  YeetInboxRowJson,
+  yeetInboxAckPath,
+  yeetInboxPaths,
+  yeetInboxRowId,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+
+const AT = "2026-08-17T00:00:00Z";
+
+const capsule = (overrides: Partial<Parameters<typeof YeetFailureCapsule.make>[0]> = {}): YeetFailureCapsule =>
+  YeetFailureCapsule.make({
+    bucket: "fail",
+    headSha: "abc123def456",
+    lane: "Check / Coverage",
+    link: "https://github.com/beep/beep/actions/runs/1/job/2",
+    observedAt: AT,
+    prNumber: 751,
+    state: "FAILURE",
+    workflow: "Check",
+    ...overrides,
+  });
+
+const row = (subject: YeetFailureCapsule): YeetCheckFailedRow =>
+  YeetCheckFailedRow.make({
+    capsule: subject,
+    checkout: "/repo",
+    id: yeetInboxRowId(subject),
+    severity: "P0",
+    ts: AT,
+  });
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+const inTempRepo = Effect.fn("inTempRepo")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+describe("yeetInboxRowId", () => {
+  it("is deterministic over the same failure and doubles as a safe filename", () => {
+    const first = yeetInboxRowId(capsule());
+    const second = yeetInboxRowId(capsule());
+
+    expect(first).toBe(second);
+    // The id names the ack receipt file, so it must never need escaping.
+    expect(/^[A-Za-z0-9._-]+$/u.test(first)).toBe(true);
+  });
+
+  it("distinguishes head, lane, and pull request", () => {
+    const base = yeetInboxRowId(capsule());
+
+    expect(yeetInboxRowId(capsule({ headSha: "fff999" }))).not.toBe(base);
+    expect(yeetInboxRowId(capsule({ lane: "Check / Lint" }))).not.toBe(base);
+    expect(yeetInboxRowId(capsule({ prNumber: 99 }))).not.toBe(base);
+  });
+
+  it("keeps two lanes distinct even when they sanitize identically", () => {
+    // Both sanitize to "Check___Coverage"-ish segments; the digest suffix is
+    // what keeps their receipts from colliding.
+    const spaced = yeetInboxRowId(capsule({ lane: "Check / Coverage" }));
+    const starred = yeetInboxRowId(capsule({ lane: "Check * Coverage" }));
+
+    expect(spaced).not.toBe(starred);
+  });
+});
+
+describe("yeetInboxPaths", () => {
+  it.effect("resolves the inbox layout under the checkout", () =>
+    Effect.gen(function* () {
+      const paths = yield* yeetInboxPaths("/repo");
+
+      expect(paths.dir).toBe("/repo/.beep/inbox");
+      expect(paths.failuresPath).toBe("/repo/.beep/inbox/failures.ndjson");
+      expect(paths.acksDir).toBe("/repo/.beep/inbox/acks");
+    }).pipe(provideScopedLayer(NodePath.layer))
+  );
+
+  it.effect("resolves a row's ack receipt under the acks directory", () =>
+    Effect.gen(function* () {
+      const ackPath = yield* yeetInboxAckPath("/repo", "coverage-abc123");
+
+      expect(ackPath).toBe("/repo/.beep/inbox/acks/coverage-abc123");
+    }).pipe(provideScopedLayer(NodePath.layer))
+  );
+});
+
+describe("renderYeetInboxRowLine", () => {
+  it.effect("renders one single-line JSON document that round-trips through the codec", () =>
+    Effect.gen(function* () {
+      const subject = row(capsule());
+      const line = yield* renderYeetInboxRowLine(subject);
+
+      expect(Str.includes("\n")(line)).toBe(false);
+      const decoded = yield* YeetInboxRowJson.decode(line);
+      expect(decoded.kind).toBe("check-failed");
+      expect(decoded.schemaVersion).toBe(YEET_INBOX_SCHEMA_VERSION);
+      expect(decoded.capsule).toStrictEqual(subject.capsule);
+    })
+  );
+
+  it("rejects garbage instead of decaying to a partial row", () => {
+    expect(O.isNone(YeetInboxRowJson.decodeOption("not json"))).toBe(true);
+    expect(O.isNone(YeetInboxRowJson.decodeOption('{"kind":"check-failed"}'))).toBe(true);
+  });
+});
+
+describe("appendYeetInboxRow", () => {
+  it.live("creates the inbox on first use and appends whole decodable lines", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const first = row(capsule());
+        const second = row(capsule({ lane: "Check / Lint" }));
+
+        yield* appendYeetInboxRow(root, first);
+        yield* appendYeetInboxRow(root, second);
+
+        const paths = yield* yeetInboxPaths(root);
+        const text = yield* fs.readFileString(paths.failuresPath);
+        const lines = A.filter(Str.split(text, "\n"), Str.isNonEmpty);
+        expect(A.length(lines)).toBe(2);
+
+        const decoded = yield* Effect.forEach(lines, (line) => YeetInboxRowJson.decode(line));
+        expect(A.map(decoded, (entry) => entry.capsule.lane)).toEqual(["Check / Coverage", "Check / Lint"]);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("fails with a typed error when the inbox location is unusable", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        // A file squatting on the inbox directory path makes mkdir fail.
+        yield* fs.makeDirectory(`${root}/.beep`, { recursive: true });
+        yield* fs.writeFileString(`${root}/.beep/inbox`, "squatter");
+
+        const failure = yield* Effect.flip(appendYeetInboxRow(root, row(capsule())));
+        expect(failure.message).toContain("inbox");
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-remediation.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-remediation.test.ts
@@ -1,0 +1,388 @@
+import {
+  decideYeetRemediation,
+  dispatchYeetCheckFailure,
+  loadYeetRemediationWave,
+  renderYeetDispatchLine,
+  renderYeetDispatchStateWarning,
+  supersedeYeetDispatchState,
+  supersedeYeetRemediationWave,
+  YEET_DISPATCH_SCHEMA_VERSION,
+  YeetCheckFailedRow,
+  YeetCheckSignal,
+  YeetDispatchReport,
+  YeetFailureCapsule,
+  YeetInboxRowJson,
+  YeetRemediationInput,
+  YeetRemediationOutcome,
+  YeetRemediationWave,
+  YeetRemediationWaveJson,
+  YeetWatchCheck,
+  YeetWatchSnapshot,
+  YeetWaveSupersedeInput,
+  yeetDispatchStatePath,
+  yeetInboxPaths,
+  yeetInboxRowId,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+import * as TestConsole from "effect/testing/TestConsole";
+
+const AT = "2026-08-17T00:00:00Z";
+const LATER = "2026-08-17T00:00:10Z";
+
+const wave = (overrides: Partial<Parameters<typeof YeetRemediationWave.make>[0]> = {}): YeetRemediationWave =>
+  YeetRemediationWave.make({
+    capsuleIds: ["coverage-abc"],
+    headSha: "aaa111",
+    prNumber: 751,
+    sessionStartedAt: AT,
+    updatedAt: AT,
+    ...overrides,
+  });
+
+const decide = (input: Parameters<typeof YeetRemediationInput.make>[0]) =>
+  decideYeetRemediation(YeetRemediationInput.make(input));
+
+describe("decideYeetRemediation", () => {
+  it("starts the repair session on the first red for a head", () => {
+    const outcome = decide({ at: AT, capsuleId: "coverage-abc", headSha: "aaa111", prNumber: 751, wave: null });
+
+    expect(outcome.decision).toBe("start-session");
+    expect(outcome.wave.sessionStartedAt).toBe(AT);
+    expect(outcome.wave.capsuleIds).toEqual(["coverage-abc"]);
+    expect(outcome.wave.headSha).toBe("aaa111");
+    expect(outcome.wave.prNumber).toBe(751);
+  });
+
+  it("queues a later red for the same head onto the running session", () => {
+    const outcome = decide({ at: LATER, capsuleId: "lint-def", headSha: "aaa111", prNumber: 751, wave: wave() });
+
+    expect(outcome.decision).toBe("queue");
+    expect(outcome.wave.capsuleIds).toEqual(["coverage-abc", "lint-def"]);
+    expect(outcome.wave.sessionStartedAt).toBe(AT);
+    expect(outcome.wave.updatedAt).toBe(LATER);
+  });
+
+  it("drops an already-queued capsule as a duplicate without touching the wave", () => {
+    const current = wave();
+    const outcome = decide({ at: LATER, capsuleId: "coverage-abc", headSha: "aaa111", prNumber: 751, wave: current });
+
+    expect(outcome.decision).toBe("duplicate");
+    expect(outcome.wave).toStrictEqual(current);
+  });
+
+  it("starts fresh when the persisted wave belongs to another head", () => {
+    const outcome = decide({ at: LATER, capsuleId: "lint-bbb", headSha: "bbb222", prNumber: 751, wave: wave() });
+
+    expect(outcome.decision).toBe("start-session");
+    expect(outcome.wave.headSha).toBe("bbb222");
+    expect(outcome.wave.capsuleIds).toEqual(["lint-bbb"]);
+    expect(outcome.wave.sessionStartedAt).toBe(LATER);
+  });
+
+  // A branch tip re-opened as a new PR shares the head with the dead PR's
+  // wave; matching on head alone would swallow the new PR's session start.
+  it("starts fresh when the persisted wave belongs to another pull request on the same head", () => {
+    const outcome = decide({ at: LATER, capsuleId: "coverage-752", headSha: "aaa111", prNumber: 752, wave: wave() });
+
+    expect(outcome.decision).toBe("start-session");
+    expect(outcome.wave.prNumber).toBe(752);
+    expect(outcome.wave.capsuleIds).toEqual(["coverage-752"]);
+  });
+
+  it("starts the session on the first red after a push opened an empty wave", () => {
+    const empty = wave({ capsuleIds: [], sessionStartedAt: null });
+    const outcome = decide({ at: LATER, capsuleId: "coverage-abc", headSha: "aaa111", prNumber: 751, wave: empty });
+
+    expect(outcome.decision).toBe("start-session");
+    expect(outcome.wave.sessionStartedAt).toBe(LATER);
+    expect(outcome.wave.capsuleIds).toEqual(["coverage-abc"]);
+  });
+});
+
+describe("supersedeYeetRemediationWave", () => {
+  it("opens a fresh, sessionless wave for a new head", () => {
+    const next = supersedeYeetRemediationWave(
+      YeetWaveSupersedeInput.make({ at: LATER, headSha: "bbb222", prNumber: 751, wave: wave() })
+    );
+
+    expect(next.headSha).toBe("bbb222");
+    expect(next.capsuleIds).toEqual([]);
+    expect(next.sessionStartedAt).toBeNull();
+  });
+
+  it("opens the same fresh wave when no record exists", () => {
+    const next = supersedeYeetRemediationWave(
+      YeetWaveSupersedeInput.make({ at: LATER, headSha: "bbb222", prNumber: 751, wave: null })
+    );
+
+    expect(next.capsuleIds).toEqual([]);
+  });
+
+  it("passes a wave already on the observed head through unchanged", () => {
+    const current = wave();
+    const next = supersedeYeetRemediationWave(
+      YeetWaveSupersedeInput.make({ at: LATER, headSha: "aaa111", prNumber: 751, wave: current })
+    );
+
+    expect(next).toStrictEqual(current);
+  });
+
+  it("supersedes a same-head wave that belongs to another pull request", () => {
+    const next = supersedeYeetRemediationWave(
+      YeetWaveSupersedeInput.make({ at: LATER, headSha: "aaa111", prNumber: 752, wave: wave() })
+    );
+
+    expect(next.prNumber).toBe(752);
+    expect(next.capsuleIds).toEqual([]);
+    expect(next.sessionStartedAt).toBeNull();
+  });
+});
+
+const capsule = (overrides: Partial<Parameters<typeof YeetFailureCapsule.make>[0]> = {}): YeetFailureCapsule =>
+  YeetFailureCapsule.make({
+    bucket: "fail",
+    headSha: "aaa111bbb",
+    lane: "Check / Coverage",
+    link: "https://github.com/beep/beep/actions/runs/1/job/2",
+    observedAt: AT,
+    prNumber: 751,
+    state: "FAILURE",
+    workflow: "Check",
+    ...overrides,
+  });
+
+describe("renderYeetDispatchLine", () => {
+  const report = (outcome: YeetRemediationOutcome): YeetDispatchReport => {
+    const subject = capsule();
+    return YeetDispatchReport.make({
+      outcome,
+      row: YeetCheckFailedRow.make({
+        capsule: subject,
+        checkout: "/repo",
+        id: yeetInboxRowId(subject),
+        severity: "P0",
+        ts: AT,
+      }),
+    });
+  };
+
+  it("announces each decision distinctly", () => {
+    const started = renderYeetDispatchLine(
+      report(YeetRemediationOutcome.make({ decision: "start-session", wave: wave() }))
+    );
+    const queued = renderYeetDispatchLine(
+      report(YeetRemediationOutcome.make({ decision: "queue", wave: wave({ capsuleIds: ["a", "b"] }) }))
+    );
+    const duplicate = renderYeetDispatchLine(
+      report(YeetRemediationOutcome.make({ decision: "duplicate", wave: wave() }))
+    );
+
+    expect(started).toContain("repair session opened");
+    expect(started).toContain('"Check / Coverage"');
+    expect(started).toContain("aaa111b");
+    expect(queued).toContain("queued to the head");
+    expect(queued).toContain("2 capsules");
+    expect(duplicate).toContain("already queued");
+  });
+});
+
+describe("renderYeetDispatchStateWarning", () => {
+  it("names the reason and the consequence", () => {
+    const line = renderYeetDispatchStateWarning("disk is full");
+
+    expect(line).toContain("disk is full");
+    expect(line).toContain("dedup safely");
+  });
+});
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+const inTempRepo = Effect.fn("inTempRepo")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+const snapshotWithFailure = (root: YeetWatchCheck): YeetWatchSnapshot =>
+  YeetWatchSnapshot.make({
+    checks: [root],
+    headSha: "aaa111bbb",
+    mergeable: "MERGEABLE",
+    prNumber: 751,
+    state: "OPEN",
+    threads: [],
+  });
+
+const failingCheck = YeetWatchCheck.make({
+  name: "Check / Coverage",
+  outcome: "fail",
+  link: "https://github.com/beep/beep/actions/runs/1/job/2",
+  signal: YeetCheckSignal.make({ bucket: "cancel", state: "CANCELLED" }),
+  workflow: "Check",
+});
+
+const readInboxRows = Effect.fn("readInboxRows")(function* (root: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const paths = yield* yeetInboxPaths(root);
+  const text = yield* Effect.option(fs.readFileString(paths.failuresPath));
+  const lines = O.match(text, {
+    onNone: () => A.empty<string>(),
+    onSome: (value) => A.filter(Str.split(value, "\n"), Str.isNonEmpty),
+  });
+  return yield* Effect.forEach(lines, (line) => YeetInboxRowJson.decode(line));
+});
+
+describe("loadYeetRemediationWave", () => {
+  it.live("reads back what was persisted and refuses everything else", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        expect(O.isNone(yield* loadYeetRemediationWave(root))).toBe(true);
+
+        const statePath = yield* yeetDispatchStatePath(root);
+        yield* fs.makeDirectory(`${root}/.beep/inbox`, { recursive: true });
+        yield* fs.writeFileString(statePath, "garbage");
+        expect(O.isNone(yield* loadYeetRemediationWave(root))).toBe(true);
+
+        const json = yield* YeetRemediationWaveJson.encode(wave());
+        yield* fs.writeFileString(statePath, `${json}\n`);
+        const loaded = yield* loadYeetRemediationWave(root);
+        expect(O.isSome(loaded)).toBe(true);
+        if (O.isSome(loaded)) {
+          expect(loaded.value.schemaVersion).toBe(YEET_DISPATCH_SCHEMA_VERSION);
+          expect(loaded.value).toStrictEqual(wave());
+        }
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+});
+
+describe("supersedeYeetDispatchState", () => {
+  // A push that lands before any red superseded nothing worth announcing:
+  // the empty wave rolls forward silently.
+  it.live("stays silent when the superseded wave held no capsules", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const statePath = yield* yeetDispatchStatePath(root);
+        yield* fs.makeDirectory(`${root}/.beep/inbox`, { recursive: true });
+        const empty = wave({ capsuleIds: [], sessionStartedAt: null });
+        yield* fs.writeFileString(statePath, `${yield* YeetRemediationWaveJson.encode(empty)}\n`);
+
+        yield* supersedeYeetDispatchState(root, "bbb222", 751, LATER);
+
+        const persisted = yield* loadYeetRemediationWave(root);
+        if (O.isSome(persisted)) {
+          expect(persisted.value.headSha).toBe("bbb222");
+        }
+        expect(A.length(yield* TestConsole.errorLines)).toBe(0);
+      })
+    ).pipe(provideScopedLayer(Layer.mergeAll(TestConsole.layer, PlatformLayer)))
+  );
+
+  it.live("announces when an in-flight wave is superseded", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const statePath = yield* yeetDispatchStatePath(root);
+        yield* fs.makeDirectory(`${root}/.beep/inbox`, { recursive: true });
+        yield* fs.writeFileString(statePath, `${yield* YeetRemediationWaveJson.encode(wave())}\n`);
+
+        yield* supersedeYeetDispatchState(root, "bbb222", 751, LATER);
+
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("1-capsule wave for aaa111 is superseded")(line))).toBe(true);
+      })
+    ).pipe(provideScopedLayer(Layer.mergeAll(TestConsole.layer, PlatformLayer)))
+  );
+});
+
+describe("dispatchYeetCheckFailure", () => {
+  it.live("derives the capsule from the failing check's own record", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        yield* dispatchYeetCheckFailure(root, snapshotWithFailure(failingCheck), failingCheck, AT);
+
+        const rows = yield* readInboxRows(root);
+        expect(A.length(rows)).toBe(1);
+        const entry = rows[0];
+        expect(entry?.checkout).toBe(root);
+        expect(entry?.capsule.lane).toBe("Check / Coverage");
+        expect(entry?.capsule.link).toBe("https://github.com/beep/beep/actions/runs/1/job/2");
+        expect(entry?.capsule.workflow).toBe("Check");
+        // The raw signal survives: CANCELLED steers repair toward a rerun.
+        expect(entry?.capsule.bucket).toBe("cancel");
+        expect(entry?.capsule.state).toBe("CANCELLED");
+
+        const persisted = yield* loadYeetRemediationWave(root);
+        expect(O.isSome(persisted)).toBe(true);
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("repair session opened")(line))).toBe(true);
+      })
+    ).pipe(provideScopedLayer(Layer.mergeAll(TestConsole.layer, PlatformLayer)))
+  );
+
+  it.live("skips every write on a duplicate observation", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        yield* dispatchYeetCheckFailure(root, snapshotWithFailure(failingCheck), failingCheck, AT);
+        yield* dispatchYeetCheckFailure(root, snapshotWithFailure(failingCheck), failingCheck, LATER);
+
+        const rows = yield* readInboxRows(root);
+        expect(A.length(rows)).toBe(1);
+        const persisted = yield* loadYeetRemediationWave(root);
+        if (O.isSome(persisted)) {
+          expect(persisted.value.updatedAt).toBe(AT);
+        }
+      })
+    ).pipe(provideScopedLayer(Layer.mergeAll(TestConsole.layer, PlatformLayer)))
+  );
+
+  // The wave must never claim a capsule the inbox does not hold: a failed
+  // append skips the persist so the next observation retries the delivery.
+  it.live("does not record the wave when the inbox append fails", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.makeDirectory(`${root}/.beep`, { recursive: true });
+        yield* fs.writeFileString(`${root}/.beep/inbox`, "squatter");
+
+        yield* dispatchYeetCheckFailure(root, snapshotWithFailure(failingCheck), failingCheck, AT);
+
+        expect(O.isNone(yield* loadYeetRemediationWave(root))).toBe(true);
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("failed to deliver capsule")(line))).toBe(true);
+        expect(A.some(errors, (line) => Str.includes("NOT queued")(line))).toBe(true);
+      })
+    ).pipe(provideScopedLayer(Layer.mergeAll(TestConsole.layer, PlatformLayer)))
+  );
+
+  it.live("delivers the capsule and warns when only the wave record cannot be written", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const statePath = yield* yeetDispatchStatePath(root);
+        // A directory squatting on dispatch.json fails the state write only.
+        yield* fs.makeDirectory(statePath, { recursive: true });
+
+        yield* dispatchYeetCheckFailure(root, snapshotWithFailure(failingCheck), failingCheck, AT);
+
+        expect(A.length(yield* readInboxRows(root))).toBe(1);
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("could not persist the remediation wave record")(line))).toBe(
+          true
+        );
+      })
+    ).pipe(provideScopedLayer(Layer.mergeAll(TestConsole.layer, PlatformLayer)))
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-watch-mode.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-watch-mode.test.ts
@@ -775,6 +775,42 @@ describe("registration patience", () => {
     )
   );
 
+  // The registration budget belongs to a head: polls the OLD head spent must
+  // not shorten the NEW head's window, or a push landing late in the old
+  // window could exit green before its checks register (#754 review P1).
+  it.live("restarts the registration budget when the head changes mid-window", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+
+        expect(ended.failing).toBe(1);
+        const patience = A.filter(A.map(yield* TestConsole.errorLines, String), (line) =>
+          Str.includes("no checks registered")(line)
+        );
+        expect(A.some(patience, (line) => Str.includes("head aaa111 yet (2/10)")(line))).toBe(true);
+        expect(A.some(patience, (line) => Str.includes("head bbb222 yet (1/10)")(line))).toBe(true);
+        expect(A.some(patience, (line) => Str.includes("(3/10)")(line))).toBe(false);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          PlatformLayer,
+          scriptedSpawnerLayer([
+            unregistered("aaa111"),
+            unregistered("aaa111"),
+            unregistered("bbb222"),
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "bbb222") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "fail", name: "Coverage", state: "FAILURE" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+
   // Scenario B of the review P1: a push lands mid-watch and the next poll
   // reads the new head while gh still answers "no checks reported". Ending
   // there would retire the superseded wave AND report the new push green.

--- a/packages/tooling/tool/cli/test/yeet-watch-mode.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-watch-mode.test.ts
@@ -1,30 +1,39 @@
 import {
   collectYeetWatchSnapshot,
+  loadYeetRemediationWave,
   RepoRunContext,
   runYeetWatchStream,
   YeetCommandError,
+  YeetInboxRowJson,
   YeetWatchEvent,
+  yeetInboxPaths,
   yeetWatchExitFailure,
 } from "@beep/repo-cli/test/Yeet";
 import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Ref, Sink, Stream } from "effect";
+import { Effect, FileSystem, Layer, Ref, Sink, Stream } from "effect";
 import * as A from "effect/Array";
+import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import * as TestConsole from "effect/testing/TestConsole";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
-const context = RepoRunContext.make({
-  base: "origin/main",
-  branch: "feature/watch",
-  cwd: ".",
-  head: "HEAD",
-  originalArgv: [],
-  packetDir: ".beep/yeet",
-  repoRoot: ".",
-  turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
-});
+const contextFor = (repoRoot: string): RepoRunContext =>
+  RepoRunContext.make({
+    base: "origin/main",
+    branch: "feature/watch",
+    cwd: repoRoot,
+    head: "HEAD",
+    originalArgv: [],
+    packetDir: ".beep/yeet",
+    repoRoot,
+    turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+  });
+
+const context = contextFor(".");
 
 const encoder = new TextEncoder();
 
@@ -51,10 +60,26 @@ interface PollScript {
 }
 
 const viewJson = (state: string, headSha: string): string =>
-  JSON.stringify({ headRefOid: headSha, id: "PR_watch", mergeable: "MERGEABLE", state });
+  JSON.stringify({ headRefOid: headSha, id: "PR_watch", mergeable: "MERGEABLE", number: 751, state });
 
-const checksJson = (rows: ReadonlyArray<{ readonly name: string; readonly bucket: string; readonly state: string }>) =>
-  JSON.stringify(rows);
+interface CheckRowFixture {
+  readonly bucket: string;
+  readonly link?: string;
+  readonly name: string;
+  readonly state: string;
+  readonly workflow?: string;
+}
+
+const checksJson = (rows: ReadonlyArray<CheckRowFixture>) =>
+  JSON.stringify(
+    A.map(rows, (row) => ({
+      bucket: row.bucket,
+      link: row.link ?? "https://github.com/beep/beep/actions/runs/1/job/2",
+      name: row.name,
+      state: row.state,
+      workflow: row.workflow ?? "CI",
+    }))
+  );
 
 const threadsJson = (nodes: ReadonlyArray<{ readonly id: string; readonly isResolved: boolean }>) =>
   JSON.stringify({ data: { node: { reviewThreads: { nodes } } } });
@@ -93,15 +118,50 @@ const greenScript = (headSha: string): PollScript => ({
   threads: { exitCode: 0, output: threadsJson([]) },
 });
 
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+// Watch runs in a disposable checkout root, because dispatching reds writes
+// the inbox and the wave record under `<repoRoot>/.beep/inbox/`.
+const inTempRepo = Effect.fn("inTempRepo")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+const readInboxRows = Effect.fn("readInboxRows")(function* (root: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const paths = yield* yeetInboxPaths(root);
+  const text = yield* Effect.option(fs.readFileString(paths.failuresPath));
+  const lines = O.match(text, {
+    onNone: () => A.empty<string>(),
+    onSome: (value) => A.filter(Str.split(value, "\n"), Str.isNonEmpty),
+  });
+  return yield* Effect.forEach(lines, (line) => YeetInboxRowJson.decode(line));
+});
+
 describe("collectYeetWatchSnapshot", () => {
-  it.effect("decodes and classifies one full snapshot", () =>
+  it.effect("decodes, classifies, and keeps each check's own record", () =>
     Effect.gen(function* () {
       const snapshot = yield* collectYeetWatchSnapshot(context);
 
       expect(snapshot.headSha).toBe("aaa111");
       expect(snapshot.state).toBe("OPEN");
+      expect(snapshot.prNumber).toBe(751);
       expect(A.map(snapshot.checks, (check) => check.outcome)).toEqual(["pending", "fail"]);
       expect(A.map(snapshot.threads, (thread) => thread.isResolved)).toEqual([false]);
+
+      // The failing check keeps its own record for capsule derivation; a
+      // plain commit status's empty link/workflow read as null, not "".
+      const failing = snapshot.checks[1];
+      expect(failing?.link).toBe("https://github.com/beep/beep/actions/runs/9/job/9");
+      expect(failing?.workflow).toBe("Check");
+      expect(failing?.signal.bucket).toBe("fail");
+      expect(failing?.signal.state).toBe("FAILURE");
+      expect(snapshot.checks[0]?.link).toBeNull();
+      expect(snapshot.checks[0]?.workflow).toBeNull();
     }).pipe(
       provideScopedLayer(
         scriptedSpawnerLayer([
@@ -110,8 +170,14 @@ describe("collectYeetWatchSnapshot", () => {
             checks: {
               exitCode: 0,
               output: checksJson([
-                { bucket: "pending", name: "Coverage", state: "IN_PROGRESS" },
-                { bucket: "fail", name: "Lint", state: "FAILURE" },
+                { bucket: "pending", link: "", name: "Coverage", state: "IN_PROGRESS", workflow: "" },
+                {
+                  bucket: "fail",
+                  link: "https://github.com/beep/beep/actions/runs/9/job/9",
+                  name: "Lint",
+                  state: "FAILURE",
+                  workflow: "Check",
+                },
               ]),
             },
             threads: { exitCode: 0, output: threadsJson([{ id: "T1", isResolved: false }]) },
@@ -215,7 +281,13 @@ describe("collectYeetWatchSnapshot", () => {
           {
             view: {
               exitCode: 0,
-              output: JSON.stringify({ headRefOid: "aaa111", id: "PR_watch", mergeable: null, state: "OPEN" }),
+              output: JSON.stringify({
+                headRefOid: "aaa111",
+                id: "PR_watch",
+                mergeable: null,
+                number: 751,
+                state: "OPEN",
+              }),
             },
             checks: { exitCode: 0, output: checksJson([]) },
             threads: { exitCode: 0, output: JSON.stringify({ data: { node: null } }) },
@@ -232,22 +304,25 @@ describe("runYeetWatchStream", () => {
   // it.live: the loop sleeps between polls, and under the TestClock a real
   // sleep parks forever (A7's receipt). Zero interval keeps it instant.
   it.live("streams started, transitions, and ended rows as decodable NDJSON", () =>
-    Effect.gen(function* () {
-      const ended = yield* runYeetWatchStream(context, { intervalMillis: 0 });
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
 
-      expect(ended.reason).toBe("all-terminal");
-      expect(ended.failing).toBe(1);
+        expect(ended.reason).toBe("all-terminal");
+        expect(ended.failing).toBe(1);
 
-      const lines = A.map(yield* TestConsole.logLines, String);
-      const events = yield* Effect.forEach(lines, (line) => decodeLine(line));
-      expect(A.map(events, (event) => event.kind)).toEqual(["watch-started", "check-transition", "watch-ended"]);
-      const transition = events[1] as Extract<YeetWatchEvent, { readonly kind: "check-transition" }>;
-      expect(transition.from).toBe("pending");
-      expect(transition.to).toBe("fail");
-    }).pipe(
+        const lines = A.map(yield* TestConsole.logLines, String);
+        const events = yield* Effect.forEach(lines, (line) => decodeLine(line));
+        expect(A.map(events, (event) => event.kind)).toEqual(["watch-started", "check-transition", "watch-ended"]);
+        const transition = events[1] as Extract<YeetWatchEvent, { readonly kind: "check-transition" }>;
+        expect(transition.from).toBe("pending");
+        expect(transition.to).toBe("fail");
+      })
+    ).pipe(
       provideScopedLayer(
         Layer.mergeAll(
           TestConsole.layer,
+          PlatformLayer,
           scriptedSpawnerLayer([
             {
               view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
@@ -266,20 +341,23 @@ describe("runYeetWatchStream", () => {
   );
 
   it.live("converts a failed later poll into a typed poll-error ending", () =>
-    Effect.gen(function* () {
-      const ended = yield* runYeetWatchStream(context, { intervalMillis: 0 });
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
 
-      expect(ended.reason).toBe("poll-error");
-      expect(ended.failing).toBe(0);
-      const lines = A.map(yield* TestConsole.logLines, String);
-      const events = yield* Effect.forEach(lines, (line) => decodeLine(line));
-      expect(A.map(events, (event) => event.kind)).toEqual(["watch-started", "watch-ended"]);
-      const errors = A.map(yield* TestConsole.errorLines, String);
-      expect(A.some(errors, (line) => Str.includes("watch poll failed")(line))).toBe(true);
-    }).pipe(
+        expect(ended.reason).toBe("poll-error");
+        expect(ended.failing).toBe(0);
+        const lines = A.map(yield* TestConsole.logLines, String);
+        const events = yield* Effect.forEach(lines, (line) => decodeLine(line));
+        expect(A.map(events, (event) => event.kind)).toEqual(["watch-started", "watch-ended"]);
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("watch poll failed")(line))).toBe(true);
+      })
+    ).pipe(
       provideScopedLayer(
         Layer.mergeAll(
           TestConsole.layer,
+          PlatformLayer,
           scriptedSpawnerLayer([
             {
               view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
@@ -298,14 +376,469 @@ describe("runYeetWatchStream", () => {
   );
 
   it.live("ends immediately when the first snapshot is already terminal", () =>
-    Effect.gen(function* () {
-      const ended = yield* runYeetWatchStream(context, { intervalMillis: 0 });
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
 
-      expect(ended.reason).toBe("all-terminal");
-      expect(ended.failing).toBe(0);
-      const lines = A.map(yield* TestConsole.logLines, String);
-      expect(A.length(lines)).toBe(2);
-    }).pipe(provideScopedLayer(Layer.mergeAll(TestConsole.layer, scriptedSpawnerLayer([greenScript("aaa111")]))))
+        expect(ended.reason).toBe("all-terminal");
+        expect(ended.failing).toBe(0);
+        const lines = A.map(yield* TestConsole.logLines, String);
+        expect(A.length(lines)).toBe(2);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(TestConsole.layer, PlatformLayer, scriptedSpawnerLayer([greenScript("aaa111")]))
+      )
+    )
+  );
+});
+
+describe("remediation dispatch through the watch", () => {
+  // A1 acceptance, first half: the capsule is appended on the same poll tick
+  // that observes the transition — no batching, no end-of-watch flush — so
+  // with the production 10s interval a first red reaches the inbox well
+  // inside the 15s p95 budget.
+  it.live("delivers a first red's capsule to the inbox on the tick that observes it", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+        expect(ended.failing).toBe(1);
+
+        const rows = yield* readInboxRows(root);
+        expect(A.length(rows)).toBe(1);
+        const row = rows[0];
+        expect(row?.kind).toBe("check-failed");
+        expect(row?.severity).toBe("P0");
+        expect(row?.checkout).toBe(root);
+        expect(row?.capsule.lane).toBe("Coverage");
+        expect(row?.capsule.headSha).toBe("aaa111");
+        expect(row?.capsule.prNumber).toBe(751);
+        expect(row?.capsule.link).toBe("https://github.com/beep/beep/actions/runs/3/job/4");
+        expect(row?.capsule.workflow).toBe("Check");
+        expect(row?.capsule.state).toBe("FAILURE");
+
+        const wave = yield* loadYeetRemediationWave(root);
+        expect(O.isSome(wave)).toBe(true);
+        if (O.isSome(wave)) {
+          expect(wave.value.headSha).toBe("aaa111");
+          expect(wave.value.sessionStartedAt).not.toBeNull();
+          expect(wave.value.capsuleIds).toEqual([row?.id]);
+        }
+
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("repair session opened")(line))).toBe(true);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          PlatformLayer,
+          scriptedSpawnerLayer([
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "pending", name: "Coverage", state: "QUEUED" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  {
+                    bucket: "fail",
+                    link: "https://github.com/beep/beep/actions/runs/3/job/4",
+                    name: "Coverage",
+                    state: "FAILURE",
+                    workflow: "Check",
+                  },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([{ id: "T1", isResolved: false }]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+
+  // A1 acceptance, second half: three reds on one head produce ONE repair
+  // session with three queued capsules — not three sessions, not one capsule.
+  it.live("queues three reds on one head into a single repair session", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+        expect(ended.reason).toBe("all-terminal");
+        expect(ended.failing).toBe(3);
+
+        const rows = yield* readInboxRows(root);
+        expect(A.length(rows)).toBe(3);
+        expect(A.map(rows, (row) => row.capsule.lane)).toEqual(["Check", "Coverage", "Lint"]);
+
+        const wave = yield* loadYeetRemediationWave(root);
+        expect(O.isSome(wave)).toBe(true);
+        if (O.isSome(wave)) {
+          expect(A.length(wave.value.capsuleIds)).toBe(3);
+          expect(wave.value.capsuleIds).toEqual(A.map(rows, (row) => row.id));
+        }
+
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.length(A.filter(errors, (line) => Str.includes("repair session opened")(line)))).toBe(1);
+        expect(A.length(A.filter(errors, (line) => Str.includes("queued to the head")(line)))).toBe(2);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          PlatformLayer,
+          scriptedSpawnerLayer([
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "pending", name: "Check", state: "QUEUED" },
+                  { bucket: "pending", name: "Coverage", state: "QUEUED" },
+                  { bucket: "pending", name: "Lint", state: "QUEUED" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Check", state: "FAILURE" },
+                  { bucket: "pending", name: "Coverage", state: "QUEUED" },
+                  { bucket: "pending", name: "Lint", state: "QUEUED" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Check", state: "FAILURE" },
+                  { bucket: "fail", name: "Coverage", state: "FAILURE" },
+                  { bucket: "pending", name: "Lint", state: "QUEUED" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Check", state: "FAILURE" },
+                  { bucket: "fail", name: "Coverage", state: "FAILURE" },
+                  { bucket: "fail", name: "Lint", state: "FAILURE" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+
+  // Dedup by headSha+lane: a lane that re-runs (fail → pending → fail) on the
+  // same head re-derives the same capsule id and must not duplicate the row.
+  it.live("does not duplicate a capsule when the same lane goes red twice on one head", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+        expect(ended.failing).toBe(1);
+
+        const rows = yield* readInboxRows(root);
+        expect(A.length(rows)).toBe(1);
+
+        const wave = yield* loadYeetRemediationWave(root);
+        if (O.isSome(wave)) {
+          expect(A.length(wave.value.capsuleIds)).toBe(1);
+        }
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.length(A.filter(errors, (line) => Str.includes("repair session opened")(line)))).toBe(1);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          PlatformLayer,
+          scriptedSpawnerLayer([
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "pending", name: "Coverage", state: "QUEUED" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "fail", name: "Coverage", state: "FAILURE" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "pending", name: "Coverage", state: "QUEUED" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "fail", name: "Coverage", state: "FAILURE" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+
+  // A new push supersedes the wave: the old head's capsules stay in the
+  // inbox, the wave record restarts on the new head, and reds already present
+  // in the new baseline are seeded even though they emit no transition.
+  it.live("supersedes the wave on a head change and seeds the new baseline's reds", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+        expect(ended.reason).toBe("all-terminal");
+
+        const rows = yield* readInboxRows(root);
+        expect(A.map(rows, (row) => [row.capsule.lane, row.capsule.headSha])).toEqual([
+          ["Coverage", "aaa111"],
+          ["Coverage", "bbb222"],
+        ]);
+
+        const wave = yield* loadYeetRemediationWave(root);
+        expect(O.isSome(wave)).toBe(true);
+        if (O.isSome(wave)) {
+          expect(wave.value.headSha).toBe("bbb222");
+          expect(A.length(wave.value.capsuleIds)).toBe(1);
+        }
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("superseded")(line))).toBe(true);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          PlatformLayer,
+          scriptedSpawnerLayer([
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "pending", name: "Coverage", state: "QUEUED" },
+                  { bucket: "pending", name: "Lint", state: "QUEUED" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Coverage", state: "FAILURE" },
+                  { bucket: "pending", name: "Lint", state: "QUEUED" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "bbb222") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Coverage", state: "FAILURE" },
+                  { bucket: "pending", name: "Lint", state: "QUEUED" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "bbb222") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Coverage", state: "FAILURE" },
+                  { bucket: "pass", name: "Lint", state: "SUCCESS" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+
+  // A watch attached to an already-red wave seeds the baseline, and a second
+  // watch over the same checkout re-derives the same ids and stays silent —
+  // restart idempotency is what makes the seed safe to run unconditionally.
+  it.live("seeds already-failing checks at watch start, idempotently across restarts", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const first = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+        expect(first.reason).toBe("all-terminal");
+        expect(first.failing).toBe(1);
+
+        const second = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+        expect(second.failing).toBe(1);
+
+        const rows = yield* readInboxRows(root);
+        expect(A.length(rows)).toBe(1);
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.length(A.filter(errors, (line) => Str.includes("repair session opened")(line)))).toBe(1);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          PlatformLayer,
+          scriptedSpawnerLayer([
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "fail", name: "Coverage", state: "FAILURE" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+});
+
+describe("registration patience", () => {
+  const unregistered = (headSha: string): PollScript => ({
+    view: { exitCode: 0, output: viewJson("OPEN", headSha) },
+    checks: { exitCode: 1, output: "no checks reported on the 'feature/watch' branch" },
+    threads: { exitCode: 0, output: threadsJson([]) },
+  });
+
+  // The #751-class fix: a zero-check OPEN snapshot inside gh's registration
+  // gap must not end the watch as a green all-terminal — the push's checks
+  // are about to run and may all fail.
+  it.live("polls through the registration gap at watch start instead of settling green", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+
+        expect(ended.reason).toBe("all-terminal");
+        expect(ended.failing).toBe(1);
+        expect(A.length(yield* readInboxRows(root))).toBe(1);
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("no checks registered")(line))).toBe(true);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          PlatformLayer,
+          scriptedSpawnerLayer([
+            unregistered("aaa111"),
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "pending", name: "Coverage", state: "QUEUED" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: { exitCode: 0, output: checksJson([{ bucket: "fail", name: "Coverage", state: "FAILURE" }]) },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
+  );
+
+  it.live("believes a genuinely checkless PR once the patience bound is spent", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+
+        expect(ended.reason).toBe("all-terminal");
+        expect(ended.failing).toBe(0);
+        const errors = A.filter(A.map(yield* TestConsole.errorLines, String), (line) =>
+          Str.includes("no checks registered")(line)
+        );
+        // One patience line per empty observation, then the bound is spent.
+        expect(A.length(errors)).toBe(10);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(TestConsole.layer, PlatformLayer, scriptedSpawnerLayer([unregistered("aaa111")]))
+      )
+    )
+  );
+
+  // Scenario B of the review P1: a push lands mid-watch and the next poll
+  // reads the new head while gh still answers "no checks reported". Ending
+  // there would retire the superseded wave AND report the new push green.
+  it.live("polls through a mid-watch push whose checks have not registered yet", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const ended = yield* runYeetWatchStream(contextFor(root), { intervalMillis: 0 });
+
+        expect(ended.reason).toBe("all-terminal");
+        expect(ended.failing).toBe(1);
+
+        const rows = yield* readInboxRows(root);
+        expect(A.map(rows, (row) => [row.capsule.lane, row.capsule.headSha])).toEqual([
+          ["Coverage", "aaa111"],
+          ["Coverage", "bbb222"],
+        ]);
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        expect(A.some(errors, (line) => Str.includes("superseded")(line))).toBe(true);
+        expect(A.some(errors, (line) => Str.includes("no checks registered")(line))).toBe(true);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          TestConsole.layer,
+          PlatformLayer,
+          scriptedSpawnerLayer([
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "aaa111") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Coverage", state: "FAILURE" },
+                  { bucket: "pending", name: "Lint", state: "QUEUED" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            unregistered("bbb222"),
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "bbb222") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Coverage", state: "FAILURE" },
+                  { bucket: "pending", name: "Lint", state: "QUEUED" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+            {
+              view: { exitCode: 0, output: viewJson("OPEN", "bbb222") },
+              checks: {
+                exitCode: 0,
+                output: checksJson([
+                  { bucket: "fail", name: "Coverage", state: "FAILURE" },
+                  { bucket: "pass", name: "Lint", state: "SUCCESS" },
+                ]),
+              },
+              threads: { exitCode: 0, output: threadsJson([]) },
+            },
+          ])
+        )
+      )
+    )
   );
 });
 

--- a/packages/tooling/tool/cli/test/yeet-watch-stream.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-watch-stream.test.ts
@@ -29,6 +29,7 @@ const snapshot = (overrides: Partial<Parameters<typeof YeetWatchSnapshot.make>[0
     checks: [],
     headSha: "aaa111",
     mergeable: "MERGEABLE",
+    prNumber: 751,
     state: "OPEN",
     threads: [],
     ...overrides,


### PR DESCRIPTION
# feat(yeet): dispatch failure capsules from the watch stream

Ship-velocity **A1, PR-2 of 2** (PR-0 #749, PR-1 #751). The `yeet monitor --watch` stream now
*acts* on every red it observes, completing A1's accumulate-and-remediate contract.

## What lands

- **`Inbox.ts` — the `yeet-inbox/v1` contract** (A2's row shape, per
  `research/adhd-ideation.md` §deepen1): typed NDJSON rows
  `{kind, schemaVersion, id, severity, checkout, ts, capsule}` appended to
  `<checkout>/.beep/inbox/failures.ndjson`; ack receipts live at `.beep/inbox/acks/<id>`.
  Row ids are deterministic over `(prNumber, headSha, lane)` — the dedup key — and path-safe,
  because the id doubles as the receipt filename. A2's hook adapters consume these rows without
  touching GitHub.
- **Failure capsules derive from the failing check's own record** — its name, job `link`,
  `workflow`, and raw `bucket`/`state` strings as `gh pr checks` reported them — never from a
  classifier pass over composite output (the misattributed-hint failure class in the ledger).
  Raw signal preserved deliberately: a `CANCELLED` capsule steers repair toward a rerun
  (burst-worker TTL reap), a `FAILURE` capsule toward the diff.
- **`Remediation.ts` — the dispatch policy** (`.beep/inbox/dispatch.json`, `yeet-dispatch/v1`):
  a pure total decision over the persisted wave record. First red for a head opens the wave's
  repair session; later reds queue onto it; an already-queued id (job re-run went red again) is
  a duplicate with zero writes; a new push supersedes the wave before the new baseline's reds
  are seeded. The wave record is the countable "repair session" unit — live attach/spawn is
  deliberately A2 (hook adapters) / A4 (leases for the busy-owner case).
- **Watch wiring**: reds already present at watch start (or in the first post-push snapshot,
  which emits no transition) are seeded through the same dispatcher; deterministic ids make
  seeding idempotent across watch restarts. Every dispatch failure degrades to a loud stderr
  line without cancelling check watching (A7 posture), and a failed inbox append skips the wave
  persist so the next observation retries instead of believing the capsule was delivered.

## Hardened by pre-publish adversarial review

A 3-lens/18-agent review pass over the diff (correctness, Effect-v4 law compliance, SPEC
fidelity) confirmed four defects, all fixed here before publish:

- **Registration-gap green (P1, inherited from #751)**: a zero-check OPEN snapshot — gh's
  post-push "no checks reported" window — ended the watch as a green `all-terminal`, exit 0.
  The loop now polls through up to 10 consecutive zero-check observations (~100s at the 10s
  interval, mirroring the classic monitor's `YEET_CHECK_REGISTRATION_BACKOFF` budget) before
  believing an empty rollup, at watch start *and* after a mid-watch push. Ledger receipt
  recorded (the sibling surface had this law; the stream path claimed-but-lacked it).
- **Wave freshness ignored `prNumber` (P2)**: a stale `dispatch.json` from a dead PR on the same
  branch tip would swallow a new PR's session-start signal as a mere "queue". Freshness is now
  `(prNumber, headSha)`, and the watch also converges the record at start.
- **Steady-red append retry (P2)**: dispatch now *converges the inbox to the snapshot on every
  tick* (idempotent via deterministic ids) instead of firing only on transitions — a capsule
  whose append failed retries on the next poll even when its red never transitions again.
- **Name-based capsule derivation (P3)**: dispatch receives the failing check's record itself,
  never a name to re-resolve — a rollup can carry two same-named checks.

Accepted-and-documented (not code): every red is stamped `P0` until A6's required/optional
split; live session attach/spawn rides A2's hook adapters and A4's leases; rows are immutable
first-observation evidence, and consumers derive liveness by joining a row's
`capsule.prNumber`/`headSha` against the wave record (now stated in the Inbox contract JSDoc).

## Acceptance (SPEC A1)

- *Synthetic first-red reaches the inbox in <15s p95*: the capsule is appended on the same poll
  tick that observes the transition — no batching, no end-of-watch flush — so delivery is
  bounded by one 10s poll interval. Pinned by test.
- *Three reds on one head produce one repair session with three queued capsules*: pinned by
  test — one wave record, `sessionStartedAt` set once, three ordered capsule ids, three rows.

Coverage: 100% statements/branches/functions/lines across all four touched modules; 66 tests.

Part of `goals/ship-velocity` P2; flips PLAN.md A1 in the same PR.
