### PR TITLE
fix(quality): stabilize nightly property-law sweep flake classes

### DIFF
--- a/.changeset/nightly-property-lane-677.md
+++ b/.changeset/nightly-property-lane-677.md
@@ -1,0 +1,14 @@
+---
+"@beep/md": patch
+"@beep/tika": patch
+---
+
+Stabilize the nightly property-law sweep (issue #677) against its two recurring
+failure classes. `@beep/md` bounds the five recursive Markdown child-list
+schemas with an arbitrary-only `maxLength` hint, so schema-derived generation
+of `Document`-bearing models stays inside the nightly 1000-run budget without
+constraining decoded documents. `@beep/tika` moves `TikaError` equivalence into
+the schema declaration as a fields-only `toEquivalence` annotation, replacing
+the `Equal.equals` declaration fallback that compared non-schema `Error`
+runtime metadata and failed round-trip laws seed-dependently; the property test
+now validates the public comparator directly instead of a test-local override.

--- a/packages/drivers/tika/src/Tika.errors.ts
+++ b/packages/drivers/tika/src/Tika.errors.ts
@@ -90,6 +90,26 @@ export class TikaErrorOptions extends S.Class<TikaErrorOptions>($I`TikaErrorOpti
   })
 ) {}
 
+const TikaErrorFields = {
+  cause: S.OptionFromOptionalKey(S.String).pipe(
+    SchemaUtils.withNoneDefault,
+    S.annotateKey({
+      description: "Sanitized technical cause string when one is safe to retain.",
+    })
+  ),
+  reason: TikaErrorReason.annotateKey({
+    description: "Redacted technical error reason.",
+  }),
+  statusCode: S.OptionFromOptionalKey(NonNegativeInt).pipe(
+    SchemaUtils.withNoneDefault,
+    S.annotateKey({
+      description: "HTTP or process status code associated with the Tika failure when one was available.",
+    })
+  ),
+} satisfies S.Struct.Fields;
+const sameTikaErrorFields = S.toEquivalence(S.TaggedStruct("TikaError", TikaErrorFields));
+const sameTikaError = (self: TikaError, that: TikaError): boolean => sameTikaErrorFields(self, that);
+
 /**
  * Technical failure raised inside the Tika driver boundary.
  *
@@ -107,25 +127,10 @@ export class TikaErrorOptions extends S.Class<TikaErrorOptions>($I`TikaErrorOpti
  */
 export class TikaError extends S.TaggedError<TikaError>($I`TikaError`)(
   "TikaError",
-  {
-    cause: S.OptionFromOptionalKey(S.String).pipe(
-      SchemaUtils.withNoneDefault,
-      S.annotateKey({
-        description: "Sanitized technical cause string when one is safe to retain.",
-      })
-    ),
-    reason: TikaErrorReason.annotateKey({
-      description: "Redacted technical error reason.",
-    }),
-    statusCode: S.OptionFromOptionalKey(NonNegativeInt).pipe(
-      SchemaUtils.withNoneDefault,
-      S.annotateKey({
-        description: "HTTP or process status code associated with the Tika failure when one was available.",
-      })
-    ),
-  },
-  $I.annote("TikaError", {
+  TikaErrorFields,
+  $I.annoteClass<S.declare<TikaError>, readonly [S.TaggedStruct<"TikaError", typeof TikaErrorFields>]>("TikaError", {
     description: "Redacted technical failure raised inside the Tika driver boundary.",
+    toEquivalence: () => sameTikaError,
   })
 ) {
   /**

--- a/packages/drivers/tika/test/Tika.service.test.ts
+++ b/packages/drivers/tika/test/Tika.service.test.ts
@@ -20,7 +20,6 @@ const ExtractFileOperationArbitrary = S.toArbitrary(ExtractFileOperation)(fc);
 const TikaErrorReasonArbitrary = S.toArbitrary(TikaErrorReason)(fc);
 const TikaErrorOptionsArbitrary = S.toArbitrary(TikaErrorOptions)(fc);
 const TikaErrorArbitrary = S.toArbitrary(TikaError)(fc);
-const sameTikaErrorFields = S.toEquivalence(S.Struct(TikaError.fields));
 const encodeSourceArtifact = S.encodeEffect(SourceArtifact);
 const decodeSourceArtifact = S.decodeUnknownEffect(SourceArtifact);
 const encodeExtractFileOperation = S.encodeEffect(ExtractFileOperation);
@@ -32,16 +31,12 @@ const encode = <Codec extends S.Codec<unknown, unknown>>(schema: Codec, value: C
 const decode = <Codec extends S.Codec<unknown, unknown>>(schema: Codec, value: Codec["Encoded"]): Codec["Type"] =>
   Result.getOrThrow(S.decodeUnknownResult(schema)(value));
 
-const expectRoundTrip = <Codec extends S.Codec<unknown, unknown>>(
-  schema: Codec,
-  value: Codec["Type"],
-  equivalence: (self: Codec["Type"], that: Codec["Type"]) => boolean = S.toEquivalence(schema)
-): void => {
+const expectRoundTrip = <Codec extends S.Codec<unknown, unknown>>(schema: Codec, value: Codec["Type"]): void => {
   const encoded = encode(schema, value);
   const decoded = decode(schema, encoded);
 
   expect(encode(schema, decoded)).toEqual(encoded);
-  expect(equivalence(decoded, value)).toBe(true);
+  expect(S.toEquivalence(schema)(decoded, value)).toBe(true);
 };
 
 const fixtureIds = Effect.all({
@@ -120,7 +115,7 @@ describe("@beep/tika", () => {
 
           expectRoundTrip(TikaErrorReason, errorReason);
           expectRoundTrip(TikaErrorOptions, errorOptions);
-          expectRoundTrip(TikaError, error, sameTikaErrorFields);
+          expectRoundTrip(TikaError, error);
         }
       ),
       fcRuns(25)

--- a/packages/foundation/modeling/md/src/Md.model.ts
+++ b/packages/foundation/modeling/md/src/Md.model.ts
@@ -16,6 +16,18 @@ const $I = $MdId.create("Md.model");
 const codeFenceLanguagePattern = /^[A-Za-z0-9][A-Za-z0-9_+.-]*$/u;
 const youtubeVideoIdPattern = /^[A-Za-z0-9_-]{11}$/u;
 const footnoteIdentifierPattern = /^[A-Za-z0-9][A-Za-z0-9_.:-]*$/u;
+// This check never rejects a document. Effect's arbitrary compiler alone reads
+// the maxLength hint, keeping recursive child-list breadth bounded.
+const MarkdownArbitraryArraySizeHint = S.makeFilter<ReadonlyArray<unknown>>(() => true, {
+  identifier: $I`MarkdownArbitraryArraySizeHint`,
+  title: "Markdown arbitrary array size hint",
+  description: "Caps derived arbitrary child arrays at two elements without constraining decoded Markdown documents.",
+  arbitrary: {
+    constraint: {
+      maxLength: 2,
+    },
+  },
+});
 
 /**
  * Single safe Markdown fenced-code info-string token.
@@ -290,11 +302,13 @@ export type EmbedKind = typeof EmbedKind.Type;
  * @category models
  * @since 0.0.0
  */
-export const InlineChildren = S.Array(S.suspend((): S.Codec<Inline.Type, Inline.Encoded> => Inline)).pipe(
-  $I.annoteSchema("InlineChildren", {
-    description: "Recursive inline children used by Markdown inline container nodes.",
-  })
-);
+export const InlineChildren = S.Array(S.suspend((): S.Codec<Inline.Type, Inline.Encoded> => Inline))
+  .check(MarkdownArbitraryArraySizeHint)
+  .pipe(
+    $I.annoteSchema("InlineChildren", {
+      description: "Recursive inline children used by Markdown inline container nodes.",
+    })
+  );
 
 /**
  * Type for {@link InlineChildren}.
@@ -1192,11 +1206,13 @@ export declare namespace Inline {
  * @category models
  * @since 0.0.0
  */
-export const BlockChildren = S.Array(S.suspend((): S.Codec<Block.Type, Block.Encoded> => Block)).pipe(
-  $I.annoteSchema("BlockChildren", {
-    description: "Recursive block children used by Markdown block container nodes.",
-  })
-);
+export const BlockChildren = S.Array(S.suspend((): S.Codec<Block.Type, Block.Encoded> => Block))
+  .check(MarkdownArbitraryArraySizeHint)
+  .pipe(
+    $I.annoteSchema("BlockChildren", {
+      description: "Recursive block children used by Markdown block container nodes.",
+    })
+  );
 
 /**
  * Type for {@link BlockChildren}.
@@ -1334,11 +1350,13 @@ export declare namespace ListItemChild {
  * @category models
  * @since 0.0.0
  */
-export const ListItemChildren = S.Array(ListItemChild).pipe(
-  $I.annoteSchema("ListItemChildren", {
-    description: "Inline and block children rendered inside a Markdown list item.",
-  })
-);
+export const ListItemChildren = S.Array(ListItemChild)
+  .check(MarkdownArbitraryArraySizeHint)
+  .pipe(
+    $I.annoteSchema("ListItemChildren", {
+      description: "Inline and block children rendered inside a Markdown list item.",
+    })
+  );
 
 /**
  * Type for {@link ListItemChildren}.
@@ -1637,11 +1655,13 @@ export declare namespace Li {
  * @category models
  * @since 0.0.0
  */
-export const ListChildren = S.Array(Li).pipe(
-  $I.annoteSchema("ListChildren", {
-    description: "List item nodes used by ordered and unordered list blocks.",
-  })
-);
+export const ListChildren = S.Array(Li)
+  .check(MarkdownArbitraryArraySizeHint)
+  .pipe(
+    $I.annoteSchema("ListChildren", {
+      description: "List item nodes used by ordered and unordered list blocks.",
+    })
+  );
 
 /**
  * Type for {@link ListChildren}.
@@ -1945,11 +1965,13 @@ export type TaskListItemSpec = typeof TaskListItemSpec.Type;
  * @category models
  * @since 0.0.0
  */
-export const TaskItemChildren = S.Array(TaskItem).pipe(
-  $I.annoteSchema("TaskItemChildren", {
-    description: "Task item children used by GFM task list blocks.",
-  })
-);
+export const TaskItemChildren = S.Array(TaskItem)
+  .check(MarkdownArbitraryArraySizeHint)
+  .pipe(
+    $I.annoteSchema("TaskItemChildren", {
+      description: "Task item children used by GFM task list blocks.",
+    })
+  );
 
 /**
  * Type for {@link TaskItemChildren}.

--- a/packages/foundation/modeling/md/test/Md.test.ts
+++ b/packages/foundation/modeling/md/test/Md.test.ts
@@ -29,14 +29,19 @@ import {
 import { renderSafeHtml, safeHtmlValue } from "@beep/md/Md.html";
 import {
   Block,
+  BlockChildren,
   CodeFenceLanguage,
   Document,
   FootnoteIdentifier,
   Inline,
+  InlineChildren,
+  ListChildren,
+  ListItemChildren,
   Pre,
   Table,
   TableCell,
   TableRow,
+  TaskItemChildren,
   Text,
 } from "@beep/md/Md.model";
 import {
@@ -414,6 +419,26 @@ https://www.youtube.com/watch?v=M7lc1UVf-VE
       }),
       fcRuns(50)
     ));
+
+  it("bounds derived child-list arbitraries without constraining Markdown documents", () => {
+    const childListArbitrary = fc.oneof(
+      S.toArbitrary(InlineChildren)(fc),
+      S.toArbitrary(BlockChildren)(fc),
+      S.toArbitrary(ListItemChildren)(fc),
+      S.toArbitrary(ListChildren)(fc),
+      S.toArbitrary(TaskItemChildren)(fc)
+    );
+
+    fc.assert(
+      fc.property(childListArbitrary, (children) => {
+        expect(children.length).toBeLessThanOrEqual(2);
+      }),
+      fcRuns(100)
+    );
+
+    const text = Text.make({ value: "unbounded domain" });
+    expect(Result.isSuccess(S.decodeResult(InlineChildren)([text, text, text]))).toBe(true);
+  });
 
   it("encoded documents survive a JSON boundary (jsonb columns, rpc/ndjson wire)", () => {
     // Regression: a real Option in an encoded node must survive a JSON string


### PR DESCRIPTION
## fix(quality): stabilize nightly property-law sweep flake classes

Two recurring seed-dependent nightly failures (issue #677). @beep/md bounds
its five recursive child-list schemas with an arbitrary-only maxLength hint
so Document-bearing schema arbitraries stay inside the 1000-run lane budget
without constraining decoded documents. @beep/tika moves TikaError
equivalence into the schema declaration as a fields-only toEquivalence
annotation, so S.toEquivalence(TikaError) no longer falls back to
Equal.equals over non-schema Error runtime metadata; the property test now
validates the public comparator instead of a test-local override.

Fixes #677

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit:amend: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_nightly-property-laws-677-4cc2583fde6d/verdict.json

---

## Provenance

- Branch: <code>fix/nightly-property-laws-677</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/nightly-property-laws-677",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790147222&installation_model_id=424656&pr_number=780&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F780&signature=bbfc0432fb1dddb7ed08d947cb0905c0af657d90d1a7b7903d0cca574ff6e795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->