### PR TITLE
feat(yeet): add yeet-ack receipts and the inbox list|ack|append porcelain

### DIFF
--- a/.changeset/yeet-inbox-ack-cli.md
+++ b/.changeset/yeet-inbox-ack-cli.md
@@ -1,0 +1,12 @@
+---
+"@beep/repo-cli": minor
+---
+
+Add the `yeet inbox` porcelain — `list`, `ack`, and `append` — over the checkout
+failure inbox (ship-velocity A2, PR-1 of the hook-mutex series). `yeet-ack/v1`
+receipts record what was done about a row (fix SHA, reasoned wontfix, or review
+thread URL) under `.beep/inbox/acks/<id>`; the shared inbox view joins each row
+with its ack state and its liveness against the `yeet-dispatch/v1` wave record,
+so the CLI and the upcoming harness hook adapters provably read the same
+contract. `append` validates deterministic row-id integrity for external
+writers.

--- a/goals/ship-velocity/PLAN.md
+++ b/goals/ship-velocity/PLAN.md
@@ -57,7 +57,12 @@ the C5 metric correction and the new C7 item below.
   15s p95), and three reds on one head produce one session record with three queued capsules.
   Live session attach/spawn is deliberately not part of A1: attaching consumes the inbox via
   A2's hook adapters, and spawn-when-owner-busy needs A4's leases.
-- A2 hook-mutex + ACK inbox (Claude deny / Codex inject / Grok tail adapters).
+- A2 hook-mutex + ACK inbox (Claude deny / Codex inject / Grok tail adapters). In progress —
+  PR-1 of 3 landed the shared contract: `yeet inbox list|ack|append` porcelain, `yeet-ack/v1`
+  receipts (fix SHA / reasoned wontfix / thread URL; receipt existence is the ack even when
+  unreadable), and the joined inbox view with liveness against the `yeet-dispatch/v1` wave
+  record. PR-2 wires the Claude adapters (PreToolUse deny + incident mode, session splice;
+  settings.json edit is operator-gated); PR-3 the Codex inject + Grok tail.
 - A3 can't-leave-the-scene (Stop-hook veto + yeet poison-pill + waives).
 - A5 package-scoped gates (skill instructions + script gap fill + create-package templates).
 - A6 merge-ready v2.

--- a/goals/ship-velocity/research/OPPORTUNITIES.md
+++ b/goals/ship-velocity/research/OPPORTUNITIES.md
@@ -482,3 +482,21 @@ is itself the fourth receipt below; the batching is the symptom, not the practic
   away; (2) a docstring that assigns a responsibility "upstream" is a claim about a mechanism and
   needs the same mechanism check as an exoneration — name the call site that implements it or
   implement it where the claim lives.
+
+## 2026-08-17 — A2 PR-1: the per-file coverage ratchet is only probeable by the full lane
+
+- What was happening: landing the `yeet inbox` CLI (PR #759). The new-file coverage ratchet
+  (`no baseline file identity` → every new file needs near-total coverage) failed four times,
+  and each attempt cost a full `beep ci lane coverage` run (~11 min local, ~14 min hosted)
+  because nothing cheaper evaluates the ratchet's per-file verdict.
+- Evidence: hosted job 95500703836 (first red), then local lane runs coverage-lane2/3/4/5 in
+  this session's scratchpad; the passing run compared 127 packages to adjudicate 4 files.
+  A fifth round-trip came from proving a fix on a tree that then changed (the `CommandStdinSource`
+  rework landed after the green lane run — proof binds to the exact tree, and the hosted rerun
+  caught the drift).
+- What would have prevented it: a `beep quality coverage-probe --filter=@beep/repo-cli
+  --files <changed>` that runs the package's vitest coverage once and evaluates ONLY the
+  ratchet's per-file rules against the changed set (the ratchet compare is already pure —
+  `CoverageRegression.ts` — it just has no entry point below the full lane). Sub-minute
+  feedback instead of four ~11-minute loops; also makes "re-verify after any source edit"
+  cheap enough that stale-tree proofs stop being tempting.

--- a/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
@@ -482,7 +482,7 @@ const yeetFallowFixtureCheckCommand = Command.make(
   ({ assert, emit, fixturePath }) => runYeetFallowFixtureCheck({ assertions: assert, emit, fixturePath })
 ).pipe(Command.withDescription("Verify Fallow envelope fixtures map into Yeet quality issues"));
 
-const yeetInboxListCommand = Command.make("list", inboxListFlags, (options) => runYeetInboxList(options)).pipe(
+const yeetInboxListCommand = Command.make("list", inboxListFlags, runYeetInboxList).pipe(
   Command.withDescription("List the checkout's failure inbox rows joined with ack state and wave liveness")
 );
 
@@ -495,14 +495,14 @@ const yeetInboxAckCommand = Command.make(
     threadUrl: inboxThreadUrlFlag,
     wontfix: inboxWontfixFlag,
   },
-  (options) => runYeetInboxAck(options)
+  runYeetInboxAck
 ).pipe(Command.withDescription("Acknowledge one inbox row with a fix SHA, a reasoned wontfix, or a thread URL"));
 
-const yeetInboxAppendCommand = Command.make("append", { fromStdin: inboxRowStdinFlag }, (options) =>
-  runYeetInboxAppend(options)
-).pipe(Command.withDescription("Append one typed failure row from stdin to the checkout's inbox"));
+const yeetInboxAppendCommand = Command.make("append", { fromStdin: inboxRowStdinFlag }, runYeetInboxAppend).pipe(
+  Command.withDescription("Append one typed failure row from stdin to the checkout's inbox")
+);
 
-const yeetInboxCommand = Command.make("inbox", inboxListFlags, (options) => runYeetInboxList(options)).pipe(
+const yeetInboxCommand = Command.make("inbox", inboxListFlags, runYeetInboxList).pipe(
   Command.withDescription("Read and acknowledge the checkout's typed failure inbox"),
   Command.withSubcommands([yeetInboxListCommand, yeetInboxAckCommand, yeetInboxAppendCommand])
 );

--- a/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
@@ -7,6 +7,7 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { SchemaUtils } from "@beep/schema";
+import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import {
@@ -15,6 +16,8 @@ import {
   runYeetPlanContractCheck,
 } from "./internal/FallowFeedback.ts";
 import { runYeet } from "./internal/Handler.ts";
+import { YeetInboxSeverity } from "./internal/Inbox.ts";
+import { runYeetInboxAck, runYeetInboxAppend, runYeetInboxList } from "./internal/InboxPorcelain.ts";
 import { DEFAULT_YEET_PACKET_DIR, YeetProofTier } from "./internal/Planner.ts";
 import {
   runYeetMerge,
@@ -219,6 +222,51 @@ const expectArgsFlag = Flag.string("expect-args").pipe(
   Flag.withDescription("Required plan step args rendered as a space-separated string"),
   Flag.withDefault("")
 );
+
+const inboxUnackedFlag = Flag.boolean("unacked").pipe(Flag.withDescription("Show only rows without an ack receipt"));
+
+const inboxSeverityFlagChoices: ReadonlyArray<readonly ["all" | YeetInboxSeverity, "all" | YeetInboxSeverity]> = [
+  ["all", "all"],
+  ...A.map(YeetInboxSeverity.Options, (tier) => [tier, tier] as const),
+];
+
+const inboxSeverityFlag = Flag.choiceWithValue("severity", inboxSeverityFlagChoices).pipe(
+  Flag.withDescription("Show only rows of this severity tier"),
+  Flag.withDefault("all" as const)
+);
+
+const inboxFixShaFlag = Flag.string("fix-sha").pipe(
+  Flag.withDescription("Acknowledge the row as fixed by this commit"),
+  Flag.withDefault("")
+);
+
+const inboxWontfixFlag = Flag.boolean("wontfix").pipe(
+  Flag.withDescription("Acknowledge the row as deliberately not fixed; requires --reason")
+);
+
+const inboxReasonFlag = Flag.string("reason").pipe(
+  Flag.withDescription("Why the row is not being fixed; only applies with --wontfix"),
+  Flag.withDefault("")
+);
+
+const inboxThreadUrlFlag = Flag.string("thread-url").pipe(
+  Flag.withDescription("Acknowledge the row as continued in this review thread"),
+  Flag.withDefault("")
+);
+
+const inboxRowStdinFlag = Flag.boolean("from-stdin").pipe(
+  Flag.withDescription("Read one inbox row JSON document from stdin")
+);
+
+const inboxAckIdArgument = Argument.string("id").pipe(
+  Argument.withDescription("Inbox row id to acknowledge, as printed by yeet inbox list")
+);
+
+const inboxListFlags = {
+  json: jsonFlag,
+  severity: inboxSeverityFlag,
+  unacked: inboxUnackedFlag,
+} as const;
 
 const sharedFlags = {
   base: baseFlag,
@@ -434,6 +482,31 @@ const yeetFallowFixtureCheckCommand = Command.make(
   ({ assert, emit, fixturePath }) => runYeetFallowFixtureCheck({ assertions: assert, emit, fixturePath })
 ).pipe(Command.withDescription("Verify Fallow envelope fixtures map into Yeet quality issues"));
 
+const yeetInboxListCommand = Command.make("list", inboxListFlags, (options) => runYeetInboxList(options)).pipe(
+  Command.withDescription("List the checkout's failure inbox rows joined with ack state and wave liveness")
+);
+
+const yeetInboxAckCommand = Command.make(
+  "ack",
+  {
+    fixSha: inboxFixShaFlag,
+    id: inboxAckIdArgument,
+    reason: inboxReasonFlag,
+    threadUrl: inboxThreadUrlFlag,
+    wontfix: inboxWontfixFlag,
+  },
+  (options) => runYeetInboxAck(options)
+).pipe(Command.withDescription("Acknowledge one inbox row with a fix SHA, a reasoned wontfix, or a thread URL"));
+
+const yeetInboxAppendCommand = Command.make("append", { fromStdin: inboxRowStdinFlag }, (options) =>
+  runYeetInboxAppend(options)
+).pipe(Command.withDescription("Append one typed failure row from stdin to the checkout's inbox"));
+
+const yeetInboxCommand = Command.make("inbox", inboxListFlags, (options) => runYeetInboxList(options)).pipe(
+  Command.withDescription("Read and acknowledge the checkout's typed failure inbox"),
+  Command.withSubcommands([yeetInboxListCommand, yeetInboxAckCommand, yeetInboxAppendCommand])
+);
+
 const yeetPlanContractCheckCommand = Command.make(
   "plan-contract-check",
   {
@@ -476,6 +549,7 @@ export const yeetCommand = Command.make("yeet", publishFlags, (options) => runYe
     yeetSweepCommand,
     yeetMergeCommand,
     yeetReplyCommand,
+    yeetInboxCommand,
     yeetPrePushHookCommand,
     yeetFallowFeedbackCommand,
     yeetFallowFixtureCheckCommand,

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Ack.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Ack.ts
@@ -1,0 +1,369 @@
+/**
+ * Ack receipts: the work-log side of the checkout failure inbox.
+ *
+ * **Details**
+ *
+ * An inbox row keeps re-presenting until a receipt file exists at
+ * `<checkout>/.beep/inbox/acks/<id>` — the ship-velocity A2 contract that the
+ * harness adapters (Claude deny, Codex inject, Grok tail) all enforce from.
+ * The receipt is not a bare tombstone: it records what was actually done about
+ * the failure — the SHA of the fix commit, a wontfix decision with its reason,
+ * or the review-thread URL where the discussion continues — so `yeet monitor`
+ * and the operator can audit an acknowledgment instead of trusting it.
+ *
+ * **Gotchas**
+ *
+ * The receipt file's *existence* is the acknowledgment; its decodability is
+ * not. A receipt that fails to decode still acks its row — un-acking on
+ * corruption would re-arm a P0 denial over a bookkeeping defect, and the A2
+ * mutex must never manufacture the interruption it exists to relieve. The
+ * typed state ({@link YeetAckState}) therefore separates `acked` (the file
+ * exists) from `receipt` (its decoded content, when readable).
+ *
+ * Re-acking overwrites: a wrong receipt (a typo'd SHA, a premature wontfix)
+ * must never dead-end the fix path, so the last resolution wins and the CLI
+ * reports that a prior receipt was replaced.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { Effect, FileSystem, Match } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import { yeetInboxAckPath, yeetInboxPaths } from "./Inbox.ts";
+import type { Path } from "effect";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Ack");
+
+/**
+ * Schema version stamped on every ack receipt.
+ *
+ * **Example** (Read the version)
+ *
+ * ```ts
+ * import { YEET_ACK_SCHEMA_VERSION } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_ACK_SCHEMA_VERSION) // "yeet-ack/v1"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_ACK_SCHEMA_VERSION = "yeet-ack/v1";
+
+/**
+ * The failure was fixed; the receipt names the commit that did it.
+ *
+ * **Example** (Build a fix resolution)
+ *
+ * ```ts
+ * import { YeetAckFixResolution } from "@beep/repo-cli/test/Yeet"
+ *
+ * const resolution = YeetAckFixResolution.make({ sha: "2817f286d3" })
+ * console.log(resolution.kind) // "fix-sha"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetAckFixResolution extends S.Class<YeetAckFixResolution>($I`YeetAckFixResolution`)(
+  {
+    kind: S.tag("fix-sha"),
+    sha: S.NonEmptyString,
+  },
+  $I.annote("YeetAckFixResolution", {
+    description: "Acknowledgment that the failure was fixed, naming the fix commit.",
+  })
+) {}
+
+/**
+ * The failure will not be fixed; the receipt carries the reason.
+ *
+ * **Example** (Build a wontfix resolution)
+ *
+ * ```ts
+ * import { YeetAckWontfixResolution } from "@beep/repo-cli/test/Yeet"
+ *
+ * const resolution = YeetAckWontfixResolution.make({ reason: "flaky infra lane, rerun queued" })
+ * console.log(resolution.kind) // "wontfix"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetAckWontfixResolution extends S.Class<YeetAckWontfixResolution>($I`YeetAckWontfixResolution`)(
+  {
+    kind: S.tag("wontfix"),
+    reason: S.NonEmptyString,
+  },
+  $I.annote("YeetAckWontfixResolution", {
+    description: "Acknowledgment that the failure is deliberately not being fixed, with the reason.",
+  })
+) {}
+
+/**
+ * The failure moved to a review conversation; the receipt links the thread.
+ *
+ * **Example** (Build a thread resolution)
+ *
+ * ```ts
+ * import { YeetAckThreadResolution } from "@beep/repo-cli/test/Yeet"
+ *
+ * const resolution = YeetAckThreadResolution.make({ url: "https://github.com/o/r/pull/1#discussion_r2" })
+ * console.log(resolution.kind) // "thread-url"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetAckThreadResolution extends S.Class<YeetAckThreadResolution>($I`YeetAckThreadResolution`)(
+  {
+    kind: S.tag("thread-url"),
+    url: S.NonEmptyString,
+  },
+  $I.annote("YeetAckThreadResolution", {
+    description: "Acknowledgment that the failure's follow-up lives in a linked review thread.",
+  })
+) {}
+
+/**
+ * What was done about an inbox row: the ack protocol's three closing moves.
+ *
+ * **Details**
+ *
+ * The members mirror the SPEC A2 receipt contract verbatim — fix SHA, wontfix
+ * plus reason, or thread URL. There is deliberately no bare "seen" member: a
+ * receipt with no work log would turn the ack protocol into a dismissal
+ * button, and dismissals are A3's *waive* concept with attribution and expiry,
+ * not an acknowledgment.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetAckResolution = S.Union([
+  YeetAckFixResolution,
+  YeetAckWontfixResolution,
+  YeetAckThreadResolution,
+]).pipe(
+  $I.annoteSchema("YeetAckResolution", {
+    title: "Yeet Ack Resolution",
+    description: "What was done about one inbox row: a fix commit, a reasoned wontfix, or a review thread.",
+  })
+);
+
+/**
+ * What was done about an inbox row: the ack protocol's three closing moves.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetAckResolution = typeof YeetAckResolution.Type;
+
+/**
+ * Render one resolution as its operator-facing phrase.
+ *
+ * **Example** (Render a fix)
+ *
+ * ```ts
+ * import { renderYeetAckResolution, YeetAckFixResolution } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(renderYeetAckResolution(YeetAckFixResolution.make({ sha: "2817f28" }))) // "fix-sha 2817f28"
+ * ```
+ *
+ * @param resolution - The resolution to render.
+ * @returns The one-phrase rendering used by list lines and ack confirmations.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetAckResolution = (resolution: YeetAckResolution): string =>
+  Match.value(resolution).pipe(
+    Match.discriminatorsExhaustive("kind")({
+      "fix-sha": (fix) => `fix-sha ${fix.sha}`,
+      "thread-url": (thread) => `thread ${thread.url}`,
+      wontfix: (wontfix) => `wontfix: ${wontfix.reason}`,
+    })
+  );
+
+/**
+ * One ack receipt: the row it closes, what was done, and when.
+ *
+ * **Example** (Build a receipt)
+ *
+ * ```ts
+ * import { YeetAckFixResolution, YeetAckReceipt } from "@beep/repo-cli/test/Yeet"
+ *
+ * const receipt = YeetAckReceipt.make({
+ *   ackedAt: "2026-08-17T00:00:00Z",
+ *   id: "coverage-abc123def456",
+ *   resolution: YeetAckFixResolution.make({ sha: "2817f286d3" })
+ * })
+ *
+ * console.log(receipt.schemaVersion) // "yeet-ack/v1"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetAckReceipt extends S.Class<YeetAckReceipt>($I`YeetAckReceipt`)(
+  {
+    schemaVersion: S.Literal(YEET_ACK_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_ACK_SCHEMA_VERSION))
+    ),
+    id: S.NonEmptyString,
+    resolution: YeetAckResolution,
+    ackedAt: S.String,
+  },
+  $I.annote("YeetAckReceipt", {
+    description: "One ack receipt: the inbox row id it closes, the resolution, and the acknowledgment time.",
+  })
+) {}
+
+/**
+ * JSON string codec for one ack receipt.
+ *
+ * **Example** (Reject garbage)
+ *
+ * ```ts
+ * import { YeetAckReceiptJson } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * console.log(O.isNone(YeetAckReceiptJson.decodeOption("not json"))) // true
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const YeetAckReceiptJson = JsonStringCodec(YeetAckReceipt);
+
+/**
+ * The typed ack state of one inbox row.
+ *
+ * **Details**
+ *
+ * `acked` reports whether the receipt file exists — the enforcement question —
+ * while `receipt` carries its decoded content when readable — the audit
+ * question. The two are separate fields because they fail separately: a
+ * corrupt receipt file still acks its row, it just cannot say what was done.
+ *
+ * **Example** (An unacked state)
+ *
+ * ```ts
+ * import { YeetAckState } from "@beep/repo-cli/test/Yeet"
+ *
+ * const state = YeetAckState.make({ acked: false, receipt: null })
+ * console.log(state.acked) // false
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetAckState extends S.Class<YeetAckState>($I`YeetAckState`)(
+  {
+    acked: S.Boolean,
+    receipt: S.NullOr(YeetAckReceipt),
+  },
+  $I.annote("YeetAckState", {
+    description: "Whether one inbox row's receipt file exists, and its decoded content when readable.",
+  })
+) {}
+
+/**
+ * Read the ack state of one inbox row.
+ *
+ * **Details**
+ *
+ * Every failure mode folds into the state rather than the error channel: a
+ * missing file is `acked: false`, an unreadable or undecodable file is
+ * `acked: true, receipt: null`. Consumers on the hook hot path get one total
+ * read with no failure cases to mishandle into a stuck denial.
+ *
+ * **Example** (Build the read effect)
+ *
+ * ```ts
+ * import { readYeetAckState } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(readYeetAckState("/repo", "coverage-abc"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout the inbox belongs to.
+ * @param id - The inbox row id whose receipt is read.
+ * @returns The row's ack state; never fails.
+ * @category services
+ * @since 0.0.0
+ */
+export const readYeetAckState = Effect.fn("Yeet.readYeetAckState")(function* (
+  repoRoot: string,
+  id: string
+): Effect.fn.Return<YeetAckState, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const ackPath = yield* yeetInboxAckPath(repoRoot, id);
+  // Existence and readability are decided separately: a receipt that exists
+  // but cannot be read (permissions, a directory squatting on the path, EIO)
+  // still acks its row — folding those read failures into "unacked" would
+  // re-arm enforcement over a bookkeeping defect.
+  const acked = yield* fs.exists(ackPath).pipe(Effect.orElseSucceed(() => false));
+  if (!acked) {
+    return YeetAckState.make({ acked: false, receipt: null });
+  }
+  const text = yield* Effect.option(fs.readFileString(ackPath));
+  return YeetAckState.make({
+    acked: true,
+    receipt: O.getOrNull(O.flatMap(text, YeetAckReceiptJson.decodeOption)),
+  });
+});
+
+/**
+ * Write one ack receipt, overwriting any prior receipt for the row.
+ *
+ * **Details**
+ *
+ * Creates the acks directory on first use. Overwriting is the contract, not a
+ * hazard: receipts are keyed by deterministic row id, so "again" always means
+ * "the same failure, re-resolved", and the last resolution is the one that
+ * should stand. Callers that want to report a replacement read the state
+ * first via {@link readYeetAckState}.
+ *
+ * **Example** (Build the write effect)
+ *
+ * ```ts
+ * import { writeYeetAckReceipt, YeetAckFixResolution, YeetAckReceipt } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const receipt = YeetAckReceipt.make({
+ *   ackedAt: "2026-08-17T00:00:00Z",
+ *   id: "coverage-abc",
+ *   resolution: YeetAckFixResolution.make({ sha: "2817f28" })
+ * })
+ *
+ * console.log(Effect.isEffect(writeYeetAckReceipt("/repo", receipt))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout the inbox belongs to.
+ * @param receipt - The receipt to persist under `acks/<receipt.id>`.
+ * @returns The path the receipt was written to.
+ * @category services
+ * @since 0.0.0
+ */
+export const writeYeetAckReceipt = Effect.fn("Yeet.writeYeetAckReceipt")(function* (
+  repoRoot: string,
+  receipt: YeetAckReceipt
+): Effect.fn.Return<string, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const paths = yield* yeetInboxPaths(repoRoot);
+  const ackPath = yield* yeetInboxAckPath(repoRoot, receipt.id);
+  const json = yield* YeetAckReceiptJson.encode(receipt).pipe(
+    Effect.mapError(YeetCommandError.new("Failed to encode an ack receipt."))
+  );
+  yield* fs
+    .makeDirectory(paths.acksDir, { recursive: true })
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to create the acks directory "${paths.acksDir}".`)));
+  yield* fs
+    .writeFileString(ackPath, `${json}\n`)
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to write the ack receipt "${ackPath}".`)));
+  return ackPath;
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Ack.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Ack.ts
@@ -29,6 +29,7 @@
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
+import { thunkFalse } from "@beep/utils";
 import { Effect, FileSystem, Match } from "effect";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -306,7 +307,7 @@ export const readYeetAckState = Effect.fn("Yeet.readYeetAckState")(function* (
   // but cannot be read (permissions, a directory squatting on the path, EIO)
   // still acks its row — folding those read failures into "unacked" would
   // re-arm enforcement over a bookkeeping defect.
-  const acked = yield* fs.exists(ackPath).pipe(Effect.orElseSucceed(() => false));
+  const acked = yield* fs.exists(ackPath).pipe(Effect.orElseSucceed(thunkFalse));
   if (!acked) {
     return YeetAckState.make({ acked: false, receipt: null });
   }

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/FallowFeedback.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/FallowFeedback.ts
@@ -16,6 +16,7 @@ import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { csvValues } from "../../../internal/cli/Flags.ts";
+import { readStdinDocument } from "../../../internal/cli/Stdin.ts";
 import { commandTextForStep, RepoRunPlan } from "../../../internal/repo-run/index.ts";
 import {
   FallowFeatureFamily,
@@ -651,30 +652,12 @@ export const runYeetFallowFixtureCheck = Effect.fn("YeetFallowFeedback.runYeetFa
   yield* Console.log(`[yeet] Fallow fixture check ok: ${options.fixturePath}`);
 });
 
-const readStdinText = Effect.fn("YeetFallowFeedback.readStdinText")(function* (
-  fromStdin: boolean
-): Effect.fn.Return<string, YeetCommandError> {
-  if (!fromStdin) {
-    return yield* YeetCommandError.make({
-      message: "yeet plan-contract-check requires --from-stdin.",
-      exitCode: 1,
-    });
-  }
-  if (process.stdin.isTTY) {
-    return yield* YeetCommandError.make({
-      message: "yeet plan-contract-check --from-stdin received no stdin.",
-      exitCode: 1,
-    });
-  }
-  return yield* Effect.tryPromise(() => Bun.stdin.text()).pipe(
-    Effect.mapError((cause) =>
-      YeetCommandError.make({
-        message: `Failed to read yeet plan stdin: ${cause instanceof Error ? cause.message : String(cause)}`,
-        exitCode: 1,
-      })
-    )
-  );
-});
+const readStdinText = (fromStdin: boolean): Effect.Effect<string, YeetCommandError> =>
+  readStdinDocument(fromStdin, {
+    missingFlag: "yeet plan-contract-check requires --from-stdin.",
+    noStdin: "yeet plan-contract-check --from-stdin received no stdin.",
+    readFailurePrefix: "Failed to read yeet plan stdin",
+  }).pipe(Effect.mapError((error) => YeetCommandError.make({ message: error.message, exitCode: 1 })));
 
 const decodePlanText = Effect.fn("YeetFallowFeedback.decodePlanText")(function* (
   text: string

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/InboxPorcelain.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/InboxPorcelain.ts
@@ -196,7 +196,7 @@ export const renderYeetInboxEntryLine = (entry: YeetInboxEntry): string =>
  * ```ts
  * import { renderYeetInboxView, YeetInboxView } from "@beep/repo-cli/test/Yeet"
  *
- * const view = YeetInboxView.make({ entries: [], skippedLines: 0 })
+ * const view = YeetInboxView.make({ entries: [], skippedLines: 0, unreadable: false })
  * console.log(renderYeetInboxView(view)) // "[yeet] inbox: 0 row(s), 0 unacked, 0 skipped line(s)"
  * ```
  *
@@ -207,7 +207,8 @@ export const renderYeetInboxEntryLine = (entry: YeetInboxEntry): string =>
  */
 export const renderYeetInboxView = (view: YeetInboxView): string => {
   const unacked = A.length(A.filter(view.entries, (entry) => !entry.ack.acked));
-  const header = `[yeet] inbox: ${A.length(view.entries)} row(s), ${unacked} unacked, ${view.skippedLines} skipped line(s)`;
+  const suffix = view.unreadable ? " — failures file exists but is unreadable; inbox state unknown, not empty" : "";
+  const header = `[yeet] inbox: ${A.length(view.entries)} row(s), ${unacked} unacked, ${view.skippedLines} skipped line(s)${suffix}`;
   return A.join([header, ...A.map(view.entries, renderYeetInboxEntryLine)], "\n");
 };
 
@@ -423,7 +424,7 @@ const readYeetInboxStdin = (fromStdin: boolean): Effect.Effect<string, YeetComma
  * import { renderYeetInboxListOutput, YeetInboxView } from "@beep/repo-cli/test/Yeet"
  * import { Effect } from "effect"
  *
- * const view = YeetInboxView.make({ entries: [], skippedLines: 0 })
+ * const view = YeetInboxView.make({ entries: [], skippedLines: 0, unreadable: false })
  * const output = renderYeetInboxListOutput(view, { json: false, severity: "all", unacked: false })
  * console.log(Effect.runSync(output)) // "[yeet] inbox: 0 row(s), 0 unacked, 0 skipped line(s)"
  * ```
@@ -441,6 +442,7 @@ export const renderYeetInboxListOutput = Effect.fn("Yeet.renderYeetInboxListOutp
   const filtered = YeetInboxView.make({
     entries: filterYeetInboxEntries(view.entries, options),
     skippedLines: view.skippedLines,
+    unreadable: view.unreadable,
   });
   if (options.json) {
     return yield* YeetInboxViewJson.encode(filtered).pipe(

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/InboxPorcelain.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/InboxPorcelain.ts
@@ -1,0 +1,537 @@
+/**
+ * Command-layer engines and runners for the `yeet inbox` porcelain:
+ * `yeet inbox list`, `yeet inbox ack`, and `yeet inbox append`.
+ *
+ * **Details**
+ *
+ * The engines — {@link ackYeetInboxRow}, {@link appendYeetInboxRowFromText},
+ * {@link filterYeetInboxEntries} — take a repo root or plain data and know
+ * nothing about flags, so tests drive them against temp checkouts directly.
+ * The runners at the bottom are the flag seam `Yeet.command.ts` wires: they
+ * resolve the repo root, delegate, and render, keeping the CLI surface a
+ * declaration rather than a place behavior accumulates.
+ *
+ * **Gotchas**
+ *
+ * `append` guards row-id integrity: a row whose `id` does not equal the
+ * deterministic id derived from its capsule is refused, because a
+ * wrongly-minted id would fork the failure's identity away from its ack
+ * receipt and its dedup history. External writers should not be trusted to
+ * get this right silently.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { findRepoRoot } from "@beep/repo-utils";
+import { Console, DateTime, Effect } from "effect";
+import * as A from "effect/Array";
+import { dual } from "effect/Function";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { readStdinDocument } from "../../../internal/cli/Stdin.ts";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import {
+  renderYeetAckResolution,
+  writeYeetAckReceipt,
+  YeetAckFixResolution,
+  YeetAckReceipt,
+  YeetAckThreadResolution,
+  YeetAckWontfixResolution,
+} from "./Ack.ts";
+import { appendYeetInboxRow, YeetInboxRowJson, yeetInboxRowId } from "./Inbox.ts";
+import { loadYeetInboxView, YeetInboxView, YeetInboxViewJson } from "./InboxView.ts";
+import type { FileSystem, Path } from "effect";
+import type { YeetAckResolution, YeetAckState } from "./Ack.ts";
+import type { YeetInboxRow, YeetInboxSeverity } from "./Inbox.ts";
+import type { YeetInboxEntry } from "./InboxView.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/InboxPorcelain");
+
+const isoNow = DateTime.now.pipe(Effect.map(DateTime.formatIso));
+
+const shortSha = Str.slice(0, 7);
+
+const locateRepoRoot = (): Effect.Effect<string, YeetCommandError, FileSystem.FileSystem> =>
+  findRepoRoot().pipe(Effect.mapError(YeetCommandError.new("Failed to locate repo root.")));
+
+/**
+ * The parsed severity selection of `yeet inbox list`: a tier, or every tier.
+ */
+type YeetInboxSeverityFilter = "all" | YeetInboxSeverity;
+
+/**
+ * The list filter: which entries `yeet inbox list` shows.
+ */
+interface YeetInboxListFilter {
+  readonly severity: YeetInboxSeverityFilter;
+  readonly unacked: boolean;
+}
+
+/**
+ * Parsed `yeet inbox list` flag values.
+ */
+interface YeetInboxListOptions extends YeetInboxListFilter {
+  readonly json: boolean;
+}
+
+/**
+ * The resolution-shaped subset of `yeet inbox ack` flags, before validation
+ * proves exactly one resolution was requested.
+ */
+interface YeetAckResolutionFlags {
+  readonly fixSha: string;
+  readonly reason: string;
+  readonly threadUrl: string;
+  readonly wontfix: boolean;
+}
+
+/**
+ * Parsed `yeet inbox ack` flag values.
+ */
+interface YeetInboxAckOptions extends YeetAckResolutionFlags {
+  readonly id: string;
+}
+
+/**
+ * Parsed `yeet inbox append` flag values.
+ */
+interface YeetInboxAppendOptions {
+  readonly fromStdin: boolean;
+}
+
+/**
+ * Keep the entries a list filter selects.
+ *
+ * **Example** (An empty inbox stays empty)
+ *
+ * ```ts
+ * import { filterYeetInboxEntries } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(filterYeetInboxEntries([], { severity: "all", unacked: false })) // []
+ * ```
+ *
+ * @param entries - The joined inbox entries.
+ * @param filter - Severity tier to keep (or every tier) and whether to keep only unacked rows.
+ * @returns The entries the filter selects, in their original order.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const filterYeetInboxEntries: {
+  (filter: YeetInboxListFilter): (entries: ReadonlyArray<YeetInboxEntry>) => ReadonlyArray<YeetInboxEntry>;
+  (entries: ReadonlyArray<YeetInboxEntry>, filter: YeetInboxListFilter): ReadonlyArray<YeetInboxEntry>;
+} = dual(
+  2,
+  (entries: ReadonlyArray<YeetInboxEntry>, filter: YeetInboxListFilter): ReadonlyArray<YeetInboxEntry> =>
+    A.filter(
+      entries,
+      (entry) =>
+        (filter.severity === "all" || entry.row.severity === filter.severity) && (!filter.unacked || !entry.ack.acked)
+    )
+);
+
+const renderAckPhrase = (ack: YeetAckState): string =>
+  ack.acked
+    ? O.match(O.fromNullOr(ack.receipt), {
+        onNone: () => "acked (unreadable receipt)",
+        onSome: (receipt) => `acked ${renderYeetAckResolution(receipt.resolution)}`,
+      })
+    : "unacked";
+
+/**
+ * Render one joined inbox entry as its list line.
+ *
+ * **Example** (Render an unacked entry)
+ *
+ * ```ts
+ * import {
+ *   renderYeetInboxEntryLine,
+ *   YeetAckState,
+ *   YeetCheckFailedRow,
+ *   YeetFailureCapsule,
+ *   YeetInboxEntry,
+ *   yeetInboxRowId
+ * } from "@beep/repo-cli/test/Yeet"
+ *
+ * const capsule = YeetFailureCapsule.make({
+ *   bucket: "fail",
+ *   headSha: "abc123def456",
+ *   lane: "Check / Coverage",
+ *   link: null,
+ *   observedAt: "2026-08-17T00:00:00Z",
+ *   prNumber: 754,
+ *   state: "FAILURE",
+ *   workflow: null
+ * })
+ * const entry = YeetInboxEntry.make({
+ *   ack: YeetAckState.make({ acked: false, receipt: null }),
+ *   liveness: "live",
+ *   row: YeetCheckFailedRow.make({
+ *     capsule,
+ *     checkout: "/repo",
+ *     id: yeetInboxRowId(capsule),
+ *     severity: "P0",
+ *     ts: "2026-08-17T00:00:00Z"
+ *   })
+ * })
+ *
+ * console.log(renderYeetInboxEntryLine(entry).includes("P0 live unacked")) // true
+ * ```
+ *
+ * @param entry - The entry to render.
+ * @returns One indented list line: severity, liveness, ack phrase, lane, id, and PR coordinates.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetInboxEntryLine = (entry: YeetInboxEntry): string =>
+  `  ${entry.row.severity} ${entry.liveness} ${renderAckPhrase(entry.ack)} — ${entry.row.capsule.lane} [${entry.row.id}] (pr #${entry.row.capsule.prNumber} @ ${shortSha(entry.row.capsule.headSha)})`;
+
+/**
+ * Render one inbox view as the operator listing.
+ *
+ * **Example** (Render an empty view)
+ *
+ * ```ts
+ * import { renderYeetInboxView, YeetInboxView } from "@beep/repo-cli/test/Yeet"
+ *
+ * const view = YeetInboxView.make({ entries: [], skippedLines: 0 })
+ * console.log(renderYeetInboxView(view)) // "[yeet] inbox: 0 row(s), 0 unacked, 0 skipped line(s)"
+ * ```
+ *
+ * @param view - The view to render, already filtered to what should be shown.
+ * @returns The header line plus one line per entry.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetInboxView = (view: YeetInboxView): string => {
+  const unacked = A.length(A.filter(view.entries, (entry) => !entry.ack.acked));
+  const header = `[yeet] inbox: ${A.length(view.entries)} row(s), ${unacked} unacked, ${view.skippedLines} skipped line(s)`;
+  return A.join([header, ...A.map(view.entries, renderYeetInboxEntryLine)], "\n");
+};
+
+/**
+ * Prove that the ack flags request exactly one resolution, and build it.
+ *
+ * **Details**
+ *
+ * The three resolution flags are mutually exclusive because a receipt records
+ * one closing move — SPEC A2's fix SHA, wontfix plus reason, or thread URL.
+ * `--wontfix` without `--reason` is refused rather than defaulted: an
+ * unexplained wontfix is exactly the dismissal-button failure mode the
+ * resolution union exists to prevent.
+ *
+ * **Example** (A fix SHA parses)
+ *
+ * ```ts
+ * import { parseYeetAckResolution } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const resolution = Effect.runSync(
+ *   parseYeetAckResolution({ fixSha: "2817f28", reason: "", threadUrl: "", wontfix: false })
+ * )
+ * console.log(resolution.kind) // "fix-sha"
+ * ```
+ *
+ * @param flags - The resolution-shaped `yeet inbox ack` flag values.
+ * @returns The single requested resolution, or a typed refusal naming the rule broken.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const parseYeetAckResolution = Effect.fn("Yeet.parseYeetAckResolution")(function* (
+  flags: YeetAckResolutionFlags
+): Effect.fn.Return<YeetAckResolution, YeetCommandError> {
+  const reasonRule = yeetAckReasonRuleViolation(flags);
+  if (O.isSome(reasonRule)) {
+    return yield* YeetCommandError.make({ message: reasonRule.value });
+  }
+  const candidates = yeetAckResolutionCandidates(flags);
+  if (!A.isReadonlyArrayNonEmpty(candidates) || A.length(candidates) !== 1) {
+    return yield* YeetCommandError.make({
+      message:
+        "yeet inbox ack requires exactly one of --fix-sha <sha>, --wontfix --reason <text>, or --thread-url <url>.",
+    });
+  }
+  return A.headNonEmpty(candidates);
+});
+
+const yeetAckReasonRuleViolation = (flags: YeetAckResolutionFlags): O.Option<string> => {
+  if (flags.wontfix && Str.isEmpty(flags.reason)) {
+    return O.some("yeet inbox ack --wontfix requires --reason.");
+  }
+  if (!flags.wontfix && Str.isNonEmpty(flags.reason)) {
+    return O.some("yeet inbox ack --reason only applies with --wontfix.");
+  }
+  return O.none();
+};
+
+// Callers run the reason rule first, so a wontfix candidate never sees an
+// empty reason here.
+const yeetAckResolutionCandidates = (flags: YeetAckResolutionFlags): ReadonlyArray<YeetAckResolution> =>
+  A.getSomes([
+    Str.isNonEmpty(flags.fixSha) ? O.some(YeetAckFixResolution.make({ sha: flags.fixSha })) : O.none(),
+    flags.wontfix ? O.some(YeetAckWontfixResolution.make({ reason: flags.reason })) : O.none(),
+    Str.isNonEmpty(flags.threadUrl) ? O.some(YeetAckThreadResolution.make({ url: flags.threadUrl })) : O.none(),
+  ]);
+
+/**
+ * What one ack pass did: the receipt, where it lives, and whether it replaced
+ * a prior one.
+ *
+ * **Example** (Build a report)
+ *
+ * ```ts
+ * import { YeetAckFixResolution, YeetAckReceipt, YeetInboxAckReport } from "@beep/repo-cli/test/Yeet"
+ *
+ * const report = YeetInboxAckReport.make({
+ *   receipt: YeetAckReceipt.make({
+ *     ackedAt: "2026-08-17T00:00:00Z",
+ *     id: "coverage-abc",
+ *     resolution: YeetAckFixResolution.make({ sha: "2817f28" })
+ *   }),
+ *   receiptPath: "/repo/.beep/inbox/acks/coverage-abc",
+ *   replacedPrior: false
+ * })
+ *
+ * console.log(report.replacedPrior) // false
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetInboxAckReport extends S.Class<YeetInboxAckReport>($I`YeetInboxAckReport`)(
+  {
+    receipt: YeetAckReceipt,
+    receiptPath: S.NonEmptyString,
+    replacedPrior: S.Boolean,
+  },
+  $I.annote("YeetInboxAckReport", {
+    description: "The written receipt, its path, and whether a prior receipt for the row was replaced.",
+  })
+) {}
+
+/**
+ * Acknowledge one inbox row with a resolution.
+ *
+ * **Details**
+ *
+ * The id must name a row the inbox actually contains — a receipt for a
+ * mistyped id would ack nothing while looking like progress. Re-acking an
+ * already-acked row is allowed and reported: overwriting is how a wrong
+ * receipt gets corrected, and the fix path must never dead-end.
+ *
+ * **Example** (Build the ack effect)
+ *
+ * ```ts
+ * import { ackYeetInboxRow, YeetAckFixResolution } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const resolution = YeetAckFixResolution.make({ sha: "2817f28" })
+ * console.log(Effect.isEffect(ackYeetInboxRow("/repo", "coverage-abc", resolution, "2026-08-17T00:00:00Z"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout the inbox belongs to.
+ * @param id - The inbox row id to acknowledge.
+ * @param resolution - What was done about the failure.
+ * @param ackedAt - The acknowledgment timestamp stamped on the receipt.
+ * @returns The written receipt and whether it replaced a prior one.
+ * @category services
+ * @since 0.0.0
+ */
+export const ackYeetInboxRow = Effect.fn("Yeet.ackYeetInboxRow")(function* (
+  repoRoot: string,
+  id: string,
+  resolution: YeetAckResolution,
+  ackedAt: string
+): Effect.fn.Return<YeetInboxAckReport, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const view = yield* loadYeetInboxView(repoRoot);
+  const entry = A.findFirst(view.entries, (candidate) => candidate.row.id === id);
+  if (O.isNone(entry)) {
+    return yield* YeetCommandError.make({
+      message: `No inbox row with id "${id}". Run "bun run beep yeet inbox list" to see the known rows.`,
+    });
+  }
+  const receipt = YeetAckReceipt.make({ ackedAt, id, resolution });
+  const receiptPath = yield* writeYeetAckReceipt(repoRoot, receipt);
+  return YeetInboxAckReport.make({ receipt, receiptPath, replacedPrior: entry.value.ack.acked });
+});
+
+/**
+ * Decode, id-check, and append one inbox row from its NDJSON text.
+ *
+ * **Details**
+ *
+ * This is the shared-writer seam behind `yeet inbox append`: external writers
+ * (local lane runners, sibling-checkout collision detectors) hand a full row
+ * document to the CLI instead of reimplementing the append contract. The row
+ * must already carry the deterministic id its capsule derives — a mismatch is
+ * refused, because the id is the join key for dedup and ack receipts.
+ *
+ * **Example** (Build the append effect)
+ *
+ * ```ts
+ * import { appendYeetInboxRowFromText } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(appendYeetInboxRowFromText("/repo", "{}"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout whose inbox receives the row.
+ * @param text - The row as a JSON document.
+ * @returns The decoded row after it was appended.
+ * @category services
+ * @since 0.0.0
+ */
+export const appendYeetInboxRowFromText = Effect.fn("Yeet.appendYeetInboxRowFromText")(function* (
+  repoRoot: string,
+  text: string
+): Effect.fn.Return<YeetInboxRow, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const row = yield* YeetInboxRowJson.decode(Str.trim(text)).pipe(
+    Effect.mapError(YeetCommandError.new("Failed to decode the inbox row document."))
+  );
+  const expected = yeetInboxRowId(row.capsule);
+  if (row.id !== expected) {
+    return yield* YeetCommandError.make({
+      message: `Inbox row id "${row.id}" does not match the deterministic id "${expected}" for (pr #${row.capsule.prNumber}, head ${row.capsule.headSha}, lane "${row.capsule.lane}"). Row ids are the dedup and ack join key; derive them with yeetInboxRowId.`,
+    });
+  }
+  yield* appendYeetInboxRow(repoRoot, row);
+  return row;
+});
+
+const readYeetInboxStdin = (fromStdin: boolean): Effect.Effect<string, YeetCommandError> =>
+  readStdinDocument(fromStdin, {
+    missingFlag: "yeet inbox append requires --from-stdin.",
+    noStdin: "yeet inbox append --from-stdin received no stdin.",
+    readFailurePrefix: "Failed to read the inbox row from stdin",
+  }).pipe(Effect.mapError((error) => YeetCommandError.make({ message: error.message })));
+
+/**
+ * Filter one loaded view and produce the exact text `yeet inbox list` prints.
+ *
+ * **Details**
+ *
+ * This is the whole list pass minus IO: apply the filter, rebuild the view so
+ * the JSON document carries only the shown entries, then either encode it or
+ * render the operator text. Extracted so the composition — including the
+ * `--json` path — is provable without a real checkout.
+ *
+ * **Example** (An empty view renders its header)
+ *
+ * ```ts
+ * import { renderYeetInboxListOutput, YeetInboxView } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const view = YeetInboxView.make({ entries: [], skippedLines: 0 })
+ * const output = renderYeetInboxListOutput(view, { json: false, severity: "all", unacked: false })
+ * console.log(Effect.runSync(output)) // "[yeet] inbox: 0 row(s), 0 unacked, 0 skipped line(s)"
+ * ```
+ *
+ * @param view - The loaded inbox view before filtering.
+ * @param options - Parsed `yeet inbox list` flag values.
+ * @returns The JSON document or operator text the list pass prints.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetInboxListOutput = Effect.fn("Yeet.renderYeetInboxListOutput")(function* (
+  view: YeetInboxView,
+  options: YeetInboxListOptions
+): Effect.fn.Return<string, YeetCommandError> {
+  const filtered = YeetInboxView.make({
+    entries: filterYeetInboxEntries(view.entries, options),
+    skippedLines: view.skippedLines,
+  });
+  if (options.json) {
+    return yield* YeetInboxViewJson.encode(filtered).pipe(
+      Effect.mapError(YeetCommandError.new("Failed to encode the inbox view."))
+    );
+  }
+  return renderYeetInboxView(filtered);
+});
+
+/**
+ * Run one `yeet inbox list` pass: load, filter, render or encode.
+ *
+ * **Example** (Build the list runner effect)
+ *
+ * ```ts
+ * import { runYeetInboxList } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = runYeetInboxList({ json: false, severity: "all", unacked: false })
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Parsed `yeet inbox list` flag values.
+ * @returns Void once the filtered view was printed.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetInboxList = Effect.fn("Yeet.runInboxListCommand")(function* (
+  options: YeetInboxListOptions
+): Effect.fn.Return<void, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const repoRoot = yield* locateRepoRoot();
+  const view = yield* loadYeetInboxView(repoRoot);
+  yield* Console.log(yield* renderYeetInboxListOutput(view, options));
+});
+
+/**
+ * Run one `yeet inbox ack` pass: parse the resolution, write the receipt.
+ *
+ * **Example** (Build the ack runner effect)
+ *
+ * ```ts
+ * import { runYeetInboxAck } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = runYeetInboxAck({ fixSha: "2817f28", id: "coverage-abc", reason: "", threadUrl: "", wontfix: false })
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Parsed `yeet inbox ack` flag values.
+ * @returns Void once the receipt was written and reported.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetInboxAck = Effect.fn("Yeet.runInboxAckCommand")(function* (
+  options: YeetInboxAckOptions
+): Effect.fn.Return<void, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const resolution = yield* parseYeetAckResolution(options);
+  const repoRoot = yield* locateRepoRoot();
+  const ackedAt = yield* isoNow;
+  const report = yield* ackYeetInboxRow(repoRoot, options.id, resolution, ackedAt);
+  yield* Console.log(`[yeet] acked ${options.id} (${renderYeetAckResolution(resolution)}) -> ${report.receiptPath}`);
+  if (report.replacedPrior) {
+    yield* Console.log("[yeet] replaced an existing receipt; the last resolution stands.");
+  }
+});
+
+/**
+ * Run one `yeet inbox append` pass: read stdin, decode, id-check, append.
+ *
+ * **Example** (Build the append runner effect)
+ *
+ * ```ts
+ * import { runYeetInboxAppend } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = runYeetInboxAppend({ fromStdin: false })
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Parsed `yeet inbox append` flag values.
+ * @returns Void once the row was appended and reported.
+ * @category commands
+ * @since 0.0.0
+ */
+export const runYeetInboxAppend = Effect.fn("Yeet.runInboxAppendCommand")(function* (
+  options: YeetInboxAppendOptions
+): Effect.fn.Return<void, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const text = yield* readYeetInboxStdin(options.fromStdin);
+  const repoRoot = yield* locateRepoRoot();
+  const row = yield* appendYeetInboxRowFromText(repoRoot, text);
+  yield* Console.log(
+    `[yeet] appended ${row.id} (${row.severity} ${row.capsule.lane}) for pr #${row.capsule.prNumber} @ ${shortSha(row.capsule.headSha)}`
+  );
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/InboxView.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/InboxView.ts
@@ -1,0 +1,313 @@
+/**
+ * The consumer-side view of the checkout failure inbox.
+ *
+ * **Details**
+ *
+ * Writers append immutable rows (`appendYeetInboxRow`) and never look
+ * back; this module is where every consumer — the `yeet inbox` CLI today, the
+ * A2 harness adapters (Claude hook deny/inject, Codex splice, Grok tail) next
+ * — turns that append-only evidence into the three joined facts enforcement
+ * runs on: what failed (the row), whether it was dealt with (the ack state),
+ * and whether it still matters (liveness against the current remediation
+ * wave).
+ *
+ * **Gotchas**
+ *
+ * The reader is deliberately tolerant. Undecodable lines are counted and
+ * skipped, never fatal: the inbox is a shared append-only file and one
+ * writer's garbage must not blind consumers to every other writer's rows.
+ * Duplicate ids keep the first occurrence — rows are immutable
+ * first-observation evidence, so a re-appended id is the same failure
+ * re-announced, not new information.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import { Effect, FileSystem, MutableHashSet } from "effect";
+import * as A from "effect/Array";
+import { dual } from "effect/Function";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
+import { readYeetAckState, YeetAckState } from "./Ack.ts";
+import { YeetInboxRow, YeetInboxRowJson, yeetInboxPaths } from "./Inbox.ts";
+import { loadYeetRemediationWave } from "./Remediation.ts";
+import type { Path } from "effect";
+import type { YeetRemediationWave } from "./Remediation.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/InboxView");
+
+/**
+ * Schema version stamped on every rendered inbox view.
+ *
+ * **Example** (Read the version)
+ *
+ * ```ts
+ * import { YEET_INBOX_VIEW_SCHEMA_VERSION } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_INBOX_VIEW_SCHEMA_VERSION) // "yeet-inbox-view/v1"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_INBOX_VIEW_SCHEMA_VERSION = "yeet-inbox-view/v1";
+
+/**
+ * Whether an inbox row still gates anything.
+ *
+ * **Details**
+ *
+ * `live` means the row's identity matches the current remediation wave —
+ * same PR, same head — so its failure is about the code the checkout is
+ * standing on. `superseded` means a later push made the row historical, and
+ * a superseded row must not gate anything. `unknown` means there is no
+ * usable wave record to join against — it is *not* a verdict either way.
+ * Only the watch dispatcher maintains the wave record today, so rows from
+ * writers that never touch it (SPEC A2's local lane runners and collision
+ * detectors, A5's package audits) are expected to be `unknown` rather than
+ * dead: liveness rules out stale rows, and the consumer's severity policy
+ * decides what an `unknown` row's tier still enforces.
+ *
+ * **Example** (Check a liveness)
+ *
+ * ```ts
+ * import { YeetInboxLiveness } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetInboxLiveness.is.live("live")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetInboxLiveness = LiteralKit(["live", "superseded", "unknown"]).pipe(
+  $I.annoteSchema("YeetInboxLiveness", {
+    title: "Yeet Inbox Liveness",
+    description: "Whether one inbox row belongs to the current remediation wave, a superseded one, or no known wave.",
+  })
+);
+
+/**
+ * Whether an inbox row still gates anything.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetInboxLiveness = typeof YeetInboxLiveness.Type;
+
+/**
+ * Decide one row's liveness against the persisted wave record.
+ *
+ * **Example** (No wave record means unknown)
+ *
+ * ```ts
+ * import { yeetInboxRowLiveness, YeetCheckFailedRow, YeetFailureCapsule, yeetInboxRowId } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const capsule = YeetFailureCapsule.make({
+ *   bucket: "fail",
+ *   headSha: "abc123",
+ *   lane: "Check",
+ *   link: null,
+ *   observedAt: "2026-08-17T00:00:00Z",
+ *   prNumber: 754,
+ *   state: "FAILURE",
+ *   workflow: null
+ * })
+ * const row = YeetCheckFailedRow.make({
+ *   capsule,
+ *   checkout: "/repo",
+ *   id: yeetInboxRowId(capsule),
+ *   severity: "P0",
+ *   ts: "2026-08-17T00:00:00Z"
+ * })
+ *
+ * console.log(yeetInboxRowLiveness(row, O.none())) // "unknown"
+ * ```
+ *
+ * @param row - The inbox row to place.
+ * @param wave - The persisted remediation wave, when one exists.
+ * @returns The row's liveness tier.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const yeetInboxRowLiveness: {
+  (wave: O.Option<YeetRemediationWave>): (row: YeetInboxRow) => YeetInboxLiveness;
+  (row: YeetInboxRow, wave: O.Option<YeetRemediationWave>): YeetInboxLiveness;
+} = dual(
+  2,
+  (row: YeetInboxRow, wave: O.Option<YeetRemediationWave>): YeetInboxLiveness =>
+    O.match(wave, {
+      onNone: () => "unknown" as const,
+      onSome: (current) =>
+        current.headSha === row.capsule.headSha && current.prNumber === row.capsule.prNumber
+          ? ("live" as const)
+          : ("superseded" as const),
+    })
+);
+
+/**
+ * One inbox row joined with everything a consumer decides on.
+ *
+ * **Example** (Build an entry)
+ *
+ * ```ts
+ * import {
+ *   YeetAckState,
+ *   YeetCheckFailedRow,
+ *   YeetFailureCapsule,
+ *   YeetInboxEntry,
+ *   yeetInboxRowId
+ * } from "@beep/repo-cli/test/Yeet"
+ *
+ * const capsule = YeetFailureCapsule.make({
+ *   bucket: "fail",
+ *   headSha: "abc123",
+ *   lane: "Check",
+ *   link: null,
+ *   observedAt: "2026-08-17T00:00:00Z",
+ *   prNumber: 754,
+ *   state: "FAILURE",
+ *   workflow: null
+ * })
+ * const entry = YeetInboxEntry.make({
+ *   ack: YeetAckState.make({ acked: false, receipt: null }),
+ *   liveness: "live",
+ *   row: YeetCheckFailedRow.make({
+ *     capsule,
+ *     checkout: "/repo",
+ *     id: yeetInboxRowId(capsule),
+ *     severity: "P0",
+ *     ts: "2026-08-17T00:00:00Z"
+ *   })
+ * })
+ *
+ * console.log(entry.ack.acked) // false
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetInboxEntry extends S.Class<YeetInboxEntry>($I`YeetInboxEntry`)(
+  {
+    row: YeetInboxRow,
+    ack: YeetAckState,
+    liveness: YeetInboxLiveness,
+  },
+  $I.annote("YeetInboxEntry", {
+    description: "One inbox row joined with its ack state and its liveness against the current wave.",
+  })
+) {}
+
+/**
+ * The joined inbox: every deduplicated row plus the reader's accounting.
+ *
+ * **Example** (Build an empty view)
+ *
+ * ```ts
+ * import { YeetInboxView } from "@beep/repo-cli/test/Yeet"
+ *
+ * const view = YeetInboxView.make({ entries: [], skippedLines: 0 })
+ * console.log(view.schemaVersion) // "yeet-inbox-view/v1"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetInboxView extends S.Class<YeetInboxView>($I`YeetInboxView`)(
+  {
+    schemaVersion: S.Literal(YEET_INBOX_VIEW_SCHEMA_VERSION).pipe(
+      S.withConstructorDefault(Effect.succeed(YEET_INBOX_VIEW_SCHEMA_VERSION))
+    ),
+    entries: S.Array(YeetInboxEntry),
+    skippedLines: S.Finite,
+  },
+  $I.annote("YeetInboxView", {
+    description: "Every deduplicated inbox entry plus the count of undecodable lines the reader skipped.",
+  })
+) {}
+
+/**
+ * JSON string codec for one rendered inbox view.
+ *
+ * **Example** (Reject garbage)
+ *
+ * ```ts
+ * import { YeetInboxViewJson } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * console.log(O.isNone(YeetInboxViewJson.decodeOption("not json"))) // true
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const YeetInboxViewJson = JsonStringCodec(YeetInboxView);
+
+const dedupeRowsById = (rows: ReadonlyArray<YeetInboxRow>): ReadonlyArray<YeetInboxRow> => {
+  const seen = MutableHashSet.empty<string>();
+  return A.filter(rows, (row) => {
+    if (MutableHashSet.has(seen, row.id)) {
+      return false;
+    }
+    MutableHashSet.add(seen, row.id);
+    return true;
+  });
+};
+
+/**
+ * Load the joined inbox view for one checkout.
+ *
+ * **Details**
+ *
+ * Reads the failures file tolerantly (a missing file is an empty inbox;
+ * undecodable lines are counted in `skippedLines`), dedupes rows by id
+ * keeping the first observation, then joins each row with its ack state and
+ * its liveness against the persisted wave record. This is the one read every
+ * consumer shares, so the CLI and the hook adapters provably see the same
+ * inbox.
+ *
+ * **Example** (Build the load effect)
+ *
+ * ```ts
+ * import { loadYeetInboxView } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(loadYeetInboxView("/repo"))) // true
+ * ```
+ *
+ * @param repoRoot - The checkout whose inbox is read.
+ * @returns The joined view; an unreadable inbox is empty, never an error.
+ * @category services
+ * @since 0.0.0
+ */
+export const loadYeetInboxView = Effect.fn("Yeet.loadYeetInboxView")(function* (
+  repoRoot: string
+): Effect.fn.Return<YeetInboxView, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const paths = yield* yeetInboxPaths(repoRoot);
+  const text = yield* Effect.option(fs.readFileString(paths.failuresPath));
+  const lines = A.filter(
+    Str.split(
+      O.getOrElse(text, () => ""),
+      "\n"
+    ),
+    Str.isNonEmpty
+  );
+  const rows = A.getSomes(A.map(lines, YeetInboxRowJson.decodeOption));
+  const deduped = dedupeRowsById(rows);
+  const wave = yield* loadYeetRemediationWave(repoRoot);
+  const entries = yield* Effect.forEach(deduped, (row) =>
+    readYeetAckState(repoRoot, row.id).pipe(
+      Effect.map((ack) => YeetInboxEntry.make({ ack, liveness: yeetInboxRowLiveness(row, wave), row }))
+    )
+  );
+  return YeetInboxView.make({
+    entries,
+    skippedLines: A.length(lines) - A.length(rows),
+  });
+});

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/InboxView.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/InboxView.ts
@@ -26,6 +26,7 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit } from "@beep/schema";
+import { thunkFalse } from "@beep/utils";
 import { Effect, FileSystem, MutableHashSet } from "effect";
 import * as A from "effect/Array";
 import { dual } from "effect/Function";
@@ -34,7 +35,7 @@ import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
 import { readYeetAckState, YeetAckState } from "./Ack.ts";
-import { YeetInboxRow, YeetInboxRowJson, yeetInboxPaths } from "./Inbox.ts";
+import { YeetInboxRow, YeetInboxRowJson, yeetInboxPaths, yeetInboxRowId } from "./Inbox.ts";
 import { loadYeetRemediationWave } from "./Remediation.ts";
 import type { Path } from "effect";
 import type { YeetRemediationWave } from "./Remediation.ts";
@@ -206,12 +207,20 @@ export class YeetInboxEntry extends S.Class<YeetInboxEntry>($I`YeetInboxEntry`)(
 /**
  * The joined inbox: every deduplicated row plus the reader's accounting.
  *
+ * **Details**
+ *
+ * `unreadable` distinguishes "the failures file does not exist" (a genuinely
+ * empty inbox) from "the file exists but could not be read" (permissions, a
+ * directory squatting on the path, IO failure). An enforcement consumer must
+ * not treat the second case as an empty backlog — the inbox state is unknown,
+ * not clear.
+ *
  * **Example** (Build an empty view)
  *
  * ```ts
  * import { YeetInboxView } from "@beep/repo-cli/test/Yeet"
  *
- * const view = YeetInboxView.make({ entries: [], skippedLines: 0 })
+ * const view = YeetInboxView.make({ entries: [], skippedLines: 0, unreadable: false })
  * console.log(view.schemaVersion) // "yeet-inbox-view/v1"
  * ```
  *
@@ -225,9 +234,11 @@ export class YeetInboxView extends S.Class<YeetInboxView>($I`YeetInboxView`)(
     ),
     entries: S.Array(YeetInboxEntry),
     skippedLines: S.Finite,
+    unreadable: S.Boolean,
   },
   $I.annote("YeetInboxView", {
-    description: "Every deduplicated inbox entry plus the count of undecodable lines the reader skipped.",
+    description:
+      "Every deduplicated inbox entry, the count of skipped lines, and whether the failures file was unreadable.",
   })
 ) {}
 
@@ -259,17 +270,32 @@ const dedupeRowsById = (rows: ReadonlyArray<YeetInboxRow>): ReadonlyArray<YeetIn
   });
 };
 
+// Appends write one whole `line\n` per call, so an unterminated tail is an
+// in-flight append the next read will see whole — provisional, not garbage.
+// Only newline-terminated content is complete evidence.
+const terminatedPortion = (text: string): string =>
+  Str.endsWith("\n")(text)
+    ? text
+    : O.match(Str.lastIndexOf("\n")(text), {
+        onNone: () => "",
+        onSome: (index) => Str.slice(0, index + 1)(text),
+      });
+
 /**
  * Load the joined inbox view for one checkout.
  *
  * **Details**
  *
- * Reads the failures file tolerantly (a missing file is an empty inbox;
- * undecodable lines are counted in `skippedLines`), dedupes rows by id
- * keeping the first observation, then joins each row with its ack state and
- * its liveness against the persisted wave record. This is the one read every
- * consumer shares, so the CLI and the hook adapters provably see the same
- * inbox.
+ * Reads the failures file tolerantly: a missing file is an empty inbox, an
+ * existing-but-unreadable file is flagged `unreadable` instead of decaying to
+ * empty, an unterminated final line is treated as an in-flight append and
+ * ignored without counting, and terminated lines that fail to decode — or
+ * whose id breaks the deterministic {@link yeetInboxRowId} contract the
+ * append path enforces — are counted in `skippedLines`. Surviving rows are
+ * deduplicated by id keeping the first observation, then joined with their
+ * ack state and their liveness against the persisted wave record. This is the
+ * one read every consumer shares, so the CLI and the hook adapters provably
+ * see the same inbox.
  *
  * **Example** (Build the load effect)
  *
@@ -281,7 +307,7 @@ const dedupeRowsById = (rows: ReadonlyArray<YeetInboxRow>): ReadonlyArray<YeetIn
  * ```
  *
  * @param repoRoot - The checkout whose inbox is read.
- * @returns The joined view; an unreadable inbox is empty, never an error.
+ * @returns The joined view; never an error — failure modes fold into the view's accounting.
  * @category services
  * @since 0.0.0
  */
@@ -290,16 +316,18 @@ export const loadYeetInboxView = Effect.fn("Yeet.loadYeetInboxView")(function* (
 ): Effect.fn.Return<YeetInboxView, never, FileSystem.FileSystem | Path.Path> {
   const fs = yield* FileSystem.FileSystem;
   const paths = yield* yeetInboxPaths(repoRoot);
+  const exists = yield* fs.exists(paths.failuresPath).pipe(Effect.orElseSucceed(thunkFalse));
+  if (!exists) {
+    return YeetInboxView.make({ entries: [], skippedLines: 0, unreadable: false });
+  }
   const text = yield* Effect.option(fs.readFileString(paths.failuresPath));
-  const lines = A.filter(
-    Str.split(
-      O.getOrElse(text, () => ""),
-      "\n"
-    ),
-    Str.isNonEmpty
-  );
+  if (O.isNone(text)) {
+    return YeetInboxView.make({ entries: [], skippedLines: 0, unreadable: true });
+  }
+  const lines = A.filter(Str.split(terminatedPortion(text.value), "\n"), Str.isNonEmpty);
   const rows = A.getSomes(A.map(lines, YeetInboxRowJson.decodeOption));
-  const deduped = dedupeRowsById(rows);
+  const wellFormed = A.filter(rows, (row) => row.id === yeetInboxRowId(row.capsule));
+  const deduped = dedupeRowsById(wellFormed);
   const wave = yield* loadYeetRemediationWave(repoRoot);
   const entries = yield* Effect.forEach(deduped, (row) =>
     readYeetAckState(repoRoot, row.id).pipe(
@@ -308,6 +336,7 @@ export const loadYeetInboxView = Effect.fn("Yeet.loadYeetInboxView")(function* (
   );
   return YeetInboxView.make({
     entries,
-    skippedLines: A.length(lines) - A.length(rows),
+    skippedLines: A.length(lines) - A.length(wellFormed),
+    unreadable: false,
   });
 });

--- a/packages/tooling/tool/cli/src/internal/cli/Stdin.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/Stdin.ts
@@ -69,10 +69,12 @@ interface CommandStdinShape {
  * @since 0.0.0
  */
 export const CommandStdinSource: Context.Reference<CommandStdinShape> = Context.Reference($I`CommandStdinSource`, {
+  /* v8 ignore start -- the production stdin bridge: tests always provide a stub, because a real stdin.text() read blocks until the worker's held-open pipe reaches EOF */
   defaultValue: (): CommandStdinShape => ({
     interactive: () => process.stdin.isTTY === true,
     text: () => Bun.stdin.text(),
   }),
+  /* v8 ignore stop */
 });
 
 /**

--- a/packages/tooling/tool/cli/src/internal/cli/Stdin.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/Stdin.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared stdin-document reading for `--from-stdin` command flags.
+ *
+ * @internal
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { Effect } from "effect";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("internal/cli/Stdin");
+
+/**
+ * Failure while reading a stdin document, carrying the caller's phrasing.
+ *
+ * **Example** (Make StdinDocumentError instance)
+ *
+ * ```ts
+ * import { StdinDocumentError } from "@beep/repo-cli/internal/cli/Stdin"
+ *
+ * const error = StdinDocumentError.make({ message: "no stdin" })
+ * console.log(error.message)
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class StdinDocumentError extends S.TaggedError<StdinDocumentError>($I`StdinDocumentError`)(
+  "StdinDocumentError",
+  {
+    message: S.String,
+  },
+  $I.annote("StdinDocumentError", {
+    description: "Failure while reading a stdin document for a --from-stdin command flag.",
+  })
+) {}
+
+/**
+ * The caller-specific phrasing for each way a stdin read can fail.
+ */
+interface StdinDocumentMessages {
+  /** Refusal when the command ran without its `--from-stdin` flag. */
+  readonly missingFlag: string;
+  /** Refusal when stdin is an interactive terminal with nothing piped. */
+  readonly noStdin: string;
+  /** Prefix for a failed read, completed with the underlying cause. */
+  readonly readFailurePrefix: string;
+}
+
+/**
+ * Read one whole document from stdin, or fail with the caller's phrasing.
+ *
+ * **Example** (Refuse without the flag)
+ *
+ * ```ts
+ * import { readStdinDocument } from "@beep/repo-cli/internal/cli/Stdin"
+ * import { Effect } from "effect"
+ *
+ * const read = readStdinDocument(false, {
+ *   missingFlag: "requires --from-stdin",
+ *   noStdin: "received no stdin",
+ *   readFailurePrefix: "failed to read stdin"
+ * })
+ * console.log(Effect.isEffect(read)) // true
+ * ```
+ *
+ * @param fromStdin - Whether the command's `--from-stdin` flag was passed.
+ * @param messages - The caller's phrasing for the three failure modes.
+ * @returns The full stdin text.
+ * @category services
+ * @since 0.0.0
+ */
+export const readStdinDocument = Effect.fn("Cli.readStdinDocument")(function* (
+  fromStdin: boolean,
+  messages: StdinDocumentMessages
+): Effect.fn.Return<string, StdinDocumentError> {
+  if (!fromStdin) {
+    return yield* StdinDocumentError.make({ message: messages.missingFlag });
+  }
+  if (process.stdin.isTTY) {
+    return yield* StdinDocumentError.make({ message: messages.noStdin });
+  }
+  return yield* Effect.tryPromise(() => Bun.stdin.text()).pipe(
+    Effect.mapError((cause) =>
+      StdinDocumentError.make({
+        message: `${messages.readFailurePrefix}: ${cause instanceof Error ? cause.message : String(cause)}`,
+      })
+    )
+  );
+});

--- a/packages/tooling/tool/cli/src/internal/cli/Stdin.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/Stdin.ts
@@ -7,7 +7,7 @@
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
-import { Effect } from "effect";
+import { Context, Effect } from "effect";
 import * as S from "effect/Schema";
 
 const $I = $RepoCliId.create("internal/cli/Stdin");
@@ -36,6 +36,44 @@ export class StdinDocumentError extends S.TaggedError<StdinDocumentError>($I`Std
     description: "Failure while reading a stdin document for a --from-stdin command flag.",
   })
 ) {}
+
+/**
+ * How a command observes and consumes the process stdin.
+ */
+interface CommandStdinShape {
+  /** Whether stdin is an interactive terminal with nothing piped into it. */
+  readonly interactive: () => boolean;
+  /** Read the whole piped document. */
+  readonly text: () => Promise<string>;
+}
+
+/**
+ * The process-stdin source, injectable so tests never touch real stdin.
+ *
+ * **Details**
+ *
+ * The default reads the real process stdin through the Bun runtime the CLI
+ * ships on. Tests must always provide a stub: a real `stdin.text()` read
+ * blocks until the pipe reaches EOF, and test runners hold their workers'
+ * stdin open — the read would hang for the length of the test timeout.
+ *
+ * **Example** (Read the reference key)
+ *
+ * ```ts
+ * import { CommandStdinSource } from "@beep/repo-cli/internal/cli/Stdin"
+ *
+ * console.log(typeof CommandStdinSource.key) // "string"
+ * ```
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export const CommandStdinSource: Context.Reference<CommandStdinShape> = Context.Reference($I`CommandStdinSource`, {
+  defaultValue: (): CommandStdinShape => ({
+    interactive: () => process.stdin.isTTY === true,
+    text: () => Bun.stdin.text(),
+  }),
+});
 
 /**
  * The caller-specific phrasing for each way a stdin read can fail.
@@ -79,14 +117,12 @@ export const readStdinDocument = Effect.fn("Cli.readStdinDocument")(function* (
   if (!fromStdin) {
     return yield* StdinDocumentError.make({ message: messages.missingFlag });
   }
-  if (process.stdin.isTTY) {
+  const source = yield* CommandStdinSource;
+  if (source.interactive()) {
     return yield* StdinDocumentError.make({ message: messages.noStdin });
   }
-  return yield* Effect.tryPromise(() => Bun.stdin.text()).pipe(
-    Effect.mapError((cause) =>
-      StdinDocumentError.make({
-        message: `${messages.readFailurePrefix}: ${cause instanceof Error ? cause.message : String(cause)}`,
-      })
-    )
-  );
+  return yield* Effect.tryPromise({
+    try: () => source.text(),
+    catch: (cause) => StdinDocumentError.make({ message: `${messages.readFailurePrefix}: ${String(cause)}` }),
+  });
 });

--- a/packages/tooling/tool/cli/src/test/Cli.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Cli.test-kit.ts
@@ -13,5 +13,6 @@ export * from "../internal/cli/Json.ts";
 export * from "../internal/cli/Printer.ts";
 export * from "../internal/cli/Progress.ts";
 export * from "../internal/cli/RunMode.ts";
+export * from "../internal/cli/Stdin.ts";
 export * from "../internal/cli/Timing.ts";
 export * from "../internal/cli/UnknownProbe.ts";

--- a/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
@@ -6,6 +6,7 @@
  */
 
 export * from "@beep/repo-cli/commands/Yeet/index";
+export * from "../commands/Yeet/internal/Ack.ts";
 export * from "../commands/Yeet/internal/ArtifactPaths.ts";
 export * from "../commands/Yeet/internal/AttemptJournal.ts";
 export * from "../commands/Yeet/internal/Closeout.ts";
@@ -32,6 +33,8 @@ export {
 export * from "../commands/Yeet/internal/Guards.ts";
 export * from "../commands/Yeet/internal/Handler.ts";
 export * from "../commands/Yeet/internal/Inbox.ts";
+export * from "../commands/Yeet/internal/InboxPorcelain.ts";
+export * from "../commands/Yeet/internal/InboxView.ts";
 export * from "../commands/Yeet/internal/IssueArtifacts.ts";
 export * from "../commands/Yeet/internal/IssueClassification.ts";
 export * from "../commands/Yeet/internal/IssueParser.ts";

--- a/packages/tooling/tool/cli/test/cli-stdin.test.ts
+++ b/packages/tooling/tool/cli/test/cli-stdin.test.ts
@@ -1,0 +1,61 @@
+import { CommandStdinSource, readStdinDocument, StdinDocumentError } from "@beep/repo-cli/test/Cli";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+const MESSAGES = {
+  missingFlag: "test command requires --from-stdin.",
+  noStdin: "test command --from-stdin received no stdin.",
+  readFailurePrefix: "Failed to read the test document from stdin",
+};
+
+// Tests always inject the stdin source: a real stdin.text() read blocks until
+// the pipe reaches EOF, and test runners hold their workers' stdin open.
+const stdinSource = (text: () => Promise<string>, interactive = false) =>
+  Effect.provideService(CommandStdinSource, { interactive: () => interactive, text });
+
+describe("StdinDocumentError", () => {
+  it("carries the caller's message", () => {
+    const error = StdinDocumentError.make({ message: "no stdin" });
+    expect(error.message).toBe("no stdin");
+    expect(error._tag).toBe("StdinDocumentError");
+  });
+});
+
+describe("readStdinDocument", () => {
+  it.effect("refuses when the --from-stdin flag was not passed", () =>
+    Effect.gen(function* () {
+      const failure = yield* Effect.flip(readStdinDocument(false, MESSAGES));
+
+      expect(failure.message).toBe(MESSAGES.missingFlag);
+    })
+  );
+
+  it.effect("refuses when stdin is an interactive terminal", () =>
+    Effect.gen(function* () {
+      const failure = yield* Effect.flip(
+        readStdinDocument(true, MESSAGES).pipe(stdinSource(() => Promise.resolve(""), true))
+      );
+
+      expect(failure.message).toBe(MESSAGES.noStdin);
+    })
+  );
+
+  it.effect("returns the piped document whole", () =>
+    Effect.gen(function* () {
+      const text = yield* readStdinDocument(true, MESSAGES).pipe(stdinSource(() => Promise.resolve('{"a":1}\n')));
+
+      expect(text).toBe('{"a":1}\n');
+    })
+  );
+
+  it.effect("wraps a failed read in the caller's phrasing", () =>
+    Effect.gen(function* () {
+      const failure = yield* Effect.flip(
+        readStdinDocument(true, MESSAGES).pipe(stdinSource(() => Promise.reject(new Error("pipe burst"))))
+      );
+
+      expect(failure.message).toContain(MESSAGES.readFailurePrefix);
+      expect(failure.message).toContain("pipe burst");
+    })
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-ack.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-ack.test.ts
@@ -1,0 +1,181 @@
+import {
+  readYeetAckState,
+  renderYeetAckResolution,
+  writeYeetAckReceipt,
+  YEET_ACK_SCHEMA_VERSION,
+  YeetAckFixResolution,
+  YeetAckReceipt,
+  YeetAckReceiptJson,
+  YeetAckThreadResolution,
+  YeetAckWontfixResolution,
+  yeetInboxAckPath,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer } from "effect";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+
+const AT = "2026-08-17T00:00:00Z";
+
+const fixReceipt = (id: string): YeetAckReceipt =>
+  YeetAckReceipt.make({
+    ackedAt: AT,
+    id,
+    resolution: YeetAckFixResolution.make({ sha: "2817f286d3" }),
+  });
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+const inTempRepo = Effect.fn("inTempRepo")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+describe("renderYeetAckResolution", () => {
+  it("phrases each of the three closing moves", () => {
+    expect(renderYeetAckResolution(YeetAckFixResolution.make({ sha: "2817f28" }))).toBe("fix-sha 2817f28");
+    expect(renderYeetAckResolution(YeetAckWontfixResolution.make({ reason: "flaky infra lane" }))).toBe(
+      "wontfix: flaky infra lane"
+    );
+    expect(renderYeetAckResolution(YeetAckThreadResolution.make({ url: "https://example.test/t/1" }))).toBe(
+      "thread https://example.test/t/1"
+    );
+  });
+});
+
+describe("YeetAckReceiptJson", () => {
+  it.effect("round-trips a receipt through the codec", () =>
+    Effect.gen(function* () {
+      const receipt = fixReceipt("coverage-abc123");
+      const encoded = yield* YeetAckReceiptJson.encode(receipt);
+      const decoded = yield* YeetAckReceiptJson.decode(encoded);
+
+      expect(decoded.schemaVersion).toBe(YEET_ACK_SCHEMA_VERSION);
+      expect(decoded.id).toBe("coverage-abc123");
+      expect(decoded.resolution).toStrictEqual(receipt.resolution);
+    })
+  );
+
+  it("rejects garbage instead of decaying to a partial receipt", () => {
+    expect(O.isNone(YeetAckReceiptJson.decodeOption("not json"))).toBe(true);
+    expect(O.isNone(YeetAckReceiptJson.decodeOption('{"id":"x"}'))).toBe(true);
+  });
+});
+
+describe("readYeetAckState", () => {
+  it.live("reports a missing receipt as unacked", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const state = yield* readYeetAckState(root, "coverage-abc123");
+
+        expect(state.acked).toBe(false);
+        expect(state.receipt).toBeNull();
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("reports a written receipt as acked with its decoded content", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        yield* writeYeetAckReceipt(root, fixReceipt("coverage-abc123"));
+
+        const state = yield* readYeetAckState(root, "coverage-abc123");
+
+        expect(state.acked).toBe(true);
+        expect(state.receipt?.resolution).toStrictEqual(YeetAckFixResolution.make({ sha: "2817f286d3" }));
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("keeps an unreadable receipt acked while dropping its content", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const ackPath = yield* yeetInboxAckPath(root, "coverage-abc123");
+        yield* fs.makeDirectory(`${root}/.beep/inbox/acks`, { recursive: true });
+        yield* fs.writeFileString(ackPath, "corrupted receipt");
+
+        const state = yield* readYeetAckState(root, "coverage-abc123");
+
+        // Existence is the acknowledgment; corruption must not re-arm a denial.
+        expect(state.acked).toBe(true);
+        expect(state.receipt).toBeNull();
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("keeps a receipt that exists but cannot be read as a file acked", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        // A directory squatting on the receipt path: it exists, but reading it
+        // as a file fails — the ack must survive the read failure.
+        yield* fs.makeDirectory(yield* yeetInboxAckPath(root, "coverage-abc123"), { recursive: true });
+
+        const state = yield* readYeetAckState(root, "coverage-abc123");
+
+        expect(state.acked).toBe(true);
+        expect(state.receipt).toBeNull();
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+});
+
+describe("writeYeetAckReceipt", () => {
+  it.live("creates the acks directory and writes a decodable receipt at the returned path", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const receipt = fixReceipt("coverage-abc123");
+
+        const written = yield* writeYeetAckReceipt(root, receipt);
+
+        expect(written).toBe(`${root}/.beep/inbox/acks/coverage-abc123`);
+        const decoded = yield* YeetAckReceiptJson.decode(Str.trim(yield* fs.readFileString(written)));
+        expect(decoded.id).toBe("coverage-abc123");
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("overwrites a prior receipt so the last resolution stands", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        yield* writeYeetAckReceipt(
+          root,
+          YeetAckReceipt.make({
+            ackedAt: AT,
+            id: "coverage-abc123",
+            resolution: YeetAckWontfixResolution.make({ reason: "premature" }),
+          })
+        );
+        yield* writeYeetAckReceipt(root, fixReceipt("coverage-abc123"));
+
+        const state = yield* readYeetAckState(root, "coverage-abc123");
+
+        expect(state.receipt?.resolution).toStrictEqual(YeetAckFixResolution.make({ sha: "2817f286d3" }));
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("fails with a typed error when the acks location is unusable", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        // A file squatting on the acks directory path makes mkdir fail.
+        yield* fs.makeDirectory(`${root}/.beep/inbox`, { recursive: true });
+        yield* fs.writeFileString(`${root}/.beep/inbox/acks`, "squatter");
+
+        const failure = yield* Effect.flip(writeYeetAckReceipt(root, fixReceipt("coverage-abc123")));
+
+        expect(failure.message).toContain("acks");
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-command-wiring.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-command-wiring.test.ts
@@ -33,3 +33,17 @@ describe("yeet merge-loop command wiring", () => {
     );
   });
 });
+
+describe("yeet inbox command wiring", () => {
+  it("registers the inbox subcommand with its list, ack, and append children", () => {
+    expect(subcommandNames).toContain("inbox");
+
+    const inbox = findSubcommand("inbox");
+    expect(inbox._tag).toBe("Some");
+    const children =
+      inbox._tag === "Some"
+        ? A.flatMap(inbox.value.subcommands, (group) => A.map(group.commands, (command) => command.name))
+        : [];
+    expect(children).toEqual(expect.arrayContaining(["list", "ack", "append"]));
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet-inbox-porcelain.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-inbox-porcelain.test.ts
@@ -1,3 +1,4 @@
+import { CommandStdinSource } from "@beep/repo-cli/test/Cli";
 import {
   ackYeetInboxRow,
   appendYeetInboxRow,
@@ -9,6 +10,9 @@ import {
   renderYeetInboxEntryLine,
   renderYeetInboxListOutput,
   renderYeetInboxView,
+  runYeetInboxAck,
+  runYeetInboxAppend,
+  runYeetInboxList,
   writeYeetAckReceipt,
   YeetAckFixResolution,
   YeetAckReceipt,
@@ -28,7 +32,9 @@ import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, FileSystem, Layer, pipe } from "effect";
 import * as A from "effect/Array";
+import * as O from "effect/Option";
 import * as Str from "effect/String";
+import * as TestConsole from "effect/testing/TestConsole";
 
 const AT = "2026-08-17T00:00:00Z";
 
@@ -127,6 +133,7 @@ describe("renderYeetInboxView", () => {
     const view = YeetInboxView.make({
       entries: [entry(row(capsule())), entry(row(capsule({ lane: "Check / Lint" })), true)],
       skippedLines: 3,
+      unreadable: false,
     });
 
     const rendered = renderYeetInboxView(view);
@@ -137,11 +144,20 @@ describe("renderYeetInboxView", () => {
   });
 });
 
+describe("renderYeetInboxView (unreadable)", () => {
+  it("flags an unreadable failures file in the header", () => {
+    const view = YeetInboxView.make({ entries: [], skippedLines: 0, unreadable: true });
+
+    expect(renderYeetInboxView(view)).toContain("unreadable; inbox state unknown, not empty");
+  });
+});
+
 describe("renderYeetInboxListOutput", () => {
   const view = () =>
     YeetInboxView.make({
       entries: [entry(row(capsule())), entry(row(capsule({ lane: "Check / Lint" }), "P1"), true)],
       skippedLines: 2,
+      unreadable: false,
     });
 
   it.effect("renders the filtered operator text", () =>
@@ -296,5 +312,99 @@ describe("appendYeetInboxRowFromText", () => {
         expect(failure.message).toContain("Failed to decode the inbox row document");
       })
     ).pipe(provideScopedLayer(PlatformLayer))
+  );
+});
+
+// The runners resolve the checkout through findRepoRoot from process.cwd, so
+// these tests chdir into a temp directory carrying a bun.lock root marker.
+// The suite runs with fileParallelism disabled, so the cwd swap cannot race
+// another file.
+const inTempCheckout = Effect.fn("inTempCheckout")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const original = process.cwd();
+  const enter = Effect.gen(function* () {
+    const made = yield* fs.makeTempDirectory();
+    yield* fs.writeFileString(`${made}/bun.lock`, "");
+    yield* Effect.sync(() => process.chdir(made));
+    // findRepoRoot walks from process.cwd(), which may canonicalize the temp
+    // path, so the tests join on whatever cwd now reports.
+    return process.cwd();
+  });
+  return yield* Effect.acquireUseRelease(enter, use, (root) =>
+    Effect.sync(() => process.chdir(original)).pipe(Effect.andThen(Effect.ignore(fs.remove(root, { recursive: true }))))
+  );
+});
+
+const RunnerLayer = Layer.mergeAll(TestConsole.layer, PlatformLayer);
+
+// Inject the stdin source: a real stdin read blocks until EOF and test
+// runners hold their workers' stdin open, so runner tests always stub it.
+const providedStdin = (text: string) =>
+  Effect.provideService(CommandStdinSource, { interactive: () => false, text: () => Promise.resolve(text) });
+
+describe("yeet inbox runners", () => {
+  it.live("list prints the resolved checkout's inbox as text and as decodable JSON", () =>
+    inTempCheckout((root) =>
+      Effect.gen(function* () {
+        yield* appendYeetInboxRow(root, row(capsule()));
+
+        yield* runYeetInboxList({ json: false, severity: "all", unacked: false });
+        yield* runYeetInboxList({ json: true, severity: "all", unacked: true });
+
+        // The text listing is one multi-line log entry; the JSON document is
+        // the second entry.
+        const lines = A.map(yield* TestConsole.logLines, String);
+        expect(A.length(lines)).toBe(2);
+        expect(O.getOrElse(A.head(lines), () => "")).toContain("[yeet] inbox: 1 row(s), 1 unacked, 0 skipped line(s)");
+        const decoded = yield* YeetInboxViewJson.decode(O.getOrElse(A.last(lines), () => ""));
+        expect(A.length(decoded.entries)).toBe(1);
+      })
+    ).pipe(provideScopedLayer(RunnerLayer))
+  );
+
+  it.live("ack writes the receipt from the resolved checkout and reports a replacement on re-ack", () =>
+    inTempCheckout((root) =>
+      Effect.gen(function* () {
+        const subject = row(capsule());
+        yield* appendYeetInboxRow(root, subject);
+
+        yield* runYeetInboxAck({ fixSha: "2817f28", id: subject.id, reason: "", threadUrl: "", wontfix: false });
+        const state = yield* readYeetAckState(root, subject.id);
+        expect(state.receipt?.resolution).toStrictEqual(YeetAckFixResolution.make({ sha: "2817f28" }));
+
+        yield* runYeetInboxAck({ fixSha: "", id: subject.id, reason: "actually flaky", threadUrl: "", wontfix: true });
+
+        const lines = A.map(yield* TestConsole.logLines, String);
+        expect(A.some(lines, (line) => Str.includes("acked")(line))).toBe(true);
+        expect(A.some(lines, (line) => Str.includes("replaced an existing receipt")(line))).toBe(true);
+      })
+    ).pipe(provideScopedLayer(RunnerLayer))
+  );
+
+  it.live("append reads the row document from stdin and appends it to the resolved checkout", () =>
+    inTempCheckout((root) =>
+      Effect.gen(function* () {
+        const subject = row(capsule());
+        const text = yield* YeetInboxRowJson.encode(subject);
+        yield* runYeetInboxAppend({ fromStdin: true }).pipe(providedStdin(`${text}\n`));
+
+        const view = yield* loadYeetInboxView(root);
+        expect(A.map(view.entries, (candidate) => candidate.row.id)).toStrictEqual([subject.id]);
+        const lines = A.map(yield* TestConsole.logLines, String);
+        expect(A.some(lines, (line) => Str.includes("appended")(line))).toBe(true);
+      })
+    ).pipe(provideScopedLayer(RunnerLayer))
+  );
+
+  it.live("append refuses to run without --from-stdin before touching the checkout", () =>
+    inTempCheckout(() =>
+      Effect.gen(function* () {
+        const failure = yield* Effect.flip(runYeetInboxAppend({ fromStdin: false }));
+
+        expect(failure.message).toBe("yeet inbox append requires --from-stdin.");
+      })
+    ).pipe(provideScopedLayer(RunnerLayer))
   );
 });

--- a/packages/tooling/tool/cli/test/yeet-inbox-porcelain.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-inbox-porcelain.test.ts
@@ -1,0 +1,300 @@
+import {
+  ackYeetInboxRow,
+  appendYeetInboxRow,
+  appendYeetInboxRowFromText,
+  filterYeetInboxEntries,
+  loadYeetInboxView,
+  parseYeetAckResolution,
+  readYeetAckState,
+  renderYeetInboxEntryLine,
+  renderYeetInboxListOutput,
+  renderYeetInboxView,
+  writeYeetAckReceipt,
+  YeetAckFixResolution,
+  YeetAckReceipt,
+  YeetAckState,
+  YeetAckWontfixResolution,
+  YeetCheckFailedRow,
+  YeetFailureCapsule,
+  YeetInboxEntry,
+  YeetInboxRowJson,
+  YeetInboxView,
+  YeetInboxViewJson,
+  yeetInboxRowId,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, pipe } from "effect";
+import * as A from "effect/Array";
+import * as Str from "effect/String";
+
+const AT = "2026-08-17T00:00:00Z";
+
+const capsule = (overrides: Partial<Parameters<typeof YeetFailureCapsule.make>[0]> = {}): YeetFailureCapsule =>
+  YeetFailureCapsule.make({
+    bucket: "fail",
+    headSha: "abc123def456",
+    lane: "Check / Coverage",
+    link: null,
+    observedAt: AT,
+    prNumber: 754,
+    state: "FAILURE",
+    workflow: "Check",
+    ...overrides,
+  });
+
+const row = (subject: YeetFailureCapsule, severity: "P0" | "P1" | "P2" = "P0"): YeetCheckFailedRow =>
+  YeetCheckFailedRow.make({
+    capsule: subject,
+    checkout: "/repo",
+    id: yeetInboxRowId(subject),
+    severity,
+    ts: AT,
+  });
+
+const entry = (subject: YeetCheckFailedRow, acked = false): YeetInboxEntry =>
+  YeetInboxEntry.make({
+    ack: YeetAckState.make({ acked, receipt: null }),
+    liveness: "live",
+    row: subject,
+  });
+
+const noResolutionFlags = { fixSha: "", reason: "", threadUrl: "", wontfix: false };
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+const inTempRepo = Effect.fn("inTempRepo")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+describe("filterYeetInboxEntries", () => {
+  const p0 = entry(row(capsule()));
+  const p1 = entry(row(capsule({ lane: "Check / Lint" }), "P1"));
+  const acked = entry(row(capsule({ lane: "Check / Docs" })), true);
+
+  it("keeps everything under the identity filter", () => {
+    expect(filterYeetInboxEntries([p0, p1, acked], { severity: "all", unacked: false })).toStrictEqual([p0, p1, acked]);
+  });
+
+  it("selects by severity tier and by ack state", () => {
+    expect(filterYeetInboxEntries([p0, p1, acked], { severity: "P1", unacked: false })).toStrictEqual([p1]);
+    expect(filterYeetInboxEntries([p0, p1, acked], { severity: "all", unacked: true })).toStrictEqual([p0, p1]);
+  });
+
+  it("supports the data-last pipeable form", () => {
+    expect(pipe([p0, acked], filterYeetInboxEntries({ severity: "P0", unacked: true }))).toStrictEqual([p0]);
+  });
+});
+
+describe("renderYeetInboxEntryLine", () => {
+  it("phrases an unacked live row with its coordinates", () => {
+    const line = renderYeetInboxEntryLine(entry(row(capsule())));
+
+    expect(line).toContain("P0 live unacked");
+    expect(line).toContain("Check / Coverage");
+    expect(line).toContain("pr #754 @ abc123d");
+  });
+
+  it("phrases an acked row with its resolution, or names an unreadable receipt", () => {
+    const subject = row(capsule());
+    const withReceipt = YeetInboxEntry.make({
+      ack: YeetAckState.make({
+        acked: true,
+        receipt: YeetAckReceipt.make({
+          ackedAt: AT,
+          id: subject.id,
+          resolution: YeetAckFixResolution.make({ sha: "2817f28" }),
+        }),
+      }),
+      liveness: "superseded",
+      row: subject,
+    });
+
+    expect(renderYeetInboxEntryLine(withReceipt)).toContain("superseded acked fix-sha 2817f28");
+    expect(renderYeetInboxEntryLine(entry(subject, true))).toContain("acked (unreadable receipt)");
+  });
+});
+
+describe("renderYeetInboxView", () => {
+  it("summarizes counts in the header and lists one line per entry", () => {
+    const view = YeetInboxView.make({
+      entries: [entry(row(capsule())), entry(row(capsule({ lane: "Check / Lint" })), true)],
+      skippedLines: 3,
+    });
+
+    const rendered = renderYeetInboxView(view);
+    const lines = Str.split(rendered, "\n");
+
+    expect(A.headNonEmpty(lines)).toBe("[yeet] inbox: 2 row(s), 1 unacked, 3 skipped line(s)");
+    expect(A.length(lines)).toBe(3);
+  });
+});
+
+describe("renderYeetInboxListOutput", () => {
+  const view = () =>
+    YeetInboxView.make({
+      entries: [entry(row(capsule())), entry(row(capsule({ lane: "Check / Lint" }), "P1"), true)],
+      skippedLines: 2,
+    });
+
+  it.effect("renders the filtered operator text", () =>
+    Effect.gen(function* () {
+      const output = yield* renderYeetInboxListOutput(view(), { json: false, severity: "all", unacked: true });
+      const lines = Str.split(output, "\n");
+
+      expect(A.headNonEmpty(lines)).toBe("[yeet] inbox: 1 row(s), 1 unacked, 2 skipped line(s)");
+      expect(A.length(lines)).toBe(2);
+      expect(output).toContain("Check / Coverage");
+      expect(output).not.toContain("Check / Lint");
+    })
+  );
+
+  it.effect("encodes a decodable JSON document carrying only the shown entries", () =>
+    Effect.gen(function* () {
+      const output = yield* renderYeetInboxListOutput(view(), { json: true, severity: "P1", unacked: false });
+      const decoded = yield* YeetInboxViewJson.decode(output);
+
+      expect(decoded.schemaVersion).toBe("yeet-inbox-view/v1");
+      expect(A.map(decoded.entries, (candidate) => candidate.row.capsule.lane)).toStrictEqual(["Check / Lint"]);
+      expect(decoded.skippedLines).toBe(2);
+    })
+  );
+});
+
+describe("parseYeetAckResolution", () => {
+  it.effect("builds each of the three resolutions", () =>
+    Effect.gen(function* () {
+      const fix = yield* parseYeetAckResolution({ ...noResolutionFlags, fixSha: "2817f28" });
+      const wontfix = yield* parseYeetAckResolution({ ...noResolutionFlags, reason: "flaky", wontfix: true });
+      const thread = yield* parseYeetAckResolution({ ...noResolutionFlags, threadUrl: "https://example.test/t/1" });
+
+      expect(fix.kind).toBe("fix-sha");
+      expect(wontfix.kind).toBe("wontfix");
+      expect(thread.kind).toBe("thread-url");
+    })
+  );
+
+  it.effect("refuses zero or multiple resolutions", () =>
+    Effect.gen(function* () {
+      const none = yield* Effect.flip(parseYeetAckResolution(noResolutionFlags));
+      const both = yield* Effect.flip(
+        parseYeetAckResolution({ ...noResolutionFlags, fixSha: "2817f28", threadUrl: "https://example.test/t/1" })
+      );
+
+      expect(none.message).toContain("exactly one");
+      expect(both.message).toContain("exactly one");
+    })
+  );
+
+  it.effect("refuses a wontfix without a reason, and a reason without wontfix", () =>
+    Effect.gen(function* () {
+      const unexplained = yield* Effect.flip(parseYeetAckResolution({ ...noResolutionFlags, wontfix: true }));
+      const dangling = yield* Effect.flip(parseYeetAckResolution({ ...noResolutionFlags, reason: "flaky" }));
+
+      expect(unexplained.message).toContain("requires --reason");
+      expect(dangling.message).toContain("only applies with --wontfix");
+    })
+  );
+});
+
+describe("ackYeetInboxRow", () => {
+  it.live("writes a decodable receipt for a known row", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const subject = row(capsule());
+        yield* appendYeetInboxRow(root, subject);
+
+        const report = yield* ackYeetInboxRow(root, subject.id, YeetAckFixResolution.make({ sha: "2817f28" }), AT);
+
+        expect(report.replacedPrior).toBe(false);
+        expect(report.receipt.id).toBe(subject.id);
+        const state = yield* readYeetAckState(root, subject.id);
+        expect(state.receipt?.resolution).toStrictEqual(YeetAckFixResolution.make({ sha: "2817f28" }));
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("refuses an id the inbox does not contain", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const failure = yield* Effect.flip(
+          ackYeetInboxRow(root, "missing-row", YeetAckFixResolution.make({ sha: "2817f28" }), AT)
+        );
+
+        expect(failure.message).toContain('No inbox row with id "missing-row"');
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("reports when a re-ack replaced a prior receipt", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const subject = row(capsule());
+        yield* appendYeetInboxRow(root, subject);
+        yield* writeYeetAckReceipt(
+          root,
+          YeetAckReceipt.make({
+            ackedAt: AT,
+            id: subject.id,
+            resolution: YeetAckWontfixResolution.make({ reason: "premature" }),
+          })
+        );
+
+        const report = yield* ackYeetInboxRow(root, subject.id, YeetAckFixResolution.make({ sha: "2817f28" }), AT);
+
+        expect(report.replacedPrior).toBe(true);
+        const state = yield* readYeetAckState(root, subject.id);
+        expect(state.receipt?.resolution).toStrictEqual(YeetAckFixResolution.make({ sha: "2817f28" }));
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+});
+
+describe("appendYeetInboxRowFromText", () => {
+  it.live("appends a valid row document to the inbox", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const subject = row(capsule());
+        const text = yield* YeetInboxRowJson.encode(subject);
+
+        const appended = yield* appendYeetInboxRowFromText(root, `${text}\n`);
+
+        expect(appended.id).toBe(subject.id);
+        const view = yield* loadYeetInboxView(root);
+        expect(A.map(view.entries, (candidate) => candidate.row.id)).toStrictEqual([subject.id]);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("refuses a row whose id breaks the deterministic contract", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const forged = YeetCheckFailedRow.make({ ...row(capsule()), id: "forged-id" });
+        const text = yield* YeetInboxRowJson.encode(forged);
+
+        const failure = yield* Effect.flip(appendYeetInboxRowFromText(root, text));
+
+        expect(failure.message).toContain("does not match the deterministic id");
+        const view = yield* loadYeetInboxView(root);
+        expect(view.entries).toStrictEqual([]);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("refuses garbage instead of appending it", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const failure = yield* Effect.flip(appendYeetInboxRowFromText(root, "not json"));
+
+        expect(failure.message).toContain("Failed to decode the inbox row document");
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-inbox-view.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-inbox-view.test.ts
@@ -7,6 +7,7 @@ import {
   YeetAckReceipt,
   YeetCheckFailedRow,
   YeetFailureCapsule,
+  YeetInboxRowJson,
   YeetInboxViewJson,
   YeetRemediationWave,
   YeetRemediationWaveJson,
@@ -23,6 +24,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, FileSystem, Layer, pipe } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
+import * as Str from "effect/String";
 
 const AT = "2026-08-17T00:00:00Z";
 
@@ -105,6 +107,7 @@ describe("loadYeetInboxView", () => {
         expect(view.schemaVersion).toBe(YEET_INBOX_VIEW_SCHEMA_VERSION);
         expect(view.entries).toStrictEqual([]);
         expect(view.skippedLines).toBe(0);
+        expect(view.unreadable).toBe(false);
       })
     ).pipe(provideScopedLayer(PlatformLayer))
   );
@@ -194,6 +197,78 @@ describe("loadYeetInboxView", () => {
         const view = yield* loadYeetInboxView(root);
 
         expect(A.map(view.entries, (entry) => entry.liveness)).toStrictEqual(["live", "superseded"]);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("flags an existing-but-unreadable failures file instead of decaying to empty", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const paths = yield* yeetInboxPaths(root);
+        // A directory squatting on the failures path: it exists, but reading
+        // it as a file fails — the view must say "unknown", not "empty".
+        yield* fs.makeDirectory(paths.failuresPath, { recursive: true });
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(view.unreadable).toBe(true);
+        expect(view.entries).toStrictEqual([]);
+        expect(view.skippedLines).toBe(0);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("skips and counts rows whose id breaks the deterministic contract", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* appendYeetInboxRow(root, row(capsule()));
+        const forged = YeetCheckFailedRow.make({ ...row(capsule({ lane: "Check / Lint" })), id: "forged-id" });
+        const paths = yield* yeetInboxPaths(root);
+        const line = yield* YeetInboxRowJson.encode(forged);
+        yield* fs.writeFileString(paths.failuresPath, `${line}\n`, { flag: "a" });
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(A.map(view.entries, (entry) => entry.row.id)).toStrictEqual([row(capsule()).id]);
+        expect(view.skippedLines).toBe(1);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("treats a file holding only an unterminated line as empty, not garbage", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const paths = yield* yeetInboxPaths(root);
+        yield* fs.makeDirectory(paths.dir, { recursive: true });
+        // No newline anywhere: the whole file is one in-flight append.
+        yield* fs.writeFileString(paths.failuresPath, '{"kind":"check-fail');
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(view.entries).toStrictEqual([]);
+        expect(view.skippedLines).toBe(0);
+        expect(view.unreadable).toBe(false);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("ignores an unterminated final line as in-flight instead of counting it as garbage", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* appendYeetInboxRow(root, row(capsule()));
+        const paths = yield* yeetInboxPaths(root);
+        const partial = yield* YeetInboxRowJson.encode(row(capsule({ lane: "Check / Lint" })));
+        // Half of an in-flight append: no trailing newline.
+        yield* fs.writeFileString(paths.failuresPath, Str.slice(0, 25)(partial), { flag: "a" });
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(A.length(view.entries)).toBe(1);
+        expect(view.skippedLines).toBe(0);
       })
     ).pipe(provideScopedLayer(PlatformLayer))
   );

--- a/packages/tooling/tool/cli/test/yeet-inbox-view.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-inbox-view.test.ts
@@ -1,0 +1,214 @@
+import {
+  appendYeetInboxRow,
+  loadYeetInboxView,
+  writeYeetAckReceipt,
+  YEET_INBOX_VIEW_SCHEMA_VERSION,
+  YeetAckFixResolution,
+  YeetAckReceipt,
+  YeetCheckFailedRow,
+  YeetFailureCapsule,
+  YeetInboxViewJson,
+  YeetRemediationWave,
+  YeetRemediationWaveJson,
+  yeetDispatchStatePath,
+  yeetInboxAckPath,
+  yeetInboxPaths,
+  yeetInboxRowId,
+  yeetInboxRowLiveness,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+
+const AT = "2026-08-17T00:00:00Z";
+
+const capsule = (overrides: Partial<Parameters<typeof YeetFailureCapsule.make>[0]> = {}): YeetFailureCapsule =>
+  YeetFailureCapsule.make({
+    bucket: "fail",
+    headSha: "abc123def456",
+    lane: "Check / Coverage",
+    link: null,
+    observedAt: AT,
+    prNumber: 754,
+    state: "FAILURE",
+    workflow: "Check",
+    ...overrides,
+  });
+
+const row = (subject: YeetFailureCapsule): YeetCheckFailedRow =>
+  YeetCheckFailedRow.make({
+    capsule: subject,
+    checkout: "/repo",
+    id: yeetInboxRowId(subject),
+    severity: "P0",
+    ts: AT,
+  });
+
+const wave = (overrides: Partial<Parameters<typeof YeetRemediationWave.make>[0]> = {}): YeetRemediationWave =>
+  YeetRemediationWave.make({
+    capsuleIds: [],
+    headSha: "abc123def456",
+    prNumber: 754,
+    sessionStartedAt: AT,
+    updatedAt: AT,
+    ...overrides,
+  });
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+const inTempRepo = Effect.fn("inTempRepo")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+const persistWave = Effect.fn("persistWave")(function* (root: string, current: YeetRemediationWave) {
+  const fs = yield* FileSystem.FileSystem;
+  const paths = yield* yeetInboxPaths(root);
+  yield* fs.makeDirectory(paths.dir, { recursive: true });
+  const json = yield* YeetRemediationWaveJson.encode(current);
+  yield* fs.writeFileString(yield* yeetDispatchStatePath(root), `${json}\n`);
+});
+
+describe("yeetInboxRowLiveness", () => {
+  it("is unknown without a wave record", () => {
+    expect(yeetInboxRowLiveness(row(capsule()), O.none())).toBe("unknown");
+  });
+
+  it("is live when the row matches the wave's PR and head", () => {
+    expect(yeetInboxRowLiveness(row(capsule()), O.some(wave()))).toBe("live");
+  });
+
+  it("is superseded when the wave moved to another head or PR", () => {
+    expect(yeetInboxRowLiveness(row(capsule()), O.some(wave({ headSha: "fff999" })))).toBe("superseded");
+    expect(yeetInboxRowLiveness(row(capsule()), O.some(wave({ prNumber: 99 })))).toBe("superseded");
+  });
+
+  it("supports the data-last pipeable form", () => {
+    expect(pipe(row(capsule()), yeetInboxRowLiveness(O.some(wave())))).toBe("live");
+  });
+});
+
+describe("loadYeetInboxView", () => {
+  it.live("treats a missing inbox as empty rather than an error", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const view = yield* loadYeetInboxView(root);
+
+        expect(view.schemaVersion).toBe(YEET_INBOX_VIEW_SCHEMA_VERSION);
+        expect(view.entries).toStrictEqual([]);
+        expect(view.skippedLines).toBe(0);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("skips undecodable lines and counts them instead of failing", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* appendYeetInboxRow(root, row(capsule()));
+        const paths = yield* yeetInboxPaths(root);
+        yield* fs.writeFileString(paths.failuresPath, "garbage line\n", { flag: "a" });
+        yield* appendYeetInboxRow(root, row(capsule({ lane: "Check / Lint" })));
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(A.length(view.entries)).toBe(2);
+        expect(view.skippedLines).toBe(1);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("dedupes re-announced ids keeping the first observation", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const first = row(capsule());
+        yield* appendYeetInboxRow(root, first);
+        yield* appendYeetInboxRow(root, YeetCheckFailedRow.make({ ...first, ts: "2026-08-17T01:00:00Z" }));
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(A.length(view.entries)).toBe(1);
+        expect(A.map(view.entries, (entry) => entry.row.ts)).toStrictEqual([AT]);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("joins each row with its ack state", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const acked = row(capsule());
+        const open = row(capsule({ lane: "Check / Lint" }));
+        yield* appendYeetInboxRow(root, acked);
+        yield* appendYeetInboxRow(root, open);
+        yield* writeYeetAckReceipt(
+          root,
+          YeetAckReceipt.make({
+            ackedAt: AT,
+            id: acked.id,
+            resolution: YeetAckFixResolution.make({ sha: "2817f28" }),
+          })
+        );
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(A.map(view.entries, (entry) => entry.ack.acked)).toStrictEqual([true, false]);
+        expect(view.entries[0]?.ack.receipt?.id).toBe(acked.id);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("keeps a corrupt receipt acked with no decoded content", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const subject = row(capsule());
+        yield* appendYeetInboxRow(root, subject);
+        yield* fs.makeDirectory(`${root}/.beep/inbox/acks`, { recursive: true });
+        yield* fs.writeFileString(yield* yeetInboxAckPath(root, subject.id), "corrupted");
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(view.entries[0]?.ack.acked).toBe(true);
+        expect(view.entries[0]?.ack.receipt).toBeNull();
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("joins liveness against the persisted wave record", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        const current = row(capsule());
+        const stale = row(capsule({ headSha: "fff999" }));
+        yield* appendYeetInboxRow(root, current);
+        yield* appendYeetInboxRow(root, stale);
+        yield* persistWave(root, wave());
+
+        const view = yield* loadYeetInboxView(root);
+
+        expect(A.map(view.entries, (entry) => entry.liveness)).toStrictEqual(["live", "superseded"]);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("round-trips the joined view through its codec", () =>
+    inTempRepo((root) =>
+      Effect.gen(function* () {
+        yield* appendYeetInboxRow(root, row(capsule()));
+
+        const view = yield* loadYeetInboxView(root);
+        const encoded = yield* YeetInboxViewJson.encode(view);
+        const decoded = yield* YeetInboxViewJson.decode(encoded);
+
+        expect(decoded).toStrictEqual(view);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+});


### PR DESCRIPTION
## feat(yeet): add yeet-ack receipts and the inbox list|ack|append porcelain

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit:amend: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_yeet-inbox-ack-cli-db4d68cad999/verdict.json

---

## Provenance

- Branch: <code>feat/yeet-inbox-ack-cli</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/yeet-inbox-ack-cli",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789591059&installation_model_id=424656&pr_number=759&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F759&signature=94c434c6d3a947acd7c75886430034b775a31dc707e609f1b754aec68b63491d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->