### PR TITLE
feat(goals): packet-core P3 rung 2 — full trace projection

### DIFF
--- a/.changeset/packet-core-full-trace.md
+++ b/.changeset/packet-core-full-trace.md
@@ -1,0 +1,10 @@
+---
+"@beep/repo-cli": minor
+---
+
+Ship the full packet trace projection: `ops/trace.json` now carries the
+event timeline of the unambiguous linear prefix (`PacketTraceEntry` with
+each event's body embedded verbatim) alongside the derived state. First
+`PACKET_PROJECTOR_VERSION` bump (1 → 2): committed v1 traces retire by
+decode failure and regenerate from the stream — projections are disposable
+derived copies, never upcast.

--- a/goals/packet-control-plane-core/PLAN.md
+++ b/goals/packet-control-plane-core/PLAN.md
@@ -72,6 +72,20 @@ P1 fixtures are byte-identical — proved by the untouched golden fixtures plus
 a new `risk-override` replay fixture. Self-hosted per D9: this packet's own
 stream carries the first live override (event 3, tier `standard`).
 
+**Rung 2 — full trace projection (COMPLETE 2026-08-17).** The PLAN phrase is
+interpreted (and recorded here) as: the projection carries the packet's full
+event timeline, not just the terminal derived state. `PacketTraceEntry`
+embeds each linear-prefix event verbatim (seq, digest, timestamp, actor,
+body); events past a fork stay out of the timeline and surface through fork
+verdicts. This is the first real `PACKET_PROJECTOR_VERSION` bump (1 → 2):
+every previously valid trace changes bytes, so committed v1 traces retire by
+decode failure — projections are disposable derived copies, regenerated from
+the stream, never upcast (`schemaVersion` stays `packet-trace/v1`; the
+projector version is the evolution axis for traces). Proof: regenerated
+byte-exact expected traces for both fixtures, a committed
+`expected-trace.v1.json` retirement witness, and the live packet's
+regenerated `ops/trace.json` (fresh under `beep explore --check`).
+
 ## P4 — Yeet: PR to mergeable
 
 `bun run beep yeet repair → verify → publish --pr → monitor` until
@@ -95,7 +109,7 @@ merely to pass this packet.
 
 ## Current blockers
 
-None. P1, P2, and P3 rung 1 (risk-tier floor/override) shipped 2026-08-17;
-the remaining P3 rungs (full trace projection, fork-repair plan surface, and
-the queued idempotent-skip refinement for self-transitions) are startable —
-one small PR per rung.
+None. P1, P2, and P3 rungs 1–2 (risk-tier floor/override; full trace
+projection) shipped 2026-08-17; the remaining P3 rungs (fork-repair plan
+surface, and the queued idempotent-skip refinement for self-transitions) are
+startable — one small PR per rung.

--- a/goals/packet-control-plane-core/ops/trace.json
+++ b/goals/packet-control-plane-core/ops/trace.json
@@ -20,10 +20,46 @@
       "seq": 3
     }
   },
-  "projectorVersion": 1,
+  "projectorVersion": 2,
   "schemaVersion": "packet-trace/v1",
   "sourceTip": {
     "id": "4e844bca346947cef93244e45e2353b1b7a7a6d3fc691613075a876fd00e2344",
     "seq": 3
-  }
+  },
+  "timeline": [
+    {
+      "actor": "operator",
+      "at": "2026-08-17T15:13:10.305Z",
+      "body": {
+        "ordinal": 1,
+        "stage": "P1",
+        "status": "active",
+        "type": "packet-created"
+      },
+      "id": "44c68c33af36948157d827cf2b053336770f277666b1069cc8c9857085d5eb45",
+      "seq": 1
+    },
+    {
+      "actor": "operator",
+      "at": "2026-08-17T15:13:10.305Z",
+      "body": {
+        "previous": "active",
+        "status": "active",
+        "type": "status-set"
+      },
+      "id": "6a94f9dd8fff717256700085ffb3540dd54da38fcdf7297be82e94ea6ddaedf9",
+      "seq": 2
+    },
+    {
+      "actor": "operator",
+      "at": "2026-08-17T19:57:46.844Z",
+      "body": {
+        "reason": "D9 self-hosting pilot: first live override through the new writer; standard fits the multi-PR guarded-writer scope",
+        "tier": "standard",
+        "type": "risk-tier-overridden"
+      },
+      "id": "4e844bca346947cef93244e45e2353b1b7a7a6d3fc691613075a876fd00e2344",
+      "seq": 3
+    }
+  ]
 }

--- a/packages/tooling/tool/cli/src/commands/Explore/Check.ts
+++ b/packages/tooling/tool/cli/src/commands/Explore/Check.ts
@@ -28,7 +28,11 @@ import {
 } from "../Goals/PacketCore/PacketFold.ts";
 import { PACKET_TRACE_SEGMENTS } from "../Goals/PacketCore/PacketTransitionWriter.ts";
 import type { GoalDoctorFindingKind } from "../Goals/Doctor.ts";
-import type { PacketDerivedState, PacketTraceProjection } from "../Goals/PacketCore/PacketCore.schemas.ts";
+import type {
+  PacketDerivedState,
+  PacketTraceProjection,
+  StoredPacketEvent,
+} from "../Goals/PacketCore/PacketCore.schemas.ts";
 
 const finding = (slug: string, kind: GoalDoctorFindingKind, message: string, keySuffix = ""): GoalDoctorFinding =>
   GoalDoctorFinding.make({
@@ -52,7 +56,8 @@ const derivedSummary = (root: string, slug: string, derived: PacketDerivedState)
 const traceFindings = Effect.fn("Explore.traceFindings")(function* (
   packetPath: string,
   slug: string,
-  derived: PacketDerivedState
+  derived: PacketDerivedState,
+  events: ReadonlyArray<StoredPacketEvent>
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -91,7 +96,7 @@ const traceFindings = Effect.fn("Explore.traceFindings")(function* (
   }
   // The trace is a whole-file derivation: any byte drift from the re-rendered
   // projection (not just a moved sourceTip) means the committed copy lies.
-  const rendered = yield* renderPacketTraceFile(projectPacketTrace(derived)).pipe(
+  const rendered = yield* renderPacketTraceFile(projectPacketTrace(derived, events)).pipe(
     Effect.map(O.some),
     Effect.orElseSucceed(O.none<string>)
   );
@@ -131,7 +136,7 @@ const streamFindings = Effect.fn("Explore.streamFindings")(function* (
       )
     );
   }
-  findings = A.appendAll(findings, yield* traceFindings(packetPath, slug, derived));
+  findings = A.appendAll(findings, yield* traceFindings(packetPath, slug, derived, listing.events));
   return { derived, findings };
 });
 

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketCore.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketCore.schemas.ts
@@ -1165,22 +1165,73 @@ export class PacketDerivedState extends S.Class<PacketDerivedState>($I`PacketDer
  *
  * The version bumps only when the projector renders different bytes for a
  * previously valid stream. Additive derivations that stay absent on old
- * streams (for example the risk-tier override) keep the version: streams
- * containing the new event types do not decode under older projectors at
- * all, so no two projector versions ever disagree about the same stream.
+ * streams (for example the risk-tier override) keep the version; version 2
+ * added the required event timeline to every projection, changing the bytes
+ * of every previously valid trace, so committed v1 traces retire by failing
+ * the v2 decode (reported as stale) and regenerate on the next write.
+ * Projections are disposable derived copies — stale traces are regenerated
+ * from the stream, never upcast.
  *
  * **Example** (Read the projector version)
  *
  * ```ts
  * import { PACKET_PROJECTOR_VERSION } from "@beep/repo-cli/test/Goals"
  *
- * console.log(PACKET_PROJECTOR_VERSION) // 1
+ * console.log(PACKET_PROJECTOR_VERSION) // 2
  * ```
  *
  * @category configuration
  * @since 0.0.0
  */
-export const PACKET_PROJECTOR_VERSION = 1;
+export const PACKET_PROJECTOR_VERSION = 2;
+
+/**
+ * One event on the projected timeline of a packet trace.
+ *
+ * **Details**
+ *
+ * Timeline entries cover the unambiguous linear prefix only — events past a
+ * fork are ambiguous history and ride in the fork verdicts instead. The full
+ * event body is embedded verbatim: projections are disposable derived
+ * copies, so duplicating recorded content is free fidelity.
+ *
+ * **Example** (Construct a timeline entry)
+ *
+ * ```ts
+ * import { PacketTraceEntry } from "@beep/repo-cli/test/Goals"
+ *
+ * const entry = PacketTraceEntry.make({
+ *   seq: 1,
+ *   id: "0".repeat(64),
+ *   at: "2026-08-17T00:00:00.000Z",
+ *   actor: "operator",
+ *   body: { type: "packet-created", status: "active" },
+ * })
+ * console.log(entry.seq) // 1
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class PacketTraceEntry extends S.Class<PacketTraceEntry>($I`PacketTraceEntry`)(
+  {
+    seq: S.Int.check(
+      S.isGreaterThanOrEqualTo(1, {
+        identifier: $I`PacketTraceEntrySeqRangeCheck`,
+        title: "Packet Trace Entry Seq Range",
+        description: "Timeline entries carry their event's positive sequence number.",
+        message: "Expected a positive integer sequence number",
+      })
+    ),
+    id: PacketEventId,
+    at: PacketEventTimestamp,
+    actor: PacketEventActor,
+    body: PacketEventBody,
+  },
+  $I.annote("PacketTraceEntry", {
+    description: "One linear-prefix event on the projected packet timeline, body embedded verbatim.",
+  })
+) {}
 
 /**
  * Read-only trace projection of one packet stream.
@@ -1190,8 +1241,9 @@ export const PACKET_PROJECTOR_VERSION = 1;
  * The projection binds its `sourceTip` and `projectorVersion` so staleness is
  * always derivable: a committed trace whose source tip no longer matches the
  * folded stream (or whose projector version is outdated) is stale, never
- * silently trusted. The rendered file embeds no timestamps, so identical
- * streams project byte-identical traces.
+ * silently trusted. The rendered file reads no clock — timeline timestamps
+ * are recorded event data — so identical streams project byte-identical
+ * traces.
  *
  * **Example** (Construct a projection for an empty stream)
  *
@@ -1200,10 +1252,11 @@ export const PACKET_PROJECTOR_VERSION = 1;
  *
  * const trace = PacketTraceProjection.make({
  *   schemaVersion: "packet-trace/v1",
- *   projectorVersion: 1,
+ *   projectorVersion: 2,
+ *   timeline: [],
  *   derived: PacketDerivedState.make({ packet: "demo", root: "goals", revision: 0, forks: [], issues: [] }),
  * })
- * console.log(trace.projectorVersion) // 1
+ * console.log(trace.projectorVersion) // 2
  * ```
  *
  * @category models
@@ -1221,6 +1274,7 @@ export class PacketTraceProjection extends S.Class<PacketTraceProjection>($I`Pac
       })
     ),
     sourceTip: S.optionalKey(PacketTip),
+    timeline: S.Array(PacketTraceEntry),
     derived: PacketDerivedState,
   },
   $I.annote("PacketTraceProjection", {

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketFold.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketFold.ts
@@ -31,6 +31,7 @@ import {
   PacketForkVerdict,
   PacketRiskTierOverrideState,
   PacketTip,
+  PacketTraceEntry,
   PacketTraceProjection,
 } from "./PacketCore.schemas.ts";
 import { canonicalJsonTextPretty } from "./PacketDigest.ts";
@@ -335,30 +336,60 @@ export const foldPacketEvents = (input: {
   });
 };
 
+const timelineOf = (events: ReadonlyArray<StoredPacketEvent>): ReadonlyArray<PacketTraceEntry> => {
+  const sorted = A.sort(events, storedBySeqThenId);
+  const { prefix } = walkLinearPrefix(buildChildIndex(sorted));
+  return A.map(prefix, (stored) =>
+    PacketTraceEntry.make({
+      seq: stored.event.seq,
+      id: stored.id,
+      at: stored.event.at,
+      actor: stored.event.actor,
+      body: stored.event.body,
+    })
+  );
+};
+
 /**
- * Project a derived state into the read-only trace projection.
+ * Project a derived state plus its stored events into the trace projection.
+ *
+ * **Details**
+ *
+ * The projection carries the full event timeline of the unambiguous linear
+ * prefix alongside the derived state, so a committed `ops/trace.json` shows
+ * the packet's history without parsing CAS files. Events past a fork are
+ * excluded from the timeline — they are ambiguous history and surface
+ * through the derived state's fork verdicts instead.
  *
  * **Example** (Project an empty stream)
  *
  * ```ts
  * import { foldPacketEvents, projectPacketTrace } from "@beep/repo-cli/test/Goals"
  *
- * const trace = projectPacketTrace(foldPacketEvents({ packet: "demo", root: "goals", events: [] }))
+ * const trace = projectPacketTrace(foldPacketEvents({ packet: "demo", root: "goals", events: [] }), [])
  * console.log(trace.schemaVersion) // "packet-trace/v1"
  * ```
  *
  * @param derived - Fold result to project.
+ * @param events - Stored events the fold consumed; the timeline source.
  * @returns The trace projection bound to the fold's tip and projector version.
  * @category folding
  * @since 0.0.0
  */
-export const projectPacketTrace = (derived: PacketDerivedState): PacketTraceProjection =>
-  PacketTraceProjection.make({
-    schemaVersion: "packet-trace/v1",
-    projectorVersion: PACKET_PROJECTOR_VERSION,
-    ...optionalProp("sourceTip", O.fromUndefinedOr(derived.tip)),
-    derived,
-  });
+export const projectPacketTrace: {
+  (derived: PacketDerivedState, events: ReadonlyArray<StoredPacketEvent>): PacketTraceProjection;
+  (events: ReadonlyArray<StoredPacketEvent>): (derived: PacketDerivedState) => PacketTraceProjection;
+} = dual(
+  2,
+  (derived: PacketDerivedState, events: ReadonlyArray<StoredPacketEvent>): PacketTraceProjection =>
+    PacketTraceProjection.make({
+      schemaVersion: "packet-trace/v1",
+      projectorVersion: PACKET_PROJECTOR_VERSION,
+      ...optionalProp("sourceTip", O.fromUndefinedOr(derived.tip)),
+      timeline: timelineOf(events),
+      derived,
+    })
+);
 
 /**
  * Decide whether a committed trace projection is stale against a fresh fold.
@@ -376,7 +407,7 @@ export const projectPacketTrace = (derived: PacketDerivedState): PacketTraceProj
  * import { foldPacketEvents, packetTraceIsStale, projectPacketTrace } from "@beep/repo-cli/test/Goals"
  *
  * const derived = foldPacketEvents({ packet: "demo", root: "goals", events: [] })
- * console.log(packetTraceIsStale(projectPacketTrace(derived), derived)) // false
+ * console.log(packetTraceIsStale(projectPacketTrace(derived, []), derived)) // false
  * ```
  *
  * @param trace - Committed trace projection.
@@ -414,7 +445,7 @@ const encodePacketTrace = S.encodeUnknownEffect(PacketTraceProjection);
  * import { foldPacketEvents, projectPacketTrace, renderPacketTraceFile } from "@beep/repo-cli/test/Goals"
  * import { Effect } from "effect"
  *
- * const trace = projectPacketTrace(foldPacketEvents({ packet: "demo", root: "goals", events: [] }))
+ * const trace = projectPacketTrace(foldPacketEvents({ packet: "demo", root: "goals", events: [] }), [])
  * console.log(Effect.isEffect(renderPacketTraceFile(trace))) // true
  * ```
  *

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketTransitionWriter.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketTransitionWriter.ts
@@ -572,7 +572,7 @@ const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(func
     }
     const listing = yield* store.list(locator);
     const derived = foldPacketEvents({ packet: locator.packet, root: locator.root, events: listing.events });
-    const traceText = yield* renderPacketTraceFile(projectPacketTrace(derived)).pipe(
+    const traceText = yield* renderPacketTraceFile(projectPacketTrace(derived, listing.events)).pipe(
       Effect.mapError(streamErrorFromSchema(locator.packet, "trace projection could not be rendered"))
     );
     yield* fs

--- a/packages/tooling/tool/cli/test/explore-check.test.ts
+++ b/packages/tooling/tool/cli/test/explore-check.test.ts
@@ -92,7 +92,7 @@ describe("explore --check", () => {
             const soloId = yield* writeEvent("goals/solo", solo);
             yield* writeProjectFile(
               "goals/solo/ops/trace.json",
-              `{"schemaVersion":"packet-trace/v1","projectorVersion":1,"sourceTip":{"seq":9,"id":"${"c".repeat(64)}"},"derived":{"packet":"solo","root":"goals","revision":9,"forks":[],"issues":[]}}\n`
+              `{"schemaVersion":"packet-trace/v1","projectorVersion":2,"sourceTip":{"seq":9,"id":"${"c".repeat(64)}"},"timeline":[],"derived":{"packet":"solo","root":"goals","revision":9,"forks":[],"issues":[]}}\n`
             );
 
             // Third stream: healthy events with the byte-exact derived trace.
@@ -107,20 +107,21 @@ describe("explore --check", () => {
               body: { type: "packet-created", status: "active", stage: "P0", ordinal: 0 },
             });
             const healthyId = yield* writeEvent("goals/sound", healthy);
+            const healthyStored = [
+              StoredPacketEvent.make({
+                id: healthyId,
+                fileName: packetEventFileName(healthy, healthyId),
+                event: healthy,
+              }),
+            ];
             const healthyDerived = foldPacketEvents({
               packet: "sound",
               root: "goals",
-              events: [
-                StoredPacketEvent.make({
-                  id: healthyId,
-                  fileName: packetEventFileName(healthy, healthyId),
-                  event: healthy,
-                }),
-              ],
+              events: healthyStored,
             });
             yield* writeProjectFile(
               "goals/sound/ops/trace.json",
-              yield* renderPacketTraceFile(projectPacketTrace(healthyDerived))
+              yield* renderPacketTraceFile(projectPacketTrace(healthyDerived, healthyStored))
             );
 
             // Fourth stream: trace that is not JSON at all.
@@ -161,12 +162,13 @@ describe("explore --check", () => {
               body: { type: "packet-created", status: "active", stage: "P0", ordinal: 0 },
             });
             const id = yield* writeEvent("goals/drift", event);
+            const driftStored = [StoredPacketEvent.make({ id, fileName: packetEventFileName(event, id), event })];
             const derived = foldPacketEvents({
               packet: "drift",
               root: "goals",
-              events: [StoredPacketEvent.make({ id, fileName: packetEventFileName(event, id), event })],
+              events: driftStored,
             });
-            const traceText = yield* renderPacketTraceFile(projectPacketTrace(derived));
+            const traceText = yield* renderPacketTraceFile(projectPacketTrace(derived, driftStored));
             // sourceTip stays intact; the derived body is tampered.
             yield* writeProjectFile(
               "goals/drift/ops/trace.json",

--- a/packages/tooling/tool/cli/test/fixtures/packet-core/golden-linear/expected-trace.json
+++ b/packages/tooling/tool/cli/test/fixtures/packet-core/golden-linear/expected-trace.json
@@ -14,10 +14,68 @@
       "seq": 5
     }
   },
-  "projectorVersion": 1,
+  "projectorVersion": 2,
   "schemaVersion": "packet-trace/v1",
   "sourceTip": {
     "id": "3e504c4d293fc7e27c30e64f82d98b5a6d90c0d3f6dc7d433e387a7c0c514056",
     "seq": 5
-  }
+  },
+  "timeline": [
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T00:00:00.000Z",
+      "body": {
+        "ordinal": 0,
+        "stage": "capture",
+        "status": "active",
+        "type": "packet-created"
+      },
+      "id": "38d88c5951f93fb4b2eb4434cc1e4d8efafb73e45a85d1dd2a94d157be1017a2",
+      "seq": 1
+    },
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T00:01:00.000Z",
+      "body": {
+        "ordinal": 2,
+        "stage": "align",
+        "type": "stage-entered"
+      },
+      "id": "9c4b05e565ffcdb126daa56e0c173bda6f7b252e56e36d90dd3a145816ab180e",
+      "seq": 2
+    },
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T00:02:00.000Z",
+      "body": {
+        "ordinal": 4,
+        "stage": "decompose",
+        "type": "stage-entered"
+      },
+      "id": "a73044b02e0cce8100ddc670f989ece8bdb9922c75bcdaf0d3b337f9acc4cdf1",
+      "seq": 3
+    },
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T00:03:00.000Z",
+      "body": {
+        "ordinal": 2,
+        "stage": "align",
+        "type": "stage-entered"
+      },
+      "id": "1632ff0221f3fee4db3fd86f6f436c6ae2d7b7054adae15dcf29d67cfaee2086",
+      "seq": 4
+    },
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T00:04:00.000Z",
+      "body": {
+        "previous": "active",
+        "status": "paused",
+        "type": "status-set"
+      },
+      "id": "3e504c4d293fc7e27c30e64f82d98b5a6d90c0d3f6dc7d433e387a7c0c514056",
+      "seq": 5
+    }
+  ]
 }

--- a/packages/tooling/tool/cli/test/fixtures/packet-core/golden-linear/expected-trace.v1.json
+++ b/packages/tooling/tool/cli/test/fixtures/packet-core/golden-linear/expected-trace.v1.json
@@ -1,0 +1,23 @@
+{
+  "derived": {
+    "forks": [],
+    "furthestOrdinal": 4,
+    "furthestStage": "decompose",
+    "issues": [],
+    "packet": "golden-linear",
+    "resumeStage": "align",
+    "revision": 5,
+    "root": "goals",
+    "status": "paused",
+    "tip": {
+      "id": "3e504c4d293fc7e27c30e64f82d98b5a6d90c0d3f6dc7d433e387a7c0c514056",
+      "seq": 5
+    }
+  },
+  "projectorVersion": 1,
+  "schemaVersion": "packet-trace/v1",
+  "sourceTip": {
+    "id": "3e504c4d293fc7e27c30e64f82d98b5a6d90c0d3f6dc7d433e387a7c0c514056",
+    "seq": 5
+  }
+}

--- a/packages/tooling/tool/cli/test/fixtures/packet-core/risk-override/expected-trace.json
+++ b/packages/tooling/tool/cli/test/fixtures/packet-core/risk-override/expected-trace.json
@@ -20,10 +20,58 @@
       "seq": 4
     }
   },
-  "projectorVersion": 1,
+  "projectorVersion": 2,
   "schemaVersion": "packet-trace/v1",
   "sourceTip": {
     "id": "63470dd7c36713896c713874bda75f9e8a76017d170feeea4117b8b2e715aeae",
     "seq": 4
-  }
+  },
+  "timeline": [
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T12:00:00.000Z",
+      "body": {
+        "ordinal": 0,
+        "stage": "capture",
+        "status": "active",
+        "type": "packet-created"
+      },
+      "id": "c73b13cafa3c37e91881ef2e140493820ead38fb67fe87df25651df687f873a3",
+      "seq": 1
+    },
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T12:05:00.000Z",
+      "body": {
+        "ordinal": 2,
+        "stage": "align",
+        "type": "stage-entered"
+      },
+      "id": "7aaaecfd176bd9bc19789ba324adbdeabec91f3517cec1eba8189cba3986ac0f",
+      "seq": 2
+    },
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T12:10:00.000Z",
+      "body": {
+        "reason": "fixture: initial operator override",
+        "tier": "standard",
+        "type": "risk-tier-overridden"
+      },
+      "id": "2c60eae90066873535cb1dbd2e4a4c2ce823be380b9bf8a69d32ca9a9c1089a7",
+      "seq": 3
+    },
+    {
+      "actor": "fixture",
+      "at": "2026-08-17T12:15:00.000Z",
+      "body": {
+        "previous": "standard",
+        "reason": "fixture: raised after scope review",
+        "tier": "full",
+        "type": "risk-tier-overridden"
+      },
+      "id": "63470dd7c36713896c713874bda75f9e8a76017d170feeea4117b8b2e715aeae",
+      "seq": 4
+    }
+  ]
 }

--- a/packages/tooling/tool/cli/test/goals-packet-core.test.ts
+++ b/packages/tooling/tool/cli/test/goals-packet-core.test.ts
@@ -378,7 +378,7 @@ describe("golden replay (committed fixture)", () => {
           // upcast — it fails the v2 decode, explore --check reports it as
           // packet-trace-stale, and the next write regenerates it.
           const v1Text = yield* fs.readFileString(`${GOLDEN_PATH}/expected-trace.v1.json`);
-          const decoded = yield* Effect.exit(S.decodeUnknownEffect(S.fromJsonString(PacketTraceProjection))(v1Text));
+          const decoded = yield* Effect.exit(S.decodeEffect(S.fromJsonString(PacketTraceProjection))(v1Text));
           expect(Exit.isFailure(decoded)).toBe(true);
 
           const v2Text = yield* fs.readFileString(`${GOLDEN_PATH}/expected-trace.json`);

--- a/packages/tooling/tool/cli/test/goals-packet-core.test.ts
+++ b/packages/tooling/tool/cli/test/goals-packet-core.test.ts
@@ -325,7 +325,7 @@ describe("golden replay (committed fixture)", () => {
           expect(derived.issues).toStrictEqual([]);
 
           const expectedTrace = yield* fs.readFileString(`${GOLDEN_PATH}/expected-trace.json`);
-          const renderedTrace = yield* renderPacketTraceFile(projectPacketTrace(derived));
+          const renderedTrace = yield* renderPacketTraceFile(projectPacketTrace(derived, listing.events));
           expect(renderedTrace).toBe(expectedTrace);
 
           const expectedDerived = yield* fs.readFileString(`${GOLDEN_PATH}/expected-derived.json`);
@@ -357,12 +357,34 @@ describe("golden replay (committed fixture)", () => {
           expect(derived.issues).toStrictEqual([]);
 
           const expectedTrace = yield* fs.readFileString(`${RISK_OVERRIDE_PATH}/expected-trace.json`);
-          const renderedTrace = yield* renderPacketTraceFile(projectPacketTrace(derived));
+          const renderedTrace = yield* renderPacketTraceFile(projectPacketTrace(derived, listing.events));
           expect(renderedTrace).toBe(expectedTrace);
 
           const expectedDerived = yield* fs.readFileString(`${RISK_OVERRIDE_PATH}/expected-derived.json`);
           const encodedDerived = yield* S.encodeUnknownEffect(PacketDerivedState)(derived);
           expect(canonicalJsonTextPretty(encodedDerived)).toBe(expectedDerived);
+        }).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+
+  it(
+    "retires the committed v1 trace: stale by decode under the v2 projector, bytes changed",
+    () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          // Projections are disposable derived copies: a v1 trace is never
+          // upcast — it fails the v2 decode, explore --check reports it as
+          // packet-trace-stale, and the next write regenerates it.
+          const v1Text = yield* fs.readFileString(`${GOLDEN_PATH}/expected-trace.v1.json`);
+          const decoded = yield* Effect.exit(S.decodeUnknownEffect(S.fromJsonString(PacketTraceProjection))(v1Text));
+          expect(Exit.isFailure(decoded)).toBe(true);
+
+          const v2Text = yield* fs.readFileString(`${GOLDEN_PATH}/expected-trace.json`);
+          expect(v2Text).not.toBe(v1Text);
+          expect(v2Text).toContain('"timeline"');
+          expect(v2Text).toContain('"projectorVersion": 2');
         }).pipe(provideScopedLayer(testLayer))
       ),
     20_000
@@ -384,6 +406,12 @@ describe("golden replay (committed fixture)", () => {
           expect(derived.forks[0]?.parentSeq).toBe(2);
           expect(derived.forks[0]?.children.length).toBe(2);
           expect(derived.revision).toBe(2);
+
+          // The timeline stops at the unambiguous prefix: both seq-3 children
+          // are ambiguous history and must not project.
+          const trace = projectPacketTrace(derived, listing.events);
+          expect(A.length(trace.timeline)).toBe(2);
+          expect(A.map(trace.timeline, (entry) => entry.seq)).toStrictEqual([1, 2]);
 
           const tipId = O.getOrUndefined(O.map(O.fromUndefinedOr(derived.tip), (tip) => tip.id));
           const next = PacketEvent.make({
@@ -526,12 +554,12 @@ describe("packetTraceIsStale", () => {
             { body: { type: "packet-created", status: "active" }, at: "2026-08-17T00:00:00.000Z" },
           ]);
           const derived = foldPacketEvents({ packet: "demo", root: "goals", events });
-          const fresh = projectPacketTrace(derived);
+          const fresh = projectPacketTrace(derived, events);
           expect(packetTraceIsStale(fresh, derived)).toBe(false);
 
           const emptyDerived = foldPacketEvents({ packet: "demo", root: "goals", events: [] });
           expect(packetTraceIsStale(fresh, emptyDerived)).toBe(true);
-          expect(packetTraceIsStale(projectPacketTrace(emptyDerived), derived)).toBe(true);
+          expect(packetTraceIsStale(projectPacketTrace(emptyDerived, []), derived)).toBe(true);
 
           const outdated = PacketTraceProjection.make({ ...fresh, projectorVersion: fresh.projectorVersion + 1 });
           expect(packetTraceIsStale(outdated, derived)).toBe(true);

--- a/packages/tooling/tool/cli/test/goals-packet-core.test.ts
+++ b/packages/tooling/tool/cli/test/goals-packet-core.test.ts
@@ -20,13 +20,13 @@ import {
   StoredPacketEvent,
   upcastPacketEventJson,
 } from "@beep/repo-cli/test/Goals";
-import { provideScopedLayer } from "@beep/test-utils";
+import { fcRuns, provideScopedLayer } from "@beep/test-utils";
 import { NodeServices } from "@effect/platform-node";
 import { Cause, Effect, Exit, FileSystem, Layer } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
-import * as fc from "fast-check";
+import { FastCheck as fc } from "effect/testing";
 import { describe, expect, it } from "vitest";
 
 const testLayer = Layer.mergeAll(NodeServices.layer, PacketEventStoreLive.pipe(Layer.provideMerge(NodeServices.layer)));
@@ -137,7 +137,7 @@ describe("schema-derived properties", () => {
         const reencoded = encodeTraceEntry(decodeTraceEntry(encoded));
         return canonicalJsonText(reencoded) === canonicalJsonText(encoded);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/tooling/tool/cli/test/goals-packet-core.test.ts
+++ b/packages/tooling/tool/cli/test/goals-packet-core.test.ts
@@ -8,6 +8,7 @@ import {
   PacketEventStore,
   PacketEventStoreLive,
   PacketStreamLocator,
+  PacketTraceEntry,
   PacketTraceProjection,
   packetEventDigest,
   packetEventFileName,
@@ -25,6 +26,7 @@ import { Cause, Effect, Exit, FileSystem, Layer } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
+import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
 const testLayer = Layer.mergeAll(NodeServices.layer, PacketEventStoreLive.pipe(Layer.provideMerge(NodeServices.layer)));
@@ -120,6 +122,23 @@ describe("canonical encoding and digests", () => {
     expect(upcastPacketEventJson(unknownVersion)).toBe(unknownVersion);
     expect(upcastPacketEventJson("scalar")).toBe("scalar");
     expect("packet-event/v1" in PACKET_EVENT_UPCASTERS).toBe(true);
+  });
+});
+
+describe("schema-derived properties", () => {
+  const PacketTraceEntryArbitrary = S.toArbitrary(PacketTraceEntry)(fc);
+  const encodeTraceEntry = S.encodeUnknownSync(PacketTraceEntry);
+  const decodeTraceEntry = S.decodeUnknownSync(PacketTraceEntry);
+
+  it("round-trips arbitrary timeline entries through encode/decode byte-stably", () => {
+    fc.assert(
+      fc.property(PacketTraceEntryArbitrary, (entry) => {
+        const encoded = encodeTraceEntry(entry);
+        const reencoded = encodeTraceEntry(decodeTraceEntry(encoded));
+        return canonicalJsonText(reencoded) === canonicalJsonText(encoded);
+      }),
+      { numRuns: 50 }
+    );
   });
 });
 


### PR DESCRIPTION
P3 rung 2 of `goals/packet-control-plane-core`: the full trace projection. The P1 trace carried
only the terminal derived state; `ops/trace.json` now also carries the packet's event timeline, so
a reader gets the packet's history without parsing CAS files. The interpretation of the PLAN's
"full trace projection" phrase is recorded in the PLAN rung-2 note.

## What

- **`PacketTraceEntry`**: one timeline entry per linear-prefix event — seq, digest, timestamp,
  actor, and the event body embedded verbatim (projections are disposable derived copies, so
  duplicating recorded content is free fidelity). Events past a fork stay out of the timeline and
  surface through fork verdicts instead.
- **`PACKET_PROJECTOR_VERSION` 1 → 2** — the first real bump, exercising the documented policy:
  the timeline is required, so every previously valid trace changes bytes. Committed v1 traces
  retire by failing the v2 decode (`explore --check` reports `packet-trace-stale`) and regenerate
  from the stream — never upcast. `schemaVersion` stays `packet-trace/v1`; the projector version
  is the evolution axis for traces.
- **`projectPacketTrace(derived, events)`** — gained the events parameter (dual overloads); the
  writer and the explore check both render from the same listing, byte-deterministically.

## Proof

- Fixture `expected-trace.json` files regenerated byte-exact for both replay fixtures; committed
  `golden-linear/expected-trace.v1.json` is the retirement witness (decode-failure test + byte
  change pinned).
- Fork-cutoff pinned: the fork-fixture test projects the trace and asserts the timeline stops at
  the unambiguous prefix (`[1, 2]`) — a projector including post-fork events fails.
- A schema-derived property (`S.toArbitrary` via `effect/testing` FastCheck, `fcRuns(50)`)
  round-trips arbitrary timeline entries byte-stably.
- The live packet's own `ops/trace.json` regenerated under v2 and fresh under
  `beep explore --check` (revision 3, timeline includes the risk-tier override).
- An independent Codex adversarial review ran over the staged diff; its confirmed finding
  (fork-cutoff untested) and both advisories (version-doc wording; the stale-sourceTip fixture
  no longer reaching the tip-comparison branch) are fixed in this PR.
- Full local `yeet verify`: all lanes green on this exact tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789600349&installation_model_id=424656&pr_number=763&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F763&signature=e7f0c64684c7b518f6f47d35f14edea598096d431a27297e92ef4eb665e3b72b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->