### PR TITLE
fix(ontology): require API authentication by default to prevent anonymous conflict transitions

### DIFF
--- a/scratchpad/effect-ontology/Service/Config.ts
+++ b/scratchpad/effect-ontology/Service/Config.ts
@@ -286,8 +286,8 @@ const ApiSettings = S.Struct({
     S.annotateKey({ description: "Optional redacted comma-separated API keys." })
   ),
   requireAuth: S.Boolean.pipe(
-    SchemaUtils.withKeyDefaults(false),
-    S.annotateKey({ description: "Whether versioned API endpoints require authentication." })
+    SchemaUtils.withKeyDefaults(true),
+    S.annotateKey({ description: "Whether versioned API endpoints require authentication (enabled by default)." })
   ),
 });
 

--- a/scratchpad/effect-ontology/test/Runtime/AuthRouter.test.ts
+++ b/scratchpad/effect-ontology/test/Runtime/AuthRouter.test.ts
@@ -30,6 +30,10 @@ const AuthConfig = Layer.succeed(ConfigService, {
 const InterruptedAuthDependencies = Layer.merge(InterruptedTicketService, AuthConfig);
 
 describe("AuthRouter", () => {
+  it("requires API authentication by default", () => {
+    assert.isTrue(DEFAULT_CONFIG.api.requireAuth);
+  });
+
   it.layer(InterruptedAuthDependencies)("with an interrupted ticket service", (it) => {
     it.effect(
       "preserves interruption from ticket creation",


### PR DESCRIPTION
### Motivation

- Prevent anonymous, unauthenticated clients from reaching repository-backed timeline mutation routes (conflict `PATCH`) by addressing that `API.REQUIRE_AUTH` defaulted to `false`, which allowed the no-auth middleware path to provide a `system` actor and perform state-changing conflict transitions.

### Description

- Change the API schema default so `ApiSettings.requireAuth` is enabled by default and clarify the description, and add a regression assertion that `DEFAULT_CONFIG.api.requireAuth` is `true` to prevent accidental reversion (`scratchpad/effect-ontology/Service/Config.ts`, `scratchpad/effect-ontology/test/Runtime/AuthRouter.test.ts`).

### Testing

- Performed dependency install with `bun install --frozen-lockfile` and validated the new default via a short runtime check (`mise exec bun@1.4.0 -- bun -e 'import { DEFAULT_CONFIG } from "./scratchpad/effect-ontology/Service/Config.ts"; if (!DEFAULT_CONFIG.api.requireAuth) process.exit(1); console.log("authentication defaults to required")'`) which succeeded; attempts to run the repository test harness (`bun test` / `vitest`) and Biome checks against the scratchpad tests were partially blocked by workspace/test runner configuration and workspace/peer dependency resolution, so full integrated test execution was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8bc38cda2c832caf374d1f11c1ac36)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790162868&installation_model_id=424656&pr_number=788&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F788&signature=ff634dce4932e2e13a59534383b181e4becf71653e02b9bfaa111d2683bcff80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->